### PR TITLE
Configure CORS and production URLs

### DIFF
--- a/backend/routes/orders.js
+++ b/backend/routes/orders.js
@@ -1,13 +1,14 @@
 const express = require('express');
 const router = express.Router();
 const db = require('../db');
+const logger = require('../logger');
 
 router.get('/', async (_req, res) => {
   try {
     const { rows } = await db.query('SELECT * FROM orders ORDER BY created_at DESC');
     res.json(rows);
   } catch (error) {
-    console.error('Error al obtener pedidos:', error);
+    logger.error(`Error al obtener pedidos: ${error.message}`);
     res.status(500).json({ error: 'Error interno' });
   }
 });
@@ -19,7 +20,7 @@ router.get('/pending', async (_req, res) => {
     );
     res.json(rows);
   } catch (error) {
-    console.error('Error al obtener pedidos pendientes:', error);
+    logger.error(`Error al obtener pedidos pendientes: ${error.message}`);
     res.status(500).json({ error: 'Error interno' });
   }
 });
@@ -43,7 +44,7 @@ router.get('/:id/status', async (req, res) => {
     }
     res.json({ status: rows[0].payment_status, numeroOrden: rows[0].order_number });
   } catch (error) {
-    console.error('Error al obtener estado del pedido:', error);
+    logger.error(`Error al obtener estado del pedido: ${error.message}`);
     res.status(500).json({ error: 'Error interno' });
   }
 });
@@ -63,7 +64,7 @@ router.post('/:orderNumber/mark-paid', async (req, res) => {
     }
     res.json({ success: true });
   } catch (error) {
-    console.error('Error al actualizar pedido:', error);
+    logger.error(`Error al actualizar pedido: ${error.message}`);
     res.status(500).json({ error: 'Error interno' });
   }
 });

--- a/backend/server.js
+++ b/backend/server.js
@@ -22,8 +22,10 @@ if (!ACCESS_TOKEN) {
   throw new Error('MP_ACCESS_TOKEN no configurado');
 }
 
-const PUBLIC_URL = process.env.PUBLIC_URL || `http://localhost:${process.env.PORT || 3000}`;
-const MP_WEBHOOK_URL = process.env.MP_WEBHOOK_URL || `${PUBLIC_URL}/api/mercado-pago/webhook`;
+const PUBLIC_URL =
+  process.env.PUBLIC_URL || 'https://ecommerce-3-0.onrender.com';
+const MP_WEBHOOK_URL =
+  process.env.MP_WEBHOOK_URL || `${PUBLIC_URL}/api/mercado-pago/webhook`;
 const client = new MercadoPagoConfig({ accessToken: ACCESS_TOKEN });
 const preferenceClient = new Preference(client);
 
@@ -31,7 +33,13 @@ const app = express();
 app.enable('trust proxy');
 app.disable('x-powered-by');
 app.use(helmet());
-app.use(cors());
+const allowedOrigins = ['https://nerinparts.com.ar'];
+if (PUBLIC_URL) allowedOrigins.push(PUBLIC_URL);
+app.use(
+  cors({
+    origin: allowedOrigins,
+  })
+);
 app.use(
   express.json({
     verify: (req, res, buf) => {
@@ -147,7 +155,6 @@ app.post('/crear-preferencia', async (req, res) => {
 
     res.json({ id: result.id, init_point: url, numeroOrden });
   } catch (error) {
-    console.error(error);
     logger.error(`Error al crear preferencia: ${error.message}`);
     res.status(400).json({ error: error.message });
   }
@@ -201,7 +208,6 @@ app.post('/orden-manual', async (req, res) => {
     );
     res.json({ numeroOrden });
   } catch (error) {
-    console.error(error);
     logger.error(`Error al crear orden manual: ${error.message}`);
     res.status(400).json({ error: error.message });
   }

--- a/backend/utils/sendEmail.js
+++ b/backend/utils/sendEmail.js
@@ -1,8 +1,9 @@
 const nodemailer = require('nodemailer');
+const logger = require('../logger');
 
 async function sendEmail(to, subject, text) {
   if (!process.env.SMTP_HOST) {
-    console.log(`Mock email to ${to}: ${subject} - ${text}`);
+    logger.info(`Mock email to ${to}: ${subject} - ${text}`);
     return;
   }
   const transporter = nodemailer.createTransport({

--- a/frontend/config.example.js
+++ b/frontend/config.example.js
@@ -2,4 +2,4 @@
 // Example:
 // window.MP_PUBLIC_KEY = 'TEST-1234abcd-5678-efgh-9012-ijklmno';
 window.MP_PUBLIC_KEY = '';
-window.API_BASE_URL = 'http://localhost:3000';
+window.API_BASE_URL = 'https://ecommerce-3-0.onrender.com';

--- a/frontend/config.js
+++ b/frontend/config.js
@@ -2,4 +2,4 @@
 // Example:
 // window.MP_PUBLIC_KEY = 'TEST-1234abcd-5678-efgh-9012-ijklmno';
 window.MP_PUBLIC_KEY = '';
-window.API_BASE_URL = 'http://localhost:3000';
+window.API_BASE_URL = 'https://ecommerce-3-0.onrender.com';

--- a/frontend/confirmacion.html
+++ b/frontend/confirmacion.html
@@ -10,16 +10,17 @@
   <p>Número de pedido: <span id="num"></span></p>
   <a id="seguir" href="#">Seguir mi pedido</a>
 
-<script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+<script src="config.js"></script>
 <script>
 const prefId = window.location.pathname.split('/').pop();
 const numEl = document.getElementById('num');
 const seguir = document.getElementById('seguir');
 async function load(){
   try{
-    const res = await axios.get(`/api/orders/${prefId}/status`);
-    if(res.data.numeroOrden){
-      numEl.textContent = res.data.numeroOrden;
+    const res = await fetch(`${API_BASE_URL}/api/orders/${prefId}/status`, {mode:'cors'});
+    const data = await res.json();
+    if(data.numeroOrden){
+      numEl.textContent = data.numeroOrden;
     }
   }catch(e){console.error(e);}
   seguir.href = `/estado-pedido/${prefId}`;

--- a/frontend/estado-pedido.html
+++ b/frontend/estado-pedido.html
@@ -8,7 +8,7 @@
   <h1 id="message">Procesando pago...</h1>
   <p id="step">Paso 2 de 3</p>
   <p id="orderNumber" style="display:none"></p>
-  <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+  <script src="config.js"></script>
   <script>
     const orderId = window.location.pathname.split('/').pop();
     const messageEl = document.getElementById('message');
@@ -17,11 +17,12 @@
 
     async function checkStatus() {
       try {
-        const res = await axios.get(`/api/orders/${orderId}/status`);
-        const status = res.data.status;
-        if (res.data.numeroOrden) {
+        const res = await fetch(`${API_BASE_URL}/api/orders/${orderId}/status`, {mode:'cors'});
+        const data = await res.json();
+        const status = data.status;
+        if (data.numeroOrden) {
           orderNumberEl.style.display = 'block';
-          orderNumberEl.textContent = `Número de pedido: ${res.data.numeroOrden}`;
+          orderNumberEl.textContent = `Número de pedido: ${data.numeroOrden}`;
         }
         if (status === 'approved' || status === 'aprobado') {
           messageEl.textContent = 'Pago aprobado';


### PR DESCRIPTION
## Summary
- Configure Express with CORS allowing nerinparts.com.ar and default production URLs for Mercado Pago webhook
- Replace console logging with winston logger and mock email logging
- Update frontend to call backend using full Render URL with CORS mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e320143bc833193f781785da80d96