### PR TITLE
Add email verification and tracking improvements

### DIFF
--- a/nerin_final_updated/backend/__tests__/features.test.js
+++ b/nerin_final_updated/backend/__tests__/features.test.js
@@ -1,0 +1,87 @@
+const path = require('path');
+const request = require('supertest');
+
+jest.mock('../emailValidator');
+jest.mock('afip.ts', () => ({ Afip: class {} }), { virtual: true });
+jest.mock('resend', () => ({ Resend: class { constructor(){ this.emails={ send: jest.fn() }; } } }), { virtual: true });
+jest.mock('multer', () => {
+  const m = () => ({ single: jest.fn() });
+  m.diskStorage = () => ({}) ;
+  return m;
+}, { virtual: true });
+jest.mock('fs', () => {
+  const path = require('path');
+  const files = {};
+  return {
+    readFileSync: jest.fn((p) => {
+      p = path.normalize(p);
+      return files[p] || '{}';
+    }),
+    writeFileSync: jest.fn((p, data) => {
+      files[path.normalize(p)] = data;
+    }),
+    existsSync: jest.fn(() => true),
+    mkdirSync: jest.fn(),
+    stat: jest.fn((p, cb) => cb(null, { isDirectory: () => false })),
+  };
+});
+
+const verifyEmailMock = require('../emailValidator');
+const fs = require('fs');
+
+const ordersPath = path.join(__dirname, '../../data/orders.json');
+const configPath = path.join(__dirname, '../../data/config.json');
+const uploadsPath = path.join(__dirname, '../../data/invoice_uploads.json');
+
+describe('Ecommerce features', () => {
+  let server;
+  beforeAll(() => {
+    // prepare fake data
+    const fakeOrder = {
+      id: 'ORDER123',
+      cliente: { email: 'user@test.com' },
+      productos: [],
+      estado_pago: 'pendiente',
+      estado_envio: 'pendiente',
+      fecha: new Date().toISOString(),
+      total: 100,
+      seguimiento: 'TRK1',
+      transportista: 'Correo',
+    };
+    fs.writeFileSync(ordersPath, JSON.stringify({ orders: [fakeOrder] }));
+    fs.writeFileSync(configPath, '{}');
+    fs.writeFileSync(uploadsPath, JSON.stringify({ uploads: [{ orderId: 'ORDER123', fileName: 'fact.pdf' }] }));
+    process.env.MP_ACCESS_TOKEN = '';
+    server = require('../server');
+  });
+
+  afterAll((done) => {
+    if (server.listening) server.close(done);
+    else done();
+  });
+
+  test('email validator flags undeliverable', async () => {
+    process.env.EMAIL_VERIFICATION_API_KEY = 'testkey';
+    const realVerify = jest.requireActual('../emailValidator');
+    global.fetch = jest.fn().mockResolvedValue({
+      json: () => Promise.resolve({ deliverability: 'UNDELIVERABLE' }),
+    });
+    const result = await realVerify('fake@test.com');
+    expect(result).toBe(false);
+  });
+
+  test('track-order requires correct email', async () => {
+    verifyEmailMock.mockResolvedValue(true);
+    let res = await request(server)
+      .post('/api/track-order')
+      .send({ email: 'wrong@test.com', id: 'ORDER123' });
+    expect(res.status).toBe(404);
+
+    res = await request(server)
+      .post('/api/track-order')
+      .send({ email: 'user@test.com', id: 'ORDER123' });
+    expect(res.status).toBe(200);
+    expect(res.body.order.seguimiento).toBe('TRK1');
+    expect(res.body.order.transportista).toBe('Correo');
+  });
+});

--- a/nerin_final_updated/backend/emailValidator.js
+++ b/nerin_final_updated/backend/emailValidator.js
@@ -1,0 +1,14 @@
+async function verifyEmail(email) {
+  const apiKey = process.env.EMAIL_VERIFICATION_API_KEY;
+  if (!apiKey) return true;
+  const url = `https://emailvalidation.abstractapi.com/v1/?api_key=${apiKey}&email=${encodeURIComponent(email)}`;
+  try {
+    const res = await fetch(url);
+    const data = await res.json();
+    return data.deliverability === 'DELIVERABLE';
+  } catch {
+    return false;
+  }
+}
+
+module.exports = verifyEmail;

--- a/nerin_final_updated/frontend/js/seguimiento.js
+++ b/nerin_final_updated/frontend/js/seguimiento.js
@@ -6,6 +6,7 @@ const orderInput = document.getElementById('orderId');
 const summaryEl = document.getElementById('orderSummary');
 const trackerEl = document.getElementById('tracker');
 const contactBtn = document.getElementById('contactWhatsApp');
+let invoiceInfo = null;
 
 function updateWhatsAppLink() {
   const cfg = window.NERIN_CONFIG;
@@ -14,6 +15,19 @@ function updateWhatsAppLink() {
     contactBtn.href = `https://wa.me/${phone}`;
     const navWA = document.getElementById('navWhatsApp');
     if (navWA) navWA.href = `https://wa.me/${phone}`;
+  }
+}
+
+async function fetchInvoice(orderId) {
+  try {
+    const res = await fetch(`/api/invoice-files/${orderId}`);
+    if (res.ok) {
+      invoiceInfo = await res.json();
+    } else {
+      invoiceInfo = null;
+    }
+  } catch (_) {
+    invoiceInfo = null;
   }
 }
 
@@ -33,6 +47,7 @@ async function fetchOrder(email, id) {
       return;
     }
     const data = await res.json();
+    await fetchInvoice(data.order.id);
     renderOrder(data.order);
   } catch (e) {
     console.error(e);
@@ -52,6 +67,8 @@ function renderOrder(o) {
     ${o.metodo_pago ? `<p><strong>Método de pago:</strong> ${o.metodo_pago}</p>` : ''}
     ${o.destino ? `<p><strong>Envío a:</strong> ${o.destino}</p>` : '<p><em>Coordinación de envío por WhatsApp</em></p>'}
     ${o.cliente && o.cliente.email ? `<p><strong>Email:</strong> ${o.cliente.email}</p>` : ''}
+    ${o.seguimiento ? `<p><strong>Nº de seguimiento:</strong> ${o.seguimiento}${o.transportista ? ' (' + o.transportista + ')' : ''}</p>` : ''}
+    ${invoiceInfo && invoiceInfo.url ? `<p><a href="${invoiceInfo.url}" target="_blank">Ver/Descargar factura</a></p>` : '<p><em>Factura pendiente</em></p>'}
   `;
   summaryEl.style.display = 'block';
   renderTracker(o);


### PR DESCRIPTION
## Summary
- add email verification helper and use it when creating orders
- enforce email check in tracking endpoint
- expose server instance for testing
- show shipping info and invoice in tracking UI
- add basic tests for email and tracking

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889fe0e77208331994878e1e3dfef13