### PR TITLE
chore: specify Mercado Pago production key

### DIFF
--- a/frontend/config.js
+++ b/frontend/config.js
@@ -1,3 +1,3 @@
-// Mercado Pago public key
+// Mercado Pago public key (production)
 window.MP_PUBLIC_KEY = 'APP_USR-c28b783a-54c0-4e39-80d3-f8c7dae2b645';
 window.API_BASE_URL = 'https://ecommerce-3-0.onrender.com';


### PR DESCRIPTION
## Summary
- specify Mercado Pago production public key in config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fe4af13a883318f5098dc021c91ea