### PR TITLE
feat(admin): add catalog metadata fields

### DIFF
--- a/nerin_final_updated/data/products.json
+++ b/nerin_final_updated/data/products.json
@@ -20,7 +20,14 @@
       "warehouseStock": {
         "central": 20,
         "buenos_aires": 5
-      }
+      },
+      "subcategory": "iPhone",
+      "tags": ["pantalla", "iphone"],
+      "slug": "pantalla-iphone-12",
+      "meta_title": "Pantalla iPhone 12",
+      "meta_description": "Repuesto original de pantalla OLED para iPhone 12",
+      "visibility": "public",
+      "featured": false
     },
     {
       "id": "2",
@@ -42,7 +49,14 @@
       "warehouseStock": {
         "central": 12,
         "buenos_aires": 6
-      }
+      },
+      "subcategory": "Samsung",
+      "tags": ["pantalla", "samsung"],
+      "slug": "pantalla-samsung-s21",
+      "meta_title": "Pantalla Samsung S21",
+      "meta_description": "Pantalla AMOLED de repuesto para Galaxy S21",
+      "visibility": "public",
+      "featured": false
     },
     {
       "id": "3",
@@ -64,7 +78,14 @@
       "warehouseStock": {
         "central": 20,
         "buenos_aires": 10
-      }
+      },
+      "subcategory": "Xiaomi",
+      "tags": ["pantalla", "xiaomi"],
+      "slug": "pantalla-xiaomi-mi-11",
+      "meta_title": "Pantalla Xiaomi Mi 11",
+      "meta_description": "Pantalla AMOLED de repuesto para Xiaomi Mi 11",
+      "visibility": "public",
+      "featured": false
     },
     {
       "id": "4",
@@ -86,7 +107,14 @@
       "warehouseStock": {
         "central": 30,
         "buenos_aires": 10
-      }
+      },
+      "subcategory": "iPhone",
+      "tags": ["bateria", "iphone"],
+      "slug": "bateria-iphone-12",
+      "meta_title": "Batería iPhone 12",
+      "meta_description": "Batería de repuesto para iPhone 12 de 2815 mAh",
+      "visibility": "public",
+      "featured": false
     },
     {
       "id": "5",
@@ -108,7 +136,14 @@
       "warehouseStock": {
         "central": 35,
         "buenos_aires": 15
-      }
+      },
+      "subcategory": "iPhone",
+      "tags": ["auricular", "iphone"],
+      "slug": "auricular-iphone-11",
+      "meta_title": "Auricular iPhone 11",
+      "meta_description": "Auricular interno de repuesto para iPhone 11",
+      "visibility": "public",
+      "featured": false
     }
   ]
 }

--- a/nerin_final_updated/frontend/admin.html
+++ b/nerin_final_updated/frontend/admin.html
@@ -95,6 +95,9 @@
                 <th>Nombre</th>
                 <th>Marca</th>
                 <th>Modelo</th>
+                <th>Categoría</th>
+                <th>Subcategoría</th>
+                <th>Tags</th>
                 <th>Stock</th>
                 <th>Mín. Stock</th>
                 <th>Precio (Min.)</th>
@@ -154,6 +157,16 @@
             required
           ></textarea>
           <input type="text" id="newCategory" placeholder="Categoría" />
+          <input type="text" id="newSubcategory" placeholder="Subcategoría" />
+          <input type="text" id="newTags" placeholder="Tags (coma separados)" />
+          <input type="text" id="newSlug" placeholder="Slug" required />
+          <input type="text" id="newMetaTitle" placeholder="Meta título" />
+          <input type="text" id="newMetaDesc" placeholder="Meta descripción" />
+          <select id="newVisibility">
+            <option value="public">Público</option>
+            <option value="hidden">Oculto</option>
+          </select>
+          <label><input type="checkbox" id="newFeatured" /> Destacado</label>
           <input
             type="number"
             id="newWeight"
@@ -296,18 +309,23 @@
       </section>
 
       <!-- Gestión de costos de envío -->
-      <section id="shippingSection" class="admin-section" style="display:none">
+      <section id="shippingSection" class="admin-section" style="display: none">
         <h3>Costos de envío</h3>
-        <div id="shippingAlert" class="alert" style="display:none"></div>
+        <div id="shippingAlert" class="alert" style="display: none"></div>
         <div class="table-wrapper">
           <table class="admin-table" id="shippingTable">
             <thead>
-              <tr><th>Provincia</th><th>Costo ($)</th></tr>
+              <tr>
+                <th>Provincia</th>
+                <th>Costo ($)</th>
+              </tr>
             </thead>
             <tbody></tbody>
           </table>
         </div>
-        <button id="saveShippingBtn" class="button primary">Guardar cambios</button>
+        <button id="saveShippingBtn" class="button primary">
+          Guardar cambios
+        </button>
       </section>
 
       <!-- Sección de proveedores -->


### PR DESCRIPTION
## Summary
- extend product data with subcategories, tags and SEO metadata
- expose new catalog fields in admin interface and render empty-state message

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689dcca8d9bc8331b2e2acec0e990050