### PR TITLE
feat: add default Mercado Pago public key

### DIFF
--- a/frontend/config.js
+++ b/frontend/config.js
@@ -1,7 +1,8 @@
 // Mercado Pago public key
 // Read from environment variable or build-time config to avoid hardcoding secrets
 globalThis.MP_PUBLIC_KEY =
-  (typeof process !== 'undefined' && process.env.MP_PUBLIC_KEY) || '';
+  (typeof process !== 'undefined' && process.env.MP_PUBLIC_KEY) ||
+  'APP_USR-c28b783a-54c0-4e39-80d3-f8c7dae2b645';
 
 // URL del backend en Render (Web Service) — REEMPLAZAR con el URL real
 globalThis.API_BASE_URL = "https://ecommerce-3-0.onrender.com";


### PR DESCRIPTION
## Summary
- provide default Mercado Pago public key in frontend config

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891f3ce7478833186281d29c0558a41