### PR TITLE
Add interactive chart to metrics

### DIFF
--- a/nerin_final_updated/frontend/admin.html
+++ b/nerin_final_updated/frontend/admin.html
@@ -218,6 +218,7 @@
       <section id="metricsSection" class="admin-section" style="display: none">
         <h3>Métricas</h3>
         <div id="metricsContent"></div>
+        <canvas id="salesChartCanvas" height="200"></canvas>
       </section>
 
       <!-- Sección de devoluciones -->
@@ -396,6 +397,7 @@
         <div id="analyticsContent"></div>
       </section>
     </main>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script type="module" src="/js/admin.js"></script>
     <!-- Configuración y analíticas globales -->
     <script type="module" src="/js/config.js"></script>


### PR DESCRIPTION
## Summary
- include Chart.js on admin panel
- show canvas for metrics
- draw dynamic sales chart

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68840e72d568833195fab72faebb0e6a