### PR TITLE
Log Mercado Pago init point

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -20,6 +20,13 @@ const ACCESS_TOKEN = process.env.MP_ACCESS_TOKEN;
 if (!ACCESS_TOKEN) {
   throw new Error('MP_ACCESS_TOKEN no configurado');
 }
+if (
+  process.env.NODE_ENV === 'production' &&
+  ACCESS_TOKEN &&
+  ACCESS_TOKEN.includes('TEST')
+) {
+  console.warn('⚠️ Usando credenciales de test de Mercado Pago en producción');
+}
 
 const MP_PROD_ACCESS_TOKEN =
   'APP_USR-6696027157843761-080316-77b4090779b15dbbbefe44f660e7eae5-462376008';
@@ -89,7 +96,15 @@ app.post('/create_preference', async (_req, res) => {
   try {
     const client = new MercadoPagoConfig({ accessToken: MP_PROD_ACCESS_TOKEN });
     const preference = new Preference(client);
+    console.log('📦 preference.body:', body);
     const result = await preference.create({ body });
+    console.log('🔗 init_point recibido:', result && result.init_point);
+    if (!result || !result.init_point) {
+      console.error('❌ Mercado Pago no devolvió init_point');
+      return res
+        .status(500)
+        .json({ error: 'No se pudo generar el link de pago' });
+    }
     return res.json({ init_point: result.init_point });
   } catch (error) {
     console.error('Error al crear preferencia', error);
@@ -149,7 +164,15 @@ app.post('/crear-preferencia', async (req, res) => {
   try {
     const client = new MercadoPagoConfig({ accessToken: ACCESS_TOKEN });
     const preferenceClient = new Preference(client);
+    console.log('📦 preference.body:', body);
     const result = await preferenceClient.create({ body });
+    console.log('🔗 init_point recibido:', result && result.init_point);
+    if (!result || !result.init_point) {
+      console.error('❌ Mercado Pago no devolvió init_point');
+      return res
+        .status(500)
+        .json({ error: 'No se pudo generar el link de pago' });
+    }
     logger.debug(`Preferencia creada: ${JSON.stringify(result, null, 2)}`);
     logger.info('Preferencia creada');
 

--- a/frontend/checkout.js
+++ b/frontend/checkout.js
@@ -119,26 +119,28 @@ pagoRadios.forEach(r=>r.addEventListener('change', updateMetodoInfo));
 
 confirmar.addEventListener('click', async () => {
   try {
-    const res = await fetch(`${API_BASE_URL}/crear-preferencia`, {
-      mode: 'cors',
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        titulo: producto.titulo,
-        precio: producto.precio,
-        cantidad: producto.cantidad,
-        datos,
-        envio
-      })
-    });
-    const data = await res.json();
-    if (res.ok && data.init_point) {
-      localStorage.setItem('userInfo', JSON.stringify({ ...datos, ...envio }));
-      window.location.href = data.init_point;
-    } else {
-      alert(data.error || 'Hubo un error con el pago');
+      const res = await fetch(`${API_BASE_URL}/crear-preferencia`, {
+        mode: 'cors',
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          titulo: producto.titulo,
+          precio: producto.precio,
+          cantidad: producto.cantidad,
+          datos,
+          envio
+        })
+      });
+      const data = await res.json();
+      console.log('Respuesta crear preferencia:', data);
+      if (res.ok && data && data.init_point) {
+        localStorage.setItem('userInfo', JSON.stringify({ ...datos, ...envio }));
+        window.location.href = data.init_point;
+      } else {
+        console.error('init_point no recibido', data);
+        alert(data.error || 'Hubo un error con el pago');
+      }
+    } catch (err) {
+      alert('Hubo un error con el pago');
     }
-  } catch (err) {
-    alert('Hubo un error con el pago');
-  }
-});
+  });

--- a/frontend/confirmar-datos.html
+++ b/frontend/confirmar-datos.html
@@ -74,10 +74,12 @@
         })
       });
       const data = await res.json();
+      console.log('Respuesta crear preferencia:', data);
       if(res.ok && data.init_point){
         console.log('Mercado Pago init_point:', data.init_point);
         window.location.href = data.init_point;
       }else{
+        console.error('init_point no recibido', data);
         throw new Error(data.error || 'No se pudo obtener link de pago');
       }
     }catch(e){

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -68,11 +68,13 @@
             }),
           });
           const data = await res.json();
+          console.log('Respuesta crear preferencia:', data);
           if (res.ok && data.init_point) {
             console.log('Mercado Pago init_point:', data.init_point);
             window.location.href = data.init_point;
             return;
           }
+          console.error('init_point no recibido', data);
           throw new Error(data.error || 'No se pudo obtener link de pago');
         } catch (e) {
           console.error(e);


### PR DESCRIPTION
## Summary
- warn if Mercado Pago test credentials are used in production
- log Mercado Pago preference body and init point with error handling
- log backend responses and redirect only when init_point exists

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ffc94ad40833182d91958f9f65d55