### PR TITLE
fix(deps): add express (and cors/cookie-parser) for server startup

### DIFF
--- a/nerin_final_updated/package.json
+++ b/nerin_final_updated/package.json
@@ -10,7 +10,10 @@
     "afip.ts": "^3.2.2",
     "mercadopago": "^2.8.0",
     "resend": "^4.7.0",
-    "multer": "^1.4.5-lts.1"
+    "multer": "^1.4.5-lts.1",
+    "express": "^4.19.2",
+    "cors": "^2.8.5",
+    "cookie-parser": "^1.4.6"
   },
   "devDependencies": {
     "prettier": "^3.6.2"


### PR DESCRIPTION
## Summary
- add express, cors, and cookie-parser dependencies to support server startup

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a66887c4083318282f22967e7da08