### PR TITLE
Implement three-step checkout

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -59,6 +59,17 @@ app.get('/confirmacion/:id', (_req, res) => {
   res.sendFile(path.join(__dirname, '../frontend/confirmacion.html'));
 });
 
+app.get('/api/validate-email', async (req, res) => {
+  const email = req.query.email || '';
+  try {
+    const valid = await verifyEmail(String(email).trim());
+    res.json({ valid: !!valid });
+  } catch (e) {
+    logger.error(`Error validar email: ${e.message}`);
+    res.status(500).json({ error: 'Error al validar' });
+  }
+});
+
 app.post('/crear-preferencia', async (req, res) => {
   const { titulo, precio, cantidad, usuario, datos, envio } = req.body;
 

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -786,6 +786,19 @@ const server = http.createServer((req, res) => {
     return sendJson(res, 200, { costo });
   }
 
+  // API: validar email en tiempo real
+  if (pathname === "/api/validate-email" && req.method === "GET") {
+    const email = parsedUrl.query.email || "";
+    return verifyEmail(String(email).trim())
+      .then((valid) => {
+        return sendJson(res, 200, { valid: !!valid });
+      })
+      .catch((e) => {
+        console.error("Error validating email", e);
+        return sendJson(res, 500, { error: "Error al validar" });
+      });
+  }
+
   if (pathname === "/api/shipping-table" && req.method === "GET") {
     const table = getShippingTable();
     if (!validateShippingTable(table)) {

--- a/nerin_final_updated/frontend/checkout-steps.html
+++ b/nerin_final_updated/frontend/checkout-steps.html
@@ -11,31 +11,68 @@
     <header>
       <div class="header-inner">
         <div class="logo"><a href="/index.html">NERIN</a></div>
+        <button class="menu-toggle" id="navToggle">☰</button>
+        <nav id="mainNav">
+          <ul>
+            <li><a href="/index.html">Inicio</a></li>
+            <li><a href="/shop.html">Productos</a></li>
+            <li><a href="/contact.html">Contacto</a></li>
+            <li><a href="/seguimiento.html">Seguir mi pedido</a></li>
+            <li><a href="/cart.html">Carrito</a></li>
+            <li><a href="/login.html">Acceder</a></li>
+          </ul>
+        </nav>
       </div>
     </header>
     <main class="container">
       <div id="step1" class="checkout-step">
         <h2>Paso 1 de 3: Datos</h2>
         <form id="formDatos" class="login-container">
-          <input type="text" id="nombre" placeholder="Nombre" required />
-          <input type="text" id="apellido" placeholder="Apellido" required />
-          <input type="email" id="email" placeholder="Email" required />
-          <input type="tel" id="telefono" placeholder="Teléfono" required />
+          <label>Nombre completo
+            <input type="text" id="nombre" required />
+          </label>
+          <label>Apellido
+            <input type="text" id="apellido" required />
+          </label>
+          <label>Email
+            <input type="email" id="email" required />
+            <small id="emailError" class="error-message"></small>
+          </label>
+          <label>Teléfono
+            <input type="tel" id="telefono" required />
+          </label>
           <button type="submit">Continuar</button>
         </form>
       </div>
       <div id="step2" class="checkout-step" style="display:none">
         <h2>Paso 2 de 3: Envío</h2>
         <form id="formEnvio" class="login-container">
-          <input type="text" id="provincia" placeholder="Provincia" required />
-          <input type="text" id="localidad" placeholder="Localidad" required />
-          <input type="text" id="direccion" placeholder="Dirección" required />
-          <input type="text" id="cp" placeholder="Código Postal" required />
-          <select id="metodo" required>
-            <option value="">Método</option>
-            <option value="retiro">Retiro en local</option>
-            <option value="envio">Envío a domicilio</option>
-          </select>
+          <label>Provincia
+            <input type="text" id="provincia" required />
+          </label>
+          <label>Localidad
+            <input type="text" id="localidad" required />
+          </label>
+          <label>Calle
+            <input type="text" id="calle" required />
+          </label>
+          <label>Número
+            <input type="text" id="numero" required />
+          </label>
+          <label>Piso
+            <input type="text" id="piso" />
+          </label>
+          <label>Código Postal
+            <input type="text" id="cp" required />
+          </label>
+          <label>Método de envío
+            <select id="metodo" required>
+              <option value="">Seleccione</option>
+              <option value="retiro">Retiro en local</option>
+              <option value="estandar">Envío estándar</option>
+              <option value="express">Envío express</option>
+            </select>
+          </label>
           <p id="costoEnvio"></p>
           <button type="submit">Continuar</button>
         </form>
@@ -43,9 +80,35 @@
       <div id="step3" class="checkout-step" style="display:none">
         <h2>Paso 3 de 3: Pago</h2>
         <div id="resumen"></div>
-        <button id="confirmar">Confirmar compra</button>
+        <div class="login-container" style="margin-top:1rem">
+          <label><input type="radio" name="pago" value="mp" checked /> Mercado Pago</label>
+          <label><input type="radio" name="pago" value="transferencia" /> Transferencia bancaria</label>
+          <label><input type="radio" name="pago" value="efectivo" /> Pago en efectivo</label>
+          <div id="metodoInfo" style="margin:0.5rem 0"></div>
+          <button id="confirmar" type="button">Confirmar compra</button>
+        </div>
       </div>
     </main>
+    <footer class="container">
+      <p>📞 WhatsApp | 📧 Email | 📍 CABA</p>
+      <p>
+        <a href="https://instagram.com" target="_blank">Instagram</a> |
+        <a href="/index.html">Inicio</a> | <a href="/shop.html">Catálogo</a> |
+        <a href="/contact.html">Contacto</a> |
+        <a href="/seguimiento.html">Seguir mi pedido</a> |
+        <a href="/terms.html">Términos y condiciones</a>
+      </p>
+      <p class="legal">
+        NERIN comercializa repuestos Samsung originales Service Pack adquiridos
+        por canales oficiales. No tenemos vínculo directo con Samsung
+        Electronics.
+      </p>
+    </footer>
+    <div id="whatsapp-button">
+      <a href="https://wa.me/541112345678" target="_blank">
+        <img src="/assets/whatsapp.svg" alt="WhatsApp" />
+      </a>
+    </div>
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
     <script type="module" src="/js/checkout-steps.js"></script>
     <script type="module" src="/js/config.js"></script>

--- a/nerin_final_updated/frontend/js/cart.js
+++ b/nerin_final_updated/frontend/js/cart.js
@@ -153,7 +153,7 @@ function renderCart() {
   };
 
   payBtn.onclick = () => {
-    window.location.href = "/checkout-form.html";
+    window.location.href = "/checkout-steps.html";
   };
   // Después de renderizar el carrito actualiza la navegación para reflejar el contador del carrito
   if (window.updateNav) {

--- a/nerin_final_updated/frontend/js/checkout-steps.js
+++ b/nerin_final_updated/frontend/js/checkout-steps.js
@@ -6,16 +6,64 @@ const formEnvio = document.getElementById('formEnvio');
 const costoEl = document.getElementById('costoEnvio');
 const resumenEl = document.getElementById('resumen');
 const confirmarBtn = document.getElementById('confirmar');
+const emailInput = document.getElementById('email');
+const emailError = document.getElementById('emailError');
+const pagoRadios = document.getElementsByName('pago');
+
+const cart = JSON.parse(localStorage.getItem('nerinCart') || '[]');
+if (cart.length === 0) {
+  window.location.href = '/cart.html';
+}
 
 let datos = {};
 let envio = {};
+const saved = JSON.parse(localStorage.getItem('nerinUserInfo') || 'null');
+if (saved) {
+  document.getElementById('nombre').value = saved.nombre || '';
+  document.getElementById('apellido').value = saved.apellido || '';
+  document.getElementById('email').value = saved.email || '';
+  document.getElementById('telefono').value = saved.telefono || '';
+  document.getElementById('provincia').value = saved.provincia || '';
+  document.getElementById('localidad').value = saved.localidad || '';
+  document.getElementById('calle').value = saved.calle || '';
+  document.getElementById('numero').value = saved.numero || '';
+  document.getElementById('piso').value = saved.piso || '';
+  document.getElementById('cp').value = saved.cp || '';
+  if (saved.metodo) document.getElementById('metodo').value = saved.metodo;
+}
 
-formDatos.addEventListener('submit', (ev) => {
+async function validateEmail() {
+  const email = emailInput.value.trim();
+  if (!email) return false;
+  const format = /[^@\s]+@[^@\s]+\.[^@\s]+/.test(email);
+  if (!format) {
+    emailError.textContent = 'Formato inválido';
+    return false;
+  }
+  try {
+    const res = await fetch(`/api/validate-email?email=${encodeURIComponent(email)}`);
+    const data = await res.json();
+    if (!data.valid) {
+      emailError.textContent = 'Email no válido';
+      return false;
+    }
+  } catch {
+    emailError.textContent = 'Error al validar';
+    return false;
+  }
+  emailError.textContent = '';
+  return true;
+}
+
+emailInput.addEventListener('blur', validateEmail);
+
+formDatos.addEventListener('submit', async (ev) => {
   ev.preventDefault();
+  if (!(await validateEmail())) return;
   datos = {
     nombre: document.getElementById('nombre').value.trim(),
     apellido: document.getElementById('apellido').value.trim(),
-    email: document.getElementById('email').value.trim(),
+    email: emailInput.value.trim(),
     telefono: document.getElementById('telefono').value.trim(),
   };
   step1.style.display = 'none';
@@ -45,21 +93,72 @@ formEnvio.addEventListener('submit', (ev) => {
     ...envio,
     provincia: document.getElementById('provincia').value.trim(),
     localidad: document.getElementById('localidad').value.trim(),
-    direccion: document.getElementById('direccion').value.trim(),
+    calle: document.getElementById('calle').value.trim(),
+    numero: document.getElementById('numero').value.trim(),
+    piso: document.getElementById('piso').value.trim(),
     cp: document.getElementById('cp').value.trim(),
     metodo: document.getElementById('metodo').value,
   };
-  resumenEl.innerHTML = `
-    <p><strong>Cliente:</strong> ${datos.nombre} ${datos.apellido}</p>
-    <p><strong>Email:</strong> ${datos.email}</p>
-    <p><strong>Envío:</strong> ${envio.metodo} - ${envio.provincia}</p>
-    <p><strong>Costo envío:</strong> $${envio.costo}</p>
-  `;
+  buildResumen();
   step2.style.display = 'none';
   step3.style.display = 'block';
 });
 
-confirmarBtn.addEventListener('click', () => {
-  // Aquí se integraría la creación del pedido y preferencia MP
-  Toastify({ text: 'Pedido confirmado (demo)', duration: 3000 }).showToast();
+function buildResumen() {
+  const subtotal = cart.reduce((t, it) => t + it.price * it.quantity, 0);
+  const itemsHtml = cart
+    .map(
+      (i) =>
+        `<li>${i.name} x${i.quantity} - $${(i.price * i.quantity).toLocaleString('es-AR')}</li>`
+    )
+    .join('');
+  const total = subtotal + (envio.costo || 0);
+  resumenEl.innerHTML = `
+    <ul>${itemsHtml}</ul>
+    <p>Subtotal: $${subtotal.toLocaleString('es-AR')}</p>
+    <p>Envío: $${(envio.costo || 0).toLocaleString('es-AR')}</p>
+    <p><strong>Total: $${total.toLocaleString('es-AR')}</strong></p>
+  `;
+}
+
+confirmarBtn.addEventListener('click', async () => {
+  const metodo = Array.from(pagoRadios).find((r) => r.checked).value;
+  const body = {
+    titulo: 'Carrito NERIN',
+    precio: cart.reduce((t, it) => t + it.price * it.quantity, 0) + (envio.costo || 0),
+    cantidad: 1,
+    datos,
+    envio,
+  };
+  try {
+    if (metodo === 'mp') {
+      const res = await fetch('/crear-preferencia', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const data = await res.json();
+      if (data.init_point) {
+        localStorage.setItem('nerinUserInfo', JSON.stringify({ ...datos, ...envio }));
+        localStorage.removeItem('nerinCart');
+        window.location.href = data.init_point;
+      }
+    } else {
+      body.metodo = metodo;
+      const res = await fetch('/orden-manual', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const data = await res.json();
+      if (data.numeroOrden) {
+        localStorage.setItem('nerinUserInfo', JSON.stringify({ ...datos, ...envio }));
+        localStorage.removeItem('nerinCart');
+        window.location.href = `/confirmacion/${data.numeroOrden}`;
+      }
+    }
+  } catch (e) {
+    console.error(e);
+    Toastify({ text: 'Error al procesar el pedido', duration: 3000, backgroundColor: '#ef4444' }).showToast();
+  }
 });

--- a/nerin_final_updated/frontend/js/mp-buy.js
+++ b/nerin_final_updated/frontend/js/mp-buy.js
@@ -12,7 +12,7 @@ export function setupMpBuyButtons(selector = '.mp-buy') {
       localStorage.setItem('mp_price', price);
       localStorage.setItem('mp_quantity', quantity);
       // Redirige al nuevo formulario de checkout con pasos
-      window.location.href = '/checkout-form.html';
+      window.location.href = '/checkout-steps.html';
     });
   });
 }


### PR DESCRIPTION
## Summary
- add `/api/validate-email` endpoint on both servers
- implement real-time email validation and payment options in `checkout-steps`
- redirect cart and buy buttons to the new checkout flow
- enhance checkout HTML with header, footer and full form fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cc6dbbeac833188f35d0d77cd247c