### PR TITLE
Allow extra fields in webhook

### DIFF
--- a/backend/middleware/validateWebhook.js
+++ b/backend/middleware/validateWebhook.js
@@ -1,6 +1,8 @@
 const Joi = require('joi');
 const logger = require('../logger');
 
+// Joi schema for webhook payload. It checks required fields but
+// allows the body to include additional keys that we don't explicitly list.
 const schema = Joi.object({
   payment_id: Joi.alternatives().try(Joi.string(), Joi.number()).optional(),
   id: Joi.alternatives().try(Joi.string(), Joi.number()).optional(),
@@ -9,7 +11,8 @@ const schema = Joi.object({
   }).optional(),
 })
   .or('payment_id', 'id', 'data')
-  .unknown(false);
+  // allow additional fields in the webhook payload
+  .unknown(true);
 
 module.exports = function validateWebhook(req, res, next) {
   const { error, value } = schema.validate(req.body, { abortEarly: false });


### PR DESCRIPTION
## Summary
- relax Joi webhook schema to accept unknown properties
- document that extra fields are allowed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d33653c4c8331bcfb78778e94decc