### PR TITLE
Fix inventory updates on Mercado Pago webhook

### DIFF
--- a/nerin_final_updated/backend/index.js
+++ b/nerin_final_updated/backend/index.js
@@ -239,7 +239,7 @@ app.post("/api/orders", async (req, res) => {
       total,
       preference_id: preferenceId,
       external_reference: id,
-      inventory_applied: false,
+      inventoryApplied: false,
     };
     const orders = getOrders();
     orders.push(order);


### PR DESCRIPTION
## Summary
- map cart items to product IDs and SKUs when creating MP preferences
- add idempotent inventory service with apply and revert helpers
- update Mercado Pago webhook to apply or revert inventory once per order

## Testing
- `npm test`
- `node -e "const inv=require('./nerin_final_updated/backend/services/inventory');inv.applyInventoryForOrder({id:'ORD-mdhdukaj-508'});"`
- `node -e "const inv=require('./nerin_final_updated/backend/services/inventory');inv.applyInventoryForOrder({id:'ORD-mdhdukaj-508'});"`
- `node -e "const inv=require('./nerin_final_updated/backend/services/inventory');inv.revertInventoryForOrder({id:'ORD-mdhdukaj-508'});"`


------
https://chatgpt.com/codex/tasks/task_e_689f16eadbe0833190a9e02181f0d623