### PR TITLE
fix: redirect to Mercado Pago in 3-step checkout

### DIFF
--- a/frontend/checkout.js
+++ b/frontend/checkout.js
@@ -117,19 +117,28 @@ function updateMetodoInfo(){
 }
 pagoRadios.forEach(r=>r.addEventListener('change', updateMetodoInfo));
 
-confirmar.addEventListener('click',async()=>{
-  try{
-    const res = await fetch(`${API_BASE_URL}/create_preference`,{
-      mode:'cors',
-      method:'POST'
+confirmar.addEventListener('click', async () => {
+  try {
+    const res = await fetch(`${API_BASE_URL}/crear-preferencia`, {
+      mode: 'cors',
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        titulo: producto.titulo,
+        precio: producto.precio,
+        cantidad: producto.cantidad,
+        datos,
+        envio
+      })
     });
     const data = await res.json();
-    if(res.ok && data.init_point){
+    if (res.ok && data.init_point) {
+      localStorage.setItem('userInfo', JSON.stringify({ ...datos, ...envio }));
       window.location.href = data.init_point;
-    }else{
-      alert('Hubo un error con el pago');
+    } else {
+      alert(data.error || 'Hubo un error con el pago');
     }
-  }catch(err){
+  } catch (err) {
     alert('Hubo un error con el pago');
   }
 });


### PR DESCRIPTION
## Summary
- send checkout data to `/crear-preferencia` and redirect to Mercado Pago

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fdce6cd1883318c5e14bfc9ae6a2a