### PR TITLE
Fix Mercado Pago init_point handling

### DIFF
--- a/backend/routes/mercadoPagoPreference.js
+++ b/backend/routes/mercadoPagoPreference.js
@@ -86,11 +86,13 @@ router.post('/crear-preferencia', async (req, res) => {
     const preference = new Preference(client);
     logger.info(`📦 preference.body: ${JSON.stringify(body)}`);
     const response = await preference.create({ body });
-    logger.info(`📝 response: ${JSON.stringify(response)}`);
+    // Log completo de la respuesta de Mercado Pago para facilitar el debug
+    logger.info(`📝 response.body: ${JSON.stringify(response.body)}`);
+    console.log('Respuesta completa de Mercado Pago:', response.body);
 
-    const init_point = response && response.init_point;
+    const { id, init_point } = response.body || {};
     if (init_point) {
-      const payload = { init_point };
+      const payload = { id, init_point };
       logger.info(`⬅️ 200 ${JSON.stringify(payload)}`);
       return res.json(payload);
     }

--- a/frontend/checkout.js
+++ b/frontend/checkout.js
@@ -154,13 +154,13 @@ confirmar.addEventListener('click', async () => {
     const text = await res.text();
     try {
       const data = JSON.parse(text);
-      console.log('Respuesta API:', data);
+      console.log('Respuesta completa crear-preferencia:', data);
       if(res.ok && data.init_point){
         localStorage.setItem('userInfo', JSON.stringify(customer));
         window.location.href = data.init_point;
       }else{
-        console.error('init_point no recibido', data);
-        alert(data.error || 'Hubo un error con el pago');
+        console.error('init_point no recibido:', data);
+        alert(data.error || 'No se recibió el enlace de pago.');
       }
     } catch (e) {
       console.error('Respuesta NO JSON:', text.slice(0, 300));


### PR DESCRIPTION
## Summary
- ensure backend returns `id` and `init_point` from Mercado Pago preference response
- log full Mercado Pago response for debugging
- validate `init_point` on frontend before redirect

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893dfd5ff188331815c778ba01fa376