### PR TITLE
Fix order status updates

### DIFF
--- a/backend/routes/orders.js
+++ b/backend/routes/orders.js
@@ -12,4 +12,17 @@ router.get('/', async (_req, res) => {
   }
 });
 
+router.get('/:id/status', async (req, res) => {
+  try {
+    const { rows } = await db.query('SELECT payment_status FROM orders WHERE preference_id = $1', [req.params.id]);
+    if (rows.length === 0) {
+      return res.status(404).json({ error: 'Pedido no encontrado' });
+    }
+    res.json({ status: rows[0].payment_status });
+  } catch (error) {
+    console.error('Error al obtener estado del pedido:', error);
+    res.status(500).json({ error: 'Error interno' });
+  }
+});
+
 module.exports = router;

--- a/frontend/estado-pedido.html
+++ b/frontend/estado-pedido.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Estado del Pedido</title>
+</head>
+<body>
+  <h1 id="message">Procesando pago...</h1>
+  <h2 id="paso">Paso 2 de 3: Esperando confirmación...</h2>
+  <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+  <script>
+    const orderId = window.location.pathname.split('/').pop();
+    const messageEl = document.getElementById('message');
+
+    async function checkStatus() {
+      try {
+        const res = await axios.get(`/api/orders/${orderId}/status`);
+        const status = res.data.status;
+        if (status === 'approved' || status === 'aprobado') {
+          messageEl.textContent = 'Gracias por tu compra';
+          document.getElementById('paso').textContent = 'Paso 3 de 3: Pago aprobado';
+          clearInterval(interval);
+        } else if (status === 'rejected' || status === 'rechazado') {
+          messageEl.textContent = 'El pago fue rechazado';
+          document.getElementById('paso').textContent = 'Paso 3 de 3: Pago rechazado';
+          clearInterval(interval);
+        } else {
+          messageEl.textContent = `Pago ${status}`;
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    }
+
+    const interval = setInterval(checkStatus, 5000);
+    checkStatus();
+  </script>
+</body>
+</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
   <h1>Integración Mercado Pago - Checkout Pro</h1>
+  <h2 id="paso">Paso 1 de 3: Completa el pago</h2>
   <button id="boton-pago">Pagar con Mercado Pago</button>
 
   <div id="wallet_container"></div>
@@ -32,7 +33,7 @@
     };
 
     payButton.addEventListener('click', async () => {
-      const response = await fetch('http://localhost:3000/crear-preferencia', {
+      const response = await fetch('/crear-preferencia', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- set Mercado Pago `notification_url`
- use relative path for polling order status
- log webhook events and order creation
- show step numbers during payment process

## Testing
- `npm install`
- `node backend/server.js` *(fails: MP_ACCESS_TOKEN not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68880678ec648331baffd601aeb4da32