### PR TITLE
chore: update MercadoPago endpoint path

### DIFF
--- a/nerin_final_updated/frontend/js/checkout-steps.js
+++ b/nerin_final_updated/frontend/js/checkout-steps.js
@@ -141,7 +141,7 @@ confirmarBtn.addEventListener('click', async () => {
   const usuario = { ...datos, ...envio };
   try {
     console.log('Creando preferencia MP', { carrito, usuario });
-    const res = await fetch(`${API_BASE_URL}/api/mercado-pago/crear-preferencia`, {
+    const res = await fetch(`${API_BASE_URL}/api/mercadopago/preference`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ carrito, usuario }),


### PR DESCRIPTION
## Summary
- point checkout preference fetch to `/api/mercadopago/preference`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68920c23355483318435fbab545f8f61