### PR TITLE
fix(mp-webhook): resolver merchant_order→paymentId y soportar topic/type/resource

### DIFF
--- a/nerin_final_updated/backend/routes/mercadoPago.js
+++ b/nerin_final_updated/backend/routes/mercadoPago.js
@@ -7,6 +7,12 @@ const mpClient = new MercadoPagoConfig({ accessToken: ACCESS_TOKEN });
 const paymentClient = new Payment(mpClient);
 const merchantClient = new MerchantOrder(mpClient);
 
+const logger = {
+  info: console.log,
+  warn: console.warn,
+  error: console.error,
+};
+
 function mapStatus(mpStatus) {
   return mpStatus === 'approved'
     ? 'approved'
@@ -32,101 +38,141 @@ function saveOrders(orders) {
   fs.writeFileSync(ordersPath(), JSON.stringify({ orders }, null, 2), 'utf8');
 }
 
-async function processNotification(topic, id) {
-  try {
-    let paymentId = null;
-    let merchantOrder;
-    let preferenceId = null;
-    let externalRef = null;
-    let status = 'pending';
+async function upsertOrder({ externalRef, prefId, status, paymentId }) {
+  const identifier = prefId || externalRef;
+  if (!identifier) return;
+  const orders = getOrders();
+  const idx = orders.findIndex(
+    (o) =>
+      o.id === identifier ||
+      o.external_reference === identifier ||
+      o.order_number === identifier ||
+      String(o.preference_id) === String(identifier)
+  );
+  if (idx !== -1) {
+    const row = orders[idx];
+    row.payment_id = paymentId ? String(paymentId) : row.payment_id;
+    row.payment_status = status || row.payment_status;
+    row.estado_pago = status || row.estado_pago;
+    row.preference_id = prefId || row.preference_id;
+    row.external_reference = externalRef || row.external_reference;
+  } else {
+    orders.push({
+      id: externalRef || prefId,
+      preference_id: prefId || null,
+      external_reference: externalRef || null,
+      payment_status: status || 'pending',
+      estado_pago: status || 'pending',
+      payment_id: paymentId ? String(paymentId) : null,
+    });
+  }
+  saveOrders(orders);
+}
 
-    if (topic === 'merchant_order') {
-      merchantOrder = await merchantClient.get({ id });
-      const payments = merchantOrder.payments || [];
-      preferenceId = merchantOrder.preference_id || null;
-      externalRef = merchantOrder.external_reference || null;
-      if (!payments.length) {
-        const identifier = preferenceId || externalRef;
-        if (identifier) {
-          const orders = getOrders();
-          const idx = orders.findIndex(
-            (o) =>
-              o.id === identifier ||
-              o.external_reference === identifier ||
-              o.order_number === identifier ||
-              String(o.preference_id) === String(identifier)
-          );
-          if (idx !== -1) {
-            orders[idx].payment_status = 'pending';
-            orders[idx].estado_pago = 'pending';
-          } else {
-            orders.push({
-              id: identifier,
-              preference_id: preferenceId,
-              payment_status: 'pending',
-              estado_pago: 'pending',
-            });
-          }
-          saveOrders(orders);
+async function processNotification(input, maybeId) {
+  const body = input?.body || {};
+  const query = input?.query || {};
+  const topic = query.topic || query.type || body.type || input?.topic || input;
+  const rawId =
+    query.id ||
+    (body.data && body.data.id) ||
+    body.id ||
+    input?.id ||
+    maybeId;
+  const resource = query.resource || body.resource || input?.resource;
+
+  logger.info('mp-webhook recibido', { topic, id: rawId });
+
+  let externalRef = input?.externalRef || null;
+  let prefId = input?.prefId || null;
+  let paymentId = null;
+
+  try {
+    if (resource) {
+      const res = await fetch(resource, {
+        headers: { Authorization: `Bearer ${ACCESS_TOKEN}` },
+      });
+      const data = await res.json();
+      if (data.payments) {
+        const mo = data;
+        paymentId = mo.payments?.[0]?.id || null;
+        prefId = mo.preference_id || null;
+        externalRef = mo.external_reference || null;
+        if (!paymentId) {
+          await upsertOrder({ externalRef, prefId, status: 'pending' });
+          logger.info('mp-webhook merchant_order sin payment', {
+            externalRef,
+            prefId,
+          });
+          return;
         }
-        console.log(
-          `mp-webhook OK paymentId=null externalRef=${externalRef} prefId=${preferenceId} status=pending`
-        );
+      } else if (data.status && data.external_reference) {
+        const p = data;
+        const status = mapStatus(p.status);
+        externalRef = p.external_reference || externalRef;
+        prefId = p.preference_id || prefId;
+        await upsertOrder({
+          externalRef,
+          prefId,
+          status,
+          paymentId: p.id,
+        });
+        logger.info('mp-webhook OK', {
+          topic: 'payment',
+          paymentId: p.id,
+          externalRef,
+          prefId,
+          status,
+        });
         return;
       }
-      paymentId = payments[0].id;
-    } else {
-      paymentId = id;
     }
 
-    const payment = await paymentClient.get({ id: paymentId });
-    status = mapStatus(payment.status);
-    externalRef = payment.external_reference || externalRef;
-
-    if (payment.order && payment.order.id) {
-      merchantOrder = await merchantClient.get({ id: payment.order.id });
-      preferenceId = merchantOrder.preference_id || preferenceId;
-      externalRef = externalRef || merchantOrder.external_reference || null;
+    if (topic === 'merchant_order') {
+      const mo = await merchantClient.get({ id: rawId });
+      paymentId = mo.payments?.[0]?.id || null;
+      prefId = mo.preference_id || prefId || null;
+      externalRef = mo.external_reference || externalRef || null;
+      if (!paymentId) {
+        await upsertOrder({ externalRef, prefId, status: 'pending' });
+        logger.info('mp-webhook merchant_order sin payment', {
+          externalRef,
+          prefId,
+        });
+        return;
+      }
     }
 
-    const identifier = preferenceId || externalRef;
-    if (!identifier) {
-      console.error('No se pudieron determinar identificadores del pago');
+    if (topic === 'payment' || paymentId) {
+      const p = await paymentClient.get({ id: paymentId || rawId });
+      const status = mapStatus(p.status);
+      externalRef = p.external_reference || externalRef;
+      prefId = p.preference_id || prefId;
+      await upsertOrder({
+        externalRef,
+        prefId,
+        status,
+        paymentId: p.id,
+      });
+      logger.info('mp-webhook OK', {
+        topic: 'payment',
+        paymentId: p.id,
+        externalRef,
+        prefId,
+        status,
+      });
       return;
     }
 
-    const orders = getOrders();
-    const idx = orders.findIndex(
-      (o) =>
-        o.id === identifier ||
-        o.external_reference === identifier ||
-        o.order_number === identifier ||
-        String(o.preference_id) === String(identifier)
-    );
-
-    if (idx !== -1) {
-      const row = orders[idx];
-      row.payment_id = String(paymentId);
-      row.payment_status = status;
-      row.estado_pago = status;
-      row.preference_id = preferenceId || row.preference_id;
+    if (externalRef || prefId) {
+      await upsertOrder({ externalRef, prefId, status: 'pending' });
     } else {
-      orders.push({
-        id: externalRef || preferenceId,
-        preference_id: preferenceId,
-        payment_status: status,
-        estado_pago: status,
-        payment_id: String(paymentId),
-      });
+      logger.warn('mp-webhook sin referencias', { body, query });
     }
-    saveOrders(orders);
-
-    console.log(
-      `mp-webhook OK paymentId=${paymentId} externalRef=${externalRef} prefId=${preferenceId} status=${status}`
-    );
   } catch (error) {
-    console.error(`Error al procesar webhook: ${error.message}`);
+    logger.error(`Error al procesar webhook: ${error.message}`);
   }
 }
 
 module.exports = { processNotification };
+


### PR DESCRIPTION
## Summary
- improve Mercado Pago webhook handling to resolve merchant_order IDs to payment IDs
- support topic/type/resource params and add clear logging and upsert logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b983ced108331830450b510b3d9da