### PR TITLE
Load Mercado Pago public key in frontend

### DIFF
--- a/frontend/checkout.html
+++ b/frontend/checkout.html
@@ -63,7 +63,7 @@
   <button id="confirmar">Confirmar y pagar</button>
 </div>
 <script src="config.js"></script>
-<script src="https://sdk.mercadopago.com/js/v2"></script>
+<script src="https://sdk.mercadopago.com/js/v2" data-public-key="APP_USR-c28b783a-54c0-4e39-80d3-f8c7dae2b645"></script>
 <script src="checkout.js"></script>
 </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,7 +12,7 @@
   <div id="wallet_container"></div>
 
   <script src="config.js"></script>
-  <script src="https://sdk.mercadopago.com/js/v2"></script>
+  <script src="https://sdk.mercadopago.com/js/v2" data-public-key="APP_USR-c28b783a-54c0-4e39-80d3-f8c7dae2b645"></script>
   <script>
     // Inicializamos Mercado Pago con la public key configurada en config.js
     if (!window.MP_PUBLIC_KEY) {


### PR DESCRIPTION
## Summary
- load Mercado Pago SDK with the required public key in index and checkout pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68920eca39388331b059c0ae4407c3f7