### PR TITLE
feat: point frontend to render backend

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -70,6 +70,10 @@ app.get('/confirmacion/:id', (_req, res) => {
   res.sendFile(path.join(__dirname, '../frontend/confirmacion.html'));
 });
 
+app.get('/api/health', (req, res) => {
+  res.json({ ok: true, service: 'backend', ts: Date.now() });
+});
+
 app.get('/api/validate-email', async (req, res) => {
   const email = req.query.email || '';
   try {

--- a/frontend/checkout.js
+++ b/frontend/checkout.js
@@ -70,9 +70,16 @@ provincia.addEventListener('change',async()=>{
     const res = await fetch(`${API_BASE_URL}/api/shipping-cost?provincia=${encodeURIComponent(prov)}`, {
       mode: 'cors'
     });
-    const data = await res.json();
-    costoEnvio = data.costo||0;
-    costoEnvioEl.textContent = `Costo envío: $${costoEnvio}`;
+    const text = await res.text();
+    try {
+      const data = JSON.parse(text);
+      console.log('Respuesta API:', data);
+      costoEnvio = data.costo||0;
+      costoEnvioEl.textContent = `Costo envío: $${costoEnvio}`;
+    } catch (e) {
+      console.error('Respuesta NO JSON:', text.slice(0, 300));
+      alert('Error al obtener costo de envío (respuesta no válida del servidor)');
+    }
   }catch{}
 });
 
@@ -139,14 +146,20 @@ confirmar.addEventListener('click', async () => {
         usuario: { ...datos, ...envio }
       })
     });
-    const data = await res.json();
-    console.log('Respuesta Mercado Pago:', data);
-    if(res.ok && data.init_point){
-      localStorage.setItem('userInfo', JSON.stringify({ ...datos, ...envio }));
-      window.location.href = data.init_point;
-    }else{
-      console.error('init_point no recibido', data);
-      alert(data.error || 'Hubo un error con el pago');
+    const text = await res.text();
+    try {
+      const data = JSON.parse(text);
+      console.log('Respuesta API:', data);
+      if(res.ok && data.init_point){
+        localStorage.setItem('userInfo', JSON.stringify({ ...datos, ...envio }));
+        window.location.href = data.init_point;
+      }else{
+        console.error('init_point no recibido', data);
+        alert(data.error || 'Hubo un error con el pago');
+      }
+    } catch (e) {
+      console.error('Respuesta NO JSON:', text.slice(0, 300));
+      alert('Error al procesar el pago (respuesta no válida del servidor)');
     }
   } catch(err){
     console.error('Error al crear preferencia', err);

--- a/frontend/config.js
+++ b/frontend/config.js
@@ -3,7 +3,5 @@
 globalThis.MP_PUBLIC_KEY =
   (typeof process !== 'undefined' && process.env.MP_PUBLIC_KEY) || '';
 
-// Backend API base URL
-globalThis.API_BASE_URL =
-  (typeof process !== 'undefined' && process.env.API_BASE_URL) ||
-  'https://ecommerce-3-0.onrender.com';
+// URL del backend en Render (Web Service) — REEMPLAZAR con el URL real
+globalThis.API_BASE_URL = "https://TU-BACKEND-WEBSERVICE.onrender.com";

--- a/frontend/confirmar-datos.html
+++ b/frontend/confirmar-datos.html
@@ -66,14 +66,21 @@
           }
         })
       });
-      const data = await res.json();
-      console.log('Respuesta crear preferencia:', data);
-      if(res.ok && data.init_point){
-        console.log('Mercado Pago init_point:', data.init_point);
-        window.location.href = data.init_point;
-      }else{
-        console.error('init_point no recibido', data);
-        throw new Error(data.error || 'No se pudo obtener link de pago');
+      const text = await res.text();
+      try {
+        const data = JSON.parse(text);
+        console.log('Respuesta API:', data);
+        if(res.ok && data.init_point){
+          console.log('Mercado Pago init_point:', data.init_point);
+          window.location.href = data.init_point;
+        }else{
+          console.error('init_point no recibido', data);
+          throw new Error(data.error || 'No se pudo obtener link de pago');
+        }
+      } catch (e) {
+        console.error('Respuesta NO JSON:', text.slice(0, 300));
+        alert('Error al procesar el pago (respuesta no válida del servidor)');
+        return;
       }
     }catch(e){
       console.error(e);


### PR DESCRIPTION
## Summary
- configure frontend API base URL for Render
- add JSON response guards to checkout
- expose backend health endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689134f479c48331b7487d7666f010a8