### PR TITLE
fix: improve payment error message in checkout

### DIFF
--- a/nerin_final_updated/frontend/js/checkout-steps.js
+++ b/nerin_final_updated/frontend/js/checkout-steps.js
@@ -157,7 +157,9 @@ confirmarBtn.addEventListener('click', async () => {
         localStorage.removeItem('nerinCart');
         window.location.href = data.init_point;
       } else {
-        const msg = data.error || 'No se pudo iniciar el pago. Verificá tus datos e intentá nuevamente.';
+        const msg =
+          data.error ||
+          'Error al generar el pago. Revisá los datos del carrito o intentá más tarde.';
         alert(msg);
         console.error('init_point no recibido', data);
       }


### PR DESCRIPTION
## Summary
- update checkout error message when Mercado Pago init_point is missing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893d8d472e0833193fd215751a7dadd