### PR TITLE
Fix Mercado Pago preference payload

### DIFF
--- a/frontend/confirmar-datos.html
+++ b/frontend/confirmar-datos.html
@@ -49,27 +49,20 @@
       return;
     }
     try{
-      const res = await fetch(`${API_BASE_URL}/api/mercado-pago/crear-preferencia`,{
-        mode:'cors',
-        method:'POST',
-        headers:{'Content-Type':'application/json'},
+      const res = await fetch(`${API_BASE_URL}/api/mercado-pago/crear-preferencia`, {
+        mode: 'cors',
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          titulo: producto.titulo,
-          precio: producto.precio,
-          cantidad: producto.cantidad,
-          datos: {
-            nombre: saved.nombre,
-            apellido: saved.apellido,
-            email: saved.email,
-            telefono: saved.telefono
-          },
-          envio: {
-            provincia: saved.provincia,
-            localidad: saved.localidad,
-            direccion: saved.direccion,
-            cp: saved.cp,
-            metodo: saved.metodo,
-            costo: saved.costo
+          carrito: [
+            {
+              titulo: producto.titulo,
+              precio: producto.precio,
+              cantidad: producto.cantidad
+            }
+          ],
+          usuario: {
+            email: saved.email
           }
         })
       });


### PR DESCRIPTION
## Summary
- Adjust Mercado Pago checkout request to send `carrito` array and `usuario.email` as backend expects

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68909cc7ded88331825a12ccf837d5c5