### PR TITLE
Fix Mercado Pago order tracking and webhook handling

### DIFF
--- a/nerin_final_updated/backend/index.js
+++ b/nerin_final_updated/backend/index.js
@@ -150,7 +150,12 @@ app.use('/api', (req, res, next) => {
 
 app.use('/api', async (req, res, next) => {
   if (!API_FORWARD_URL) return next();
-  if (req.path === '/webhooks/mp' || req.path === '/mercado-pago/webhook') return next();
+  if (
+    req.path === '/webhooks/mp' ||
+    req.path === '/mercado-pago/webhook' ||
+    /^\/orders\/[^/]+\/status$/.test(req.path)
+  )
+    return next();
   try {
     const base = API_FORWARD_URL.replace(/\/$/, '');
     const target = base + req.originalUrl.replace(/^\/api/, '');


### PR DESCRIPTION
## Summary
- upsert orders when creating Mercado Pago preference
- handle Mercado Pago webhook and test endpoint
- expose order status via NRN or preference id
- avoid proxying webhook and status routes

## Testing
- `curl -s -i -X POST http://localhost:3000/api/webhooks/mp/test -H "Content-Type: application/json" -d '{"ping":true}'`
- `curl -s -i -X POST http://localhost:3000/api/webhooks/mp -H "Content-Type: application/json" -d '{"external_reference":"ORD-mdhdukaj-508","status":"approved","id":"pay_1","preference_id":"pref_1"}'`
- `curl -s -i http://localhost:3000/api/orders/ORD-mdhdukaj-508/status`
- `curl -s -i http://localhost:3000/api/orders/NRN-404/status`

------
https://chatgpt.com/codex/tasks/task_e_689b809f22588331953ce6eb8038a139