### PR TITLE
Capture Mercado Pago preference ID on order creation

### DIFF
--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -743,6 +743,8 @@ const server = http.createServer((req, res) => {
             }
             const prefRes = await mpPreference.create({ body: mpPref });
             mpInit = prefRes.init_point;
+            orderEntry.preference_id = prefRes.id;
+            saveOrders(orders);
           } catch (prefErr) {
             console.error(
               "Error al crear preferencia de Mercado Pago:",
@@ -828,6 +830,8 @@ const server = http.createServer((req, res) => {
             }
             const prefRes = await mpPreference.create({ body: pref });
             initPoint = prefRes.init_point;
+            order.preference_id = prefRes.id;
+            saveOrders(orders);
           } catch (e) {
             console.error("Error MP preference", e);
           }


### PR DESCRIPTION
## Summary
- store preference ID returned by Mercado Pago on checkout
- save the order after adding the preference ID

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68894a35f8888331bfd7cf3649f4e744