### PR TITLE
fix: handle corrupt cart storage

### DIFF
--- a/nerin_final_updated/frontend/js/cart.js
+++ b/nerin_final_updated/frontend/js/cart.js
@@ -31,9 +31,22 @@ function calculateDiscountedPrice(basePrice, quantity) {
   return Math.round(basePrice * (1 - discount));
 }
 
+// Obtener y validar el contenido del carrito desde localStorage
+function getStoredCart() {
+  try {
+    const raw = localStorage.getItem("nerinCart");
+    const cart = JSON.parse(raw || "[]");
+    return Array.isArray(cart) ? cart : [];
+  } catch (err) {
+    console.warn("Cart storage corrupt, resetting", err);
+    localStorage.removeItem("nerinCart");
+    return [];
+  }
+}
+
 // Renderizar el carrito completo
 function renderCart() {
-  const cart = JSON.parse(localStorage.getItem("nerinCart") || "[]");
+  const cart = getStoredCart();
   itemsContainer.innerHTML = "";
   let subtotal = 0;
   if (cart.length === 0) {


### PR DESCRIPTION
## Summary
- guard against malformed data in localStorage when loading cart
- reset storage if parsing fails to avoid rendering empty cart

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68965bd027bc8331b2a305bae2a68bde