### PR TITLE
Log Mercado Pago init_point and use it for redirects

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -152,6 +152,11 @@ app.post('/crear-preferencia', async (req, res) => {
     if (ACCESS_TOKEN.startsWith('TEST-') && result.sandbox_init_point) {
       url = result.sandbox_init_point;
     }
+    logger.info(`init_point devuelto: ${result.init_point}`);
+    if (result.sandbox_init_point) {
+      logger.info(`sandbox_init_point devuelto: ${result.sandbox_init_point}`);
+    }
+    logger.info(`URL de pago utilizada: ${url}`);
 
     res.json({ id: result.id, init_point: url, numeroOrden });
   } catch (error) {

--- a/frontend/checkout.js
+++ b/frontend/checkout.js
@@ -137,6 +137,7 @@ confirmar.addEventListener('click',async()=>{
       const res = await fetch(url,{ mode:'cors', method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body)});
       const data = await res.json();
       if(res.ok && data.init_point){
+          console.log('Mercado Pago init_point:', data.init_point);
         const stored = Object.assign({}, datos, envio);
         localStorage.setItem('userInfo', JSON.stringify(stored));
         window.location.href = data.init_point;

--- a/frontend/confirmar-datos.html
+++ b/frontend/confirmar-datos.html
@@ -75,6 +75,7 @@
       });
       const data = await res.json();
       if(data.init_point){
+        console.log('Mercado Pago init_point:', data.init_point);
         window.location.href = data.init_point;
       }
     }catch(e){

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -65,6 +65,7 @@
           });
           const data = await res.json();
           if (data.init_point) {
+            console.log('Mercado Pago init_point:', data.init_point);
             window.location.href = data.init_point;
             return;
           }


### PR DESCRIPTION
## Summary
- Log Mercado Pago init_point and sandbox_init_point in backend and return the selected URL
- Ensure frontend pages log and redirect using the init_point provided by the backend

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e3578cf088331add80b87d603e0a1