### PR TITLE
Add inline editing to admin products table

### DIFF
--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -933,9 +933,25 @@ nav a:hover {
   margin-left: 0.25rem;
 }
 
+.admin-table button.save-btn {
+  background-color: var(--color-success);
+  color: #fff;
+}
+
+.admin-table button.cancel-btn {
+  background-color: var(--color-danger);
+  color: #fff;
+  margin-left: 0.25rem;
+}
+
 .admin-table button.save-status-btn {
   background-color: var(--color-primary);
   color: #fff;
+}
+
+/* Resaltar fila en modo edición */
+.admin-table tr.editing {
+  background-color: #f3f3f3;
 }
 
 /* Resaltar filas con bajo stock en la tabla de productos */


### PR DESCRIPTION
## Summary
- allow editing a single row inline instead of prompts
- highlight row in edit mode and add Save/Cancel buttons
- style Save and Cancel buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889394131e08331a80347d0c13d9865