### PR TITLE
Format cart items for backend checkout

### DIFF
--- a/nerin_final_updated/frontend/js/checkout-steps.js
+++ b/nerin_final_updated/frontend/js/checkout-steps.js
@@ -137,10 +137,16 @@ confirmarBtn.addEventListener('click', async () => {
   const customer = { ...datos, ...envio };
   try {
     console.log('Creando preferencia MP', { cart, customer });
+    const carritoBackend = cart.map(({ name, price, quantity }) => ({
+      titulo: name,
+      precio: price,
+      cantidad: quantity,
+    }));
+    console.log('carritoBackend', carritoBackend);
     const res = await fetch('/api/mercado-pago/crear-preferencia', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ carrito: cart, usuario: customer }),
+      body: JSON.stringify({ carrito: carritoBackend, usuario: customer }),
     });
     const text = await res.text();
     try {


### PR DESCRIPTION
## Summary
- Transform cart items to backend format before creating Mercado Pago preference
- Log `carritoBackend` for debugging and send formatted data in request

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689233d691f88331af3e2f49e3adf20c