### PR TITLE
fix: prevent skipping checkout steps when paying

### DIFF
--- a/nerin_final_updated/frontend/js/cart.js
+++ b/nerin_final_updated/frontend/js/cart.js
@@ -153,7 +153,20 @@ function renderCart() {
   };
 
   payBtn.onclick = () => {
-    window.location.href = "/checkout-steps.html?step=3";
+    const saved = JSON.parse(localStorage.getItem("nerinUserInfo") || "null");
+    const hasInfo =
+      saved &&
+      saved.email &&
+      saved.provincia &&
+      saved.localidad &&
+      saved.calle &&
+      saved.numero &&
+      saved.cp &&
+      saved.metodo;
+
+    window.location.href = hasInfo
+      ? "/checkout-steps.html?step=3"
+      : "/checkout-steps.html";
   };
   // Después de renderizar el carrito actualiza la navegación para reflejar el contador del carrito
   if (window.updateNav) {


### PR DESCRIPTION
## Summary
- check for saved user information before redirecting from cart to checkout step 3
- default to full checkout flow when data is incomplete

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68956590c8c483319151df7eb7af7861