### PR TITLE
fix: update Mercado Pago webhook URL

### DIFF
--- a/backend/routes/mercadoPagoPreference.js
+++ b/backend/routes/mercadoPagoPreference.js
@@ -48,7 +48,7 @@ router.post('/crear-preferencia', async (req, res) => {
     items,
     payer: { email: usuario.email },
     external_reference: numeroOrden,
-    notification_url: `${PUBLIC_URL}/api/webhooks/mp`,
+    notification_url: `${PUBLIC_URL}/api/mercado-pago/webhook`,
     back_urls: {
       success: `${PUBLIC_URL}/success`,
       failure: `${PUBLIC_URL}/failure`,


### PR DESCRIPTION
## Summary
- update Mercado Pago preference route notification URL to new webhook path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68912ad401a88331b219798ea5543106