### PR TITLE
chore: add joi dependency for webhook validation

### DIFF
--- a/nerin_final_updated/package.json
+++ b/nerin_final_updated/package.json
@@ -8,12 +8,13 @@
   },
   "dependencies": {
     "afip.ts": "^3.2.2",
-    "mercadopago": "^2.8.0",
-    "resend": "^4.7.0",
-    "multer": "^1.4.5-lts.1",
-    "express": "^4.19.2",
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
-    "cookie-parser": "^1.4.6"
+    "express": "^4.19.2",
+    "joi": "^17.12.0",
+    "mercadopago": "^2.8.0",
+    "multer": "^1.4.5-lts.1",
+    "resend": "^4.7.0"
   },
   "devDependencies": {
     "prettier": "^3.6.2"


### PR DESCRIPTION
## Summary
- add joi to dependencies so webhook validation middleware can require it

## Testing
- `npm install`
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_689b9395faa883319e155d7a41084aa6