### PR TITLE
Aumenta tamaño del logo en el encabezado

### DIFF
--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -73,7 +73,7 @@ header .logo {
 /* Estilos para el logo clickeable */
 header .logo a {
   display: block;
-  width: 32px;
+  width: 180px;
   height: 32px;
   background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAACAAAAAFlCAIAAADwZJ9dAAB1NUlEQVR4Ae3d\
 B7RdVZ0wcMhLL6QASQi9KgJCqAoIUYSQkFANMo6KODac0ZkRZXTN8luZouO3\
@@ -746,6 +746,8 @@ ECBAgAABAgQIECBAgAABAgQIECBAgEAeBf4/0aLxBKY634cAAAAASUVORK5C\
 YII=");
   background-size: contain;
   background-repeat: no-repeat;
+  background-position: center;
+  background-color: #fff;
   text-decoration: none;
 }
 


### PR DESCRIPTION
## Summary
- Amplía el ancho del logo a 180px para que se vea proporcionado con el header
- Centra el logo y establece fondo blanco para mejorar la visibilidad

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dd0f4bfc083319987c1c3dc61d4f8