### PR TITLE
Refactor Mercado Pago preference endpoint for checkout

### DIFF
--- a/nerin_final_updated/frontend/js/checkout-steps.js
+++ b/nerin_final_updated/frontend/js/checkout-steps.js
@@ -1,3 +1,4 @@
+const API_BASE_URL = ''; // dejamos vacío para usar rutas relativas
 const step1 = document.getElementById('step1');
 const step2 = document.getElementById('step2');
 const step3 = document.getElementById('step3');
@@ -136,10 +137,10 @@ confirmarBtn.addEventListener('click', async () => {
   const customer = { ...datos, ...envio };
   try {
     console.log('Creando preferencia MP', { cart, customer });
-    const res = await fetch(`${API_BASE_URL}/api/mercadopago/preference`, {
+    const res = await fetch('/api/mercado-pago/crear-preferencia', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ cart, customer }),
+      body: JSON.stringify({ carrito: cart, usuario: customer }),
     });
     const text = await res.text();
     try {


### PR DESCRIPTION
## Summary
- set empty `API_BASE_URL` for relative routes
- call new `/api/mercado-pago/crear-preferencia` endpoint with updated payload

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689229347ee4833188c020dfbd6415c0