### PR TITLE
Add readable order number generator

### DIFF
--- a/backend/routes/orders.js
+++ b/backend/routes/orders.js
@@ -14,11 +14,14 @@ router.get('/', async (_req, res) => {
 
 router.get('/:id/status', async (req, res) => {
   try {
-    const { rows } = await db.query('SELECT payment_status FROM orders WHERE preference_id = $1', [req.params.id]);
+    const { rows } = await db.query(
+      'SELECT payment_status, order_number FROM orders WHERE preference_id = $1',
+      [req.params.id]
+    );
     if (rows.length === 0) {
       return res.status(404).json({ error: 'Pedido no encontrado' });
     }
-    res.json({ status: rows[0].payment_status });
+    res.json({ status: rows[0].payment_status, numeroOrden: rows[0].order_number });
   } catch (error) {
     console.error('Error al obtener estado del pedido:', error);
     res.status(500).json({ error: 'Error interno' });

--- a/backend/server.js
+++ b/backend/server.js
@@ -3,6 +3,7 @@ const cors = require('cors');
 const helmet = require('helmet');
 const path = require('path');
 const db = require('./db');
+const generarNumeroOrden = require('./utils/generarNumeroOrden');
 const { MercadoPagoConfig, Preference } = require('mercadopago');
 const logger = require('./logger');
 require('dotenv').config();
@@ -73,10 +74,12 @@ app.post('/crear-preferencia', async (req, res) => {
     const result = await preferenceClient.create({ body });
     logger.info('Preferencia creada');
 
+    const numeroOrden = generarNumeroOrden();
     logger.info('Guardando pedido en DB');
     await db.query(
-      'INSERT INTO orders (preference_id, payment_status, product_title, unit_price, quantity, user_email, total_amount) VALUES ($1, $2, $3, $4, $5, $6, $7)',
+      'INSERT INTO orders (order_number, preference_id, payment_status, product_title, unit_price, quantity, user_email, total_amount) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)',
       [
+        numeroOrden,
         result.id,
         'pending',
         titulo,
@@ -87,7 +90,7 @@ app.post('/crear-preferencia', async (req, res) => {
       ]
     );
 
-    res.json({ id: result.id, init_point: result.init_point });
+    res.json({ id: result.id, init_point: result.init_point, numeroOrden });
   } catch (error) {
     logger.error(`Error al crear preferencia: ${error.message}`);
     res.status(500).json({ error: 'No se pudo crear la preferencia' });

--- a/backend/utils/generarNumeroOrden.js
+++ b/backend/utils/generarNumeroOrden.js
@@ -1,0 +1,10 @@
+function generarNumeroOrden() {
+  const fecha = new Date();
+  const dia = String(fecha.getDate()).padStart(2, '0');
+  const mes = String(fecha.getMonth() + 1).padStart(2, '0');
+  const anio = fecha.getFullYear().toString().slice(-2);
+  const random = Math.floor(1000 + Math.random() * 9000);
+  return `NRN-${dia}${mes}${anio}-${random}`;
+}
+
+module.exports = generarNumeroOrden;

--- a/frontend/estado-pedido.html
+++ b/frontend/estado-pedido.html
@@ -7,16 +7,22 @@
 <body>
   <h1 id="message">Procesando pago...</h1>
   <p id="step">Paso 2 de 3</p>
+  <p id="orderNumber" style="display:none"></p>
   <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
   <script>
     const orderId = window.location.pathname.split('/').pop();
     const messageEl = document.getElementById('message');
     const stepEl = document.getElementById('step');
+    const orderNumberEl = document.getElementById('orderNumber');
 
     async function checkStatus() {
       try {
         const res = await axios.get(`/api/orders/${orderId}/status`);
         const status = res.data.status;
+        if (res.data.numeroOrden) {
+          orderNumberEl.style.display = 'block';
+          orderNumberEl.textContent = `Número de pedido: ${res.data.numeroOrden}`;
+        }
         if (status === 'approved' || status === 'aprobado') {
           messageEl.textContent = 'Pago aprobado';
           stepEl.textContent = 'Paso 3 de 3';

--- a/nerin_final_updated/backend/index.js
+++ b/nerin_final_updated/backend/index.js
@@ -12,6 +12,7 @@ const express = require("express");
 const bodyParser = require("body-parser");
 const cors = require("cors");
 const { MercadoPagoConfig, Preference } = require("mercadopago");
+const generarNumeroOrden = require("../../backend/utils/generarNumeroOrden");
 let Resend;
 try {
   ({ Resend } = require("resend"));
@@ -112,8 +113,7 @@ app.post("/api/orders", async (req, res) => {
     if (!Array.isArray(productos) || productos.length === 0) {
       return res.status(400).json({ error: "Carrito vacío" });
     }
-    const id =
-      "ORD-" + Date.now().toString(36) + "-" + Math.floor(Math.random() * 1000);
+    const id = generarNumeroOrden();
     const total = productos.reduce(
       (t, it) => t + Number(it.price) * Number(it.quantity),
       0,

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -17,6 +17,7 @@ const { MercadoPagoConfig, Preference, Payment } = require("mercadopago");
 const { Afip } = require("afip.ts");
 const { Resend } = require("resend");
 const multer = require("multer");
+const generarNumeroOrden = require("../../backend/utils/generarNumeroOrden");
 require("dotenv").config();
 const CONFIG = getConfig();
 const APP_PORT = process.env.PORT || 3000;
@@ -634,12 +635,8 @@ const server = http.createServer((req, res) => {
           console.error("Error al validar stock:", e);
           return sendJson(res, 500, { error: "Error al validar stock" });
         }
-        // Generar un ID simple basado en timestamp y contador aleatorio
-        const orderId =
-          "ORD-" +
-          Date.now().toString(36) +
-          "-" +
-          Math.floor(Math.random() * 1000);
+        // Generar un número de orden legible
+        const orderId = generarNumeroOrden();
         const orders = getOrders();
         // Calcular total del pedido (utilizando precio base del producto)
         let total = 0;
@@ -745,11 +742,7 @@ const server = http.createServer((req, res) => {
         if (!Array.isArray(items) || items.length === 0) {
           return sendJson(res, 400, { error: "Carrito vacío" });
         }
-        const orderId =
-          "ORD-" +
-          Date.now().toString(36) +
-          "-" +
-          Math.floor(Math.random() * 1000);
+        const orderId = generarNumeroOrden();
         const orders = getOrders();
         const total = items.reduce((t, it) => t + it.price * it.quantity, 0);
         const impuestosCalc = Math.round(total * 0.21);


### PR DESCRIPTION
## Summary
- create utility to generate order numbers like `NRN-DDMMYY-XXXX`
- store generated number when saving orders
- expose `order_number` in order status endpoint
- display order number on the tracking page
- update older backend scripts to use the new order number generator

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889b8159cdc833196259288717aeb81