### PR TITLE
refactor: remove deprecated preference endpoints

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -26,9 +26,6 @@ if (ACCESS_TOKEN.startsWith('TEST-')) {
   );
 }
 
-const MP_PROD_ACCESS_TOKEN =
-  'APP_USR-6696027157843761-080316-77b4090779b15dbbbefe44f660e7eae5-462376008';
-
 const PUBLIC_URL =
   process.env.PUBLIC_URL || 'https://ecommerce-3-0.onrender.com';
 
@@ -73,54 +70,6 @@ app.get('/confirmacion/:id', (_req, res) => {
   res.sendFile(path.join(__dirname, '../frontend/confirmacion.html'));
 });
 
-app.post('/create_preference', async (_req, res) => {
-  const body = {
-    items: [
-      {
-        title: 'Pantalla Samsung Service Pack',
-        unit_price: 15000,
-        currency_id: 'ARS',
-        quantity: 1,
-      },
-    ],
-    back_urls: {
-      success: 'https://nerinparts.com.ar/success',
-      failure: 'https://nerinparts.com.ar/failure',
-      pending: 'https://nerinparts.com.ar/pending',
-    },
-    auto_return: 'approved',
-  };
-
-  try {
-    if (MP_PROD_ACCESS_TOKEN.startsWith('TEST-')) {
-      console.warn(
-        '⚠️ Advertencia: usando access_token de prueba de Mercado Pago'
-      );
-    }
-    const client = new MercadoPagoConfig({ accessToken: MP_PROD_ACCESS_TOKEN });
-    const preference = new Preference(client);
-    console.log('📦 preference.body:', body);
-    const response = await preference.create({ body });
-    console.log('📝 response.body:', response.body);
-    console.log('🔗 response.body.init_point:', response?.body?.init_point);
-    const result = response.body || response;
-    if (!result.init_point || !result.init_point.includes('mercadopago')) {
-      console.error(
-        'Preferencia inválida: init_point no generado correctamente.'
-      );
-      return res.status(500).json({
-        error: 'Preferencia inválida: init_point no generado correctamente.',
-      });
-    }
-    return res.json({ init_point: result.init_point });
-  } catch (error) {
-    console.error('Error al crear preferencia', error);
-    return res
-      .status(500)
-      .json({ error: 'No se pudo generar el link de pago' });
-  }
-});
-
 app.get('/api/validate-email', async (req, res) => {
   const email = req.query.email || '';
   try {
@@ -132,9 +81,11 @@ app.get('/api/validate-email', async (req, res) => {
   }
 });
 
-app.post('/crear-preferencia', async (req, res) => {
+app.post('/api/mercado-pago/crear-preferencia', async (req, res) => {
   logger.info(`Crear preferencia body: ${JSON.stringify(req.body)}`);
-  logger.debug(`crear-preferencia req.body ${JSON.stringify(req.body)}`);
+  logger.debug(
+    `api/mercado-pago/crear-preferencia req.body ${JSON.stringify(req.body)}`
+  );
   const { titulo, precio, cantidad, usuario, datos, envio } = req.body;
 
   if (datos && datos.email) {

--- a/frontend/confirmar-datos.html
+++ b/frontend/confirmar-datos.html
@@ -49,7 +49,7 @@
       return;
     }
     try{
-      const res = await fetch(`${API_BASE_URL}/crear-preferencia`,{
+      const res = await fetch(`${API_BASE_URL}/api/mercado-pago/crear-preferencia`,{
         mode:'cors',
         method:'POST',
         headers:{'Content-Type':'application/json'},

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -43,7 +43,7 @@
       // el flujo de checkout completo.
       if (saved && saved.email && saved.direccion) {
         try {
-          const res = await fetch(`${API_BASE_URL}/crear-preferencia`, {
+          const res = await fetch(`${API_BASE_URL}/api/mercado-pago/crear-preferencia`, {
             mode: 'cors',
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },

--- a/nerin_final_updated/frontend/js/checkout.js
+++ b/nerin_final_updated/frontend/js/checkout.js
@@ -7,7 +7,7 @@ document.querySelector(".mp-buy").addEventListener("click", async (ev) => {
   const quantity = Number(localStorage.getItem("mp_quantity")) || 1;
 
   try {
-    const res = await fetch("/crear-preferencia", {
+    const res = await fetch("/api/mercado-pago/crear-preferencia", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- remove obsolete `/create_preference` route from server
- expose new `/api/mercado-pago/crear-preferencia` endpoint
- update frontend references to new preference route

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68900e55119483318a56b8d3b737b1fa