### PR TITLE
Style logo link

### DIFF
--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -47,6 +47,12 @@ header .logo {
   letter-spacing: -0.5px;
 }
 
+/* Estilos para el logo clickeable */
+header .logo a {
+  color: var(--color-secondary);
+  text-decoration: none;
+}
+
 nav ul {
   list-style: none;
   margin: 0;


### PR DESCRIPTION
## Summary
- keep the NERIN logo from showing default blue link style

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_688399c2b5548331b10cdc8245d0f632