### PR TITLE
Fix Mercado Pago preference creation

### DIFF
--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -1427,7 +1427,7 @@ const server = http.createServer((req, res) => {
         if (!mpPreference) {
           throw new Error("Mercado Pago no está configurado");
         }
-        const result = await mpPreference.create(preference);
+        const result = await mpPreference.create({ body: preference });
         return sendJson(res, 200, { preference: result.id });
       } catch (err) {
         console.error(err);
@@ -1473,7 +1473,7 @@ const server = http.createServer((req, res) => {
         if (!mpPreference) {
           throw new Error("Mercado Pago no está configurado");
         }
-        const result = await mpPreference.create(preference);
+        const result = await mpPreference.create({ body: preference });
         return sendJson(res, 200, { preferenceId: result.id });
       } catch (err) {
         console.error(err);
@@ -1520,7 +1520,7 @@ const server = http.createServer((req, res) => {
           },
           auto_return: "approved",
         };
-        const result = await mpPreference.create(preference);
+        const result = await mpPreference.create({ body: preference });
         return sendJson(res, 200, {
           preferenceId: result.id,
           init_point: result.init_point,


### PR DESCRIPTION
## Summary
- update `nerin_final_updated/backend/server.js` to send MercadoPago preference in the correct body format

## Testing
- `npm install` inside `nerin_final_updated`
- `node backend/server.js` *(fails to reach MercadoPago: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68864c2801148331862af8f66b2c88c2