### PR TITLE
Include external reference in Mercado Pago preference creation

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -97,6 +97,7 @@ app.post('/crear-preferencia', async (req, res) => {
       return res.status(500).json({ error: 'Error al verificar email' });
     }
   }
+  const numeroOrden = generarNumeroOrden();
   const body = {
     items: [
       {
@@ -112,6 +113,7 @@ app.post('/crear-preferencia', async (req, res) => {
     },
     auto_return: 'approved',
     notification_url: MP_WEBHOOK_URL,
+    external_reference: numeroOrden,
   };
 
   try {
@@ -119,7 +121,6 @@ app.post('/crear-preferencia', async (req, res) => {
     logger.debug(`Preferencia creada: ${JSON.stringify(result, null, 2)}`);
     logger.info('Preferencia creada');
 
-    const numeroOrden = generarNumeroOrden();
     logger.info('Guardando pedido en DB');
     const costoEnvio = getShippingCost(envio && envio.provincia);
     await db.query(


### PR DESCRIPTION
## Summary
- generate order number prior to creating Mercado Pago preference
- send that order number as `external_reference` when creating the preference

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f5a8b30888331a5de7056820c8711