### PR TITLE
feat(receipts): redesign order receipts with copy/share

### DIFF
--- a/nerin_final_updated/frontend/css/success.css
+++ b/nerin_final_updated/frontend/css/success.css
@@ -1,112 +1,105 @@
 @import url('../style.css');
 
 body {
-  background: #fff;
+  background: var(--color-bg);
   color: var(--color-secondary);
 }
 
-.status-icon {
-  width: clamp(56px, 12vw, 96px);
-  height: clamp(56px, 12vw, 96px);
-  margin: 24px auto 0;
+.receipt {
+  max-width: 880px;
+  margin: 24px auto;
+  padding: 0 16px;
+}
+
+.icon-hero {
+  width: 72px;
+  height: 72px;
+  margin: 0 auto 16px;
+  border-radius: 50%;
+  background: #eef2ff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   color: var(--color-success);
 }
-.status-icon svg {
-  width: 100%;
-  height: 100%;
+.icon-hero svg {
+  width: 40px;
+  height: 40px;
   display: block;
-}
-.status-icon .draw {
-  fill: none;
   stroke: currentColor;
   stroke-width: 3;
   stroke-linecap: round;
   stroke-linejoin: round;
-  stroke-dasharray: 64;
-  stroke-dashoffset: 64;
-  animation: draw 0.8s forwards, pop var(--transition) 0.8s;
+  fill: none;
 }
-.status-icon.pending {
-  color: #854D0E;
+.icon-hero.success svg .draw {
+  stroke-dasharray: 72;
+  stroke-dashoffset: 72;
+  animation: draw 0.7s forwards cubic-bezier(0.22,1,0.36,1);
 }
-.status-icon.failure {
-  color: #991B1B;
+.icon-hero.pending {
+  color: var(--color-primary);
+}
+.icon-hero.pending svg {
+  animation: rotate 1.2s linear infinite;
+}
+.icon-hero.failure {
+  color: var(--color-danger);
+}
+.icon-hero.failure svg {
+  animation: scaleIn 0.3s cubic-bezier(0.22,1,0.36,1) both;
 }
 
 @keyframes draw {
-  to {
-    stroke-dashoffset: 0;
-  }
+  to { stroke-dashoffset: 0; }
 }
-@keyframes pop {
-  0% {
-    transform: scale(0.96);
-    opacity: 0;
-  }
-  100% {
-    transform: scale(1);
-    opacity: 1;
-  }
+@keyframes rotate {
+  to { transform: rotate(360deg); }
+}
+@keyframes scaleIn {
+  0% { transform: scale(0.8); opacity: 0; }
+  100% { transform: scale(1); opacity: 1; }
 }
 
-.receipt {
-  max-width: 900px;
-  margin: 16px auto;
-  padding: 20px;
-  background: #fff;
+.receipt-card {
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
-  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.06);
+  background: var(--color-bg);
+  box-shadow: 0 6px 24px rgba(0,0,0,0.06);
+  padding: 20px;
+  margin-top: 16px;
 }
 @media (min-width: 768px) {
-  .receipt {
-    padding: 28px;
-  }
+  .receipt-card { padding: 28px; }
 }
 
-.receipt h1 {
-  font-size: clamp(22px, 5vw, 28px);
-  margin: 0 0 8px;
-  text-align: center;
+.receipt-card h2 {
+  margin-top: 0;
+  font-size: 1.25rem;
 }
-.date {
-  text-align: center;
-  color: var(--color-muted);
-  margin-bottom: 24px;
-}
-.section {
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius);
-  padding: 16px;
-  margin-bottom: 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-.section h2 {
-  font-size: clamp(18px, 4.2vw, 22px);
-  margin: 0;
-}
-.order-number {
+
+.receipt-row {
   display: flex;
   align-items: center;
-  gap: 4px;
+  justify-content: space-between;
+  gap: 8px;
   word-break: break-word;
   overflow-wrap: anywhere;
 }
-.copy-btn {
-  background: none;
-  border: none;
-  color: var(--color-primary);
-  cursor: pointer;
+
+.items {
+  list-style: none;
+  margin: 16px 0 0;
   padding: 0;
-  font-size: 1rem;
-  line-height: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
-.copy-btn:focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
+.items .total-line {
+  font-weight: 700;
+  margin-top: 12px;
 }
+
 .badge {
   display: inline-block;
   padding: 2px 8px;
@@ -116,72 +109,50 @@ body {
   text-transform: capitalize;
 }
 .badge.aprobado {
-  background: #E7F9F1;
-  color: #047857;
+  background: #e7f9f1;
+  color: var(--color-success);
 }
 .badge.pendiente {
-  background: #FEF9C3;
-  color: #854D0E;
+  background: #fef9c3;
+  color: #854d0e;
 }
 .badge.rechazado {
-  background: #FEE2E2;
-  color: #991B1B;
+  background: #fee2e2;
+  color: var(--color-danger);
 }
-.items {
-  list-style: none;
-  margin: 0;
+
+.copy-btn {
+  background: none;
+  border: none;
+  color: var(--color-primary);
+  cursor: pointer;
   padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
+  display: inline-flex;
+  line-height: 1;
 }
-.items li {
-  display: flex;
-  justify-content: space-between;
-  gap: 8px;
-  word-break: break-word;
-  overflow-wrap: anywhere;
+.copy-btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
-.items .total-line {
-  font-weight: 700;
-  margin-top: 12px;
-}
-.actions {
+
+.receipt-actions {
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
   justify-content: center;
   margin-top: 24px;
 }
-.actions .button {
-  text-decoration: none;
+
+.date {
+  text-align: center;
+  color: var(--color-muted);
+  margin-bottom: 16px;
 }
-.spinner {
-  width: 32px;
-  height: 32px;
-  border: 3px solid var(--color-border);
-  border-top-color: var(--color-primary);
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
-  margin: 0 auto;
+.guide {
+  text-align: center;
+  margin-bottom: 16px;
 }
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-.skeleton {
-  background: var(--color-muted);
-  height: 1rem;
-  border-radius: var(--radius);
-  margin-bottom: 12px;
-}
-.skeleton.title {
-  width: 60%;
-}
-.skeleton.block {
-  height: 80px;
-}
+
 .toast {
   position: fixed;
   bottom: 16px;
@@ -192,11 +163,34 @@ body {
   padding: 8px 12px;
   border-radius: var(--radius);
   opacity: 0;
-  animation: fade 0.2s forwards;
+  animation: fadein 0.2s forwards;
   z-index: 1000;
 }
-@keyframes fade {
-  to {
-    opacity: 1;
+@keyframes fadein {
+  to { opacity: 1; }
+}
+
+.skeleton {
+  background: var(--color-muted);
+  border-radius: var(--radius);
+  margin: 0 auto 12px;
+}
+.skeleton.hero {
+  width: 72px;
+  height: 72px;
+}
+.skeleton.title {
+  width: 60%;
+  height: 24px;
+}
+.skeleton.block {
+  height: 80px;
+}
+
+@media (min-width: 1024px) {
+  .receipt-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 24px;
   }
 }

--- a/nerin_final_updated/frontend/failure.html
+++ b/nerin_final_updated/frontend/failure.html
@@ -25,21 +25,21 @@
       </div>
     </header>
     <main class="container">
-      <div class="status-icon failure" aria-hidden="true">
-        <svg viewBox="0 0 24 24" class="icon">
-          <path class="draw" d="M18 6L6 18" />
-          <path class="draw" d="M6 6l12 12" />
-        </svg>
-      </div>
-      <article class="receipt">
+      <article class="receipt" aria-live="polite">
+        <div class="icon-hero failure" aria-hidden="true">
+          <svg viewBox="0 0 24 24">
+            <path d="M18 6L6 18" />
+            <path d="M6 6l12 12" />
+          </svg>
+        </div>
         <h1>Pago rechazado</h1>
         <p class="date" id="fecha"></p>
-        <section class="section">
-          <p>Tu pago fue rechazado.</p>
-        </section>
-        <div class="actions">
-          <a class="button primary" href="/seguimiento.html">Ver estado del pedido</a>
-          <a class="button secondary" href="/index.html">Volver al inicio</a>
+        <div class="receipt-card">
+          <p>Tu pago no pudo procesarse. Podés intentar nuevamente o comunicarte con nosotros.</p>
+        </div>
+        <div class="receipt-actions">
+          <a class="button primary" href="/checkout.html">Reintentar</a>
+          <a class="button secondary" id="whatsLink" target="_blank">Contactar por WhatsApp</a>
         </div>
       </article>
     </main>
@@ -51,6 +51,14 @@
         year: 'numeric',
         hour: '2-digit',
         minute: '2-digit'
+      });
+      document.addEventListener('DOMContentLoaded', () => {
+        const cfg = window.NERIN_CONFIG || {};
+        const wa = document.getElementById('whatsLink');
+        if (wa) {
+          const phone = (cfg.whatsappNumber || '').replace(/[^0-9]/g, '');
+          wa.href = phone ? `https://wa.me/${phone}` : '#';
+        }
       });
     </script>
   </body>

--- a/nerin_final_updated/frontend/js/order-status.js
+++ b/nerin_final_updated/frontend/js/order-status.js
@@ -6,8 +6,10 @@
       params.get('pref_id') ||
       params.get('o') ||
       params.get('order') ||
+      params.get('nrn') ||
       params.get('external_reference') ||
       params.get('collection_id') ||
+      localStorage.getItem('nerin.lastNRN') ||
       localStorage.getItem('mp_last_pref') ||
       localStorage.getItem('mp_last_nrn');
     return id || null;
@@ -59,4 +61,13 @@
   window.showProcessing = showProcessing;
   window.showApproved = showApproved;
   window.showRejected = showRejected;
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const email = localStorage.getItem('nerin.lastEmail');
+    const nrn = localStorage.getItem('nerin.lastNRN');
+    const emailInput = document.getElementById('email');
+    const orderInput = document.getElementById('orderId');
+    if (email && emailInput && !emailInput.value) emailInput.value = email;
+    if (nrn && orderInput && !orderInput.value) orderInput.value = nrn;
+  });
 })();

--- a/nerin_final_updated/frontend/js/success.js
+++ b/nerin_final_updated/frontend/js/success.js
@@ -1,121 +1,206 @@
-const card = document.getElementById('card');
+const receipt = document.getElementById('card');
 
 function showToast(message) {
   const t = document.createElement('div');
   t.className = 'toast';
   t.setAttribute('role', 'status');
-  t.setAttribute('aria-live', 'polite');
   t.textContent = message;
   document.body.appendChild(t);
-  setTimeout(() => t.remove(), 1500);
+  setTimeout(() => t.remove(), 1600);
 }
 
-function getIdentifier() {
-  const params = new URLSearchParams(location.search);
+function getNRN() {
+  const p = new URLSearchParams(location.search);
   return (
-    params.get('nrn') ||
-    params.get('order') ||
-    params.get('o') ||
-    params.get('external_reference') ||
+    p.get('nrn') ||
+    p.get('order') ||
+    p.get('o') ||
+    p.get('external_reference') ||
+    localStorage.getItem('nerin.lastNRN') ||
     localStorage.getItem('mp_last_nrn') ||
     localStorage.getItem('mp_last_pref')
   );
 }
 
-const fmt = (n) => new Intl.NumberFormat('es-AR', { minimumFractionDigits: 2 }).format(n ?? 0);
-
-async function init() {
-  const id = getIdentifier();
-  if (!id) {
-    card.innerHTML = '<p>No encontramos la orden.</p>';
-    return;
-  }
-  let order;
-  try {
-    const res = await fetch(`/api/orders/${encodeURIComponent(id)}`);
-    if (res.ok) {
-      const data = await res.json();
-      order = data.order;
-    }
-  } catch (e) {}
-  order = order || { numeroOrden: id, payment_status: 'aprobado', items: [], total: 0 };
-  render(order);
-  localStorage.removeItem('mp_last_pref');
-  localStorage.removeItem('mp_last_nrn');
+function resolveTotal(order = {}, payment = {}, merchant = {}, items = []) {
+  const sum = items.reduce(
+    (s, i) => s + ((i.unit_price ?? i.price ?? 0) * (i.quantity ?? 1)),
+    0
+  );
+  return (
+    order.total ??
+    order.totalAmount ??
+    payment.transaction_amount ??
+    merchant.paid_amount ??
+    sum
+  );
 }
 
-function render(order) {
+function mapData(data = {}, fallbackId) {
+  const order = data.order || {};
+  const payment = data.payment || {};
+  const merchant = data.merchant_order || {};
+  const preference = data.preference || {};
+  const items = order.items || preference.items || [];
+  const nrn =
+    order.external_reference ||
+    payment.external_reference ||
+    order.numeroOrden ||
+    fallbackId;
+  const statusRaw = String(
+    payment.status || order.paymentStatus || order.payment_status || ''
+  ).toLowerCase();
+  let status = 'pendiente';
+  if (['approved', 'aprobado', 'pagado'].includes(statusRaw)) status = 'aprobado';
+  else if (['rejected', 'rechazado'].includes(statusRaw)) status = 'rechazado';
+  const total = resolveTotal(order, payment, merchant, items);
+  const tracking =
+    order.tracking_number || order.tracking || order.seguimiento || '';
+  const email =
+    order.cliente?.email || order.buyer?.email || order.email || null;
   const fecha = new Date(order.created_at || order.fecha || Date.now());
-  const estado = order.payment_status || order.estado_pago || 'aprobado';
-  const tracking = order.tracking_number || order.seguimiento || '';
-  const items = order.items || [];
+  return { nrn, items, status, total, tracking, email, fecha };
+}
+
+const currency = new Intl.NumberFormat('es-AR', {
+  style: 'currency',
+  currency: 'ARS'
+});
+
+function render(info) {
+  const { nrn, items, status, total, tracking, fecha } = info;
+  const statusClass = status;
+  const title =
+    status === 'aprobado'
+      ? 'Pago aprobado'
+      : status === 'rechazado'
+      ? 'Pago rechazado'
+      : 'Pago en revisión';
+  const guide =
+    status === 'pendiente'
+      ? '<p class="guide">Te avisamos por email. Podés seguir el estado con tu número de pedido.</p>'
+      : '';
   const itemsHtml = items
-    .map((i) => `<li><span>${i.name} x${i.quantity}</span><span>$ ${fmt(i.price)}</span></li>`)
+    .map(
+      (i) =>
+        `<li class="receipt-row"><span>${
+          i.title || i.name || ''
+        } x${i.quantity || 1}</span><span>${currency.format(
+          i.unit_price ?? i.price ?? 0
+        )}</span></li>`
+    )
     .join('');
-  const badge =
-    estado === 'rechazado' ? 'rechazado' : estado === 'pendiente' ? 'pendiente' : 'aprobado';
-  card.innerHTML = `
-    <h1>Pago ${badge === 'aprobado' ? 'aprobado' : badge === 'pendiente' ? 'pendiente' : 'rechazado'}</h1>
-    <p class="date" id="fecha"></p>
-    <section class="section">
-      <h2>Tu pedido</h2>
-      <p class="order-number">Nº de pedido: <span id="orderNumber">${order.numeroOrden}</span><button id="copyBtn" class="copy-btn" aria-label="Copiar número de pedido">📋</button></p>
-      <p>Estado de pago: <span class="badge ${badge}">${estado}</span></p>
-      <ul class="items">
-        ${itemsHtml}
-        <li class="total-line"><span>Total</span><span id="total"></span></li>
-      </ul>
-    </section>
-    <section class="section">
-      <h2>Seguimiento</h2>
+  const totalDisplay =
+    total > 0
+      ? currency.format(total)
+      : '<span class="badge pendiente">Total no disponible</span>';
+  if (!(total > 0)) console.warn('Total no disponible para pedido', nrn);
+  const trackingHtml = tracking
+    ? `<p class="receipt-row"><span id="track">${tracking}</span><button class="copy-btn" data-copy="${tracking}" aria-label="Copiar número de seguimiento">📋</button></p>`
+    : '<p>Aún sin número de envío</p>';
+  receipt.innerHTML = `
+    <div class="icon-hero ${statusClass}" aria-hidden="true">
       ${
-        tracking
-          ? `<p class="order-number"><span id="track">${tracking}</span><button id="copyTrack" class="copy-btn" aria-label="Copiar número de seguimiento">📋</button></p>`
-          : '<p>Aún sin número de envío</p>'
+        status === 'aprobado'
+          ? '<svg viewBox="0 0 24 24"><path class="draw" d="M20 6L9 17l-5-5"/></svg>'
+          : status === 'pendiente'
+          ? '<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 8v4l2 2"/></svg>'
+          : '<svg viewBox="0 0 24 24"><path d="M18 6L6 18"/><path d="M6 6l12 12"/></svg>'
       }
-    </section>
-    <div class="actions">
-      <a class="button primary" id="trackLink" href="/seguimiento.html?order=${encodeURIComponent(order.numeroOrden)}">Ver estado del pedido</a>
+    </div>
+    <h1>${title}</h1>
+    <p class="date">${fecha.toLocaleString('es-AR', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    })}</p>
+    ${guide}
+    <div class="receipt-grid">
+      <div class="receipt-card">
+        <h2>Tu pedido</h2>
+        <p class="receipt-row">Nº de pedido <span id="orderNumber">${nrn}</span><button class="copy-btn" data-copy="${nrn}" aria-label="Copiar número de pedido">📋</button></p>
+        <p class="receipt-row">Estado de pago: <span class="badge ${statusClass}">${status}</span></p>
+        <ul class="items">
+          ${itemsHtml}
+          <li class="receipt-row total-line"><span>Total</span><span id="total">${totalDisplay}</span></li>
+        </ul>
+      </div>
+      <div class="receipt-card">
+        <h2>Seguimiento</h2>
+        ${trackingHtml}
+      </div>
+    </div>
+    <div class="receipt-actions">
+      <a class="button primary" id="trackLink" href="/seguimiento.html">Ver estado del pedido</a>
       <button class="button secondary" id="shareBtn" type="button">Compartir</button>
       <a class="button secondary" href="/index.html">Volver al inicio</a>
     </div>
   `;
-  document.getElementById('fecha').textContent = fecha.toLocaleString('es-AR', {
-    day: '2-digit',
-    month: '2-digit',
-    year: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit'
+  attachHandlers();
+}
+
+function attachHandlers() {
+  document.querySelectorAll('.copy-btn').forEach((btn) => {
+    btn.addEventListener('click', async () => {
+      try {
+        await navigator.clipboard.writeText(btn.dataset.copy || '');
+        showToast('Copiado');
+      } catch (_) {}
+    });
   });
-  document.getElementById('total').textContent = `$ ${fmt(order.total)}`;
-  const copyBtn = document.getElementById('copyBtn');
-  copyBtn.addEventListener('click', async () => {
-    await navigator.clipboard.writeText(order.numeroOrden);
-    showToast('Copiado');
-  });
-  const copyTrack = document.getElementById('copyTrack');
-  if (copyTrack) {
-    copyTrack.addEventListener('click', async () => {
-      await navigator.clipboard.writeText(tracking);
-      showToast('Copiado');
+  const shareBtn = document.getElementById('shareBtn');
+  if (shareBtn) {
+    shareBtn.addEventListener('click', async () => {
+      const url = location.href;
+      try {
+        if (navigator.share) {
+          await navigator.share({ title: 'Mi pedido NERIN', url });
+        } else {
+          await navigator.clipboard.writeText(url);
+          showToast('Enlace copiado');
+        }
+      } catch (_) {}
     });
   }
-  const shareBtn = document.getElementById('shareBtn');
-  shareBtn.addEventListener('click', async () => {
-    const shareData = {
-      title: `Pedido NERIN ${order.numeroOrden}`,
-      text: `Estado: ${estado} – Total: $ ${fmt(order.total)}`,
-      url: location.href
-    };
-    try {
-      if (navigator.share) {
-        await navigator.share(shareData);
-      } else {
-        await navigator.clipboard.writeText(shareData.url);
-        showToast('Enlace copiado');
-      }
-    } catch (e) {}
-  });
+}
+
+function persist(info) {
+  if (info.nrn) localStorage.setItem('nerin.lastNRN', info.nrn);
+  let email = info.email || localStorage.getItem('nerin.lastEmail');
+  if (!email) {
+    const tmp = prompt('Ingresá tu email para seguimiento');
+    if (tmp) email = tmp.trim();
+  }
+  if (email) {
+    localStorage.setItem('nerin.lastEmail', email);
+  }
+  const link = document.getElementById('trackLink');
+  if (link && info.nrn) {
+    const qs = new URLSearchParams();
+    qs.set('order', info.nrn);
+    if (email) qs.set('email', email);
+    link.href = `/seguimiento.html?${qs.toString()}`;
+  }
+}
+
+async function init() {
+  const id = getNRN();
+  if (!id) {
+    receipt.innerHTML = '<p>No encontramos la orden.</p>';
+    return;
+  }
+  let data = {};
+  try {
+    const res = await fetch(`/api/orders/${encodeURIComponent(id)}`);
+    if (res.ok) data = await res.json();
+  } catch (_) {}
+  const info = mapData(data, id);
+  render(info);
+  persist(info);
+  localStorage.removeItem('mp_last_pref');
+  localStorage.removeItem('mp_last_nrn');
 }
 
 document.addEventListener('DOMContentLoaded', init);

--- a/nerin_final_updated/frontend/pending.html
+++ b/nerin_final_updated/frontend/pending.html
@@ -38,51 +38,28 @@
       </div>
     </noscript>
     <main class="container">
-      <div class="status-icon pending" aria-hidden="true">
-        <svg viewBox="0 0 24 24" class="icon">
-          <circle class="draw" cx="12" cy="12" r="9" />
-          <path class="draw" d="M12 8v4l2 2" />
-        </svg>
-      </div>
-      <article class="receipt" id="statusContainer">
-        <h1>Pago pendiente</h1>
-        <p class="date" id="fecha"></p>
-        <div id="statusMessage">
-          <div class="spinner"></div>
-          <p>Estamos confirmando tu pago...</p>
-        </div>
+      <article id="card" class="receipt" aria-live="polite">
+        <div class="skeleton hero"></div>
+        <div class="skeleton title"></div>
+        <div class="skeleton block"></div>
       </article>
     </main>
     <script type="module" src="/js/config.js"></script>
     <script src="/js/order-status.js"></script>
+    <script type="module" src="/js/success.js"></script>
     <script>
-      document.getElementById('fecha').textContent = new Date().toLocaleString('es-AR', {
-        day: '2-digit',
-        month: '2-digit',
-        year: 'numeric',
-        hour: '2-digit',
-        minute: '2-digit'
-      });
       document.addEventListener('DOMContentLoaded', async () => {
         try {
           const id = getIdentifier();
-          showProcessing();
           if (!id) return;
           const { status, id: resolvedId, numeroOrden } = await pollOrderStatus(id);
           if (status === 'approved') {
             showApproved(numeroOrden || resolvedId);
-            localStorage.removeItem('mp_last_pref');
-            localStorage.removeItem('mp_last_nrn');
           } else if (status === 'rejected') {
             showRejected();
-          } else {
-            showProcessing('Estamos acreditando tu pago...');
           }
         } catch (e) {
-          const el = document.getElementById('statusMessage');
-          if (el) {
-            el.innerHTML = '<p>Ocurrió un problema al verificar tu pago. Intentá nuevamente más tarde.</p>';
-          }
+          // silent
         }
       });
     </script>

--- a/nerin_final_updated/frontend/success.html
+++ b/nerin_final_updated/frontend/success.html
@@ -38,12 +38,8 @@
       </div>
     </noscript>
     <main class="container">
-      <div id="statusIcon" class="status-icon success" aria-hidden="true">
-        <svg viewBox="0 0 24 24" class="icon">
-          <path class="draw" d="M20 6L9 17l-5-5" />
-        </svg>
-      </div>
       <article id="card" class="receipt" aria-live="polite">
+        <div class="skeleton hero"></div>
         <div class="skeleton title"></div>
         <div class="skeleton block"></div>
       </article>


### PR DESCRIPTION
## Summary
- redesign success, pending and failure receipts with animated hero icons and responsive cards
- show order details with copy/share buttons and persist NRN/email for tracking
- preload stored email/NRN in order status flow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e8a0130508331ab1c967d2f7e099d