### PR TITLE
feat: support legacy Mercado Pago route

### DIFF
--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -1721,7 +1721,11 @@ const server = http.createServer((req, res) => {
   }
 
   // === Integración con Mercado Pago ===
-  if (pathname === "/api/mercadopago/preference" && req.method === "POST") {
+  if (
+    (pathname === "/api/mercadopago/preference" ||
+      pathname === "/api/mercado-pago/crear-preferencia") &&
+    req.method === "POST"
+  ) {
     let body = "";
     req.on("data", (chunk) => {
       body += chunk;


### PR DESCRIPTION
## Summary
- accept `/api/mercado-pago/crear-preferencia` as an alias for Mercado Pago preferences

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893c89fb9088331887fd4914db7d6bc