### PR TITLE
fix: ensure header and logo scale on mobile

### DIFF
--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -46,7 +46,7 @@ header {
   position: sticky;
   top: 0;
   z-index: 100;
-  background-color: var(--color-bg);
+  background-color: #fff;
   border-bottom: 1px solid var(--color-border);
 }
 
@@ -77,7 +77,8 @@ header .brand {
 }
 
 header .brand .site-logo {
-  height: clamp(28px, 5vw, 40px);
+  height: clamp(28px, 6vw, 40px);
+  max-height: 56px;
   width: auto;
   object-fit: contain;
 }
@@ -645,7 +646,7 @@ nav a:hover {
     position: absolute;
     right: 1rem;
     top: 100%;
-    background: var(--color-bg);
+    background: #fff;
     border: 1px solid var(--color-border);
     border-top: none;
     width: 200px;


### PR DESCRIPTION
## Summary
- force white header background
- constrain logo height and add mobile nav background

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689df4335fb483318f6dff94376252fb