### PR TITLE
Implement shipping cost API and checkout steps

### DIFF
--- a/nerin_final_updated/data/shipping.json
+++ b/nerin_final_updated/data/shipping.json
@@ -1,0 +1,9 @@
+{
+  "costos": [
+    {"provincia": "CABA", "costo": 1500},
+    {"provincia": "Buenos Aires", "costo": 2000},
+    {"provincia": "Córdoba", "costo": 2500},
+    {"provincia": "Santa Fe", "costo": 2200},
+    {"provincia": "Otras", "costo": 3000}
+  ]
+}

--- a/nerin_final_updated/frontend/checkout-steps.html
+++ b/nerin_final_updated/frontend/checkout-steps.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Checkout</title>
+    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css" />
+  </head>
+  <body>
+    <header>
+      <div class="header-inner">
+        <div class="logo"><a href="/index.html">NERIN</a></div>
+      </div>
+    </header>
+    <main class="container">
+      <div id="step1" class="checkout-step">
+        <h2>Paso 1 de 3: Datos</h2>
+        <form id="formDatos" class="login-container">
+          <input type="text" id="nombre" placeholder="Nombre" required />
+          <input type="text" id="apellido" placeholder="Apellido" required />
+          <input type="email" id="email" placeholder="Email" required />
+          <input type="tel" id="telefono" placeholder="Teléfono" required />
+          <button type="submit">Continuar</button>
+        </form>
+      </div>
+      <div id="step2" class="checkout-step" style="display:none">
+        <h2>Paso 2 de 3: Envío</h2>
+        <form id="formEnvio" class="login-container">
+          <input type="text" id="provincia" placeholder="Provincia" required />
+          <input type="text" id="localidad" placeholder="Localidad" required />
+          <input type="text" id="direccion" placeholder="Dirección" required />
+          <input type="text" id="cp" placeholder="Código Postal" required />
+          <select id="metodo" required>
+            <option value="">Método</option>
+            <option value="retiro">Retiro en local</option>
+            <option value="envio">Envío a domicilio</option>
+          </select>
+          <p id="costoEnvio"></p>
+          <button type="submit">Continuar</button>
+        </form>
+      </div>
+      <div id="step3" class="checkout-step" style="display:none">
+        <h2>Paso 3 de 3: Pago</h2>
+        <div id="resumen"></div>
+        <button id="confirmar">Confirmar compra</button>
+      </div>
+    </main>
+    <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
+    <script type="module" src="/js/checkout-steps.js"></script>
+    <script type="module" src="/js/config.js"></script>
+  </body>
+</html>

--- a/nerin_final_updated/frontend/js/checkout-steps.js
+++ b/nerin_final_updated/frontend/js/checkout-steps.js
@@ -1,0 +1,65 @@
+const step1 = document.getElementById('step1');
+const step2 = document.getElementById('step2');
+const step3 = document.getElementById('step3');
+const formDatos = document.getElementById('formDatos');
+const formEnvio = document.getElementById('formEnvio');
+const costoEl = document.getElementById('costoEnvio');
+const resumenEl = document.getElementById('resumen');
+const confirmarBtn = document.getElementById('confirmar');
+
+let datos = {};
+let envio = {};
+
+formDatos.addEventListener('submit', (ev) => {
+  ev.preventDefault();
+  datos = {
+    nombre: document.getElementById('nombre').value.trim(),
+    apellido: document.getElementById('apellido').value.trim(),
+    email: document.getElementById('email').value.trim(),
+    telefono: document.getElementById('telefono').value.trim(),
+  };
+  step1.style.display = 'none';
+  step2.style.display = 'block';
+});
+
+async function updateCosto() {
+  const provincia = document.getElementById('provincia').value.trim();
+  if (!provincia) return;
+  try {
+    const res = await fetch(`/api/shipping-cost?provincia=${encodeURIComponent(provincia)}`);
+    if (res.ok) {
+      const data = await res.json();
+      costoEl.textContent = `Costo de envío: $${data.costo}`;
+      envio.costo = data.costo;
+    }
+  } catch {}
+}
+
+document.getElementById('provincia').addEventListener('change', updateCosto);
+
+envio.costo = 0;
+
+formEnvio.addEventListener('submit', (ev) => {
+  ev.preventDefault();
+  envio = {
+    ...envio,
+    provincia: document.getElementById('provincia').value.trim(),
+    localidad: document.getElementById('localidad').value.trim(),
+    direccion: document.getElementById('direccion').value.trim(),
+    cp: document.getElementById('cp').value.trim(),
+    metodo: document.getElementById('metodo').value,
+  };
+  resumenEl.innerHTML = `
+    <p><strong>Cliente:</strong> ${datos.nombre} ${datos.apellido}</p>
+    <p><strong>Email:</strong> ${datos.email}</p>
+    <p><strong>Envío:</strong> ${envio.metodo} - ${envio.provincia}</p>
+    <p><strong>Costo envío:</strong> $${envio.costo}</p>
+  `;
+  step2.style.display = 'none';
+  step3.style.display = 'block';
+});
+
+confirmarBtn.addEventListener('click', () => {
+  // Aquí se integraría la creación del pedido y preferencia MP
+  Toastify({ text: 'Pedido confirmado (demo)', duration: 3000 }).showToast();
+});


### PR DESCRIPTION
## Summary
- add shipping cost table and retrieval functions
- expose `/api/shipping-cost` endpoint
- prototype multi-step checkout page with JS logic

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688aa459f1588331a9ab73dd690c203b