### PR TITLE
Implement Mercado Pago checkout integration

### DIFF
--- a/nerin_final_updated/frontend/cart.html
+++ b/nerin_final_updated/frontend/cart.html
@@ -34,6 +34,7 @@
           Confirmar pedido
         </button>
       </div>
+      <div id="orderSummary" class="payment-summary" style="display: none"></div>
     </main>
     <div id="whatsapp-button">
       <a href="https://wa.me/541112345678" target="_blank">

--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -621,6 +621,17 @@ nav a:hover {
   text-align: center;
 }
 
+.payment-summary {
+  margin-top: 1.5rem;
+  padding: 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  background-color: var(--color-muted);
+}
+.payment-summary h3 {
+  margin-top: 0;
+}
+
 @media (max-width: 600px) {
   .cart-item {
     grid-template-columns: 1fr 1fr;


### PR DESCRIPTION
## Summary
- enable Mercado Pago token via env vars
- add endpoint `/api/payments/create-preference`
- show payment summary with Mercado Pago button after confirming cart
- style summary section

## Testing
- `npm start` *(fails without mercadopago, then install works)*
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68852f5cd4b0833197a612fba9bd540e