### PR TITLE
feat: add script to list Mercado Pago webhooks

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -30,6 +30,17 @@ Se utilizan las siguientes variables para la integración con Mercado Pago:
 - `MP_CLIENT_ID` y `MP_CLIENT_SECRET`: credenciales OAuth asociadas a la cuenta.
 - `PUBLIC_URL`: URL pública del servidor utilizada para las redirecciones. El webhook de Mercado Pago debe configurarse en el panel de IPN apuntando a `https://ecommerce-3-0.onrender.com/api/webhooks/mp`.
 
+VERIFICAR WEBHOOKS
+--------------------
+
+Para listar los webhooks configurados en tu cuenta ejecutá:
+
+```bash
+npm run list:webhooks
+```
+
+Necesitás tener `MP_ACCESS_TOKEN` configurado en tu entorno.
+
 PRUEBAS AUTOMÁTICAS
 -------------------
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "backend/server.js",
   "scripts": {
     "start": "node backend/server.js",
-    "test": "jest"
+    "test": "jest",
+    "list:webhooks": "node scripts/listMpWebhooks.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/scripts/listMpWebhooks.js
+++ b/scripts/listMpWebhooks.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+require('dotenv').config();
+
+const accessToken = process.env.MP_ACCESS_TOKEN;
+
+if (!accessToken) {
+  console.error('MP_ACCESS_TOKEN no configurado');
+  process.exit(1);
+}
+
+async function listarWebhooks() {
+  try {
+    const res = await fetch('https://api.mercadopago.com/users/me/notifications/webhooks', {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    if (!res.ok) {
+      const txt = await res.text();
+      throw new Error(`Error HTTP ${res.status}: ${txt}`);
+    }
+
+    const webhooks = await res.json();
+
+    if (Array.isArray(webhooks) && webhooks.length > 0) {
+      webhooks.forEach((wh, i) => {
+        console.log(`Webhook ${i + 1}`);
+        console.log(`  URL: ${wh.url}`);
+        const events = wh.event_types || wh.events || [];
+        console.log(`  Eventos: ${events.join(', ')}`);
+        console.log('---');
+      });
+    } else {
+      console.log('No hay webhooks configurados.');
+    }
+  } catch (err) {
+    console.error('Error al consultar webhooks:', err.message);
+  }
+}
+
+listarWebhooks();


### PR DESCRIPTION
## Summary
- add script to check Mercado Pago webhook configuration
- expose npm task to invoke webhook listing script
- document how to list configured Mercado Pago webhooks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893f0667c4c83319722540f91ec21d4