### PR TITLE
feat: add Mercado Pago preference creation route

### DIFF
--- a/backend/routes/mercadoPagoPreference.js
+++ b/backend/routes/mercadoPagoPreference.js
@@ -1,0 +1,52 @@
+const express = require('express');
+const { MercadoPagoConfig, Preference } = require('mercadopago');
+
+const router = express.Router();
+
+const ACCESS_TOKEN = process.env.MP_ACCESS_TOKEN;
+const PUBLIC_URL = process.env.PUBLIC_URL || 'https://ecommerce-3-0.onrender.com';
+
+router.post('/crear-preferencia', async (req, res) => {
+  const { carrito, usuario } = req.body || {};
+  console.log('📥 body recibido:', req.body);
+
+  try {
+    if (!Array.isArray(carrito)) {
+      return res.status(400).json({ error: 'carrito debe ser un array' });
+    }
+
+    const items = carrito.map(({ titulo, precio, cantidad }) => ({
+      title: titulo,
+      unit_price: Number(precio),
+      quantity: Number(cantidad),
+    }));
+
+    const body = {
+      items,
+      payer: { email: usuario && usuario.email },
+      back_urls: {
+        success: `${PUBLIC_URL}/success`,
+        failure: `${PUBLIC_URL}/failure`,
+        pending: `${PUBLIC_URL}/pending`,
+      },
+      auto_return: 'approved',
+    };
+
+    const client = new MercadoPagoConfig({ accessToken: ACCESS_TOKEN });
+    const preference = new Preference(client);
+    console.log('📦 preference.body:', body);
+    const response = await preference.create({ body });
+    console.log('📝 response.body:', response.body);
+
+    const init_point = response && response.body && response.body.init_point;
+    if (init_point) {
+      return res.json({ init_point });
+    }
+    return res.status(500).json({ error: 'init_point no recibido' });
+  } catch (error) {
+    console.error('Error al crear preferencia:', error);
+    return res.status(500).json({ error: error.message });
+  }
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -10,6 +10,7 @@ const logger = require('./logger');
 require('dotenv').config();
 
 const webhookRoutes = require('./routes/mercadoPago');
+const mercadoPagoPreferenceRoutes = require('./routes/mercadoPagoPreference');
 const orderRoutes = require('./routes/orders');
 const shippingRoutes = require('./routes/shipping');
 const { getShippingCost } = require('./utils/shippingCosts');
@@ -281,6 +282,7 @@ app.post('/orden-manual', async (req, res) => {
 app.use('/api/webhooks/mp', webhookRoutes);
 app.use('/api/orders', orderRoutes);
 app.use('/api', shippingRoutes);
+app.use('/api/mercado-pago', mercadoPagoPreferenceRoutes);
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- add Mercado Pago preference creation endpoint to build payment preferences from cart and user data
- register the new Mercado Pago API route under `/api/mercado-pago`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68900e65bab88331bb427a62c77de677