### PR TITLE
Fix order status field

### DIFF
--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -649,7 +649,7 @@ const server = http.createServer((req, res) => {
           date: new Date().toISOString(),
           // Clonar items para no mutar las cantidades al actualizar inventario
           items: cart.map((it) => ({ ...it })),
-          status: "pendiente",
+          estado_pago: "pendiente",
           total,
         };
         // Si existe información de cliente, agregarla

--- a/nerin_final_updated/data/orders.json
+++ b/nerin_final_updated/data/orders.json
@@ -11,7 +11,7 @@
           "quantity": 1
         }
       ],
-      "status": "entregado",
+      "estado_pago": "entregado",
       "total": 100,
       "customer": {
         "email": "test@example.com",


### PR DESCRIPTION
## Summary
- use `estado_pago` instead of `status` when creating checkout orders
- migrate sample data to the new field

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68894a364cc88331b9adeb36eeab8d0b