### PR TITLE
Add product image upload and tweak admin form

### DIFF
--- a/nerin_final_updated/frontend/admin.html
+++ b/nerin_final_updated/frontend/admin.html
@@ -155,22 +155,13 @@
             placeholder="Dimensiones (L×A×A cm)"
           />
           <input type="text" id="newColor" placeholder="Color" />
-          <label
-            style="
-              display: flex;
-              align-items: center;
-              gap: 0.5rem;
-              margin: 0.25rem 0;
-            "
-          >
-            <input type="checkbox" id="newVipOnly" /> Solo VIP
-          </label>
           <input
-            type="text"
+            type="file"
             id="newImage"
-            placeholder="Ruta de imagen (e.g., /assets/miimagen.png)"
+            accept=".jpg,.jpeg,.png"
             required
           />
+          <div id="imagePreview" class="image-preview"></div>
           <button type="submit" class="button primary">Agregar</button>
         </form>
       </section>

--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -798,6 +798,20 @@ nav a:hover {
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
 }
+.admin-form input[type="file"] {
+  padding: 0.2rem;
+}
+
+.admin-form .image-preview {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.admin-form .image-preview img {
+  max-width: 80px;
+  border-radius: var(--radius);
+}
 
 .admin-form button {
   padding: 0.5rem 1rem;

--- a/nerin_final_updated/package.json
+++ b/nerin_final_updated/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "afip.ts": "^3.2.2",
     "mercadopago": "^2.8.0",
-    "resend": "^4.7.0"
+    "resend": "^4.7.0",
+    "multer": "^1.4.5-lts.1"
   },
   "devDependencies": {
     "prettier": "^3.6.2"


### PR DESCRIPTION
## Summary
- allow uploading product images to `/api/product-image/:sku` using `multer`
- hide the "Solo VIP" option in the product form
- replace text path with file picker and preview
- store image path returned from upload when adding a product
- update styles for image preview and file input
- install multer dependency

## Testing
- `npm install --silent`
- `node backend/server.js` *(launched and terminated)*

------
https://chatgpt.com/codex/tasks/task_e_6887f5b47a4c8331adda80bbdee9702c