### PR TITLE
Handle Mercado Pago merchant_order notifications

### DIFF
--- a/backend/routes/mercadoPago.js
+++ b/backend/routes/mercadoPago.js
@@ -19,43 +19,72 @@ router.post('/test', (req, res) => {
   res.sendStatus(200);
 });
 
-router.post(
-  '/',
-  requireHttps,
-  webhookRateLimit,
-  enforcePostJson,
-  
-  validateWebhook,
-  async (req, res) => {
-    console.log('📥 mp-webhook recibido:', req.body);
-    logger.info('mp-webhook recibido');
-    const paymentId =
-      req.body.payment_id ||
-      (req.body.data && req.body.data.id) ||
-      req.body.id;
-    if (!paymentId) {
-      return res.status(400).json({ error: 'payment_id requerido' });
+function mapStatus(mpStatus) {
+  return mpStatus === 'approved'
+    ? 'approved'
+    : mpStatus === 'rejected'
+    ? 'rejected'
+    : 'pending';
+}
+
+async function processNotification(topic, id) {
+  try {
+    let paymentId = null;
+    let merchantOrder;
+    let preferenceId = null;
+    let externalRef = null;
+    let status = 'pending';
+
+    if (topic === 'merchant_order') {
+      merchantOrder = await merchantClient.get({ id });
+      const payments = merchantOrder.payments || [];
+      preferenceId = merchantOrder.preference_id || null;
+      externalRef = merchantOrder.external_reference || null;
+      if (!payments.length) {
+        const identifier = preferenceId || externalRef;
+        if (identifier) {
+          const whereField = preferenceId ? 'preference_id' : 'order_number';
+          const existing = await db.query(
+            `SELECT id FROM orders WHERE ${whereField} = $1`,
+            [identifier]
+          );
+          if (existing.rowCount > 0) {
+            await db.query(
+              `UPDATE orders SET payment_status = $1 WHERE ${whereField} = $2`,
+              ['pending', identifier]
+            );
+          } else {
+            await db.query(
+              `INSERT INTO orders (${whereField}, payment_status) VALUES ($1,$2)`,
+              [identifier, 'pending']
+            );
+          }
+        }
+        logger.info(
+          `mp-webhook OK paymentId=null externalRef=${externalRef} prefId=${preferenceId} status=pending`
+        );
+        return;
+      }
+      paymentId = payments[0].id;
+    } else {
+      paymentId = id;
     }
 
-  try {
     const payment = await paymentClient.get({ id: paymentId });
-    const status = payment.status;
-    const orderNumber = payment.external_reference;
+    status = mapStatus(payment.status);
+    externalRef = payment.external_reference || externalRef;
 
-    let merchantOrder;
     if (payment.order && payment.order.id) {
       merchantOrder = await merchantClient.get({ id: payment.order.id });
+      preferenceId = merchantOrder.preference_id || preferenceId;
+      externalRef = externalRef || merchantOrder.external_reference || null;
     }
 
-    const preferenceId = merchantOrder?.preference_id;
-
-    if (!preferenceId && !orderNumber) {
+    const identifier = preferenceId || externalRef;
+    if (!identifier) {
       logger.error('No se pudieron determinar identificadores del pago');
-      return res
-        .status(400)
-        .json({ error: 'Identificador de orden no encontrado' });
+      return;
     }
-    const identifier = preferenceId || orderNumber;
     const whereField = preferenceId ? 'preference_id' : 'order_number';
     const existing = await db.query(
       `SELECT id FROM orders WHERE ${whereField} = $1`,
@@ -68,24 +97,22 @@ router.post(
         [status, String(paymentId), identifier]
       );
     } else {
-      const item =
-        (merchantOrder && merchantOrder.items && merchantOrder.items[0]) || {};
+      const item = merchantOrder?.items?.[0] || {};
       const payer = payment.payer || {};
-      const shipment =
-        (merchantOrder && merchantOrder.shipments && merchantOrder.shipments[0]) || {};
+      const shipment = merchantOrder?.shipments?.[0] || {};
       const address = shipment.receiver_address || {};
       const shippingOption = shipment.shipping_option || {};
       const shippingCost = shippingOption.cost || shipment.shipping_cost || 0;
       const shippingMethod =
         shippingOption.name || shipment.shipping_mode || null;
       const totalAmount =
-        (merchantOrder && merchantOrder.total_amount) ||
+        merchantOrder?.total_amount ||
         (payment.transaction_amount + shippingCost);
 
       await db.query(
         'INSERT INTO orders (order_number, preference_id, payment_status, payment_id, product_title, unit_price, quantity, user_email, first_name, last_name, phone, shipping_province, shipping_city, shipping_address, shipping_zip, shipping_method, shipping_cost, total_amount) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18)',
         [
-          orderNumber,
+          externalRef,
           preferenceId,
           status,
           String(paymentId),
@@ -108,14 +135,40 @@ router.post(
     }
 
     logger.info(
-      `mp-webhook ${(orderNumber || preferenceId)} OK estado ${status} payment_id ${paymentId}`
+      `mp-webhook OK paymentId=${paymentId} externalRef=${externalRef} prefId=${preferenceId} status=${status}`
     );
-
-    res.sendStatus(200);
   } catch (error) {
     logger.error(`Error al procesar webhook: ${error.message}`);
-    res.status(500).json({ error: 'Error interno' });
   }
-});
+}
+
+router.post(
+  '/',
+  requireHttps,
+  webhookRateLimit,
+  enforcePostJson,
+
+  validateWebhook,
+  (req, res) => {
+    const topic = req.query.topic || req.body.topic;
+    const id =
+      req.query.id ||
+      req.body.id ||
+      req.body.payment_id ||
+      (req.body.data && req.body.data.id);
+
+    console.log('📥 mp-webhook recibido:', { topic, id });
+    logger.info(`mp-webhook recibido: ${JSON.stringify({ topic, id })}`);
+
+    res.sendStatus(200);
+
+    if (!id) {
+      logger.warn('id requerido');
+      return;
+    }
+
+    processNotification(topic, id);
+  }
+);
 
 module.exports = router;

--- a/nerin_final_updated/backend/middleware/validateWebhook.js
+++ b/nerin_final_updated/backend/middleware/validateWebhook.js
@@ -1,8 +1,7 @@
 const Joi = require('joi');
-const logger = require('../logger');
 
 // Joi schema for webhook payload. It accepts an empty body so that
-// topic/id can also arrive via query parameters. Additional keys are
+// topic and id can also arrive via query parameters. Additional keys are
 // allowed beyond the ones explicitly listed here.
 const schema = Joi.object({
   payment_id: Joi.alternatives().try(Joi.string(), Joi.number()).optional(),
@@ -13,12 +12,12 @@ const schema = Joi.object({
   }).optional(),
 }).unknown(true);
 
-module.exports = function validateWebhook(req, res, next) {
-  const { error, value } = schema.validate(req.body, { abortEarly: false });
+module.exports = function validateWebhook(body = {}) {
+  const { error, value } = schema.validate(body, { abortEarly: false });
   if (error) {
-    logger.warn(`invalid body: ${error.message}`);
-    return res.status(400).json({ error: 'Invalid payload' });
+    const err = new Error(error.message);
+    err.name = 'ValidationError';
+    throw err;
   }
-  req.body = value;
-  next();
+  return value;
 };

--- a/nerin_final_updated/backend/routes/mercadoPago.js
+++ b/nerin_final_updated/backend/routes/mercadoPago.js
@@ -1,0 +1,132 @@
+const fs = require('fs');
+const path = require('path');
+const { MercadoPagoConfig, Payment, MerchantOrder } = require('mercadopago');
+
+const ACCESS_TOKEN = process.env.MP_ACCESS_TOKEN || '';
+const mpClient = new MercadoPagoConfig({ accessToken: ACCESS_TOKEN });
+const paymentClient = new Payment(mpClient);
+const merchantClient = new MerchantOrder(mpClient);
+
+function mapStatus(mpStatus) {
+  return mpStatus === 'approved'
+    ? 'approved'
+    : mpStatus === 'rejected'
+    ? 'rejected'
+    : 'pending';
+}
+
+function ordersPath() {
+  return path.join(__dirname, '../../data/orders.json');
+}
+
+function getOrders() {
+  try {
+    const file = fs.readFileSync(ordersPath(), 'utf8');
+    return JSON.parse(file).orders || [];
+  } catch {
+    return [];
+  }
+}
+
+function saveOrders(orders) {
+  fs.writeFileSync(ordersPath(), JSON.stringify({ orders }, null, 2), 'utf8');
+}
+
+async function processNotification(topic, id) {
+  try {
+    let paymentId = null;
+    let merchantOrder;
+    let preferenceId = null;
+    let externalRef = null;
+    let status = 'pending';
+
+    if (topic === 'merchant_order') {
+      merchantOrder = await merchantClient.get({ id });
+      const payments = merchantOrder.payments || [];
+      preferenceId = merchantOrder.preference_id || null;
+      externalRef = merchantOrder.external_reference || null;
+      if (!payments.length) {
+        const identifier = preferenceId || externalRef;
+        if (identifier) {
+          const orders = getOrders();
+          const idx = orders.findIndex(
+            (o) =>
+              o.id === identifier ||
+              o.external_reference === identifier ||
+              o.order_number === identifier ||
+              String(o.preference_id) === String(identifier)
+          );
+          if (idx !== -1) {
+            orders[idx].payment_status = 'pending';
+            orders[idx].estado_pago = 'pending';
+          } else {
+            orders.push({
+              id: identifier,
+              preference_id: preferenceId,
+              payment_status: 'pending',
+              estado_pago: 'pending',
+            });
+          }
+          saveOrders(orders);
+        }
+        console.log(
+          `mp-webhook OK paymentId=null externalRef=${externalRef} prefId=${preferenceId} status=pending`
+        );
+        return;
+      }
+      paymentId = payments[0].id;
+    } else {
+      paymentId = id;
+    }
+
+    const payment = await paymentClient.get({ id: paymentId });
+    status = mapStatus(payment.status);
+    externalRef = payment.external_reference || externalRef;
+
+    if (payment.order && payment.order.id) {
+      merchantOrder = await merchantClient.get({ id: payment.order.id });
+      preferenceId = merchantOrder.preference_id || preferenceId;
+      externalRef = externalRef || merchantOrder.external_reference || null;
+    }
+
+    const identifier = preferenceId || externalRef;
+    if (!identifier) {
+      console.error('No se pudieron determinar identificadores del pago');
+      return;
+    }
+
+    const orders = getOrders();
+    const idx = orders.findIndex(
+      (o) =>
+        o.id === identifier ||
+        o.external_reference === identifier ||
+        o.order_number === identifier ||
+        String(o.preference_id) === String(identifier)
+    );
+
+    if (idx !== -1) {
+      const row = orders[idx];
+      row.payment_id = String(paymentId);
+      row.payment_status = status;
+      row.estado_pago = status;
+      row.preference_id = preferenceId || row.preference_id;
+    } else {
+      orders.push({
+        id: externalRef || preferenceId,
+        preference_id: preferenceId,
+        payment_status: status,
+        estado_pago: status,
+        payment_id: String(paymentId),
+      });
+    }
+    saveOrders(orders);
+
+    console.log(
+      `mp-webhook OK paymentId=${paymentId} externalRef=${externalRef} prefId=${preferenceId} status=${status}`
+    );
+  } catch (error) {
+    console.error(`Error al procesar webhook: ${error.message}`);
+  }
+}
+
+module.exports = { processNotification };


### PR DESCRIPTION
## Summary
- support `topic` and `id` from query or body in Mercado Pago webhook
- fetch merchant order to resolve payment IDs and create/update pending orders
- map payment status and upsert orders while logging details

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b8a7376c88331a05ae722fd09b9c5