### PR TITLE
feat: add API logging and fix preference route

### DIFF
--- a/backend/routes/mercadoPagoPreference.js
+++ b/backend/routes/mercadoPagoPreference.js
@@ -16,22 +16,29 @@ function getPublicUrl(req) {
 }
 
 router.post('/crear-preferencia', async (req, res) => {
+  logger.info(`➡️ ${req.method} ${req.originalUrl}`);
   const { carrito, usuario } = req.body || {};
   logger.info(`📥 body recibido: ${JSON.stringify(req.body)}`);
 
   if (!Array.isArray(carrito) || carrito.length === 0) {
-    return res
-      .status(400)
-      .json({ error: 'carrito debe ser un array con al menos un item' });
+    const payload = {
+      error: 'carrito debe ser un array con al menos un item',
+    };
+    logger.info(`⬅️ 400 ${JSON.stringify(payload)}`);
+    return res.status(400).json(payload);
   }
 
   if (!usuario || !usuario.email) {
-    return res.status(400).json({ error: 'email requerido' });
+    const payload = { error: 'email requerido' };
+    logger.info(`⬅️ 400 ${JSON.stringify(payload)}`);
+    return res.status(400).json(payload);
   }
 
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   if (!emailRegex.test(usuario.email)) {
-    return res.status(400).json({ error: 'email inválido' });
+    const payload = { error: 'email inválido' };
+    logger.info(`⬅️ 400 ${JSON.stringify(payload)}`);
+    return res.status(400).json(payload);
   }
 
   const items = carrito.map(({ titulo, precio, cantidad }) => ({
@@ -66,12 +73,18 @@ router.post('/crear-preferencia', async (req, res) => {
 
     const init_point = response && response.body && response.body.init_point;
     if (init_point) {
-      return res.json({ init_point });
+      const payload = { init_point };
+      logger.info(`⬅️ 200 ${JSON.stringify(payload)}`);
+      return res.json(payload);
     }
-    return res.status(500).json({ error: 'init_point no recibido' });
+    const payload = { error: 'init_point no recibido' };
+    logger.info(`⬅️ 500 ${JSON.stringify(payload)}`);
+    return res.status(500).json(payload);
   } catch (error) {
     logger.error(`Error al crear preferencia: ${error.message}`);
-    return res.status(500).json({ error: 'Error al crear preferencia' });
+    const payload = { error: 'Error al crear preferencia' };
+    logger.info(`⬅️ 500 ${JSON.stringify(payload)}`);
+    return res.status(500).json(payload);
   }
 });
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -70,6 +70,18 @@ app.get('/confirmacion/:id', (_req, res) => {
   res.sendFile(path.join(__dirname, '../frontend/confirmacion.html'));
 });
 
+// Log all /api/* requests and responses
+app.use('/api', (req, res, next) => {
+  logger.info(`➡️ ${req.method} ${req.originalUrl}`);
+  logger.info(`📥 body: ${JSON.stringify(req.body)}`);
+  const originalJson = res.json.bind(res);
+  res.json = (body) => {
+    logger.info(`⬅️ ${res.statusCode} ${JSON.stringify(body)}`);
+    return originalJson(body);
+  };
+  next();
+});
+
 app.get('/api/health', (req, res) => {
   res.json({ ok: true, service: 'backend', ts: Date.now() });
 });
@@ -140,8 +152,9 @@ app.post('/orden-manual', async (req, res) => {
 
 app.use('/api/webhooks/mp', webhookRoutes);
 app.use('/api/orders', orderRoutes);
-app.use('/api', shippingRoutes);
+// Specific Mercado Pago routes before generic /api routes
 app.use('/api/mercado-pago', mercadoPagoPreferenceRoutes);
+app.use('/api', shippingRoutes);
 
 app.use(express.static(path.join(__dirname, '../frontend')));
 


### PR DESCRIPTION
## Summary
- add global API logging for method, body and responses
- log Mercado Pago preference creation details and outcomes
- ensure Mercado Pago preference routes register before generic /api routes

## Testing
- `npm test`
- `curl -i -X POST http://localhost:3000/api/mercado-pago/crear-preferencia -H "Content-Type: application/json" -d '{"carrito":[{"titulo":"Test","precio":123,"cantidad":1}], "usuario":{"email":"test@ex.com"}}'`


------
https://chatgpt.com/codex/tasks/task_e_689169f20768833185e8ee7f97def5b8