### PR TITLE
Implement Mercado Pago order flow with webhooks

### DIFF
--- a/nerin_final_updated/backend/index.js
+++ b/nerin_final_updated/backend/index.js
@@ -11,9 +11,25 @@ const fs = require("fs");
 const express = require("express");
 const bodyParser = require("body-parser");
 const cors = require("cors");
+const { MercadoPagoConfig, Preference } = require("mercadopago");
+let Resend;
+try {
+  ({ Resend } = require("resend"));
+} catch {
+  Resend = null;
+}
+require("dotenv").config();
 
 const app = express();
 const PORT = process.env.PORT || 3000;
+
+const MP_TOKEN = process.env.MP_ACCESS_TOKEN || "";
+const mpClient = MP_TOKEN ? new MercadoPagoConfig({ accessToken: MP_TOKEN }) : null;
+const mpPreference = mpClient ? new Preference(mpClient) : null;
+const resendApiKey = process.env.RESEND_API_KEY || "";
+const resend = Resend && resendApiKey ? new Resend(resendApiKey) : null;
+const PUBLIC_URL = process.env.PUBLIC_URL || `http://localhost:${PORT}`;
+const ADMIN_EMAIL = process.env.ADMIN_EMAIL || "";
 
 // Middleware
 app.use(cors());
@@ -25,11 +41,54 @@ app.use("/", express.static(path.join(__dirname, "../frontend")));
 // Ruta para servir las imágenes de productos y otros activos
 app.use("/assets", express.static(path.join(__dirname, "../assets")));
 
+// Rutas de retorno de Mercado Pago
+app.get("/success", (_req, res) => {
+  res.sendFile(path.join(__dirname, "../frontend/success.html"));
+});
+app.get("/failure", (_req, res) => {
+  res.sendFile(path.join(__dirname, "../frontend/failure.html"));
+});
+app.get("/pending", (_req, res) => {
+  res.sendFile(path.join(__dirname, "../frontend/pending.html"));
+});
+
 // Leer productos desde el archivo JSON
 function getProducts() {
   const dataPath = path.join(__dirname, "../data/products.json");
   const file = fs.readFileSync(dataPath, "utf8");
   return JSON.parse(file).products;
+}
+
+function getOrders() {
+  const dataPath = path.join(__dirname, "../data/orders.json");
+  try {
+    const file = fs.readFileSync(dataPath, "utf8");
+    return JSON.parse(file).orders || [];
+  } catch {
+    return [];
+  }
+}
+
+function saveOrders(orders) {
+  const dataPath = path.join(__dirname, "../data/orders.json");
+  fs.writeFileSync(dataPath, JSON.stringify({ orders }, null, 2), "utf8");
+}
+
+function sendOrderPaidEmail(order) {
+  if (!resend || !order.cliente || !order.cliente.email) return;
+  try {
+    const tpl = path.join(__dirname, "../emails/orderPaid.html");
+    let html = fs.readFileSync(tpl, "utf8");
+    const url = `${PUBLIC_URL}/account.html?orderId=${encodeURIComponent(order.id)}`;
+    html = html.replace("{{ORDER_URL}}", url);
+    const to = [order.cliente.email];
+    if (ADMIN_EMAIL) to.push(ADMIN_EMAIL);
+    resend.emails
+      .send({ from: "no-reply@nerin.com", to, subject: "Confirmación de compra", html })
+      .catch((e) => console.error("Email error", e));
+  } catch (e) {
+    console.error("send email failed", e);
+  }
 }
 
 // API: obtener la lista de productos
@@ -40,6 +99,100 @@ app.get("/api/products", (_req, res) => {
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: "No se pudieron cargar los productos" });
+  }
+});
+
+// Crear un nuevo pedido y generar preferencia de Mercado Pago
+app.post("/api/orders", async (req, res) => {
+  try {
+    const { cliente = {}, productos = [] } = req.body;
+    if (!Array.isArray(productos) || productos.length === 0) {
+      return res.status(400).json({ error: "Carrito vacío" });
+    }
+    const id =
+      "ORD-" + Date.now().toString(36) + "-" + Math.floor(Math.random() * 1000);
+    const total = productos.reduce(
+      (t, it) => t + Number(it.price) * Number(it.quantity),
+      0,
+    );
+    const order = {
+      id,
+      cliente,
+      productos,
+      estado_pago: "pendiente",
+      estado_envio: "pendiente",
+      fecha: new Date().toISOString(),
+      total,
+    };
+    const orders = getOrders();
+    orders.push(order);
+    saveOrders(orders);
+
+    let initPoint = null;
+    if (mpPreference) {
+      try {
+        const pref = {
+          items: productos.map((p) => ({
+            title: p.name,
+            quantity: Number(p.quantity),
+            unit_price: Number(p.price),
+          })),
+          back_urls: {
+            success: `${PUBLIC_URL}/success`,
+            failure: `${PUBLIC_URL}/failure`,
+            pending: `${PUBLIC_URL}/pending`,
+          },
+          auto_return: "approved",
+          external_reference: id,
+        };
+        if (PUBLIC_URL) {
+          pref.notification_url = `${PUBLIC_URL}/api/webhooks/mp`;
+        }
+        const prefRes = await mpPreference.create({ body: pref });
+        initPoint = prefRes.init_point;
+      } catch (e) {
+        console.error("MP preference error", e);
+      }
+    }
+
+    return res.status(201).json({ orderId: id, init_point: initPoint });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: "No se pudo crear el pedido" });
+  }
+});
+
+// Obtener pedido por ID
+app.get("/api/orders/:id", (req, res) => {
+  const orders = getOrders();
+  const order = orders.find((o) => o.id === req.params.id);
+  if (!order) return res.status(404).json({ error: "Pedido no encontrado" });
+  res.json({ order });
+});
+
+// Webhook de Mercado Pago para actualizar estado de pedido
+app.post("/api/webhooks/mp", (req, res) => {
+  try {
+    const event = req.body || {};
+    const payment = event.data && event.data.id ? event.data : null;
+    if (!payment) return res.json({ received: true });
+    const orders = getOrders();
+    const order = orders.find((o) => o.id === payment.external_reference);
+    if (order) {
+      if (payment.status === "approved") {
+        order.estado_pago = "pagado";
+        order.paymentId = payment.id;
+        saveOrders(orders);
+        sendOrderPaidEmail(order);
+      } else if (payment.status === "rejected") {
+        order.estado_pago = "rechazado";
+        saveOrders(orders);
+      }
+    }
+    return res.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    return res.status(400).json({ error: "Webhook inválido" });
   }
 });
 

--- a/nerin_final_updated/frontend/success.html
+++ b/nerin_final_updated/frontend/success.html
@@ -8,7 +8,36 @@
   <body>
     <div class="contenedor">
       <p>✅ ¡Pago aprobado! Gracias por tu compra.</p>
+      <div id="orderSummary"></div>
       <a class="btn" href="/index.html">Volver a la tienda</a>
     </div>
+    <script>
+      document.addEventListener("DOMContentLoaded", async () => {
+        const params = new URLSearchParams(window.location.search);
+        const id = params.get("external_reference") || params.get("orderId");
+        if (!id) return;
+        try {
+          const resp = await fetch(`/api/orders/${id}`);
+          if (!resp.ok) return;
+          const data = await resp.json();
+          const order = data.order;
+          const cont = document.getElementById("orderSummary");
+          if (order && cont) {
+            cont.innerHTML = `
+              <h3>Pedido ${order.id}</h3>
+              <ul>${order.productos
+                .map((p) => `<li>${p.name} x${p.quantity}</li>`)
+                .join("")}</ul>
+              <p>Total: $${order.total.toLocaleString("es-AR")}</p>
+            `;
+            if (order.estado_pago === "pagado") {
+              localStorage.removeItem("nerinCart");
+            }
+          }
+        } catch (e) {
+          console.error(e);
+        }
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- handle Mercado Pago tokens and email config in Express backend
- serve explicit success/failure/pending routes
- store orders and create Mercado Pago preferences
- expose order info and process payment webhooks
- show order summary in success page

## Testing
- `node -c nerin_final_updated/backend/index.js`
- `MP_ACCESS_TOKEN=dummy PUBLIC_URL=http://localhost:3000 node nerin_final_updated/backend/index.js & sleep 1; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_68878ba173b4833198e6642e148bd068