### PR TITLE
Ensure Mercado Pago preference uses ARS currency

### DIFF
--- a/nerin_final_updated/backend/index.js
+++ b/nerin_final_updated/backend/index.js
@@ -139,6 +139,7 @@ app.post("/api/orders", async (req, res) => {
             title: p.name,
             quantity: Number(p.quantity),
             unit_price: Number(p.price),
+            currency_id: "ARS",
           })),
           back_urls: {
             success: `${PUBLIC_URL}/success`,


### PR DESCRIPTION
## Summary
- include `currency_id: "ARS"` for each item when creating a Mercado Pago preference in the updated backend

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689127ef01708331a827bc82c31fabd5