### PR TITLE
Revamped tracking page

### DIFF
--- a/nerin_final_updated/frontend/js/seguimiento.js
+++ b/nerin_final_updated/frontend/js/seguimiento.js
@@ -1,0 +1,98 @@
+// Módulo para consultar el estado de un pedido
+
+const form = document.getElementById('trackForm');
+const emailInput = document.getElementById('email');
+const orderInput = document.getElementById('orderId');
+const summaryEl = document.getElementById('orderSummary');
+const trackerEl = document.getElementById('tracker');
+const contactBtn = document.getElementById('contactWhatsApp');
+
+function updateWhatsAppLink() {
+  const cfg = window.NERIN_CONFIG;
+  if (cfg && cfg.whatsappNumber && contactBtn) {
+    const phone = cfg.whatsappNumber.replace(/[^0-9]/g, '');
+    contactBtn.href = `https://wa.me/${phone}`;
+    const navWA = document.getElementById('navWhatsApp');
+    if (navWA) navWA.href = `https://wa.me/${phone}`;
+  }
+}
+
+async function fetchOrder(email, id) {
+  summaryEl.style.display = 'none';
+  trackerEl.style.display = 'none';
+  if (!email || !id) return;
+  summaryEl.textContent = 'Buscando...';
+  try {
+    const res = await fetch('/api/track-order', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, id })
+    });
+    if (!res.ok) {
+      summaryEl.textContent = 'No encontramos un pedido con esos datos.';
+      return;
+    }
+    const data = await res.json();
+    renderOrder(data.order);
+  } catch (e) {
+    console.error(e);
+    summaryEl.textContent = 'Error al buscar el pedido.';
+  }
+}
+
+function renderOrder(o) {
+  const items = (o.productos || []).map(p => `<li>${p.name} x${p.quantity} - $${p.price.toLocaleString('es-AR')}</li>`).join('');
+  summaryEl.innerHTML = `
+    <p><strong>Número de pedido:</strong> ${o.id}</p>
+    <p><strong>Estado del pago:</strong> ${o.estado_pago}</p>
+    <p><strong>Estado del envío:</strong> ${o.estado_envio}</p>
+    <p><strong>Fecha:</strong> ${new Date(o.fecha).toLocaleDateString('es-AR')}</p>
+    <ul>${items}</ul>
+    <p><strong>Total:</strong> $${o.total.toLocaleString('es-AR')}</p>
+    ${o.metodo_pago ? `<p><strong>Método de pago:</strong> ${o.metodo_pago}</p>` : ''}
+    ${o.destino ? `<p><strong>Envío a:</strong> ${o.destino}</p>` : '<p><em>Coordinación de envío por WhatsApp</em></p>'}
+    ${o.cliente && o.cliente.email ? `<p><strong>Email:</strong> ${o.cliente.email}</p>` : ''}
+  `;
+  summaryEl.style.display = 'block';
+  renderTracker(o);
+}
+
+function renderTracker(o) {
+  const steps = [
+    'Pedido recibido',
+    'Pago acreditado',
+    'Preparando el pedido',
+    'Enviado',
+    'Entregado'
+  ];
+  let current = 0;
+  if (o.estado_pago === 'pagado') current = 1;
+  if (o.estado_envio === 'en preparación') current = 2;
+  if (o.estado_envio === 'enviado') current = 3;
+  if (o.estado_envio === 'entregado') current = 4;
+  trackerEl.innerHTML = steps.map((s, i) => {
+    let cls = 'step todo';
+    if (i < current) cls = 'step done';
+    else if (i === current) cls = 'step current';
+    return `<li class="${cls}">${s}</li>`;
+  }).join('');
+  trackerEl.style.display = 'block';
+}
+
+form.addEventListener('submit', ev => {
+  ev.preventDefault();
+  fetchOrder(emailInput.value.trim(), orderInput.value.trim());
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+  const params = new URLSearchParams(window.location.search);
+  if (params.get('email')) emailInput.value = params.get('email');
+  if (params.get('order')) orderInput.value = params.get('order');
+  if (emailInput.value && orderInput.value) {
+    fetchOrder(emailInput.value.trim(), orderInput.value.trim());
+  }
+  updateWhatsAppLink();
+  if (window.updateNav) window.updateNav();
+});
+
+window.addEventListener('load', updateWhatsAppLink);

--- a/nerin_final_updated/frontend/seguimiento.html
+++ b/nerin_final_updated/frontend/seguimiento.html
@@ -2,54 +2,55 @@
 <html lang="es">
   <head>
     <meta charset="UTF-8" />
-    <title>Seguimiento de pedido</title>
-    <link rel="stylesheet" href="/css/style.css" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Seguimiento de tu pedido – NERIN</title>
+    <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <div class="contenedor">
-      <h1>Seguimiento de pedido</h1>
-      <form id="trackForm">
+    <header>
+      <div class="header-inner">
+        <div class="logo"><a href="/index.html">NERIN</a></div>
+        <button class="menu-toggle" id="navToggle">☰</button>
+        <nav id="mainNav">
+          <ul>
+            <li><a href="/index.html">Inicio</a></li>
+            <li><a href="/shop.html">Productos</a></li>
+            <li><a href="/seguimiento.html">Seguir otro pedido</a></li>
+            <li><a href="#" id="navWhatsApp">WhatsApp</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+    <main class="container tracking-container">
+      <h1>Seguimiento de tu pedido</h1>
+      <p>
+        Acá podés ver en qué estado está tu compra. Ante cualquier duda,
+        escribinos por WhatsApp.
+      </p>
+
+      <form id="trackForm" class="login-container">
         <input type="email" id="email" placeholder="Tu email" required />
         <input type="text" id="orderId" placeholder="Número de pedido" required />
         <button type="submit">Ver estado</button>
       </form>
-      <div id="result" style="margin-top: 1rem"></div>
-    </div>
-    <script>
-      const form = document.getElementById('trackForm');
-      const emailEl = document.getElementById('email');
-      const orderEl = document.getElementById('orderId');
-      const resultEl = document.getElementById('result');
-      const params = new URLSearchParams(window.location.search);
-      if (params.get('email')) emailEl.value = params.get('email');
-      if (params.get('order')) orderEl.value = params.get('order');
-      form.addEventListener('submit', async (ev) => {
-        ev.preventDefault();
-        resultEl.textContent = 'Buscando...';
-        try {
-          const res = await fetch('/api/track-order', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ email: emailEl.value.trim(), id: orderEl.value.trim() })
-          });
-          if (!res.ok) {
-            resultEl.textContent = 'No encontramos un pedido con esos datos.';
-            return;
-          }
-          const data = await res.json();
-          const o = data.order;
-          const items = (o.productos || []).map(p => `<li>${p.name} x${p.quantity}</li>`).join('');
-          resultEl.innerHTML = `
-            <p><strong>Estado pago:</strong> ${o.estado_pago}</p>
-            <p><strong>Estado envío:</strong> ${o.estado_envio}</p>
-            <ul>${items}</ul>
-            <p><strong>Total:</strong> $${o.total.toLocaleString('es-AR')}</p>
-            <p><strong>Fecha:</strong> ${new Date(o.fecha).toLocaleDateString('es-AR')}</p>`;
-        } catch (e) {
-          console.error(e);
-          resultEl.textContent = 'Error al buscar el pedido.';
-        }
-      });
-    </script>
+
+      <div id="orderSummary" class="order-card" style="display:none"></div>
+
+      <ul id="tracker" class="progress-tracker" style="display:none"></ul>
+
+      <div class="contact-section">
+        <p>Si tenés alguna duda, escribinos con tu número de pedido.</p>
+        <a id="contactWhatsApp" class="button primary" target="_blank">
+          <img src="/assets/whatsapp.svg" alt="WhatsApp" /> WhatsApp
+        </a>
+      </div>
+
+      <div style="margin-top:2rem;text-align:center">
+        <a href="/index.html" class="button secondary">Volver al inicio</a>
+      </div>
+    </main>
+
+    <script type="module" src="/js/seguimiento.js"></script>
+    <script type="module" src="/js/config.js"></script>
   </body>
 </html>

--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -1168,3 +1168,55 @@ footer .legal {
   gap: 1rem;
   margin: 0.5rem 0;
 }
+
+/* ==== Seguimiento de pedidos ==== */
+.order-card {
+  margin-top: 1rem;
+  padding: 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  background: var(--color-muted);
+}
+
+.progress-tracker {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0;
+}
+
+.progress-tracker .step {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 0;
+  color: var(--color-secondary);
+}
+
+.progress-tracker .done {
+  color: var(--color-success);
+}
+
+.progress-tracker .current {
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.progress-tracker .todo {
+  opacity: 0.6;
+}
+
+.contact-section {
+  margin-top: 2rem;
+  text-align: center;
+}
+
+.contact-section .button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.contact-section .button img {
+  width: 24px;
+  height: 24px;
+}


### PR DESCRIPTION
## Summary
- redesign `/seguimiento` with header, order summary and progress tracker
- style components for the tracking view
- add JS module to fetch and display order data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68897d7a2aa0833192b8cb57cb81f3bd