### PR TITLE
Fix duplicated Admin link

### DIFF
--- a/nerin_final_updated/frontend/account.html
+++ b/nerin_final_updated/frontend/account.html
@@ -23,7 +23,6 @@
             <li><a href="/index.html">Inicio</a></li>
             <li><a href="/shop.html">Productos</a></li>
             <li><a href="/contact.html">Contacto</a></li>
-            <li><a href="/admin.html">Admin</a></li>
             <li><a href="/cart.html">Carrito</a></li>
             <li><a href="/account.html" class="active">Mi cuenta</a></li>
           </ul>

--- a/nerin_final_updated/frontend/admin.html
+++ b/nerin_final_updated/frontend/admin.html
@@ -23,7 +23,6 @@
             <li><a href="/index.html">Inicio</a></li>
             <li><a href="/shop.html">Productos</a></li>
             <li><a href="/contact.html">Contacto</a></li>
-            <li><a href="/admin.html" class="active">Admin</a></li>
             <li><a href="/cart.html">Carrito</a></li>
             <li><a href="/login.html">Acceder</a></li>
           </ul>

--- a/nerin_final_updated/frontend/cart.html
+++ b/nerin_final_updated/frontend/cart.html
@@ -23,7 +23,6 @@
             <li><a href="/index.html">Inicio</a></li>
             <li><a href="/shop.html">Productos</a></li>
             <li><a href="/contact.html">Contacto</a></li>
-            <li><a href="/admin.html">Admin</a></li>
             <li><a href="/cart.html" class="active">Carrito</a></li>
             <li><a href="/login.html">Acceder</a></li>
           </ul>

--- a/nerin_final_updated/frontend/contact.html
+++ b/nerin_final_updated/frontend/contact.html
@@ -23,7 +23,6 @@
             <li><a href="/index.html">Inicio</a></li>
             <li><a href="/shop.html">Productos</a></li>
             <li><a href="/contact.html" class="active">Contacto</a></li>
-            <li><a href="/admin.html">Admin</a></li>
             <li><a href="/cart.html">Carrito</a></li>
             <li><a href="/login.html">Acceder</a></li>
           </ul>

--- a/nerin_final_updated/frontend/index.html
+++ b/nerin_final_updated/frontend/index.html
@@ -23,7 +23,6 @@
             <li><a href="/index.html">Inicio</a></li>
             <li><a href="/shop.html">Productos</a></li>
             <li><a href="/contact.html">Contacto</a></li>
-            <li><a href="/admin.html">Admin</a></li>
             <li><a href="/cart.html">Carrito</a></li>
             <li><a href="/login.html">Acceder</a></li>
           </ul>

--- a/nerin_final_updated/frontend/invoice.html
+++ b/nerin_final_updated/frontend/invoice.html
@@ -60,7 +60,6 @@
             <li><a href="/index.html">Inicio</a></li>
             <li><a href="/shop.html">Productos</a></li>
             <li><a href="/contact.html">Contacto</a></li>
-            <li><a href="/admin.html">Admin</a></li>
             <li><a href="/cart.html">Carrito</a></li>
             <!-- Enlace de acceso para login o cuenta; updateNav lo actualiza -->
             <li><a href="/login.html">Acceder</a></li>

--- a/nerin_final_updated/frontend/login.html
+++ b/nerin_final_updated/frontend/login.html
@@ -23,7 +23,6 @@
             <li><a href="/index.html">Inicio</a></li>
             <li><a href="/shop.html">Productos</a></li>
             <li><a href="/contact.html">Contacto</a></li>
-            <li><a href="/admin.html">Admin</a></li>
             <li><a href="/cart.html">Carrito</a></li>
             <!-- Mantener el enlace de acceso para permitir que updateNav lo reemplace o conserve -->
             <li><a href="/login.html" class="active">Acceder</a></li>

--- a/nerin_final_updated/frontend/product.html
+++ b/nerin_final_updated/frontend/product.html
@@ -23,7 +23,6 @@
             <li><a href="/index.html">Inicio</a></li>
             <li><a href="/shop.html">Productos</a></li>
             <li><a href="/contact.html">Contacto</a></li>
-            <li><a href="/admin.html">Admin</a></li>
             <li><a href="/cart.html">Carrito</a></li>
             <li><a href="/login.html">Acceder</a></li>
           </ul>

--- a/nerin_final_updated/frontend/register.html
+++ b/nerin_final_updated/frontend/register.html
@@ -23,7 +23,6 @@
             <li><a href="/index.html">Inicio</a></li>
             <li><a href="/shop.html">Productos</a></li>
             <li><a href="/contact.html">Contacto</a></li>
-            <li><a href="/admin.html">Admin</a></li>
             <li><a href="/cart.html">Carrito</a></li>
             <!-- Enlace de acceso; updateNav lo cambia según rol -->
             <li><a href="/login.html">Acceder</a></li>

--- a/nerin_final_updated/frontend/shop.html
+++ b/nerin_final_updated/frontend/shop.html
@@ -23,7 +23,6 @@
             <li><a href="/index.html">Inicio</a></li>
             <li><a href="/shop.html" class="active">Productos</a></li>
             <li><a href="/contact.html">Contacto</a></li>
-            <li><a href="/admin.html">Admin</a></li>
             <li><a href="/cart.html">Carrito</a></li>
             <li><a href="/login.html">Acceder</a></li>
           </ul>


### PR DESCRIPTION
## Summary
- remove hardcoded Admin link from navigation menus to prevent duplicates

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6888d2a423c48331890f1ba537e8c685