### PR TITLE
Add order tracking flow

### DIFF
--- a/nerin_final_updated/emails/orderPaid.html
+++ b/nerin_final_updated/emails/orderPaid.html
@@ -2,7 +2,8 @@
 <html>
   <body style="font-family: Arial, sans-serif">
     <h2>Gracias por tu compra</h2>
-    <p>Tu pago fue aprobado.</p>
+    <p>Número de orden: {{ORDER_ID}}</p>
+    <p>Podés consultar el estado de tu pedido en el siguiente enlace:</p>
     <p>
       <a
         href="{{ORDER_URL}}"
@@ -13,7 +14,7 @@
           border-radius: 4px;
           text-decoration: none;
         "
-        >Ver mi pedido</a
+        >Seguir mi pedido</a
       >
     </p>
   </body>

--- a/nerin_final_updated/frontend/seguimiento-pedido.html
+++ b/nerin_final_updated/frontend/seguimiento-pedido.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Seguimiento de pedido</title>
+    <link rel="stylesheet" href="/css/style.css" />
+  </head>
+  <body>
+    <div class="contenedor">
+      <h1>Seguimiento de pedido</h1>
+      <form id="trackForm">
+        <input type="email" id="email" placeholder="Tu email" required />
+        <input type="text" id="orderId" placeholder="Número de pedido" required />
+        <button type="submit">Ver estado</button>
+      </form>
+      <div id="result" style="margin-top: 1rem"></div>
+    </div>
+    <script>
+      const form = document.getElementById('trackForm');
+      const emailEl = document.getElementById('email');
+      const orderEl = document.getElementById('orderId');
+      const resultEl = document.getElementById('result');
+      const params = new URLSearchParams(window.location.search);
+      if (params.get('email')) emailEl.value = params.get('email');
+      if (params.get('orderId')) orderEl.value = params.get('orderId');
+      form.addEventListener('submit', async (ev) => {
+        ev.preventDefault();
+        resultEl.textContent = 'Buscando...';
+        try {
+          const res = await fetch('/api/track-order', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ email: emailEl.value.trim(), id: orderEl.value.trim() })
+          });
+          if (!res.ok) {
+            resultEl.textContent = 'No encontramos un pedido con esos datos.';
+            return;
+          }
+          const data = await res.json();
+          const o = data.order;
+          const items = (o.productos || []).map(p => `<li>${p.name} x${p.quantity}</li>`).join('');
+          resultEl.innerHTML = `
+            <p><strong>Estado pago:</strong> ${o.estado_pago}</p>
+            <p><strong>Estado envío:</strong> ${o.estado_envio}</p>
+            <ul>${items}</ul>
+            <p><strong>Total:</strong> $${o.total.toLocaleString('es-AR')}</p>
+            <p><strong>Fecha:</strong> ${new Date(o.fecha).toLocaleDateString('es-AR')}</p>`;
+        } catch (e) {
+          console.error(e);
+          resultEl.textContent = 'Error al buscar el pedido.';
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/nerin_final_updated/frontend/success.html
+++ b/nerin_final_updated/frontend/success.html
@@ -2,66 +2,52 @@
 <html lang="es">
   <head>
     <meta charset="UTF-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
-    />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Pago exitoso</title>
     <link rel="stylesheet" href="/css/style.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css" />
   </head>
   <body>
     <div class="contenedor">
-      <p id="statusMsg">Cargando información del pedido…</p>
+      <h1 id="thanksTitle">Gracias por tu compra</h1>
+      <p id="orderIdText"></p>
       <div id="orderSummary" class="payment-summary"></div>
       <div class="buttons">
+        <a class="btn" id="trackBtn">Seguir mi pedido</a>
         <a class="btn" href="/index.html">Inicio</a>
         <a class="btn" href="/shop.html">Seguir comprando</a>
       </div>
+      <p style="margin-top:1rem">Si no recibís el mail, escribinos a WhatsApp con tu número de orden</p>
     </div>
     <script>
-      document.addEventListener("DOMContentLoaded", async () => {
+      document.addEventListener('DOMContentLoaded', async () => {
         const params = new URLSearchParams(window.location.search);
-        const id =
-          params.get("external_reference") || params.get("orderId");
-        const msgEl = document.getElementById("statusMsg");
-        const sumEl = document.getElementById("orderSummary");
+        const id = params.get('external_reference') || params.get('orderId');
+        const msgEl = document.getElementById('thanksTitle');
+        const idEl = document.getElementById('orderIdText');
+        const sumEl = document.getElementById('orderSummary');
+        const trackBtn = document.getElementById('trackBtn');
         if (!id) {
-          msgEl.textContent = "No se encontró el pedido.";
+          msgEl.textContent = 'Pedido no encontrado';
           return;
         }
         try {
-          const resp = await fetch(
-            `/api/orders/${encodeURIComponent(id)}`,
-          );
-          if (!resp.ok) throw new Error("not found");
+          const resp = await fetch(`/api/orders/${encodeURIComponent(id)}`);
+          if (!resp.ok) throw new Error('not found');
           const data = await resp.json();
           const order = data.order;
           if (!order) {
-            msgEl.textContent =
-              "No pudimos obtener los datos de tu pedido.";
+            msgEl.textContent = 'No pudimos obtener los datos de tu pedido.';
             return;
           }
-          if (order.estado_pago === "pagado") {
-            msgEl.textContent = "✅ ¡Pago aprobado! Gracias por tu compra.";
-            const itemsHtml = (order.productos || [])
-              .map((p) => `<li>${p.name} x${p.quantity}</li>`) 
-              .join("");
-            sumEl.innerHTML = `
-              <h3>Pedido ${order.id}</h3>
-              <ul>${itemsHtml}</ul>
-              <p class="cart-total-amount">Total: $${order.total.toLocaleString(
-                "es-AR",
-              )}</p>
-            `;
-            localStorage.removeItem("nerinCart");
-          } else {
-            msgEl.textContent =
-              "Tu pago está pendiente o fue rechazado. Estamos esperando confirmación.";
-          }
+          msgEl.textContent = `Gracias por tu compra${order.cliente && order.cliente.nombre ? ', ' + order.cliente.nombre : ''}`;
+          idEl.textContent = `Orden: ${order.id}`;
+          const itemsHtml = (order.productos || []).map(p => `<li>${p.name} x${p.quantity}</li>`).join('');
+          sumEl.innerHTML = `<ul>${itemsHtml}</ul><p class="cart-total-amount">Total: $${order.total.toLocaleString('es-AR')}</p>`;
+          trackBtn.href = `/seguimiento-pedido?orderId=${encodeURIComponent(order.id)}&email=${encodeURIComponent(order.cliente && order.cliente.email ? order.cliente.email : '')}`;
+          localStorage.removeItem('nerinCart');
         } catch (e) {
           console.error(e);
-          msgEl.textContent = "Error al cargar el pedido.";
+          msgEl.textContent = 'Error al cargar el pedido.';
         }
       });
     </script>


### PR DESCRIPTION
## Summary
- show thank you page with order info and tracking link
- email includes order number and tracking link
- add public tracking page and backend route
- expose POST /api/track-order endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688957f9cf608331befba3ca7e0ed7df