### PR TITLE
feat: modern success screen with copy actions

### DIFF
--- a/nerin_final_updated/frontend/css/success.css
+++ b/nerin_final_updated/frontend/css/success.css
@@ -1,0 +1,175 @@
+@import url("../style.css");
+
+:root {
+  --bg: #f5f5f5;
+  --card: #ffffff;
+  --accent: #10b981;
+  --text: #111827;
+  --muted: #6b7280;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #1f2937;
+    --card: #111827;
+    --text: #f9fafb;
+    --muted: #9ca3af;
+  }
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: inherit;
+}
+
+.success-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 1rem;
+}
+
+.card {
+  background: var(--card);
+  border-radius: var(--radius);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  padding: 1.5rem;
+  width: 100%;
+  max-width: 700px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.header {
+  text-align: center;
+}
+
+.header svg {
+  width: 48px;
+  height: 48px;
+  display: block;
+  margin: 0 auto 0.5rem;
+  color: var(--accent);
+}
+
+.details {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .details {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.block {
+  padding: 1rem;
+  background: var(--bg);
+  border-radius: var(--radius);
+}
+
+.block h2 {
+  margin-top: 0;
+  font-size: 1.1rem;
+}
+
+.items {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.actions a,
+.actions button {
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius);
+  text-decoration: none;
+  cursor: pointer;
+  font-size: 1rem;
+  border: none;
+}
+
+.actions .primary {
+  background: var(--accent);
+  color: #fff;
+}
+
+.actions .secondary {
+  background: var(--muted);
+  color: var(--card);
+}
+
+.actions button:focus-visible,
+.actions a:focus-visible,
+.copy-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.copy-btn {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  position: relative;
+  font-size: 1rem;
+  margin-left: 0.5rem;
+}
+
+.copy-btn .tooltip {
+  position: absolute;
+  top: -1.75rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--accent);
+  color: #fff;
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--radius);
+  font-size: 0.75rem;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s;
+}
+
+.copy-btn.copied .tooltip {
+  opacity: 1;
+}
+
+.copy-btn.copied .icon {
+  visibility: hidden;
+}
+
+.copy-btn.copied::after {
+  content: "✓";
+}
+
+.skeleton {
+  width: 100%;
+  height: 1rem;
+  border-radius: var(--radius);
+  background: var(--muted);
+  animation: pulse 1.5s infinite;
+}
+
+@keyframes pulse {
+  0% {
+    opacity: 0.6;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0.6;
+  }
+}

--- a/nerin_final_updated/frontend/js/success.js
+++ b/nerin_final_updated/frontend/js/success.js
@@ -1,0 +1,160 @@
+const card = document.getElementById("card");
+
+function getIdentifier() {
+  const params = new URLSearchParams(window.location.search);
+  const id =
+    params.get("preference_id") ||
+    params.get("pref_id") ||
+    params.get("o") ||
+    params.get("order") ||
+    params.get("external_reference") ||
+    params.get("collection_id") ||
+    localStorage.getItem("mp_last_pref") ||
+    localStorage.getItem("mp_last_nrn");
+  return id || null;
+}
+
+async function pollOrderStatus(id, opts = {}) {
+  const { tries = 120, interval = 1500 } = opts;
+  for (let attempt = 0; attempt < tries; attempt++) {
+    try {
+      const res = await fetch(`/api/orders/${encodeURIComponent(id)}/status`);
+      if (res.ok) {
+        const data = await res.json();
+        const st = data.status;
+        const nrn = data.numeroOrden;
+        if (st === "approved" || st === "rejected") {
+          return { status: st, id, numeroOrden: nrn };
+        }
+      }
+    } catch (_) {
+      // ignore errors
+    }
+    await new Promise((r) => setTimeout(r, interval));
+  }
+  return { status: "pending", id };
+}
+
+function formatDate(d) {
+  return new Intl.DateTimeFormat("es-AR", {
+    dateStyle: "long",
+    timeStyle: "short",
+  }).format(new Date(d));
+}
+
+function formatMoney(n) {
+  return new Intl.NumberFormat("es-AR", {
+    style: "currency",
+    currency: "ARS",
+  }).format(n);
+}
+
+function renderError(msg) {
+  card.innerHTML = `<p>${msg}</p><div class="actions"><button id="retry" class="primary">Reintentar</button><a class="secondary" href="/index.html">Volver al inicio</a></div>`;
+  const btn = document.getElementById("retry");
+  if (btn) btn.addEventListener("click", init);
+}
+
+function setupCopy(btn) {
+  const text = btn.dataset.copy;
+  btn.addEventListener("click", async () => {
+    try {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const ta = document.createElement("textarea");
+        ta.value = text;
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand("copy");
+        document.body.removeChild(ta);
+      }
+      btn.classList.add("copied");
+      setTimeout(() => btn.classList.remove("copied"), 1500);
+    } catch (_) {}
+  });
+}
+
+function setupShare(nrn, tracking) {
+  const btn = document.getElementById("shareBtn");
+  if (!btn) return;
+  if (navigator.share) {
+    btn.addEventListener("click", () => {
+      const text = `Pedido ${nrn}${tracking ? " - Seguimiento: " + tracking : ""}`;
+      navigator.share({ text });
+    });
+  } else {
+    btn.style.display = "none";
+  }
+}
+
+function renderSuccess(o) {
+  const nrn = o?.id || o?.order_number || o?.external_reference || "";
+  const tracking = o?.seguimiento || o?.tracking_number || "";
+  const paymentStatus = o?.estado_pago || o?.payment_status || "aprobado";
+  const total = typeof o?.total === "number" ? o.total : 0;
+  const fecha = o?.fecha || o?.date || new Date().toISOString();
+  const items = o?.items || o?.productos || [];
+  const itemsHtml = items
+    .map((i) => `<li>${i.name} x${i.quantity}</li>`)
+    .join("");
+  const email = o?.cliente?.email || o?.customer?.email || "";
+  card.innerHTML = `
+    <div class="header">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke="currentColor" fill="none" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+      </svg>
+      <h1>Pago aprobado</h1>
+      <p>${formatDate(fecha)}</p>
+    </div>
+    <div class="details">
+      <section class="block">
+        <h2>Tu pedido</h2>
+        ${nrn ? `<p>N° de pedido: <span id="nrn">${nrn}</span> <button class="copy-btn" data-copy="${nrn}" aria-label="Copiar número"><span class="icon">📋</span><span class="tooltip" role="status" aria-live="polite">Copiado</span></button></p>` : `<p>No encontramos el número de pedido.</p>`}
+        <p>Estado de pago: ${paymentStatus}</p>
+        <p>Total: ${formatMoney(total)}</p>
+        ${items.length ? `<ul class="items">${itemsHtml}</ul>` : ""}
+      </section>
+      <section class="block">
+        <h2>Seguimiento</h2>
+        ${tracking ? `<p>N° de seguimiento: <span id="tracking">${tracking}</span> <button class="copy-btn" data-copy="${tracking}" aria-label="Copiar número"><span class="icon">📋</span><span class="tooltip" role="status" aria-live="polite">Copiado</span></button></p>` : "<p>Aún sin número de envío</p>"}
+      </section>
+    </div>
+    <div class="actions">
+      <a id="trackLink" class="primary" href="/seguimiento.html?order=${encodeURIComponent(nrn)}${email ? `&email=${encodeURIComponent(email)}` : ""}">Ver estado del pedido</a>
+      <button id="shareBtn" class="secondary" type="button">Compartir</button>
+      <a class="secondary" href="/index.html">Volver al inicio</a>
+    </div>
+  `;
+  document.querySelectorAll(".copy-btn").forEach((b) => setupCopy(b));
+  setupShare(nrn, tracking);
+}
+
+async function init() {
+  const id = getIdentifier();
+  if (!id) {
+    renderError("No encontramos la orden.");
+    return;
+  }
+  const { status, id: resolvedId, numeroOrden } = await pollOrderStatus(id);
+  if (status === "approved") {
+    const nrn = numeroOrden || resolvedId;
+    try {
+      const res = await fetch(`/api/orders/${encodeURIComponent(nrn)}`);
+      if (res.ok) {
+        const data = await res.json();
+        renderSuccess(data.order || { id: nrn });
+        localStorage.removeItem("mp_last_pref");
+        localStorage.removeItem("mp_last_nrn");
+        return;
+      }
+    } catch (_) {}
+    renderSuccess({ id: nrn });
+  } else if (status === "rejected") {
+    renderError("Tu pago fue rechazado.");
+  } else {
+    renderError("Estamos acreditando tu pago...");
+  }
+}
+
+document.addEventListener("DOMContentLoaded", init);

--- a/nerin_final_updated/frontend/success.html
+++ b/nerin_final_updated/frontend/success.html
@@ -2,9 +2,11 @@
 <html lang="es">
   <head>
     <meta charset="UTF-8" />
-    <title>Estado del pago</title>
-    <link rel="stylesheet" href="/css/style.css" />
-    <script src="/js/order-status.js" defer></script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pago aprobado</title>
+    <link rel="stylesheet" href="/css/success.css" />
+  </head>
+  <body>
     <noscript>
       <style>
         .noscript-msg {
@@ -18,35 +20,13 @@
         Por favor habilitá JavaScript para ver el estado de tu pago.
       </div>
     </noscript>
-  </head>
-  <body>
-    <div class="contenedor" id="statusContainer">
-      <div class="spinner"></div>
-      <p>Estamos confirmando tu pago...</p>
-    </div>
-    <script>
-      document.addEventListener('DOMContentLoaded', async () => {
-        try {
-          const id = getIdentifier();
-          showProcessing();
-          if (!id) return;
-          const { status, id: resolvedId, numeroOrden } = await pollOrderStatus(id);
-          if (status === 'approved') {
-            showApproved(numeroOrden || resolvedId);
-            localStorage.removeItem('mp_last_pref');
-            localStorage.removeItem('mp_last_nrn');
-          } else if (status === 'rejected') {
-            showRejected();
-          } else {
-            showProcessing('Estamos acreditando tu pago...');
-          }
-        } catch (e) {
-          const el = document.getElementById('statusContainer');
-          if (el) {
-            el.innerHTML = '<p>Ocurrió un problema al verificar tu pago. Intentá nuevamente más tarde.</p>';
-          }
-        }
-      });
-    </script>
+    <main class="success-container">
+      <article id="card" class="card" aria-live="polite">
+        <div class="skeleton" style="height: 3rem"></div>
+        <div class="skeleton" style="height: 6rem"></div>
+        <div class="skeleton" style="height: 4rem"></div>
+      </article>
+    </main>
+    <script type="module" src="/js/success.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- replace success page with responsive card layout
- add dedicated success styles with dark mode and copy buttons
- implement success.js to fetch order details and enable share/copy actions

## Testing
- `npx prettier frontend/success.html frontend/css/success.css frontend/js/success.js --write`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689dbe2471c4833191cc23508a4a22ce