### PR TITLE
Implement persistent order tracking with Mercado Pago

### DIFF
--- a/backend/routes/mercadoPago.js
+++ b/backend/routes/mercadoPago.js
@@ -2,6 +2,11 @@ const express = require('express');
 const router = express.Router();
 const db = require('../db');
 const verifySignature = require('../middleware/verifySignature');
+const { MercadoPagoConfig, Payment, MerchantOrder } = require('mercadopago');
+const ACCESS_TOKEN = process.env.MP_ACCESS_TOKEN;
+const mpClient = new MercadoPagoConfig({ accessToken: ACCESS_TOKEN });
+const paymentClient = new Payment(mpClient);
+const merchantClient = new MerchantOrder(mpClient);
 
 router.post('/webhook', verifySignature, async (req, res) => {
   const paymentId =
@@ -13,10 +18,25 @@ router.post('/webhook', verifySignature, async (req, res) => {
   }
 
   try {
+    const payment = await paymentClient.get({ id: paymentId });
+    const status = payment.status;
+
+    let preferenceId = payment.external_reference;
+    if (!preferenceId && payment.order && payment.order.id) {
+      const orderInfo = await merchantClient.get({ id: payment.order.id });
+      preferenceId = orderInfo.preference_id;
+    }
+
+    if (!preferenceId) {
+      console.error('No se pudo determinar preference_id para el pago');
+      return res.status(400).json({ error: 'preference_id no encontrado' });
+    }
+
     await db.query(
-      'UPDATE orders SET payment_status = $1 WHERE payment_id = $2',
-      ['aprobado', String(paymentId)]
+      'UPDATE orders SET payment_status = $1, payment_id = $2 WHERE preference_id = $3',
+      [status, String(paymentId), preferenceId]
     );
+
     res.json({ success: true });
   } catch (error) {
     console.error('Error al procesar webhook:', error);

--- a/backend/routes/orders.js
+++ b/backend/routes/orders.js
@@ -12,4 +12,17 @@ router.get('/', async (_req, res) => {
   }
 });
 
+router.get('/:id/status', async (req, res) => {
+  try {
+    const { rows } = await db.query('SELECT payment_status FROM orders WHERE preference_id = $1', [req.params.id]);
+    if (rows.length === 0) {
+      return res.status(404).json({ error: 'Pedido no encontrado' });
+    }
+    res.json({ status: rows[0].payment_status });
+  } catch (error) {
+    console.error('Error al obtener estado del pedido:', error);
+    res.status(500).json({ error: 'Error interno' });
+  }
+});
+
 module.exports = router;

--- a/frontend/estado-pedido.html
+++ b/frontend/estado-pedido.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Estado del Pedido</title>
+</head>
+<body>
+  <h1 id="message">Procesando pago...</h1>
+  <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+  <script>
+    const orderId = window.location.pathname.split('/').pop();
+    const messageEl = document.getElementById('message');
+
+    async function checkStatus() {
+      try {
+        const res = await axios.get(`http://localhost:3000/api/orders/${orderId}/status`);
+        const status = res.data.status;
+        if (status === 'approved' || status === 'aprobado') {
+          messageEl.textContent = 'Gracias por tu compra';
+          clearInterval(interval);
+        } else if (status === 'rejected' || status === 'rechazado') {
+          messageEl.textContent = 'El pago fue rechazado';
+          clearInterval(interval);
+        } else {
+          messageEl.textContent = `Pago ${status}`;
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    }
+
+    const interval = setInterval(checkStatus, 5000);
+    checkStatus();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- store orders in DB before redirecting to Mercado Pago
- redirect success/failure/pending to `/estado-pedido/:id`
- add polling page for order status
- expose `/api/orders/:id/status`
- process webhook events querying Mercado Pago API

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_68880678ec648331baffd601aeb4da32