### PR TITLE
fix(order-status): return pending instead of 404 when not found yet

### DIFF
--- a/backend/routes/orders.js
+++ b/backend/routes/orders.js
@@ -40,7 +40,7 @@ router.get('/:id/status', async (req, res) => {
       ).rows;
     }
     if (rows.length === 0) {
-      return res.status(404).json({ error: 'Pedido no encontrado' });
+      return res.json({ status: 'pending', numeroOrden: null });
     }
     res.json({ status: rows[0].payment_status, numeroOrden: rows[0].order_number });
   } catch (error) {


### PR DESCRIPTION
## Summary
- return a pending status and null order number when order lookup by preference id and order number finds no match

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68992714dba88331801b109b41b8f91c