### PR TITLE
feat: redesign receipt pages

### DIFF
--- a/nerin_final_updated/frontend/css/success.css
+++ b/nerin_final_updated/frontend/css/success.css
@@ -1,0 +1,202 @@
+@import url('../style.css');
+
+body {
+  background: #fff;
+  color: var(--color-secondary);
+}
+
+.status-icon {
+  width: clamp(56px, 12vw, 96px);
+  height: clamp(56px, 12vw, 96px);
+  margin: 24px auto 0;
+  color: var(--color-success);
+}
+.status-icon svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+.status-icon .draw {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 3;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-dasharray: 64;
+  stroke-dashoffset: 64;
+  animation: draw 0.8s forwards, pop var(--transition) 0.8s;
+}
+.status-icon.pending {
+  color: #854D0E;
+}
+.status-icon.failure {
+  color: #991B1B;
+}
+
+@keyframes draw {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+@keyframes pop {
+  0% {
+    transform: scale(0.96);
+    opacity: 0;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.receipt {
+  max-width: 900px;
+  margin: 16px auto;
+  padding: 20px;
+  background: #fff;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.06);
+}
+@media (min-width: 768px) {
+  .receipt {
+    padding: 28px;
+  }
+}
+
+.receipt h1 {
+  font-size: clamp(22px, 5vw, 28px);
+  margin: 0 0 8px;
+  text-align: center;
+}
+.date {
+  text-align: center;
+  color: var(--color-muted);
+  margin-bottom: 24px;
+}
+.section {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: 16px;
+  margin-bottom: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.section h2 {
+  font-size: clamp(18px, 4.2vw, 22px);
+  margin: 0;
+}
+.order-number {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+.copy-btn {
+  background: none;
+  border: none;
+  color: var(--color-primary);
+  cursor: pointer;
+  padding: 0;
+  font-size: 1rem;
+  line-height: 1;
+}
+.copy-btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+.badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+.badge.aprobado {
+  background: #E7F9F1;
+  color: #047857;
+}
+.badge.pendiente {
+  background: #FEF9C3;
+  color: #854D0E;
+}
+.badge.rechazado {
+  background: #FEE2E2;
+  color: #991B1B;
+}
+.items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.items li {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+.items .total-line {
+  font-weight: 700;
+  margin-top: 12px;
+}
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: center;
+  margin-top: 24px;
+}
+.actions .button {
+  text-decoration: none;
+}
+.spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid var(--color-border);
+  border-top-color: var(--color-primary);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin: 0 auto;
+}
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.skeleton {
+  background: var(--color-muted);
+  height: 1rem;
+  border-radius: var(--radius);
+  margin-bottom: 12px;
+}
+.skeleton.title {
+  width: 60%;
+}
+.skeleton.block {
+  height: 80px;
+}
+.toast {
+  position: fixed;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--color-secondary);
+  color: #fff;
+  padding: 8px 12px;
+  border-radius: var(--radius);
+  opacity: 0;
+  animation: fade 0.2s forwards;
+  z-index: 1000;
+}
+@keyframes fade {
+  to {
+    opacity: 1;
+  }
+}

--- a/nerin_final_updated/frontend/failure.html
+++ b/nerin_final_updated/frontend/failure.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Pago rechazado</title>
     <link rel="stylesheet" href="style.css?v=mobfix-1" />
-    <link rel="stylesheet" href="css/receipt.css" /> <!-- nerin brand fix -->
+    <link rel="stylesheet" href="css/success.css" />
   </head>
   <body>
     <header>
@@ -24,16 +24,34 @@
         </nav>
       </div>
     </header>
-    <main class="container receipt-container">
-      <article class="receipt-card">
+    <main class="container">
+      <div class="status-icon failure" aria-hidden="true">
+        <svg viewBox="0 0 24 24" class="icon">
+          <path class="draw" d="M18 6L6 18" />
+          <path class="draw" d="M6 6l12 12" />
+        </svg>
+      </div>
+      <article class="receipt">
         <h1>Pago rechazado</h1>
-        <p>❌ Tu pago fue rechazado.</p>
+        <p class="date" id="fecha"></p>
+        <section class="section">
+          <p>Tu pago fue rechazado.</p>
+        </section>
         <div class="actions">
-          <a class="button primary" href="/checkout.html">Intentar de nuevo</a>
+          <a class="button primary" href="/seguimiento.html">Ver estado del pedido</a>
           <a class="button secondary" href="/index.html">Volver al inicio</a>
         </div>
       </article>
     </main>
     <script type="module" src="/js/config.js"></script>
+    <script>
+      document.getElementById('fecha').textContent = new Date().toLocaleString('es-AR', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit'
+      });
+    </script>
   </body>
 </html>

--- a/nerin_final_updated/frontend/js/order-status.js
+++ b/nerin_final_updated/frontend/js/order-status.js
@@ -35,7 +35,7 @@
   }
 
   function containerEl() {
-    return document.getElementById('statusContainer');
+    return document.getElementById('statusMessage');
   }
 
   function showProcessing(message = 'Estamos confirmando tu pago...') {

--- a/nerin_final_updated/frontend/pending.html
+++ b/nerin_final_updated/frontend/pending.html
@@ -5,8 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Pago pendiente</title>
     <link rel="stylesheet" href="style.css?v=mobfix-1" />
-    <link rel="stylesheet" href="css/receipt.css" /> <!-- nerin brand fix -->
-    <script src="/js/order-status.js" defer></script>
+    <link rel="stylesheet" href="css/success.css" />
   </head>
   <body>
     <header>
@@ -38,14 +37,32 @@
         Por favor habilitá JavaScript para ver el estado de tu pago.
       </div>
     </noscript>
-    <main class="container receipt-container">
-      <div class="receipt-card" id="statusContainer">
-        <div class="spinner"></div>
-        <p>Estamos confirmando tu pago...</p>
+    <main class="container">
+      <div class="status-icon pending" aria-hidden="true">
+        <svg viewBox="0 0 24 24" class="icon">
+          <circle class="draw" cx="12" cy="12" r="9" />
+          <path class="draw" d="M12 8v4l2 2" />
+        </svg>
       </div>
+      <article class="receipt" id="statusContainer">
+        <h1>Pago pendiente</h1>
+        <p class="date" id="fecha"></p>
+        <div id="statusMessage">
+          <div class="spinner"></div>
+          <p>Estamos confirmando tu pago...</p>
+        </div>
+      </article>
     </main>
     <script type="module" src="/js/config.js"></script>
+    <script src="/js/order-status.js"></script>
     <script>
+      document.getElementById('fecha').textContent = new Date().toLocaleString('es-AR', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit'
+      });
       document.addEventListener('DOMContentLoaded', async () => {
         try {
           const id = getIdentifier();
@@ -62,7 +79,7 @@
             showProcessing('Estamos acreditando tu pago...');
           }
         } catch (e) {
-          const el = document.getElementById('statusContainer');
+          const el = document.getElementById('statusMessage');
           if (el) {
             el.innerHTML = '<p>Ocurrió un problema al verificar tu pago. Intentá nuevamente más tarde.</p>';
           }

--- a/nerin_final_updated/frontend/success.html
+++ b/nerin_final_updated/frontend/success.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Pago aprobado</title>
     <link rel="stylesheet" href="style.css?v=mobfix-1" />
-    <link rel="stylesheet" href="css/receipt.css" /> <!-- nerin brand fix -->
+    <link rel="stylesheet" href="css/success.css" />
   </head>
   <body>
     <header>
@@ -37,13 +37,15 @@
         Por favor habilitá JavaScript para ver el estado de tu pago.
       </div>
     </noscript>
-    <main class="container receipt-container">
-       <article id="card" aria-live="polite">
-      <div class="receipt-card">
-        <div class="skeleton" style="height: 3rem"></div>
-        <div class="skeleton" style="height: 6rem"></div>
-        <div class="skeleton" style="height: 4rem"></div>
+    <main class="container">
+      <div id="statusIcon" class="status-icon success" aria-hidden="true">
+        <svg viewBox="0 0 24 24" class="icon">
+          <path class="draw" d="M20 6L9 17l-5-5" />
+        </svg>
       </div>
+      <article id="card" class="receipt" aria-live="polite">
+        <div class="skeleton title"></div>
+        <div class="skeleton block"></div>
       </article>
     </main>
     <script type="module" src="/js/config.js"></script>


### PR DESCRIPTION
## Summary
- revamp success, pending and failure pages with responsive receipt layout
- add animated status icons and copy/share interactions
- unify order status polling with updated markup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e5c86d004833199f29fd61a9723a3