### PR TITLE
fix: ensure api routes override static

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -143,6 +143,12 @@ app.use('/api/orders', orderRoutes);
 app.use('/api', shippingRoutes);
 app.use('/api/mercado-pago', mercadoPagoPreferenceRoutes);
 
+app.use(express.static(path.join(__dirname, '../frontend')));
+
+app.get('*', (_req, res) => {
+  res.sendFile(path.join(__dirname, '../frontend/index.html'));
+});
+
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {
   logger.info(`Servidor corriendo en http://localhost:${PORT}`);


### PR DESCRIPTION
## Summary
- serve static files and fallback after API routes to ensure priority

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68913b6094bc8331a8aa354aa054db3d