### PR TITLE
Document Mercado Pago env vars

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -21,6 +21,15 @@ INSTRUCCIONES RÁPIDAS
 El backend quedará disponible en `http://localhost:3000` y podés cambiar los
 datos del producto directamente en `frontend/index.html`.
 
+VARIABLES DE ENTORNO
+-------------------
+
+Se utilizan tres variables principales para la integración con Mercado Pago:
+
+- `MP_ACCESS_TOKEN`: token privado. Los que empiezan con `TEST-` sirven para el sandbox; para producción se necesita un token que comience con `APP_USR-`.
+- `PUBLIC_URL`: URL pública del servidor. Se usa para redireccionar y para el webhook. En producción suele ser `https://ecommerce-3-0.onrender.com`.
+- `MP_WEBHOOK_URL`: URL donde Mercado Pago enviará notificaciones. Si no se define, se construye como `${PUBLIC_URL}/api/mercado-pago/webhook`. Un ejemplo en producción es `https://ecommerce-3-0.onrender.com/api/mercado-pago/webhook`.
+
 PRUEBAS AUTOMÁTICAS
 -------------------
 


### PR DESCRIPTION
## Summary
- document MP_ACCESS_TOKEN, PUBLIC_URL and MP_WEBHOOK_URL
- show typical production values
- note that production tokens start with `APP_USR-`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d50cd97f0833189ec2732bccb2afc