### PR TITLE
Add detailed Mercado Pago response logging

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -107,6 +107,7 @@ app.post('/crear-preferencia', async (req, res) => {
 
   try {
     const result = await preferenceClient.create({ body });
+    console.log('Preferencia creada:', JSON.stringify(result, null, 2));
     logger.info('Preferencia creada');
 
     const numeroOrden = generarNumeroOrden();


### PR DESCRIPTION
## Summary
- log full Mercado Pago preference result in `POST /crear-preferencia`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d2a817a9083318b2db45e5cd7811f