### PR TITLE
Fix Mercado Pago webhook notification URL

### DIFF
--- a/backend/routes/mercadoPagoPreference.js
+++ b/backend/routes/mercadoPagoPreference.js
@@ -72,7 +72,7 @@ router.post('/crear-preferencia', async (req, res) => {
     items,
     payer: { email: usuario.email },
     external_reference: numeroOrden,
-    notification_url: `${PUBLIC_URL}/api/mercado-pago/webhook`,
+    notification_url: `${PUBLIC_URL}/api/webhooks/mp`,
     back_urls: {
       success: `${PUBLIC_URL}/success`,
       failure: `${PUBLIC_URL}/failure`,


### PR DESCRIPTION
## Summary
- fix mismatched Mercado Pago webhook path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68948c46225c8331bdf097652e31b8f0