### PR TITLE
Implement Mercado Pago order flow

### DIFF
--- a/backend/routes/mercadoPago.js
+++ b/backend/routes/mercadoPago.js
@@ -9,6 +9,7 @@ const paymentClient = new Payment(mpClient);
 const merchantClient = new MerchantOrder(mpClient);
 
 router.post('/webhook', verifySignature, async (req, res) => {
+  console.log('Webhook recibido:', req.body);
   const paymentId =
     req.body.payment_id ||
     (req.body.data && req.body.data.id) ||
@@ -35,6 +36,9 @@ router.post('/webhook', verifySignature, async (req, res) => {
     await db.query(
       'UPDATE orders SET payment_status = $1, payment_id = $2 WHERE preference_id = $3',
       [status, String(paymentId), preferenceId]
+    );
+    console.log(
+      `Pedido ${preferenceId} actualizado con estado ${status} y payment_id ${paymentId}`
     );
 
     res.json({ success: true });

--- a/backend/server.js
+++ b/backend/server.js
@@ -45,7 +45,7 @@ app.get('/estado-pedido/:id', (_req, res) => {
 });
 
 app.post('/crear-preferencia', async (req, res) => {
-  const { titulo, precio, cantidad } = req.body;
+  const { titulo, precio, cantidad, usuario } = req.body;
   const body = {
     items: [
       {
@@ -66,9 +66,18 @@ app.post('/crear-preferencia', async (req, res) => {
     const result = await preferenceClient.create({ body });
     console.log('Preferencia creada:', result.init_point);
 
+    console.log('Guardando pedido en DB');
     await db.query(
-      'INSERT INTO orders (preference_id, payment_status, product_title, unit_price, quantity) VALUES ($1, $2, $3, $4, $5)',
-      [result.id, 'pending', titulo, precio, cantidad]
+      'INSERT INTO orders (preference_id, payment_status, product_title, unit_price, quantity, user_email, total_amount) VALUES ($1, $2, $3, $4, $5, $6, $7)',
+      [
+        result.id,
+        'pending',
+        titulo,
+        precio,
+        cantidad,
+        usuario || null,
+        Number(precio) * Number(cantidad),
+      ]
     );
 
     res.json({ id: result.id, init_point: result.init_point });

--- a/frontend/estado-pedido.html
+++ b/frontend/estado-pedido.html
@@ -6,23 +6,28 @@
 </head>
 <body>
   <h1 id="message">Procesando pago...</h1>
+  <p id="step">Paso 2 de 3</p>
   <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
   <script>
     const orderId = window.location.pathname.split('/').pop();
     const messageEl = document.getElementById('message');
+    const stepEl = document.getElementById('step');
 
     async function checkStatus() {
       try {
-        const res = await axios.get(`http://localhost:3000/api/orders/${orderId}/status`);
+        const res = await axios.get(`/api/orders/${orderId}/status`);
         const status = res.data.status;
         if (status === 'approved' || status === 'aprobado') {
-          messageEl.textContent = 'Gracias por tu compra';
+          messageEl.textContent = 'Pago aprobado';
+          stepEl.textContent = 'Paso 3 de 3';
           clearInterval(interval);
         } else if (status === 'rejected' || status === 'rechazado') {
-          messageEl.textContent = 'El pago fue rechazado';
+          messageEl.textContent = 'Pago rechazado';
+          stepEl.textContent = 'Paso 3 de 3';
           clearInterval(interval);
         } else {
           messageEl.textContent = `Pago ${status}`;
+          stepEl.textContent = 'Paso 2 de 3';
         }
       } catch (err) {
         console.error(err);


### PR DESCRIPTION
## Summary
- log DB insertion with extra order info and add optional user/amount storage
- log webhook body and order update for debugging
- show progress step on the order status page and use relative URLs

## Testing
- `npm install`
- `npm start` *(fails: MP_ACCESS_TOKEN not configured)*

------
https://chatgpt.com/codex/tasks/task_e_6888145d00b08331a8374ded285ce264