### PR TITLE
fix: localize order util in nerin backend

### DIFF
--- a/nerin_final_updated/backend/index.js
+++ b/nerin_final_updated/backend/index.js
@@ -12,7 +12,7 @@ const express = require("express");
 const bodyParser = require("body-parser");
 const cors = require("cors");
 const { MercadoPagoConfig, Preference } = require("mercadopago");
-const generarNumeroOrden = require("../../backend/utils/generarNumeroOrden");
+const generarNumeroOrden = require("./utils/generarNumeroOrden");
 let Resend;
 try {
   ({ Resend } = require("resend"));

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -17,7 +17,7 @@ const { MercadoPagoConfig, Preference, Payment } = require("mercadopago");
 const { Afip } = require("afip.ts");
 const { Resend } = require("resend");
 const multer = require("multer");
-const generarNumeroOrden = require("../../backend/utils/generarNumeroOrden");
+const generarNumeroOrden = require("./utils/generarNumeroOrden");
 const verifyEmail = require("./emailValidator");
 require("dotenv").config();
 const CONFIG = getConfig();

--- a/nerin_final_updated/backend/utils/generarNumeroOrden.js
+++ b/nerin_final_updated/backend/utils/generarNumeroOrden.js
@@ -1,0 +1,10 @@
+function generarNumeroOrden() {
+  const fecha = new Date();
+  const dia = String(fecha.getDate()).padStart(2, '0');
+  const mes = String(fecha.getMonth() + 1).padStart(2, '0');
+  const anio = fecha.getFullYear().toString().slice(-2);
+  const random = Math.floor(1000 + Math.random() * 9000);
+  return `NRN-${dia}${mes}${anio}-${random}`;
+}
+
+module.exports = generarNumeroOrden;


### PR DESCRIPTION
## Summary
- copy generarNumeroOrden util into nerin backend
- update Nerin backend to use internal util for order numbers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893b93794ec833196816ae1e647bf47