### PR TITLE
Add CORS and webhook relay to standalone server

### DIFF
--- a/nerin_final_updated/package.json
+++ b/nerin_final_updated/package.json
@@ -2,9 +2,9 @@
   "name": "nerin",
   "version": "1.0.0",
   "description": "Sistema ERP + E‑commerce para NERIN Repuestos",
-  "main": "backend/index.js",
+  "main": "backend/server.js",
   "scripts": {
-    "start": "node backend/index.js"
+    "start": "node backend/server.js"
   },
   "dependencies": {
     "afip.ts": "^3.2.2",


### PR DESCRIPTION
## Summary
- start backend using server.js
- add raw-body parser, CORS headers and Mercado Pago webhook relay

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689a9e02030883318897bd4b4ea9a01a