### PR TITLE
fix: allow PUT and DELETE in CORS

### DIFF
--- a/nerin_final_updated/backend/index.js
+++ b/nerin_final_updated/backend/index.js
@@ -25,6 +25,14 @@ try {
 require("dotenv").config();
 
 const app = express();
+const ORIGIN = process.env.PUBLIC_URL || '*';
+app.use((req, res, next) => {
+  res.header('Access-Control-Allow-Origin', ORIGIN);
+  res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+  res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+  if (req.method === 'OPTIONS') return res.status(204).end();
+  next();
+});
 const PORT = process.env.PORT || 3000;
 
 const MP_TOKEN = process.env.MP_ACCESS_TOKEN || "";

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -344,7 +344,7 @@ function sendJson(res, statusCode, data) {
   res.writeHead(statusCode, {
     "Content-Type": "application/json",
     "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Methods": "GET, POST, PUT, OPTIONS",
+    "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
     "Access-Control-Allow-Headers": "Content-Type",
   });
   res.end(json);
@@ -487,7 +487,7 @@ const server = http.createServer((req, res) => {
   if (req.method === "OPTIONS") {
     res.writeHead(204, {
       "Access-Control-Allow-Origin": "*",
-      "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+      "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
       "Access-Control-Allow-Headers": "Content-Type",
     });
     return res.end();


### PR DESCRIPTION
## Summary
- allow PUT/DELETE requests in CORS preflight and responses
- add custom CORS middleware in backend index to handle PUT/DELETE and OPTIONS using PUBLIC_URL

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a785388588331b971b2d854f3f023