### PR TITLE
Use environment based public URL

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -27,7 +27,7 @@ if (ACCESS_TOKEN.startsWith('TEST-')) {
 }
 
 const PUBLIC_URL =
-  process.env.PUBLIC_URL || 'https://ecommerce-3-0.onrender.com';
+  process.env.PUBLIC_URL || 'http://localhost:3000';
 
 const app = express();
 app.enable('trust proxy');

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -23,6 +23,7 @@ require("dotenv").config();
 const CONFIG = getConfig();
 const APP_PORT = process.env.PORT || 3000;
 // Dominio público para redirecciones de Mercado Pago
+// configurable mediante la variable de entorno PUBLIC_URL
 const DOMAIN = process.env.PUBLIC_URL || "http://localhost:3000";
 const resend = CONFIG.resendApiKey ? new Resend(CONFIG.resendApiKey) : null;
 const MP_TOKEN = process.env.MP_ACCESS_TOKEN;


### PR DESCRIPTION
## Summary
- default PUBLIC_URL to localhost for local development
- document PUBLIC_URL configuration in minimal server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68912e0a4cd48331b53a149b8cfb0605