### PR TITLE
Add MercadoPago token to config

### DIFF
--- a/nerin_final_updated/data/config.json
+++ b/nerin_final_updated/data/config.json
@@ -3,7 +3,7 @@
   "metaPixelId": "",
   "whatsappNumber": "541112345678",
   "defaultCarriers": ["Andreani", "Correo Argentino", "OCA"],
-  "mercadoPagoToken": "",
+  "mercadoPagoToken": "APP_USR-5675865330226860-072710-05605f8b5a52891c1de581e371307e87-462376008",
   "afipCUIT": "",
   "afipCert": "",
   "afipKey": "",


### PR DESCRIPTION
## Summary
- insert provided MercadoPago access token into `data/config.json`

## Testing
- `npm install`
- `node backend/server.js & sleep 2; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_688646991580833192c83ba46510b145