### PR TITLE
Remove hardcoded Mercado Pago webhook URL

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -28,8 +28,7 @@ Se utilizan las siguientes variables para la integración con Mercado Pago:
 
 - `MP_ACCESS_TOKEN`: token privado. Los que empiezan con `TEST-` sirven para el sandbox; para producción se necesita un token que comience con `APP_USR-`.
 - `MP_CLIENT_ID` y `MP_CLIENT_SECRET`: credenciales OAuth asociadas a la cuenta.
-- `PUBLIC_URL`: URL pública del servidor. Se usa para redireccionar y para el webhook. En producción suele ser `https://ecommerce-3-0.onrender.com`.
-- `MP_WEBHOOK_URL`: URL donde Mercado Pago enviará notificaciones. Si no se define, se construye como `${PUBLIC_URL}/api/mercado-pago/webhook`. Un ejemplo en producción es `https://ecommerce-3-0.onrender.com/api/mercado-pago/webhook`.
+- `PUBLIC_URL`: URL pública del servidor utilizada para las redirecciones. El webhook de Mercado Pago debe configurarse en el panel de IPN apuntando a `https://ecommerce-3-0.onrender.com/api/webhooks/mp`.
 
 PRUEBAS AUTOMÁTICAS
 -------------------

--- a/backend/__tests__/webhook.test.js
+++ b/backend/__tests__/webhook.test.js
@@ -37,7 +37,7 @@ describe('Mercado Pago Webhook', () => {
         },
       })
     );
-    app.use('/api/mercado-pago', router);
+    app.use('/api/webhooks/mp', router);
   });
 
   test('returns 200 for valid webhook', async () => {
@@ -49,7 +49,7 @@ describe('Mercado Pago Webhook', () => {
       .digest('hex');
 
     await request(app)
-      .post('/api/mercado-pago/webhook')
+      .post('/api/webhooks/mp')
       .set('Content-Type', 'application/json')
       .set('x-signature', signature)
       .send(body)

--- a/backend/routes/mercadoPago.js
+++ b/backend/routes/mercadoPago.js
@@ -14,13 +14,14 @@ const paymentClient = new Payment(mpClient);
 const merchantClient = new MerchantOrder(mpClient);
 
 router.post(
-  '/webhook',
+  '/',
   requireHttps,
   webhookRateLimit,
   enforcePostJson,
   verifySignature,
   validateWebhook,
   async (req, res) => {
+    console.log('📥 Webhook recibido:', req.body);
     logger.info('Webhook recibido');
     const paymentId =
       req.body.payment_id ||
@@ -53,7 +54,7 @@ router.post(
       `Pedido ${preferenceId} actualizado con estado ${status} y payment_id ${paymentId}`
     );
 
-    res.json({ success: true });
+    res.sendStatus(200);
   } catch (error) {
     logger.error(`Error al procesar webhook: ${error.message}`);
     res.status(500).json({ error: 'Error interno' });

--- a/backend/server.js
+++ b/backend/server.js
@@ -26,8 +26,6 @@ const MP_PROD_ACCESS_TOKEN =
 
 const PUBLIC_URL =
   process.env.PUBLIC_URL || 'https://ecommerce-3-0.onrender.com';
-const MP_WEBHOOK_URL =
-  process.env.MP_WEBHOOK_URL || `${PUBLIC_URL}/api/mercado-pago/webhook`;
 
 const app = express();
 app.enable('trust proxy');
@@ -145,7 +143,6 @@ app.post('/crear-preferencia', async (req, res) => {
       pending: `${PUBLIC_URL}/pending`,
     },
     auto_return: 'approved',
-    notification_url: MP_WEBHOOK_URL,
     external_reference: numeroOrden,
   };
 
@@ -247,7 +244,7 @@ app.post('/orden-manual', async (req, res) => {
   }
 });
 
-app.use('/api/mercado-pago', webhookRoutes);
+app.use('/api/webhooks/mp', webhookRoutes);
 app.use('/api/orders', orderRoutes);
 app.use('/api', shippingRoutes);
 

--- a/nerin_final_updated/backend/index.js
+++ b/nerin_final_updated/backend/index.js
@@ -148,10 +148,6 @@ app.post("/api/orders", async (req, res) => {
           auto_return: "approved",
           external_reference: id,
         };
-        if (PUBLIC_URL) {
-          pref.notification_url =
-            'https://ecommerce-3-0.onrender.com/api/mercado-pago/webhook';
-        }
         const prefRes = await mpPreference.create({ body: pref });
         initPoint = prefRes.init_point;
       } catch (e) {

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -750,10 +750,6 @@ const server = http.createServer((req, res) => {
               auto_return: "approved",
               external_reference: orderId,
             };
-            if (CONFIG.publicUrl) {
-              mpPref.notification_url =
-                `https://ecommerce-3-0.onrender.com/api/mercado-pago/webhook`;
-            }
             const prefRes = await mpPreference.create({ body: mpPref });
             mpInit = prefRes.init_point;
             orderEntry.preference_id = prefRes.id;
@@ -890,10 +886,6 @@ const server = http.createServer((req, res) => {
               auto_return: "approved",
               external_reference: orderId,
             };
-            if (CONFIG.publicUrl) {
-              pref.notification_url =
-                `https://ecommerce-3-0.onrender.com/api/mercado-pago/webhook`;
-            }
             const prefRes = await mpPreference.create({ body: pref });
             initPoint = prefRes.init_point;
             order.preference_id = prefRes.id;
@@ -1736,10 +1728,6 @@ const server = http.createServer((req, res) => {
     req.on("end", async () => {
       try {
         const preference = JSON.parse(body || "{}");
-        if (CONFIG.publicUrl && !preference.notification_url) {
-          preference.notification_url =
-            "https://ecommerce-3-0.onrender.com/api/mercado-pago/webhook";
-        }
         if (!mpPreference) {
           throw new Error("Mercado Pago no está configurado");
         }
@@ -1783,10 +1771,6 @@ const server = http.createServer((req, res) => {
           },
           auto_return: "approved",
         };
-        if (CONFIG.publicUrl) {
-          preference.notification_url =
-            `https://ecommerce-3-0.onrender.com/api/mercado-pago/webhook`;
-        }
         if (!mpPreference) {
           throw new Error("Mercado Pago no está configurado");
         }
@@ -1836,8 +1820,6 @@ const server = http.createServer((req, res) => {
             pending: `${DOMAIN}/pending`,
           },
           auto_return: "approved",
-          notification_url:
-            "https://ecommerce-3-0.onrender.com/api/mercado-pago/webhook",
         };
         const result = await mpPreference.create({ body: preference });
         return sendJson(res, 200, {


### PR DESCRIPTION
## Summary
- rely on IPN config instead of `MP_WEBHOOK_URL`
- drop `notification_url` from preference creation
- log incoming Mercado Pago webhooks at `/api/webhooks/mp`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ff43c29788331b26aabf6ff8eebee