### PR TITLE
feat: support Mercado Pago sandbox tokens

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -144,12 +144,14 @@ app.post('/crear-preferencia', async (req, res) => {
         Number(precio) * Number(cantidad) + costoEnvio,
       ]
     );
-
-    if (!ACCESS_TOKEN.startsWith('APP_USR-')) {
-      throw new Error('El MP_ACCESS_TOKEN NO es de producción; revise .env');
+    let url;
+    if (ACCESS_TOKEN.startsWith('APP_USR-')) {
+      url = result.init_point;
+      console.log('✅ MP init_point:', url);
+    } else {
+      url = result.sandbox_init_point;
+      console.log('⚠️ MP sandbox_init_point:', url);
     }
-    const url = result.init_point; // siempre prod
-    console.log('✅ MP init_point:', url);
 
     res.json({ id: result.id, init_point: url, numeroOrden });
   } catch (error) {


### PR DESCRIPTION
## Summary
- support Mercado Pago sandbox tokens by using sandbox_init_point when a test token is configured

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ee527eef88331bb9cb0d7cc377fc5