### PR TITLE
Rediseño de carrito y paso de pago unificado

### DIFF
--- a/nerin_final_updated/frontend/cart.html
+++ b/nerin_final_updated/frontend/cart.html
@@ -31,26 +31,25 @@
       </div>
     </header>
     <main class="container cart-container">
-      <h2>Resumen de tu compra</h2>
-      <div id="cartItems"></div>
-      <div id="cartSummary" class="cart-summary"></div>
-      <div id="cartActions" class="cart-actions" style="display: none">
-        <button id="whatsappBtn" class="button secondary">
-          Enviar por WhatsApp
-        </button>
-        <button id="payBtn" class="button mp-button">
-          <img
-            src="https://http2.mlstatic.com/frontend-assets/landing-mptools/panel/mp_logo.svg"
-            alt="Mercado Pago"
-          />
-          Pagar con Mercado Pago
-        </button>
+      <div class="cart-box">
+        <h2 class="cart-title">🛒 Tu carrito de compras</h2>
+        <div id="cartItems"></div>
+        <div id="cartSummary" class="cart-summary"></div>
+        <div id="cartActions" class="cart-actions" style="display: none">
+          <a href="/shop.html" class="button secondary continue-shopping"
+            >Seguir comprando</a
+          >
+          <button id="payBtn" class="button primary">Continuar con el pago</button>
+          <button id="whatsappBtn" class="button secondary small">
+            Enviar por WhatsApp
+          </button>
+        </div>
+        <div
+          id="orderSummary"
+          class="payment-summary"
+          style="display: none"
+        ></div>
       </div>
-      <div
-        id="orderSummary"
-        class="payment-summary"
-        style="display: none"
-      ></div>
     </main>
     <div id="whatsapp-button">
       <a href="https://wa.me/541112345678" target="_blank">

--- a/nerin_final_updated/frontend/js/cart.js
+++ b/nerin_final_updated/frontend/js/cart.js
@@ -153,7 +153,7 @@ function renderCart() {
   };
 
   payBtn.onclick = () => {
-    window.location.href = "/checkout-steps.html";
+    window.location.href = "/checkout-steps.html?step=3";
   };
   // Después de renderizar el carrito actualiza la navegación para reflejar el contador del carrito
   if (window.updateNav) {

--- a/nerin_final_updated/frontend/js/checkout-steps.js
+++ b/nerin_final_updated/frontend/js/checkout-steps.js
@@ -33,6 +33,30 @@ if (saved) {
   if (saved.metodo) document.getElementById('metodo').value = saved.metodo;
 }
 
+const params = new URLSearchParams(window.location.search);
+if (params.get('step') === '3' && saved) {
+  datos = {
+    nombre: saved.nombre || '',
+    apellido: saved.apellido || '',
+    email: saved.email || '',
+    telefono: saved.telefono || '',
+  };
+  envio = {
+    provincia: saved.provincia || '',
+    localidad: saved.localidad || '',
+    calle: saved.calle || '',
+    numero: saved.numero || '',
+    piso: saved.piso || '',
+    cp: saved.cp || '',
+    metodo: saved.metodo || '',
+    costo: saved.costo || 0,
+  };
+  buildResumen();
+  step1.style.display = 'none';
+  step2.style.display = 'none';
+  step3.style.display = 'block';
+}
+
 async function validateEmail() {
   const email = emailInput.value.trim();
   if (!email) return false;

--- a/nerin_final_updated/frontend/js/checkout.js
+++ b/nerin_final_updated/frontend/js/checkout.js
@@ -31,5 +31,5 @@ document.querySelector(".mp-buy").addEventListener("click", async (ev) => {
     window.location.href = "/checkout.html?status=failure";
   }
   btn.disabled = false;
-  btn.textContent = "Pagar con Mercado Pago";
+  btn.textContent = "Continuar con el pago";
 });

--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -255,6 +255,11 @@ nav a:hover {
   background-color: #e5e7eb;
 }
 
+.button.small {
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+}
+
 /* WhatsApp botón flotante */
 #whatsapp-button {
   position: fixed;
@@ -662,16 +667,29 @@ nav a:hover {
 
 /* ========= Estilos para el carrito ========= */
 
-.cart-container h2 {
-  margin-top: 1rem;
-  margin-bottom: 1.5rem;
-  text-align: center;
-}
-
 .cart-container {
   max-width: 700px;
   margin: 2rem auto;
   padding: 0 1rem;
+}
+
+.cart-box {
+  background-color: #fff;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  padding: 2rem 1rem;
+}
+
+.cart-title {
+  text-align: center;
+  font-size: 1.8rem;
+  margin-top: 0;
+  margin-bottom: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
 }
 
 .cart-item {
@@ -779,9 +797,10 @@ nav a:hover {
 
 .cart-total-amount {
   font-weight: 700;
-  font-size: 1.6rem;
+  font-size: 2rem;
   color: var(--color-primary);
 }
+
 
 .cart-actions {
   margin-top: 1.5rem;
@@ -791,7 +810,7 @@ nav a:hover {
 }
 
 .cart-actions .button.primary {
-  flex: 1;
+  flex: 2;
   text-align: center;
 }
 
@@ -800,21 +819,8 @@ nav a:hover {
   text-align: center;
 }
 
-.mp-button {
-  background-color: #009ee3;
-  color: #fff;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  width: 100%;
-  max-width: 360px;
-  margin: 0 auto;
-}
-
-.mp-button img {
-  width: 24px;
-  height: 24px;
+.cart-actions .button.small {
+  flex: 1 1 100%;
 }
 
 .payment-summary {
@@ -848,9 +854,6 @@ nav a:hover {
   }
   .cart-actions {
     flex-direction: column;
-  }
-  .mp-button {
-    max-width: none;
   }
 }
 


### PR DESCRIPTION
## Resumen
- Rediseña la vista del carrito con estilo minimalista y botones claros
- Permite acceder directamente al paso 3 del checkout para elegir método de pago
- Ajusta textos y estilos para un flujo de pago más neutral

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894bd0b194c8331a7866516f8d9220f