### PR TITLE
feat: enable postgres persistence

### DIFF
--- a/nerin_final_updated/backend/data/configRepo.js
+++ b/nerin_final_updated/backend/data/configRepo.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const db = require('../db');
+
+const filePath = path.join(__dirname, '../../data/config.json');
+
+async function get() {
+  const pool = db.getPool();
+  if (!pool) {
+    try {
+      return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    } catch {
+      return {};
+    }
+  }
+  const { rows } = await pool.query('SELECT value FROM config WHERE key=$1', ['general']);
+  return rows[0] ? rows[0].value : {};
+}
+
+async function save(cfg) {
+  const pool = db.getPool();
+  if (!pool) {
+    fs.writeFileSync(filePath, JSON.stringify(cfg, null, 2), 'utf8');
+    return;
+  }
+  await pool.query(
+    'INSERT INTO config(key, value) VALUES ($1, $2::jsonb) ON CONFLICT (key) DO UPDATE SET value=EXCLUDED.value',
+    ['general', JSON.stringify(cfg)]
+  );
+}
+
+module.exports = { get, save };

--- a/nerin_final_updated/backend/data/ordersRepo.js
+++ b/nerin_final_updated/backend/data/ordersRepo.js
@@ -14,7 +14,9 @@ async function getAll() {
       return [];
     }
   }
-  const { rows } = await pool.query('SELECT * FROM orders ORDER BY created_at DESC');
+  const { rows } = await pool.query(
+    'SELECT id, nrn, preference_id, email, status, total, inventory_applied, created_at, updated_at FROM orders ORDER BY created_at DESC'
+  );
   return rows;
 }
 
@@ -24,7 +26,10 @@ async function getById(id) {
     const orders = await getAll();
     return orders.find((o) => String(o.id) === String(id)) || null;
   }
-  const { rows } = await pool.query('SELECT * FROM orders WHERE id=$1', [id]);
+  const { rows } = await pool.query(
+    'SELECT id, nrn, preference_id, email, status, total, inventory_applied, created_at, updated_at FROM orders WHERE id=$1',
+    [id]
+  );
   if (!rows[0]) return null;
   const order = rows[0];
   const items = await pool.query(
@@ -45,13 +50,24 @@ async function saveAll(orders) {
   try {
     for (const o of orders) {
       await pool.query(
-        `INSERT INTO orders (id, created_at, customer_email, status, total)
-         VALUES ($1,$2,$3,$4,$5)
+        `INSERT INTO orders (id, nrn, preference_id, email, status, total, created_at, updated_at)
+         VALUES ($1,$2,$3,$4,$5,$6,COALESCE($7,now()),now())
          ON CONFLICT (id) DO UPDATE SET
-           customer_email=EXCLUDED.customer_email,
+           nrn=EXCLUDED.nrn,
+           preference_id=EXCLUDED.preference_id,
+           email=EXCLUDED.email,
            status=EXCLUDED.status,
-           total=EXCLUDED.total`,
-        [o.id, o.created_at || new Date(), o.customer_email || null, o.status || 'pendiente', o.total || 0]
+           total=EXCLUDED.total,
+           updated_at=now()` ,
+        [
+          o.id,
+          o.nrn || null,
+          o.preference_id || null,
+          o.email || o.customer_email || null,
+          o.status || 'pendiente',
+          o.total || 0,
+          o.created_at || null,
+        ]
       );
     }
     await pool.query('COMMIT');
@@ -72,8 +88,15 @@ async function create(order) {
   await pool.query('BEGIN');
   try {
     await pool.query(
-      'INSERT INTO orders (id, created_at, customer_email, status, total) VALUES ($1, now(), $2, $3, $4)',
-      [order.id, order.customer_email || null, order.status || 'pendiente', order.total || 0]
+      'INSERT INTO orders (id, nrn, preference_id, email, status, total, created_at, updated_at) VALUES ($1,$2,$3,$4,$5,$6,now(),now())',
+      [
+        order.id,
+        order.nrn || null,
+        order.preference_id || null,
+        order.email || order.customer_email || null,
+        order.status || 'pendiente',
+        order.total || 0,
+      ]
     );
     for (const it of order.items || []) {
       await pool.query(
@@ -89,8 +112,9 @@ async function create(order) {
   }
 }
 
-async function createOrder({ id, customer_email, items }) {
+async function createOrder({ id, email, customer_email, items, preference_id, nrn }) {
   const pool = db.getPool();
+  const mail = email || customer_email || null;
   const total = (items || []).reduce(
     (t, it) => t + Number(it.price) * Number(it.qty || it.quantity || 0),
     0
@@ -101,7 +125,7 @@ async function createOrder({ id, customer_email, items }) {
     if (existing) return existing;
     const order = {
       id,
-      customer_email,
+      email: mail,
       status: 'approved',
       total,
       created_at: new Date().toISOString(),
@@ -112,34 +136,29 @@ async function createOrder({ id, customer_email, items }) {
     for (const it of items || []) {
       const pid = it.product_id || it.id || it.productId;
       const qty = Number(it.qty || it.quantity || 0);
-      if (pid && qty) {
-        await productsRepo.adjustStock(pid, -qty, 'order', id);
-      }
+      if (pid && qty) await productsRepo.adjustStock(pid, -qty, 'order', id);
     }
     return order;
   }
   await pool.query('BEGIN');
   try {
-    // Upsert primero, para evitar doble inserción en concurrencia
     await pool.query(
-      'INSERT INTO orders (id, created_at, customer_email, status, total, inventory_applied) ' +
-      'VALUES ($1, now(), $2, $3, $4, false) ' +
-      'ON CONFLICT (id) DO NOTHING',
-      [id, customer_email || null, 'approved', total]
+      'INSERT INTO orders (id, nrn, preference_id, email, status, total, inventory_applied, created_at, updated_at) ' +
+        'VALUES ($1,$2,$3,$4,$5,$6,false,now(),now()) ON CONFLICT (id) DO NOTHING',
+      [id, nrn || null, preference_id || null, mail, 'approved', total]
     );
-    // Ahora si: tomar lock de la fila
     const { rows } = await pool.query(
       'SELECT inventory_applied FROM orders WHERE id=$1 FOR UPDATE',
       [id]
     );
-    const alreadyApplied = !!(rows[0] && rows[0].inventory_applied);
-    if (alreadyApplied) {
+    const already = rows[0] && rows[0].inventory_applied;
+    if (already) {
       await pool.query(
-        'UPDATE orders SET customer_email=COALESCE($2, customer_email), total=$3 WHERE id=$1',
-        [id, customer_email || null, total]
+        'UPDATE orders SET email=COALESCE($2,email), total=$3, updated_at=now() WHERE id=$1',
+        [id, mail, total]
       );
       await pool.query('COMMIT');
-      return { id, customer_email, status: 'approved', total };
+      return { id, email: mail, status: 'approved', total };
     }
     for (const it of items || []) {
       const pid = it.product_id || it.id || it.productId;
@@ -155,16 +174,16 @@ async function createOrder({ id, customer_email, items }) {
         [qty, pid]
       );
       await pool.query(
-        'INSERT INTO stock_movements(product_id, delta, reason, ref_id) VALUES ($1,$2,$3,$4)',
-        [pid, -qty, 'order', id]
+        'INSERT INTO stock_movements(id, product_id, qty, reason, order_id) VALUES ($1,$2,$3,$4,$5)',
+        [require('crypto').randomUUID(), pid, -qty, 'order', id]
       );
     }
     await pool.query(
-      'UPDATE orders SET inventory_applied=true, customer_email=COALESCE($2, customer_email), total=$3 WHERE id=$1',
-      [id, customer_email || null, total]
+      'UPDATE orders SET inventory_applied=true, email=COALESCE($2,email), total=$3, updated_at=now() WHERE id=$1',
+      [id, mail, total]
     );
     await pool.query('COMMIT');
-    return { id, customer_email, status: 'approved', total };
+    return { id, email: mail, status: 'approved', total };
   } catch (e) {
     await pool.query('ROLLBACK');
     throw e;
@@ -173,14 +192,14 @@ async function createOrder({ id, customer_email, items }) {
 
 async function markInventoryApplied(id) {
   const pool = db.getPool();
-  if (!pool) return; // JSON mode not used
-  await pool.query('UPDATE orders SET inventory_applied = true WHERE id=$1', [id]);
+  if (!pool) return;
+  await pool.query('UPDATE orders SET inventory_applied=true, updated_at=now() WHERE id=$1', [id]);
 }
 
 async function clearInventoryApplied(id) {
   const pool = db.getPool();
   if (!pool) return;
-  await pool.query('UPDATE orders SET inventory_applied=false WHERE id=$1', [id]);
+  await pool.query('UPDATE orders SET inventory_applied=false, updated_at=now() WHERE id=$1', [id]);
 }
 
 module.exports = {

--- a/nerin_final_updated/backend/db/migrate.js
+++ b/nerin_final_updated/backend/db/migrate.js
@@ -1,0 +1,74 @@
+const { Pool } = require('pg');
+
+async function run() {
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    console.error('DATABASE_URL not set');
+    process.exit(1);
+  }
+  const pool = new Pool({
+    connectionString: url,
+    ssl: process.env.PGSSLMODE === 'require' ? { rejectUnauthorized: false } : undefined,
+  });
+
+  const queries = [
+    `CREATE TABLE IF NOT EXISTS products (
+      id TEXT PRIMARY KEY,
+      name TEXT,
+      price NUMERIC,
+      stock INT,
+      sku TEXT,
+      category TEXT,
+      created_at TIMESTAMPTZ DEFAULT now(),
+      updated_at TIMESTAMPTZ DEFAULT now()
+    )`,
+    `CREATE INDEX IF NOT EXISTS idx_products_sku ON products(sku)` ,
+    `CREATE TABLE IF NOT EXISTS orders (
+      id TEXT PRIMARY KEY,
+      nrn TEXT,
+      preference_id TEXT,
+      email TEXT,
+      status TEXT,
+      total NUMERIC,
+      inventory_applied BOOLEAN DEFAULT FALSE,
+      created_at TIMESTAMPTZ DEFAULT now(),
+      updated_at TIMESTAMPTZ DEFAULT now()
+    )`,
+    `CREATE INDEX IF NOT EXISTS idx_orders_email ON orders(email)`,
+    `CREATE TABLE IF NOT EXISTS order_items (
+      order_id TEXT REFERENCES orders(id),
+      product_id TEXT REFERENCES products(id),
+      qty INT,
+      price NUMERIC,
+      PRIMARY KEY(order_id, product_id)
+    )`,
+    `CREATE TABLE IF NOT EXISTS stock_movements (
+      id TEXT PRIMARY KEY,
+      product_id TEXT REFERENCES products(id),
+      qty INT,
+      reason TEXT,
+      order_id TEXT REFERENCES orders(id),
+      created_at TIMESTAMPTZ DEFAULT now()
+    )`,
+    `CREATE INDEX IF NOT EXISTS idx_stock_movements_product ON stock_movements(product_id)`,
+    `CREATE TABLE IF NOT EXISTS price_changes (
+      id TEXT PRIMARY KEY,
+      product_id TEXT REFERENCES products(id),
+      old_price NUMERIC,
+      new_price NUMERIC,
+      created_at TIMESTAMPTZ DEFAULT now()
+    )`,
+    `CREATE INDEX IF NOT EXISTS idx_price_changes_product ON price_changes(product_id)`
+  ];
+
+  for (const q of queries) {
+    await pool.query(q);
+  }
+
+  await pool.end();
+}
+
+run().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/nerin_final_updated/backend/db/seed-from-json.js
+++ b/nerin_final_updated/backend/db/seed-from-json.js
@@ -1,0 +1,46 @@
+const { Pool } = require('pg');
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+async function run() {
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    console.error('DATABASE_URL not set');
+    process.exit(1);
+  }
+  const pool = new Pool({
+    connectionString: url,
+    ssl: process.env.PGSSLMODE === 'require' ? { rejectUnauthorized: false } : undefined,
+  });
+
+  await pool.query('CREATE TABLE IF NOT EXISTS config (key TEXT PRIMARY KEY, value JSONB)');
+
+  const { rows } = await pool.query('SELECT COUNT(*) FROM products');
+  if (Number(rows[0].count) === 0) {
+    const seedPath = fs.existsSync(path.join(__dirname, '../../data/products.seed.json'))
+      ? path.join(__dirname, '../../data/products.seed.json')
+      : path.join(__dirname, '../../data/products.json');
+    const raw = JSON.parse(fs.readFileSync(seedPath, 'utf8'));
+    const list = Array.isArray(raw) ? raw : raw.products || [];
+    for (const p of list) {
+      const price = p.price != null ? p.price : p.price_minorista || 0;
+      await pool.query(
+        'INSERT INTO products(id, name, price, stock, sku, category) VALUES ($1,$2,$3,$4,$5,$6)',
+        [String(p.id || crypto.randomUUID()), p.name || '', price, p.stock || 0, p.sku || null, p.category || null]
+      );
+    }
+  }
+
+  const cfg = await pool.query('SELECT COUNT(*) FROM config');
+  if (Number(cfg.rows[0].count) === 0) {
+    await pool.query('INSERT INTO config(key, value) VALUES ($1, $2::jsonb)', ['general', JSON.stringify({})]);
+  }
+
+  await pool.end();
+}
+
+run().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/nerin_final_updated/backend/routes/mercadoPago.js
+++ b/nerin_final_updated/backend/routes/mercadoPago.js
@@ -121,8 +121,10 @@ async function upsertOrder({
     if (db.getPool()) {
       await ordersRepo.createOrder({
         id: row.external_reference || row.id,
-        customer_email: row.cliente?.email || null,
+        email: row.cliente?.email || row.email || null,
         items: row.productos || row.items || [],
+        preference_id: row.preference_id || prefId || null,
+        nrn: row.nrn || row.order_number || row.external_reference || null,
       });
     } else if (!inventoryApplied) {
       await applyInventoryForOrder(row);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "start": "node backend/server.js",
     "test": "jest",
-    "list:webhooks": "node scripts/listMpWebhooks.js"
+    "list:webhooks": "node scripts/listMpWebhooks.js",
+    "migrate": "node nerin_final_updated/backend/db/migrate.js",
+    "seed": "node nerin_final_updated/backend/db/seed-from-json.js"
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary
- add `/api/health/db` and `/api/config` endpoints
- add Postgres migration and seeding scripts
- persist products and orders using Postgres with JSON fallback
- make MercadoPago webhook idempotent with DB transactions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a200a52e408331bf0f0a36a9edf4bb