### PR TITLE
Remove hard-coded Mercado Pago credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ package-lock.json
 nerin_final_updated/node_modules/
 nerin_final_updated/package-lock.json
 nerin_final_updated/.env
+frontend/config.js

--- a/README.txt
+++ b/README.txt
@@ -7,7 +7,9 @@ INSTRUCCIONES RÁPIDAS
    cd backend
    ```
 
-2. Instalá las dependencias y ejecutá el servidor:
+2. Copiá `frontend/config.example.js` a `frontend/config.js` y completa tu
+   clave pública de Mercado Pago. Luego instalá las dependencias y ejecutá el servidor
+   (necesitás definir `MP_ACCESS_TOKEN` en tu entorno):
 
    ```bash
    npm install

--- a/backend/server.js
+++ b/backend/server.js
@@ -3,9 +3,16 @@ const express = require('express');
 const cors = require('cors');
 const { MercadoPagoConfig, Preference } = require('mercadopago');
 
-// Configuramos la SDK con las credenciales reales
+require('dotenv').config();
+
+// Configuramos la SDK con la credencial del entorno
+const ACCESS_TOKEN = process.env.MP_ACCESS_TOKEN;
+if (!ACCESS_TOKEN) {
+  throw new Error('MP_ACCESS_TOKEN no configurado');
+}
+
 const client = new MercadoPagoConfig({
-  accessToken: 'APP_USR-5675865330226860-072710-05605f8b5a52891c1de581e371307e87-462376008',
+  accessToken: ACCESS_TOKEN,
 });
 const preferenceClient = new Preference(client);
 

--- a/frontend/config.example.js
+++ b/frontend/config.example.js
@@ -1,0 +1,4 @@
+// Rename this file to config.js and set your Mercado Pago public key
+// Example:
+// window.MP_PUBLIC_KEY = 'TEST-1234abcd-5678-efgh-9012-ijklmno';
+window.MP_PUBLIC_KEY = '';

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,10 +11,14 @@
 
   <div id="wallet_container"></div>
 
+  <script src="config.js"></script>
   <script src="https://sdk.mercadopago.com/js/v2"></script>
   <script>
-    // Inicializamos Mercado Pago con la public key real
-    const mp = new MercadoPago('APP_USR-d45dd347-3839-4dac-bcd3-4bc670cb9465', {
+    // Inicializamos Mercado Pago con la public key configurada en config.js
+    if (!window.MP_PUBLIC_KEY) {
+      throw new Error('Defina MP_PUBLIC_KEY en config.js');
+    }
+    const mp = new MercadoPago(window.MP_PUBLIC_KEY, {
       locale: 'es-AR',
     });
 

--- a/nerin_final_updated/README.txt
+++ b/nerin_final_updated/README.txt
@@ -157,7 +157,7 @@ Sigue estos pasos para ponerlas en funcionamiento:
 
 1. Crea una cuenta de Mercado Pago e ingresa a las [credenciales de producción](https://www.mercadopago.com.ar/developers/panel/credentials) para obtener tu token de acceso.
 2. En el servicio de AFIP genera el certificado digital (archivo `.crt`) y la clave privada (`.key`) correspondiente al CUIT de tu empresa.
-3. Abre el archivo `data/config.json` y completa los campos `mercadoPagoToken`, `afipCUIT`, `afipCert` y `afipKey` con la información obtenida.
+3. Define la variable de entorno `MP_ACCESS_TOKEN` con el token de acceso y completa en `data/config.json` los campos `afipCUIT`, `afipCert` y `afipKey`.
 4. Reinicia el servidor con `npm start` para que los cambios surtan efecto.
 
 Una vez configurado, desde el frontend puedes crear una preferencia de pago enviando el carrito a `/api/mercadopago/preference` y redirigir al usuario a la URL devuelta. Para generar una factura electrónica debes hacer un `POST` a `/api/afip/invoice` con los datos del comprobante, que se procesará mediante la biblioteca `afip.ts`.

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -20,7 +20,7 @@ require("dotenv").config();
 const CONFIG = getConfig();
 const APP_PORT = process.env.PORT || 3000;
 const resend = CONFIG.resendApiKey ? new Resend(CONFIG.resendApiKey) : null;
-const MP_TOKEN = process.env.MP_ACCESS_TOKEN || CONFIG.mercadoPagoToken;
+const MP_TOKEN = process.env.MP_ACCESS_TOKEN;
 let mpPreference = null;
 if (MP_TOKEN) {
   const mpClient = new MercadoPagoConfig({ accessToken: MP_TOKEN });

--- a/nerin_final_updated/data/config.json
+++ b/nerin_final_updated/data/config.json
@@ -3,7 +3,7 @@
   "metaPixelId": "",
   "whatsappNumber": "541112345678",
   "defaultCarriers": ["Andreani", "Correo Argentino", "OCA"],
-  "mercadoPagoToken": "APP_USR-5675865330226860-072710-05605f8b5a52891c1de581e371307e87-462376008",
+  "mercadoPagoToken": "",
   "afipCUIT": "",
   "afipCert": "",
   "afipKey": "",


### PR DESCRIPTION
## Summary
- load credentials from the environment in the example server
- ignore local frontend config
- load Mercado Pago public key from a config file
- scrub token from data/config.json and rely on MP_ACCESS_TOKEN
- document the new setup in READMEs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68864c27a8d08331bc1120a7aaa6ecb0