### PR TITLE
Improve error logging for checkout routes

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -72,6 +72,7 @@ app.get('/api/validate-email', async (req, res) => {
 
 app.post('/crear-preferencia', async (req, res) => {
   logger.info(`Crear preferencia body: ${JSON.stringify(req.body)}`);
+  console.log('crear-preferencia req.body', req.body);
   const { titulo, precio, cantidad, usuario, datos, envio } = req.body;
 
   if (datos && datos.email) {
@@ -136,13 +137,15 @@ app.post('/crear-preferencia', async (req, res) => {
 
     res.json({ id: result.id, init_point: result.init_point, numeroOrden });
   } catch (error) {
+    console.error(error);
     logger.error(`Error al crear preferencia: ${error.message}`);
-    res.status(500).json({ error: error.message });
+    res.status(400).json({ error: error.message });
   }
 });
 
 app.post('/orden-manual', async (req, res) => {
   logger.info(`Orden manual body: ${JSON.stringify(req.body)}`);
+  console.log('orden-manual req.body', req.body);
   const { titulo, precio, cantidad, datos, envio, metodo } = req.body;
   if (datos && datos.email) {
     try {
@@ -188,8 +191,9 @@ app.post('/orden-manual', async (req, res) => {
     );
     res.json({ numeroOrden });
   } catch (error) {
+    console.error(error);
     logger.error(`Error al crear orden manual: ${error.message}`);
-    res.status(500).json({ error: error.message });
+    res.status(400).json({ error: error.message });
   }
 });
 

--- a/nerin_final_updated/frontend/js/checkout-steps.js
+++ b/nerin_final_updated/frontend/js/checkout-steps.js
@@ -163,6 +163,6 @@ confirmarBtn.addEventListener('click', async () => {
     }
   } catch (e) {
     console.error(e);
-    Toastify({ text: 'Error al procesar el pedido', duration: 3000, backgroundColor: '#ef4444' }).showToast();
+    Toastify({ text: e.message || 'Error al procesar el pedido', duration: 3000, backgroundColor: '#ef4444' }).showToast();
   }
 });


### PR DESCRIPTION
## Summary
- log request bodies in `/crear-preferencia` and `/orden-manual`
- return 400 status on failure and log error details
- show backend error messages in the checkout steps UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cf4ed42108331878b312bb8a55fd8