### PR TITLE
Improve order tracking UX

### DIFF
--- a/nerin_final_updated/backend/index.js
+++ b/nerin_final_updated/backend/index.js
@@ -51,8 +51,8 @@ app.get("/failure", (_req, res) => {
 app.get("/pending", (_req, res) => {
   res.sendFile(path.join(__dirname, "../frontend/pending.html"));
 });
-app.get("/seguimiento-pedido", (_req, res) => {
-  res.sendFile(path.join(__dirname, "../frontend/seguimiento-pedido.html"));
+app.get(["/seguimiento", "/seguimiento-pedido"], (_req, res) => {
+  res.sendFile(path.join(__dirname, "../frontend/seguimiento.html"));
 });
 
 // Leer productos desde el archivo JSON
@@ -82,7 +82,7 @@ function sendOrderPaidEmail(order) {
   try {
   const tpl = path.join(__dirname, "../emails/orderPaid.html");
   let html = fs.readFileSync(tpl, "utf8");
-  const url = `${PUBLIC_URL}/seguimiento-pedido?orderId=${encodeURIComponent(order.id)}&email=${encodeURIComponent(order.cliente.email || "")}`;
+  const url = `${PUBLIC_URL}/seguimiento?order=${encodeURIComponent(order.id)}&email=${encodeURIComponent(order.cliente.email || "")}`;
   html = html.replace("{{ORDER_URL}}", url).replace("{{ORDER_ID}}", order.id);
     const to = [order.cliente.email];
     if (ADMIN_EMAIL) to.push(ADMIN_EMAIL);

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -354,7 +354,7 @@ function sendOrderPaidEmail(order) {
   const tplPath = path.join(__dirname, "../emails/orderPaid.html");
   let html = fs.readFileSync(tplPath, "utf8");
   const urlBase = CONFIG.publicUrl || `http://localhost:${APP_PORT}`;
-  const orderUrl = `${urlBase}/seguimiento-pedido?orderId=${encodeURIComponent(order.id)}&email=${encodeURIComponent(order.cliente.email || "")}`;
+  const orderUrl = `${urlBase}/seguimiento?order=${encodeURIComponent(order.id)}&email=${encodeURIComponent(order.cliente.email || "")}`;
   html = html.replace("{{ORDER_URL}}", orderUrl).replace("{{ORDER_ID}}", order.id);
     resend.emails
       .send({
@@ -1903,8 +1903,8 @@ const server = http.createServer((req, res) => {
     return serveStatic(path.join(__dirname, "../frontend/pending.html"), res);
   }
 
-  if (pathname === "/seguimiento-pedido") {
-    return serveStatic(path.join(__dirname, "../frontend/seguimiento-pedido.html"), res);
+  if (pathname === "/seguimiento" || pathname === "/seguimiento-pedido") {
+    return serveStatic(path.join(__dirname, "../frontend/seguimiento.html"), res);
   }
 
   // Servir archivos estáticos del frontend y assets

--- a/nerin_final_updated/frontend/account.html
+++ b/nerin_final_updated/frontend/account.html
@@ -23,6 +23,7 @@
             <li><a href="/index.html">Inicio</a></li>
             <li><a href="/shop.html">Productos</a></li>
             <li><a href="/contact.html">Contacto</a></li>
+            <li><a href="/seguimiento.html">Seguir mi pedido</a></li>
             <li><a href="/cart.html">Carrito</a></li>
             <li><a href="/account.html" class="active">Mi cuenta</a></li>
           </ul>

--- a/nerin_final_updated/frontend/admin.html
+++ b/nerin_final_updated/frontend/admin.html
@@ -23,6 +23,7 @@
             <li><a href="/index.html">Inicio</a></li>
             <li><a href="/shop.html">Productos</a></li>
             <li><a href="/contact.html">Contacto</a></li>
+            <li><a href="/seguimiento.html">Seguir mi pedido</a></li>
             <li><a href="/cart.html">Carrito</a></li>
             <li><a href="/login.html">Acceder</a></li>
           </ul>

--- a/nerin_final_updated/frontend/cart.html
+++ b/nerin_final_updated/frontend/cart.html
@@ -23,6 +23,7 @@
             <li><a href="/index.html">Inicio</a></li>
             <li><a href="/shop.html">Productos</a></li>
             <li><a href="/contact.html">Contacto</a></li>
+            <li><a href="/seguimiento.html">Seguir mi pedido</a></li>
             <li><a href="/cart.html" class="active">Carrito</a></li>
             <li><a href="/login.html">Acceder</a></li>
           </ul>

--- a/nerin_final_updated/frontend/contact.html
+++ b/nerin_final_updated/frontend/contact.html
@@ -23,6 +23,7 @@
             <li><a href="/index.html">Inicio</a></li>
             <li><a href="/shop.html">Productos</a></li>
             <li><a href="/contact.html" class="active">Contacto</a></li>
+            <li><a href="/seguimiento.html">Seguir mi pedido</a></li>
             <li><a href="/cart.html">Carrito</a></li>
             <li><a href="/login.html">Acceder</a></li>
           </ul>

--- a/nerin_final_updated/frontend/index.html
+++ b/nerin_final_updated/frontend/index.html
@@ -23,6 +23,7 @@
             <li><a href="/index.html">Inicio</a></li>
             <li><a href="/shop.html">Productos</a></li>
             <li><a href="/contact.html">Contacto</a></li>
+            <li><a href="/seguimiento.html">Seguir mi pedido</a></li>
             <li><a href="/cart.html">Carrito</a></li>
             <li><a href="/login.html">Acceder</a></li>
           </ul>
@@ -97,6 +98,7 @@
         <a href="https://instagram.com" target="_blank">Instagram</a> |
         <a href="/index.html">Inicio</a> | <a href="/shop.html">Catálogo</a> |
         <a href="/contact.html">Contacto</a> |
+        <a href="/seguimiento.html">Seguir mi pedido</a> |
         <a href="/terms.html">Términos y condiciones</a>
       </p>
       <p class="legal">

--- a/nerin_final_updated/frontend/invoice.html
+++ b/nerin_final_updated/frontend/invoice.html
@@ -60,6 +60,7 @@
             <li><a href="/index.html">Inicio</a></li>
             <li><a href="/shop.html">Productos</a></li>
             <li><a href="/contact.html">Contacto</a></li>
+            <li><a href="/seguimiento.html">Seguir mi pedido</a></li>
             <li><a href="/cart.html">Carrito</a></li>
             <!-- Enlace de acceso para login o cuenta; updateNav lo actualiza -->
             <li><a href="/login.html">Acceder</a></li>

--- a/nerin_final_updated/frontend/login.html
+++ b/nerin_final_updated/frontend/login.html
@@ -23,6 +23,7 @@
             <li><a href="/index.html">Inicio</a></li>
             <li><a href="/shop.html">Productos</a></li>
             <li><a href="/contact.html">Contacto</a></li>
+            <li><a href="/seguimiento.html">Seguir mi pedido</a></li>
             <li><a href="/cart.html">Carrito</a></li>
             <!-- Mantener el enlace de acceso para permitir que updateNav lo reemplace o conserve -->
             <li><a href="/login.html" class="active">Acceder</a></li>

--- a/nerin_final_updated/frontend/product.html
+++ b/nerin_final_updated/frontend/product.html
@@ -23,6 +23,7 @@
             <li><a href="/index.html">Inicio</a></li>
             <li><a href="/shop.html">Productos</a></li>
             <li><a href="/contact.html">Contacto</a></li>
+            <li><a href="/seguimiento.html">Seguir mi pedido</a></li>
             <li><a href="/cart.html">Carrito</a></li>
             <li><a href="/login.html">Acceder</a></li>
           </ul>

--- a/nerin_final_updated/frontend/register.html
+++ b/nerin_final_updated/frontend/register.html
@@ -23,6 +23,7 @@
             <li><a href="/index.html">Inicio</a></li>
             <li><a href="/shop.html">Productos</a></li>
             <li><a href="/contact.html">Contacto</a></li>
+            <li><a href="/seguimiento.html">Seguir mi pedido</a></li>
             <li><a href="/cart.html">Carrito</a></li>
             <!-- Enlace de acceso; updateNav lo cambia según rol -->
             <li><a href="/login.html">Acceder</a></li>

--- a/nerin_final_updated/frontend/seguimiento.html
+++ b/nerin_final_updated/frontend/seguimiento.html
@@ -22,7 +22,7 @@
       const resultEl = document.getElementById('result');
       const params = new URLSearchParams(window.location.search);
       if (params.get('email')) emailEl.value = params.get('email');
-      if (params.get('orderId')) orderEl.value = params.get('orderId');
+      if (params.get('order')) orderEl.value = params.get('order');
       form.addEventListener('submit', async (ev) => {
         ev.preventDefault();
         resultEl.textContent = 'Buscando...';

--- a/nerin_final_updated/frontend/shop.html
+++ b/nerin_final_updated/frontend/shop.html
@@ -23,6 +23,7 @@
             <li><a href="/index.html">Inicio</a></li>
             <li><a href="/shop.html" class="active">Productos</a></li>
             <li><a href="/contact.html">Contacto</a></li>
+            <li><a href="/seguimiento.html">Seguir mi pedido</a></li>
             <li><a href="/cart.html">Carrito</a></li>
             <li><a href="/login.html">Acceder</a></li>
           </ul>

--- a/nerin_final_updated/frontend/success.html
+++ b/nerin_final_updated/frontend/success.html
@@ -10,13 +10,21 @@
     <div class="contenedor">
       <h1 id="thanksTitle">Gracias por tu compra</h1>
       <p id="orderIdText"></p>
+      <p id="emailText"></p>
       <div id="orderSummary" class="payment-summary"></div>
       <div class="buttons">
         <a class="btn" id="trackBtn">Seguir mi pedido</a>
         <a class="btn" href="/index.html">Inicio</a>
         <a class="btn" href="/shop.html">Seguir comprando</a>
       </div>
-      <p style="margin-top:1rem">Si no recibís el mail, escribinos a WhatsApp con tu número de orden</p>
+      <p style="margin-top:1rem" class="help-text">
+        Podés seguir tu pedido usando tu email y el número de orden. Si necesitás ayuda, contactanos por WhatsApp.
+      </p>
+      <div id="whatsapp-button">
+        <a href="https://wa.me/541112345678" target="_blank">
+          <img src="/assets/whatsapp.svg" alt="WhatsApp" />
+        </a>
+      </div>
     </div>
     <script>
       document.addEventListener('DOMContentLoaded', async () => {
@@ -26,6 +34,7 @@
         const idEl = document.getElementById('orderIdText');
         const sumEl = document.getElementById('orderSummary');
         const trackBtn = document.getElementById('trackBtn');
+        const emailEl = document.getElementById('emailText');
         if (!id) {
           msgEl.textContent = 'Pedido no encontrado';
           return;
@@ -41,9 +50,13 @@
           }
           msgEl.textContent = `Gracias por tu compra${order.cliente && order.cliente.nombre ? ', ' + order.cliente.nombre : ''}`;
           idEl.textContent = `Orden: ${order.id}`;
+          if (emailEl) {
+            emailEl.textContent = order.cliente && order.cliente.email ? `Email: ${order.cliente.email}` : '';
+          }
           const itemsHtml = (order.productos || []).map(p => `<li>${p.name} x${p.quantity}</li>`).join('');
           sumEl.innerHTML = `<ul>${itemsHtml}</ul><p class="cart-total-amount">Total: $${order.total.toLocaleString('es-AR')}</p>`;
-          trackBtn.href = `/seguimiento-pedido?orderId=${encodeURIComponent(order.id)}&email=${encodeURIComponent(order.cliente && order.cliente.email ? order.cliente.email : '')}`;
+          const emailParam = order.cliente && order.cliente.email ? order.cliente.email : '';
+          trackBtn.href = `/seguimiento?order=${encodeURIComponent(order.id)}&email=${encodeURIComponent(emailParam)}`;
           localStorage.removeItem('nerinCart');
         } catch (e) {
           console.error(e);


### PR DESCRIPTION
## Summary
- rename tracking page to `seguimiento.html`
- add tracking link in navigation across all pages
- include tracking link in footer
- enhance success page with order + email info, whatsapp button, and link
- serve `/seguimiento` in backend routes and emails

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68897a96ef8c8331ae33f16260f928f2