### PR TITLE
feat: load Mercado Pago key from env

### DIFF
--- a/frontend/config.js
+++ b/frontend/config.js
@@ -1,3 +1,9 @@
-// Mercado Pago public key (production)
-window.MP_PUBLIC_KEY = 'APP_USR-c28b783a-54c0-4e39-80d3-f8c7dae2b645';
-window.API_BASE_URL = 'https://ecommerce-3-0.onrender.com';
+// Mercado Pago public key
+// Read from environment variable or build-time config to avoid hardcoding secrets
+globalThis.MP_PUBLIC_KEY =
+  (typeof process !== 'undefined' && process.env.MP_PUBLIC_KEY) || '';
+
+// Backend API base URL
+globalThis.API_BASE_URL =
+  (typeof process !== 'undefined' && process.env.API_BASE_URL) ||
+  'https://ecommerce-3-0.onrender.com';


### PR DESCRIPTION
## Summary
- read Mercado Pago public key from env or build config instead of hardcoding it
- allow overriding API base URL from environment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689096c45df88331ab529080d95612df