### PR TITLE
Return Mercado Pago init_point

### DIFF
--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -1775,7 +1775,11 @@ const server = http.createServer((req, res) => {
           throw new Error("Mercado Pago no está configurado");
         }
         const result = await mpPreference.create({ body: preferenceBody });
-        return sendJson(res, 200, { preference: result.id });
+        console.log('Respuesta completa de Mercado Pago:', result);
+        return sendJson(res, 200, {
+          init_point: result.init_point,
+          id: result.id,
+        });
       } catch (err) {
         console.error(err);
         return sendJson(res, 500, {


### PR DESCRIPTION
## Summary
- Return both `init_point` and `id` from Mercado Pago preference API
- Log full preference response for easier debugging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893e8bea1e4833191cd2fdf08d28bb3