### PR TITLE
Replace admin analytics with Chart.js dashboard

### DIFF
--- a/nerin_final_updated/frontend/admin.html
+++ b/nerin_final_updated/frontend/admin.html
@@ -394,7 +394,7 @@
           devoluciones y clientes. Estas métricas te ayudan a tomar decisiones
           informadas.
         </p>
-        <div id="analyticsContent"></div>
+        <div id="analytics-dashboard"></div>
       </section>
     </main>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>

--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -7,6 +7,7 @@
  */
 
 import { getUserRole, logout } from "./api.js";
+import { renderAnalyticsDashboard } from "./analytics.js";
 
 // Verificar rol de administrador o vendedor
 const currentRole = getUserRole();
@@ -534,107 +535,7 @@ if (addPoForm) {
 
 // ------------ Analíticas detalladas ------------
 async function loadAnalytics() {
-  try {
-    const res = await fetch("/api/analytics/detailed");
-    const data = await res.json();
-    const container = document.getElementById("analyticsContent");
-    container.innerHTML = "";
-    const {
-      salesByCategory,
-      salesByProduct,
-      returnsByProduct,
-      topCustomers,
-      monthlySales,
-      averageOrderValue,
-      returnRate,
-      mostReturnedProduct,
-    } = data.analytics;
-
-    /**
-     * Helper para construir un gráfico de barras horizontal.
-     * Recibe un objeto donde las claves son etiquetas y los valores números.
-     * Genera un fragmento HTML con barras proporcionales al valor máximo.
-     */
-    function buildBarChart(title, dataObj, valueSuffix = "") {
-      const wrapper = document.createElement("div");
-      const h4 = document.createElement("h4");
-      h4.textContent = title;
-      wrapper.appendChild(h4);
-      const barChart = document.createElement("div");
-      barChart.className = "bar-chart";
-      const values = Object.values(dataObj);
-      const maxVal = values.length ? Math.max(...values) : 0;
-      Object.entries(dataObj).forEach(([label, val]) => {
-        const width = maxVal > 0 ? ((val / maxVal) * 100).toFixed(2) : 0;
-        const row = document.createElement("div");
-        row.className = "bar-row";
-        const spanLabel = document.createElement("span");
-        spanLabel.className = "bar-label";
-        spanLabel.textContent = label;
-        const bar = document.createElement("div");
-        bar.className = "bar";
-        bar.style.width = `${width}%`;
-        const spanVal = document.createElement("span");
-        spanVal.className = "bar-value";
-        // Formatear valores numéricos
-        spanVal.textContent =
-          valueSuffix === "u."
-            ? `${val} ${valueSuffix}`
-            : `$${val.toLocaleString("es-AR")}${valueSuffix}`;
-        row.appendChild(spanLabel);
-        row.appendChild(bar);
-        row.appendChild(spanVal);
-        barChart.appendChild(row);
-      });
-      wrapper.appendChild(barChart);
-      return wrapper;
-    }
-    // Construir y agregar gráficos
-    // Ventas por categoría (valores monetarios)
-    container.appendChild(
-      buildBarChart("Ventas por categoría", salesByCategory, ""),
-    );
-    // Unidades vendidas por producto (cantidades)
-    container.appendChild(
-      buildBarChart("Unidades vendidas por producto", salesByProduct, " u."),
-    );
-    // Devoluciones por producto (cantidades)
-    container.appendChild(
-      buildBarChart("Devoluciones por producto", returnsByProduct, " u."),
-    );
-    // Clientes con mayor facturación (valores monetarios)
-    // Convertir topCustomers en un objeto { email: total }
-    const clientTotals = {};
-    topCustomers.forEach((c) => {
-      clientTotals[c.email] = c.total;
-    });
-    container.appendChild(
-      buildBarChart("Clientes con mayor facturación", clientTotals, ""),
-    );
-
-    // Ventas por mes (valores monetarios)
-    container.appendChild(
-      buildBarChart("Ventas por mes", monthlySales, ""),
-    );
-
-    // Estadísticas adicionales
-    const stats = document.createElement("div");
-    stats.className = "analytics-stats";
-    const pAvg = document.createElement("p");
-    pAvg.textContent = `Valor medio de pedido: $${averageOrderValue.toFixed(2)}`;
-    const pRate = document.createElement("p");
-    pRate.textContent = `Tasa de devoluciones: ${(returnRate * 100).toFixed(2)}%`;
-    const pMost = document.createElement("p");
-    pMost.textContent = `Producto más devuelto: ${mostReturnedProduct || "N/A"}`;
-    stats.appendChild(pAvg);
-    stats.appendChild(pRate);
-    stats.appendChild(pMost);
-    container.appendChild(stats);
-  } catch (err) {
-    console.error(err);
-    const container = document.getElementById("analyticsContent");
-    container.innerHTML = "<p>No se pudieron cargar las analíticas</p>";
-  }
+  await renderAnalyticsDashboard("analytics-dashboard");
 }
 
 // ------------ Pedidos ------------

--- a/nerin_final_updated/frontend/js/analytics.js
+++ b/nerin_final_updated/frontend/js/analytics.js
@@ -1,0 +1,142 @@
+export async function renderAnalyticsDashboard(containerId = 'analytics-dashboard') {
+  const container = typeof containerId === 'string' ? document.getElementById(containerId) : containerId;
+  if (!container) return;
+  container.innerHTML = '<p>Cargando...</p>';
+  try {
+    const res = await fetch('/api/analytics/detailed');
+    const { analytics } = await res.json();
+    container.innerHTML = '';
+
+    const palette = ['#3b82f6', '#8b5cf6', '#10b981', '#f59e0b', '#ef4444', '#6366f1', '#14b8a6', '#f43f5e', '#ec4899', '#a3e635'];
+
+    function createChart(title, type, labels, data, { valueType = 'currency', ...opts } = {}) {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'chart-wrapper';
+      const h4 = document.createElement('h4');
+      h4.textContent = title;
+      wrapper.appendChild(h4);
+      const canvas = document.createElement('canvas');
+      wrapper.appendChild(canvas);
+      const ctx = canvas.getContext('2d');
+      const colors = labels.map((_, i) => palette[i % palette.length]);
+      const chart = new Chart(ctx, {
+        type,
+        data: {
+          labels,
+          datasets: [
+            {
+              label: title,
+              data,
+              backgroundColor: type === 'line' ? palette[0] : colors,
+              borderColor: type === 'line' ? palette[0] : colors,
+              fill: type !== 'line',
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          indexAxis: opts.indexAxis || 'x',
+          plugins: {
+            legend: { display: type === 'pie' },
+            tooltip: {
+              callbacks: {
+                label: (ctx) => {
+                  const val = type === 'pie' ? ctx.parsed : ctx.parsed.y;
+                  return valueType === 'units'
+                    ? `${val} u.`
+                    : `$${val.toLocaleString('es-AR')}`;
+                },
+              },
+            },
+          },
+          scales: type === 'pie' ? {} : { y: { beginAtZero: true } },
+        },
+      });
+
+      const btnContainer = document.createElement('div');
+      btnContainer.className = 'chart-buttons';
+      const imgBtn = document.createElement('button');
+      imgBtn.className = 'button secondary';
+      imgBtn.textContent = 'Descargar PNG';
+      imgBtn.addEventListener('click', () => {
+        const a = document.createElement('a');
+        a.href = chart.toBase64Image();
+        a.download = `${title}.png`;
+        a.click();
+      });
+      const csvBtn = document.createElement('button');
+      csvBtn.className = 'button secondary';
+      csvBtn.textContent = 'Exportar datos';
+      csvBtn.addEventListener('click', () => {
+        let csv = 'Etiqueta,Valor\n';
+        labels.forEach((lab, i) => {
+          csv += `${lab},${data[i]}\n`;
+        });
+        const blob = new Blob([csv], { type: 'text/csv' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = `${title}.csv`;
+        link.click();
+        URL.revokeObjectURL(url);
+      });
+      btnContainer.appendChild(imgBtn);
+      btnContainer.appendChild(csvBtn);
+      wrapper.appendChild(btnContainer);
+      container.appendChild(wrapper);
+    }
+
+    createChart(
+      'Ventas por categoría',
+      'pie',
+      Object.keys(analytics.salesByCategory),
+      Object.values(analytics.salesByCategory),
+    );
+
+    createChart(
+      'Unidades vendidas por producto',
+      'bar',
+      Object.keys(analytics.salesByProduct),
+      Object.values(analytics.salesByProduct),
+      { valueType: 'units' },
+    );
+
+    createChart(
+      'Devoluciones por producto',
+      'bar',
+      Object.keys(analytics.returnsByProduct),
+      Object.values(analytics.returnsByProduct),
+      { valueType: 'units' },
+    );
+
+    const clientLabels = analytics.topCustomers.map((c) => c.email);
+    const clientData = analytics.topCustomers.map((c) => c.total);
+    createChart(
+      'Clientes con mayor facturación',
+      'bar',
+      clientLabels,
+      clientData,
+      { indexAxis: 'y' },
+    );
+
+    createChart(
+      'Ventas por mes',
+      'line',
+      Object.keys(analytics.monthlySales),
+      Object.values(analytics.monthlySales),
+    );
+
+    const stats = document.createElement('div');
+    stats.className = 'analytics-stats';
+    stats.innerHTML = `
+      <p>Valor medio de pedido: $${analytics.averageOrderValue.toFixed(2)}</p>
+      <p>Tasa de devoluciones: ${(analytics.returnRate * 100).toFixed(2)}%</p>
+      <p>Producto más devuelto: ${analytics.mostReturnedProduct || 'N/A'}</p>
+    `;
+    container.appendChild(stats);
+  } catch (err) {
+    console.error(err);
+    container.innerHTML = '<p>No se pudieron cargar las analíticas</p>';
+  }
+}

--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -429,32 +429,6 @@ nav a:hover {
   transform: translateY(-4px);
 }
 
-/* === Estilos para gráficos de barras simples === */
-.bar-chart {
-  max-width: 600px;
-  margin: 1rem 0;
-}
-.bar-row {
-  display: flex;
-  align-items: center;
-  margin: 0.25rem 0;
-  font-size: 0.85rem;
-}
-.bar-label {
-  width: 120px;
-  white-space: nowrap;
-}
-.bar {
-  flex: 1;
-  height: 10px;
-  background-color: var(--color-primary);
-  margin: 0 0.5rem;
-  border-radius: 4px;
-}
-.bar-value {
-  width: 80px;
-  text-align: right;
-}
 
 .add-to-cart button:hover {
   background-color: #0057c2;
@@ -532,6 +506,25 @@ nav a:hover {
 
 .analytics-stats p {
   margin: 0.25rem 0;
+}
+
+/* Contenedor para gráficos con Chart.js */
+.chart-wrapper {
+  max-width: 600px;
+  margin: 2rem 0;
+}
+
+.chart-wrapper canvas {
+  width: 100%;
+  max-height: 320px;
+}
+
+.chart-buttons {
+  margin-top: 0.5rem;
+}
+
+.chart-buttons button {
+  margin-right: 0.5rem;
 }
 
 /* Responsivo */


### PR DESCRIPTION
## Summary
- add new `analytics.js` component to render interactive graphs using Chart.js
- replace old analytics section in `admin.js` to use the new component
- update `admin.html` with new analytics dashboard container
- remove old bar chart CSS and add styles for the Chart.js widgets

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6884f207f2948331a0795971fd46808e