### PR TITLE
Improve analytics with additional metrics

### DIFF
--- a/nerin_final_updated/README.txt
+++ b/nerin_final_updated/README.txt
@@ -290,6 +290,11 @@ en datos y conocer mejor el comportamiento de los clientes【325860026011719†L
 Puedes visualizar estas métricas en la nueva página *Analíticas* del
 panel de administración, que incluye gráficos y tablas dinámicas.
 
+A partir de esta versión se incorporan métricas adicionales como la evolución
+de ventas mensuales, el valor promedio por pedido, la tasa de devoluciones y el
+producto con más devoluciones. Estas estadísticas amplían la visibilidad sobre
+el negocio y facilitan la detección de tendencias.
+
 ### Traducciones e internacionalización
 
 El frontend incorpora un sistema básico de internacionalización que permite

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -142,7 +142,17 @@ function calculateDetailedAnalytics() {
   const salesByProduct = {};
   const returnsByProduct = {};
   const customerTotals = {};
+  const monthlySales = {};
+  let totalSales = 0;
+  let totalUnitsSold = 0;
+  let totalReturns = 0;
   orders.forEach((order) => {
+    totalSales += order.total || 0;
+    // Agrupar ventas por mes
+    if (order.date) {
+      const month = order.date.slice(0, 7); // YYYY-MM
+      monthlySales[month] = (monthlySales[month] || 0) + (order.total || 0);
+    }
     order.items.forEach((item) => {
       const prod = products.find((p) => p.id === item.id);
       if (prod) {
@@ -155,6 +165,7 @@ function calculateDetailedAnalytics() {
         salesByProduct[prod.name] =
           (salesByProduct[prod.name] || 0) + item.quantity;
       }
+      totalUnitsSold += item.quantity;
     });
     // Total por cliente
     if (order.customer && order.customer.email) {
@@ -170,6 +181,7 @@ function calculateDetailedAnalytics() {
         returnsByProduct[prod.name] =
           (returnsByProduct[prod.name] || 0) + item.quantity;
       }
+      totalReturns += item.quantity;
     });
   });
   // Top clientes
@@ -177,11 +189,21 @@ function calculateDetailedAnalytics() {
     .sort((a, b) => b[1] - a[1])
     .slice(0, 5)
     .map(([email, total]) => ({ email, total }));
+  const averageOrderValue = orders.length ? totalSales / orders.length : 0;
+  const returnRate = totalUnitsSold > 0 ? totalReturns / totalUnitsSold : 0;
+  const mostReturnedEntry = Object.entries(returnsByProduct).sort(
+    (a, b) => b[1] - a[1],
+  )[0];
+  const mostReturnedProduct = mostReturnedEntry ? mostReturnedEntry[0] : null;
   return {
     salesByCategory,
     salesByProduct,
     returnsByProduct,
     topCustomers,
+    monthlySales,
+    averageOrderValue,
+    returnRate,
+    mostReturnedProduct,
   };
 }
 

--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -539,8 +539,16 @@ async function loadAnalytics() {
     const data = await res.json();
     const container = document.getElementById("analyticsContent");
     container.innerHTML = "";
-    const { salesByCategory, salesByProduct, returnsByProduct, topCustomers } =
-      data.analytics;
+    const {
+      salesByCategory,
+      salesByProduct,
+      returnsByProduct,
+      topCustomers,
+      monthlySales,
+      averageOrderValue,
+      returnRate,
+      mostReturnedProduct,
+    } = data.analytics;
 
     /**
      * Helper para construir un gráfico de barras horizontal.
@@ -603,6 +611,25 @@ async function loadAnalytics() {
     container.appendChild(
       buildBarChart("Clientes con mayor facturación", clientTotals, ""),
     );
+
+    // Ventas por mes (valores monetarios)
+    container.appendChild(
+      buildBarChart("Ventas por mes", monthlySales, ""),
+    );
+
+    // Estadísticas adicionales
+    const stats = document.createElement("div");
+    stats.className = "analytics-stats";
+    const pAvg = document.createElement("p");
+    pAvg.textContent = `Valor medio de pedido: $${averageOrderValue.toFixed(2)}`;
+    const pRate = document.createElement("p");
+    pRate.textContent = `Tasa de devoluciones: ${(returnRate * 100).toFixed(2)}%`;
+    const pMost = document.createElement("p");
+    pMost.textContent = `Producto más devuelto: ${mostReturnedProduct || "N/A"}`;
+    stats.appendChild(pAvg);
+    stats.appendChild(pRate);
+    stats.appendChild(pMost);
+    container.appendChild(stats);
   } catch (err) {
     console.error(err);
     const container = document.getElementById("analyticsContent");

--- a/nerin_final_updated/frontend/js/lang.js
+++ b/nerin_final_updated/frontend/js/lang.js
@@ -28,6 +28,10 @@ const translations = {
     "suppliers.title": "Gestión de proveedores",
     "purchase.title": "Órdenes de compra",
     "analytics.title": "Analíticas detalladas",
+    "analytics.monthlySales": "Ventas por mes",
+    "analytics.avgOrder": "Valor medio de pedido",
+    "analytics.returnRate": "Tasa de devoluciones",
+    "analytics.mostReturned": "Producto más devuelto",
   },
   en: {
     "admin.title": "Administration Panel",
@@ -50,6 +54,10 @@ const translations = {
     "suppliers.title": "Supplier Management",
     "purchase.title": "Purchase Orders",
     "analytics.title": "Detailed Analytics",
+    "analytics.monthlySales": "Sales by month",
+    "analytics.avgOrder": "Average order value",
+    "analytics.returnRate": "Return rate",
+    "analytics.mostReturned": "Most returned product",
   },
 };
 

--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -510,6 +510,16 @@ nav a:hover {
   font-size: 0.9rem;
 }
 
+/* Bloque con estadísticas adicionales de analíticas */
+.analytics-stats {
+  max-width: 600px;
+  margin: 1rem 0;
+}
+
+.analytics-stats p {
+  margin: 0.25rem 0;
+}
+
 /* Responsivo */
 @media (max-width: 768px) {
   header {


### PR DESCRIPTION
## Summary
- extend analytics calculations to include monthly sales, average order value, return rate and most returned product
- display the new metrics on the admin analytics page
- add translations and minor styling for these stats
- document the new metrics in README

## Testing
- `node -c backend/server.js`
- `npm install mercadopago`
- `npm start` *(fails without mercadopago, installed and started successfully)*

------
https://chatgpt.com/codex/tasks/task_e_6884120189a08331ba6368b10bfcd013