### PR TITLE
Integrate Mercado Pago checkout

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -12,6 +12,7 @@ if (!ACCESS_TOKEN) {
   throw new Error('MP_ACCESS_TOKEN no configurado');
 }
 
+const PUBLIC_URL = process.env.PUBLIC_URL || `http://localhost:${process.env.PORT || 3000}`;
 const client = new MercadoPagoConfig({
   accessToken: ACCESS_TOKEN,
 });
@@ -20,6 +21,18 @@ const preferenceClient = new Preference(client);
 const app = express();
 app.use(cors());
 app.use(express.json());
+
+app.get('/success', (_req, res) => {
+  res.send('Pago completado');
+});
+
+app.get('/failure', (_req, res) => {
+  res.send('Pago rechazado');
+});
+
+app.get('/pending', (_req, res) => {
+  res.send('Pago pendiente');
+});
 
 // POST /crear-preferencia
 // Recibe titulo, precio y cantidad y genera una preferencia
@@ -35,9 +48,9 @@ app.post('/crear-preferencia', async (req, res) => {
       },
     ],
     back_urls: {
-      success: 'https://example.com/success',
-      failure: 'https://example.com/failure',
-      pending: 'https://example.com/pending',
+      success: `${PUBLIC_URL}/success`,
+      failure: `${PUBLIC_URL}/failure`,
+      pending: `${PUBLIC_URL}/pending`,
     },
     auto_return: 'approved',
   };
@@ -46,7 +59,7 @@ app.post('/crear-preferencia', async (req, res) => {
     const result = await preferenceClient.create({ body });
     // Mostramos el link en consola para pruebas manuales
     console.log('Preferencia creada:', result.init_point);
-    res.json({ id: result.id });
+    res.json({ id: result.id, init_point: result.init_point });
   } catch (error) {
     console.error('Error al crear preferencia:', error);
     res.status(500).json({ error: 'No se pudo crear la preferencia' });

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -39,18 +39,10 @@
         },
         body: JSON.stringify(producto),
       });
-
-      const { id } = await response.json();
-
-      // Mostramos el botón de Checkout Pro
-      mp.checkout({
-        preference: { id },
-        autoOpen: true,
-        render: {
-          container: '#wallet_container',
-          label: 'Pagar con Mercado Pago',
-        },
-      });
+      const { init_point } = await response.json();
+      if (init_point) {
+        window.location.href = init_point;
+      }
     });
   </script>
 </body>

--- a/nerin_final_updated/frontend/js/cart.js
+++ b/nerin_final_updated/frontend/js/cart.js
@@ -163,6 +163,10 @@ function renderCart() {
       }
       const data = await res.json().catch(() => ({}));
       const orderId = data.orderId || "N/A";
+      if (data.init_point) {
+        window.location.href = data.init_point;
+        return;
+      }
       const prefRes = await fetch("/api/payments/create-preference", {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "ecommerce-3.0",
+  "version": "1.0.0",
+  "main": "backend/server.js",
+  "scripts": {
+    "start": "node backend/server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "cors": "^2.8.5",
+    "mercadopago": "^2.8.0",
+    "dotenv": "^16.3.1"
+  }
+}


### PR DESCRIPTION
## Summary
- set public URL and return init_point when creating preferences
- expose success, failure and pending routes
- allow checkout API to create a Mercado Pago preference
- redirect from frontend cart flow using init_point
- redirect to Mercado Pago in the minimal demo frontend
- add root package.json with express and start script

## Testing
- `npm install`
- `npm start` *(fails: MP_ACCESS_TOKEN not configured)*

------
https://chatgpt.com/codex/tasks/task_e_6886b41a94b8833197327b55ec9191a1