### PR TITLE
Fix Mercado Pago return pages with status polling

### DIFF
--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -601,7 +601,7 @@ const upload = multer({
 });
 
 // Servir archivos estáticos (HTML, CSS, JS, imágenes)
-function serveStatic(filePath, res) {
+function serveStatic(filePath, res, headers = {}) {
   const ext = path.extname(filePath).toLowerCase();
   const mimeTypes = {
     ".html": "text/html",
@@ -619,7 +619,7 @@ function serveStatic(filePath, res) {
       res.writeHead(404, { "Content-Type": "text/plain" });
       res.end("Not Found");
     } else {
-      res.writeHead(200, { "Content-Type": contentType });
+      res.writeHead(200, { "Content-Type": contentType, ...headers });
       res.end(data);
     }
   });
@@ -2205,13 +2205,19 @@ const server = http.createServer((req, res) => {
 
   // Páginas de resultado de pago de Mercado Pago
   if (pathname === "/success") {
-    return serveStatic(path.join(__dirname, "../frontend/success.html"), res);
+    return serveStatic(path.join(__dirname, "../frontend/success.html"), res, {
+      "Cache-Control": "no-store",
+    });
   }
   if (pathname === "/failure") {
-    return serveStatic(path.join(__dirname, "../frontend/failure.html"), res);
+    return serveStatic(path.join(__dirname, "../frontend/failure.html"), res, {
+      "Cache-Control": "no-store",
+    });
   }
   if (pathname === "/pending") {
-    return serveStatic(path.join(__dirname, "../frontend/pending.html"), res);
+    return serveStatic(path.join(__dirname, "../frontend/pending.html"), res, {
+      "Cache-Control": "no-store",
+    });
   }
 
   if (pathname === "/seguimiento" || pathname === "/seguimiento-pedido") {

--- a/nerin_final_updated/frontend/js/order-status.js
+++ b/nerin_final_updated/frontend/js/order-status.js
@@ -7,13 +7,14 @@
       params.get('o') ||
       params.get('order') ||
       params.get('external_reference') ||
+      params.get('collection_id') ||
       localStorage.getItem('mp_last_pref') ||
       localStorage.getItem('mp_last_nrn');
     return id || null;
   }
 
   async function pollOrderStatus(id, opts = {}) {
-    const { tries = 40, interval = 1500 } = opts;
+    const { tries = 120, interval = 1500 } = opts;
     for (let attempt = 0; attempt < tries; attempt++) {
       try {
         const res = await fetch(`/api/orders/${encodeURIComponent(id)}/status`);
@@ -40,14 +41,14 @@
   function showProcessing(message = 'Estamos confirmando tu pago...') {
     const el = containerEl();
     if (el) {
-      el.innerHTML = `<p>⏳ ${message}</p>`;
+      el.innerHTML = `<div class="spinner"></div><p>${message}</p>`;
     }
   }
 
   function showApproved(nrn) {
     const el = containerEl();
     if (el) {
-      el.innerHTML = `<p>✅ ¡Pago aprobado!</p>${nrn ? `<p>N° de orden: ${nrn}</p>` : ''}`;
+      el.innerHTML = `<p>✅ ¡Pago aprobado!</p>${nrn ? `<p>N° de orden: ${nrn}</p>` : ''}<a class="btn" href="/seguimiento.html">Seguir mi pedido</a>`;
     }
   }
 

--- a/nerin_final_updated/frontend/pending.html
+++ b/nerin_final_updated/frontend/pending.html
@@ -4,27 +4,47 @@
     <meta charset="UTF-8" />
     <title>Pago pendiente</title>
     <link rel="stylesheet" href="/css/style.css" />
-    <script src="/frontend/js/order-status.js"></script>
+    <script src="/js/order-status.js" defer></script>
+    <noscript>
+      <style>
+        .noscript-msg {
+          max-width: 600px;
+          margin: 2rem auto;
+          padding: 1rem;
+          text-align: center;
+        }
+      </style>
+      <div class="noscript-msg">
+        Por favor habilitá JavaScript para ver el estado de tu pago.
+      </div>
+    </noscript>
   </head>
   <body>
-    <div class="contenedor" id="statusContainer"></div>
+    <div class="contenedor" id="statusContainer">
+      <div class="spinner"></div>
+      <p>Estamos confirmando tu pago...</p>
+    </div>
     <script>
       document.addEventListener('DOMContentLoaded', async () => {
-        const id = getIdentifier();
-        if (!id) {
+        try {
+          const id = getIdentifier();
           showProcessing();
-          return;
-        }
-        showProcessing();
-        const { status, id: resolvedId, numeroOrden } = await pollOrderStatus(id);
-        if (status === 'approved') {
-          showApproved(numeroOrden || resolvedId);
-          localStorage.removeItem('mp_last_pref');
-          localStorage.removeItem('mp_last_nrn');
-        } else if (status === 'rejected') {
-          showRejected();
-        } else {
-          showProcessing('Estamos acreditando tu pago...');
+          if (!id) return;
+          const { status, id: resolvedId, numeroOrden } = await pollOrderStatus(id);
+          if (status === 'approved') {
+            showApproved(numeroOrden || resolvedId);
+            localStorage.removeItem('mp_last_pref');
+            localStorage.removeItem('mp_last_nrn');
+          } else if (status === 'rejected') {
+            showRejected();
+          } else {
+            showProcessing('Estamos acreditando tu pago...');
+          }
+        } catch (e) {
+          const el = document.getElementById('statusContainer');
+          if (el) {
+            el.innerHTML = '<p>Ocurrió un problema al verificar tu pago. Intentá nuevamente más tarde.</p>';
+          }
         }
       });
     </script>

--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -1255,3 +1255,20 @@ footer .legal {
 .invalid {
   border-color: var(--color-danger);
 }
+
+/* Spinner for payment status pages */
+.spinner {
+  width: 40px;
+  height: 40px;
+  border: 4px solid var(--color-border);
+  border-top-color: var(--color-secondary);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin: 1rem auto;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/nerin_final_updated/frontend/success.html
+++ b/nerin_final_updated/frontend/success.html
@@ -4,27 +4,47 @@
     <meta charset="UTF-8" />
     <title>Estado del pago</title>
     <link rel="stylesheet" href="/css/style.css" />
-    <script src="/frontend/js/order-status.js"></script>
+    <script src="/js/order-status.js" defer></script>
+    <noscript>
+      <style>
+        .noscript-msg {
+          max-width: 600px;
+          margin: 2rem auto;
+          padding: 1rem;
+          text-align: center;
+        }
+      </style>
+      <div class="noscript-msg">
+        Por favor habilitá JavaScript para ver el estado de tu pago.
+      </div>
+    </noscript>
   </head>
   <body>
-    <div class="contenedor" id="statusContainer"></div>
+    <div class="contenedor" id="statusContainer">
+      <div class="spinner"></div>
+      <p>Estamos confirmando tu pago...</p>
+    </div>
     <script>
       document.addEventListener('DOMContentLoaded', async () => {
-        const id = getIdentifier();
-        if (!id) {
+        try {
+          const id = getIdentifier();
           showProcessing();
-          return;
-        }
-        showProcessing();
-        const { status, id: resolvedId, numeroOrden } = await pollOrderStatus(id);
-        if (status === 'approved') {
-          showApproved(numeroOrden || resolvedId);
-          localStorage.removeItem('mp_last_pref');
-          localStorage.removeItem('mp_last_nrn');
-        } else if (status === 'rejected') {
-          showRejected();
-        } else {
-          showProcessing('Estamos acreditando tu pago...');
+          if (!id) return;
+          const { status, id: resolvedId, numeroOrden } = await pollOrderStatus(id);
+          if (status === 'approved') {
+            showApproved(numeroOrden || resolvedId);
+            localStorage.removeItem('mp_last_pref');
+            localStorage.removeItem('mp_last_nrn');
+          } else if (status === 'rejected') {
+            showRejected();
+          } else {
+            showProcessing('Estamos acreditando tu pago...');
+          }
+        } catch (e) {
+          const el = document.getElementById('statusContainer');
+          if (el) {
+            el.innerHTML = '<p>Ocurrió un problema al verificar tu pago. Intentá nuevamente más tarde.</p>';
+          }
         }
       });
     </script>


### PR DESCRIPTION
## Summary
- serve `/success`, `/pending`, `/failure` with `Cache-Control: no-store`
- fix payment result pages to load JS correctly and add fallback UI
- add polling script with spinner and order tracking link

## Testing
- `npm test`
- `curl -s https://nerinparts.com.ar/api/orders/NRN-130825-4912/status`
- `curl -s https://nerinparts.com.ar/api/orders/462376008-795f2aad-cdf8-41a0-8620-21c161fcde68/status`
- `curl -i http://localhost:3000/success | head -n 20`
- `curl -i http://localhost:3000/pending | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689c00778eb083318201655d255f3eb4