### PR TITLE
Fix cart keys in checkout

### DIFF
--- a/frontend/checkout.js
+++ b/frontend/checkout.js
@@ -135,9 +135,9 @@ confirmar.addEventListener('click', async () => {
   if(metodo !== 'mp') return;
   try {
     const cart = [{
-      titulo: producto.titulo,
-      precio: producto.precio,
-      cantidad: producto.cantidad
+      name: producto.titulo,
+      price: producto.precio,
+      quantity: producto.cantidad
     }];
     const customer = { ...datos, ...envio };
     const carritoBackend = cart.map(({ name, price, quantity }) => ({


### PR DESCRIPTION
## Summary
- use name/price/quantity keys in checkout cart
- map cart to backend format with titulo/precio/cantidad

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892c4e5d9808331b491f5c85ebb14be