### PR TITLE
fix(mp-webhook): usar fetch nativo, raw body y alias; relay 200 inmediato

### DIFF
--- a/nerin_final_updated/package.json
+++ b/nerin_final_updated/package.json
@@ -2,9 +2,9 @@
   "name": "nerin",
   "version": "1.0.0",
   "description": "Sistema ERP + E‑commerce para NERIN Repuestos",
-  "main": "backend/server.js",
+  "main": "backend/index.js",
   "scripts": {
-    "start": "node backend/server.js"
+    "start": "node backend/index.js"
   },
   "dependencies": {
     "afip.ts": "^3.2.2",


### PR DESCRIPTION
## Summary
- usa `fetch` nativo con fallback dinámico y conserva el cuerpo crudo para reenviar el webhook de Mercado Pago
- el handler `mpWebhookRelay` confirma con 200 y reenvía en segundo plano, expuesto en `/api/mercado-pago/webhook` y `/api/webhooks/mp`
- `notification_url` de la preferencia apunta al nuevo relay público y se elimina la dependencia `node-fetch`

## Testing
- `npm install`
- `npm test` *(falla: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a5b9e251883319dd028654eb6753c