### PR TITLE
Refresh Mercado Pago init point with new token

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -24,8 +24,6 @@ const PUBLIC_URL =
   process.env.PUBLIC_URL || 'https://ecommerce-3-0.onrender.com';
 const MP_WEBHOOK_URL =
   process.env.MP_WEBHOOK_URL || `${PUBLIC_URL}/api/mercado-pago/webhook`;
-const client = new MercadoPagoConfig({ accessToken: ACCESS_TOKEN });
-const preferenceClient = new Preference(client);
 
 const app = express();
 app.enable('trust proxy');
@@ -117,6 +115,8 @@ app.post('/crear-preferencia', async (req, res) => {
   };
 
   try {
+    const client = new MercadoPagoConfig({ accessToken: ACCESS_TOKEN });
+    const preferenceClient = new Preference(client);
     const result = await preferenceClient.create({ body });
     logger.debug(`Preferencia creada: ${JSON.stringify(result, null, 2)}`);
     logger.info('Preferencia creada');
@@ -145,14 +145,12 @@ app.post('/crear-preferencia', async (req, res) => {
         Number(precio) * Number(cantidad) + costoEnvio,
       ]
     );
-    let url;
-    if (ACCESS_TOKEN.startsWith('APP_USR-')) {
-      url = result.init_point;
-      console.log('✅ MP init_point:', url);
-    } else {
-      url = result.sandbox_init_point;
-      console.log('⚠️ MP sandbox_init_point:', url);
+
+    const url = result.init_point;
+    if (!url) {
+      throw new Error('No se generó init_point');
     }
+    console.log('✅ MP init_point:', url);
 
     res.json({ id: result.id, init_point: url, numeroOrden });
   } catch (error) {

--- a/frontend/checkout.js
+++ b/frontend/checkout.js
@@ -141,12 +141,12 @@ confirmar.addEventListener('click',async()=>{
       const res = await fetch(url,{ mode:'cors', method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body)});
       const data = await res.json();
       if(res.ok && data.init_point){
-          console.log('Mercado Pago init_point:', data.init_point);
+        console.log('Mercado Pago init_point:', data.init_point);
         const stored = Object.assign({}, datos, envio);
         localStorage.setItem('userInfo', JSON.stringify(stored));
         window.location.href = data.init_point;
-      }else if(!res.ok){
-        throw new Error(data.error || 'Error al crear preferencia');
+      }else{
+        throw new Error(data.error || 'No se pudo obtener link de pago');
       }
     }else{
       url = `${API_BASE_URL}/orden-manual`;
@@ -163,6 +163,6 @@ confirmar.addEventListener('click',async()=>{
     }
   }catch(err){
     console.error(err);
-    alert('Error al crear pedido');
+    alert(err.message || 'Error al crear pedido');
   }
 });

--- a/frontend/confirmar-datos.html
+++ b/frontend/confirmar-datos.html
@@ -74,13 +74,15 @@
         })
       });
       const data = await res.json();
-      if(data.init_point){
+      if(res.ok && data.init_point){
         console.log('Mercado Pago init_point:', data.init_point);
         window.location.href = data.init_point;
+      }else{
+        throw new Error(data.error || 'No se pudo obtener link de pago');
       }
     }catch(e){
       console.error(e);
-      alert('Error al iniciar pago');
+      alert(e.message || 'Error al iniciar pago');
     }
   });
   </script>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -68,13 +68,16 @@
             }),
           });
           const data = await res.json();
-          if (data.init_point) {
+          if (res.ok && data.init_point) {
             console.log('Mercado Pago init_point:', data.init_point);
             window.location.href = data.init_point;
             return;
           }
+          throw new Error(data.error || 'No se pudo obtener link de pago');
         } catch (e) {
           console.error(e);
+          alert(e.message || 'Error al iniciar pago');
+          return;
         }
       }
       window.location.href = 'checkout.html';


### PR DESCRIPTION
## Summary
- Recreate Mercado Pago client with updated access token for each preference and return the real `init_point`
- Surface payment link errors in checkout and redirect using the fresh `init_point`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f81e0c3d88331a6ba2c46072404be