### PR TITLE
Fix checkout integration

### DIFF
--- a/nerin_final_updated/frontend/js/checkout.js
+++ b/nerin_final_updated/frontend/js/checkout.js
@@ -7,12 +7,16 @@ document.querySelector(".mp-buy").addEventListener("click", async (ev) => {
   const quantity = Number(localStorage.getItem("mp_quantity")) || 1;
 
   try {
-    const res = await fetch("/create_preference", {
+    const res = await fetch("/crear-preferencia", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ title, price, quantity }),
+      body: JSON.stringify({
+        titulo: title,
+        precio: price,
+        cantidad: quantity,
+      }),
     });
 
     const data = await res.json();

--- a/nerin_final_updated/frontend/js/mp-buy.js
+++ b/nerin_final_updated/frontend/js/mp-buy.js
@@ -11,7 +11,8 @@ export function setupMpBuyButtons(selector = '.mp-buy') {
       localStorage.setItem('mp_title', title);
       localStorage.setItem('mp_price', price);
       localStorage.setItem('mp_quantity', quantity);
-      window.location.href = '/frontend/pages/precheckout.html';
+      // Redirige al nuevo formulario de checkout con pasos
+      window.location.href = '/checkout-form.html';
     });
   });
 }


### PR DESCRIPTION
## Summary
- use `/crear-preferencia` endpoint in new checkout
- redirect MP buy buttons to the new checkout form

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c1660a0708331bc947063f0f582d8