### PR TITLE
Handle Mercado Pago pending status with polling and identifier storage

### DIFF
--- a/nerin_final_updated/backend/index.js
+++ b/nerin_final_updated/backend/index.js
@@ -244,7 +244,12 @@ app.post("/api/orders", async (req, res) => {
     orders.push(order);
     saveOrders(orders);
 
-    return res.status(201).json({ orderId: id, init_point: initPoint });
+    return res.status(201).json({
+      orderId: id,
+      init_point: initPoint,
+      preferenceId,
+      nrn: id,
+    });
   } catch (err) {
     console.error(err);
     return res.status(500).json({ error: "No se pudo crear el pedido" });

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -1998,6 +1998,8 @@ const server = http.createServer((req, res) => {
         return sendJson(res, 200, {
           init_point: pref.init_point,
           id: prefId,
+          preferenceId: prefId,
+          nrn: numeroOrden,
         });
       } catch (err) {
         console.error(err);

--- a/nerin_final_updated/frontend/failure.html
+++ b/nerin_final_updated/frontend/failure.html
@@ -2,14 +2,13 @@
 <html lang="es">
   <head>
     <meta charset="UTF-8" />
-    <title>Pago fallido</title>
+    <title>Pago rechazado</title>
     <link rel="stylesheet" href="/css/style.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css" />
   </head>
   <body>
     <div class="contenedor">
-      <p>❌ El pago no pudo completarse. Por favor intenta nuevamente.</p>
-      <a class="btn" href="/index.html">Volver a la tienda</a>
+      <p>❌ Tu pago fue rechazado.</p>
+      <a class="btn" href="/checkout.html">Elegir otro medio de pago</a>
     </div>
   </body>
 </html>

--- a/nerin_final_updated/frontend/js/checkout-form.js
+++ b/nerin_final_updated/frontend/js/checkout-form.js
@@ -67,6 +67,8 @@ document.addEventListener("DOMContentLoaded", () => {
       }
 
       if (data && data.init_point) {
+        localStorage.setItem('mp_last_pref', data.preferenceId || '');
+        localStorage.setItem('mp_last_nrn', data.nrn || data.orderId || '');
         localStorage.removeItem("nerinCart");
         window.location.href = data.init_point;
       } else {

--- a/nerin_final_updated/frontend/js/checkout-steps.js
+++ b/nerin_final_updated/frontend/js/checkout-steps.js
@@ -161,6 +161,8 @@ confirmarBtn.addEventListener('click', async () => {
       const data = JSON.parse(text);
       console.log('Respuesta preferencia MP', { status: res.status, data });
       if (res.ok && data.init_point) {
+        localStorage.setItem('mp_last_pref', data.preferenceId || '');
+        localStorage.setItem('mp_last_nrn', data.nrn || data.orderId || '');
         localStorage.setItem('nerinUserInfo', JSON.stringify(customer));
         localStorage.removeItem('nerinCart');
         window.location.href = data.init_point;

--- a/nerin_final_updated/frontend/js/checkout.js
+++ b/nerin_final_updated/frontend/js/checkout.js
@@ -22,6 +22,8 @@ document.querySelector(".mp-buy").addEventListener("click", async (ev) => {
     const data = await res.json();
 
     if (data.init_point) {
+      localStorage.setItem('mp_last_pref', data.preferenceId || '');
+      localStorage.setItem('mp_last_nrn', data.nrn || data.orderId || '');
       window.location.href = data.init_point;
     } else {
       window.location.href = "/checkout.html?status=failure";

--- a/nerin_final_updated/frontend/pending.html
+++ b/nerin_final_updated/frontend/pending.html
@@ -4,14 +4,29 @@
     <meta charset="UTF-8" />
     <title>Pago pendiente</title>
     <link rel="stylesheet" href="/css/style.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css" />
+    <script src="/frontend/js/order-status.js"></script>
   </head>
   <body>
-    <div class="contenedor">
-      <p>
-        ⏳ Tu pago está pendiente. Te avisaremos por email cuando se acredite.
-      </p>
-      <a class="btn" href="/index.html">Volver a la tienda</a>
-    </div>
+    <div class="contenedor" id="statusContainer"></div>
+    <script>
+      document.addEventListener('DOMContentLoaded', async () => {
+        const id = getIdentifier();
+        if (!id) {
+          showProcessing();
+          return;
+        }
+        showProcessing();
+        const { status, id: resolvedId, numeroOrden } = await pollOrderStatus(id);
+        if (status === 'approved') {
+          showApproved(numeroOrden || resolvedId);
+          localStorage.removeItem('mp_last_pref');
+          localStorage.removeItem('mp_last_nrn');
+        } else if (status === 'rejected') {
+          showRejected();
+        } else {
+          showProcessing('Estamos acreditando tu pago...');
+        }
+      });
+    </script>
   </body>
 </html>

--- a/nerin_final_updated/frontend/success.html
+++ b/nerin_final_updated/frontend/success.html
@@ -2,65 +2,29 @@
 <html lang="es">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <title>Pago exitoso</title>
+    <title>Estado del pago</title>
     <link rel="stylesheet" href="/css/style.css" />
+    <script src="/frontend/js/order-status.js"></script>
   </head>
   <body>
-    <div class="contenedor">
-      <h1 id="thanksTitle">Gracias por tu compra</h1>
-      <p id="orderIdText"></p>
-      <p id="emailText"></p>
-      <div id="orderSummary" class="payment-summary"></div>
-      <div class="buttons">
-        <a class="btn" id="trackBtn">Seguir mi pedido</a>
-        <a class="btn" href="/index.html">Inicio</a>
-        <a class="btn" href="/shop.html">Seguir comprando</a>
-      </div>
-      <p style="margin-top:1rem" class="help-text">
-        Podés seguir tu pedido usando tu email y el número de orden. Si necesitás ayuda, contactanos por WhatsApp.
-      </p>
-      <div id="whatsapp-button">
-        <a href="https://wa.me/541112345678" target="_blank">
-          <img src="/assets/whatsapp.svg" alt="WhatsApp" />
-        </a>
-      </div>
-    </div>
+    <div class="contenedor" id="statusContainer"></div>
     <script>
       document.addEventListener('DOMContentLoaded', async () => {
-        const params = new URLSearchParams(window.location.search);
-        const id = params.get('external_reference') || params.get('orderId');
-        const msgEl = document.getElementById('thanksTitle');
-        const idEl = document.getElementById('orderIdText');
-        const sumEl = document.getElementById('orderSummary');
-        const trackBtn = document.getElementById('trackBtn');
-        const emailEl = document.getElementById('emailText');
+        const id = getIdentifier();
         if (!id) {
-          msgEl.textContent = 'Pedido no encontrado';
+          showProcessing();
           return;
         }
-        try {
-          const resp = await fetch(`/api/orders/${encodeURIComponent(id)}`);
-          if (!resp.ok) throw new Error('not found');
-          const data = await resp.json();
-          const order = data.order;
-          if (!order) {
-            msgEl.textContent = 'No pudimos obtener los datos de tu pedido.';
-            return;
-          }
-          msgEl.textContent = `Gracias por tu compra${order.cliente && order.cliente.nombre ? ', ' + order.cliente.nombre : ''}`;
-          idEl.textContent = `Orden: ${order.id}`;
-          if (emailEl) {
-            emailEl.textContent = order.cliente && order.cliente.email ? `Email: ${order.cliente.email}` : '';
-          }
-          const itemsHtml = (order.productos || []).map(p => `<li>${p.name} x${p.quantity}</li>`).join('');
-          sumEl.innerHTML = `<ul>${itemsHtml}</ul><p class="cart-total-amount">Total: $${order.total.toLocaleString('es-AR')}</p>`;
-          const emailParam = order.cliente && order.cliente.email ? order.cliente.email : '';
-          trackBtn.href = `/seguimiento?order=${encodeURIComponent(order.id)}&email=${encodeURIComponent(emailParam)}`;
-          localStorage.removeItem('nerinCart');
-        } catch (e) {
-          console.error(e);
-          msgEl.textContent = 'Error al cargar el pedido.';
+        showProcessing();
+        const { status, id: resolvedId, numeroOrden } = await pollOrderStatus(id);
+        if (status === 'approved') {
+          showApproved(numeroOrden || resolvedId);
+          localStorage.removeItem('mp_last_pref');
+          localStorage.removeItem('mp_last_nrn');
+        } else if (status === 'rejected') {
+          showRejected();
+        } else {
+          showProcessing('Estamos acreditando tu pago...');
         }
       });
     </script>


### PR DESCRIPTION
## Summary
- poll `/api/orders/:id/status` on success/pending pages and show approved/rejected/pending states without errors
- store `preferenceId` and order number in localStorage when creating preferences
- return `preferenceId` and `nrn` from preference creation endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bdab66af883318229f77b815709a9