### PR TITLE
Persist MP order items and apply stock atomically

### DIFF
--- a/nerin_final_updated/backend/__tests__/mpWebhook.test.js
+++ b/nerin_final_updated/backend/__tests__/mpWebhook.test.js
@@ -1,0 +1,110 @@
+const path = require('path');
+
+jest.mock('../db', () => ({ getPool: () => null }));
+
+jest.mock('fs', () => {
+  const path = require('path');
+  const files = {};
+  return {
+    __files: files,
+    readFileSync: jest.fn((p) => files[path.normalize(p)] || '{}'),
+    writeFileSync: jest.fn((p, d) => {
+      files[path.normalize(p)] = d;
+    }),
+    existsSync: jest.fn(() => true),
+    mkdirSync: jest.fn(),
+    stat: jest.fn((p, cb) => cb(null, { isDirectory: () => false })),
+  };
+});
+
+jest.mock('../services/mercadoPago', () => ({
+  resolveFromWebhook: jest.fn(),
+}));
+
+const fs = require('fs');
+const { resolveFromWebhook } = require('../services/mercadoPago');
+const { processNotification } = require('../routes/mercadoPago');
+
+const productsPath = path.join(__dirname, '../../data/products.json');
+const ordersPath = path.join(__dirname, '../../data/orders.json');
+const orderItemsPath = path.join(__dirname, '../../data/order_items.json');
+
+beforeEach(() => {
+  const files = fs.__files;
+  for (const k of Object.keys(files)) delete files[k];
+  fs.readFileSync.mockClear();
+  fs.writeFileSync.mockClear();
+  files[productsPath] = JSON.stringify({
+    products: [
+      { id: 'p1', sku: 'SKU1', stock: 10, price: 100 },
+      { id: 'p2', sku: 'SKU2', stock: 5, price: 50 },
+    ],
+  });
+  files[ordersPath] = JSON.stringify({
+    orders: [
+      { id: 'ORD1', status: 'pending', total: 0, inventory_applied: false },
+      { id: 'ORD2', status: 'pending', total: 0, inventory_applied: false },
+    ],
+  });
+  files[orderItemsPath] = JSON.stringify({ order_items: [] });
+});
+
+test('persists items and applies inventory', async () => {
+  resolveFromWebhook.mockResolvedValue({
+    externalRef: 'ORD1',
+    preferenceId: 'pref1',
+    status: 'approved',
+    email: 'test@test.com',
+    items: [
+      { sku: 'SKU1', price: 100, qty: 2 },
+      { sku: 'SKU2', price: 50, qty: 1 },
+    ],
+    source: 'metadata',
+  });
+
+  await processNotification({
+    body: { data: { id: 'pay1' } },
+    query: { topic: 'payment', id: 'pay1' },
+  });
+
+  const orderItems = JSON.parse(fs.__files[orderItemsPath]).order_items;
+  expect(orderItems).toHaveLength(2);
+  const orders = JSON.parse(fs.__files[ordersPath]).orders;
+  const order = orders.find((o) => o.id === 'ORD1');
+  expect(order.total).toBe(250);
+  expect(order.inventory_applied).toBe(true);
+  const products = JSON.parse(fs.__files[productsPath]).products;
+  expect(products.find((p) => p.id === 'p1').stock).toBe(8);
+  expect(products.find((p) => p.id === 'p2').stock).toBe(4);
+
+  await processNotification({
+    body: { data: { id: 'pay1' } },
+    query: { topic: 'payment', id: 'pay1' },
+  });
+
+  const orderItems2 = JSON.parse(fs.__files[orderItemsPath]).order_items;
+  expect(orderItems2).toHaveLength(2);
+  const products2 = JSON.parse(fs.__files[productsPath]).products;
+  expect(products2.find((p) => p.id === 'p1').stock).toBe(8);
+});
+
+test('fallback merchant order items', async () => {
+  resolveFromWebhook.mockResolvedValue({
+    externalRef: 'ORD2',
+    preferenceId: 'pref2',
+    status: 'approved',
+    email: 'a@b.com',
+    items: [{ sku: 'SKU1', price: 100, qty: 1 }],
+    source: 'mo',
+  });
+
+  await processNotification({
+    body: {},
+    query: { topic: 'merchant_order', id: 'mo1' },
+  });
+
+  const orderItems = JSON.parse(fs.__files[orderItemsPath]).order_items.filter(
+    (it) => it.order_id === 'ORD2'
+  );
+  expect(orderItems).toHaveLength(1);
+});

--- a/nerin_final_updated/backend/db/migrate.js
+++ b/nerin_final_updated/backend/db/migrate.js
@@ -42,6 +42,10 @@ async function run() {
       price NUMERIC,
       PRIMARY KEY(order_id, product_id)
     )`,
+    `ALTER TABLE orders ADD COLUMN IF NOT EXISTS inventory_applied BOOLEAN DEFAULT FALSE`,
+    `ALTER TABLE order_items ADD COLUMN IF NOT EXISTS product_id TEXT REFERENCES products(id)`,
+    `ALTER TABLE order_items ADD COLUMN IF NOT EXISTS qty INT`,
+    `ALTER TABLE order_items ADD COLUMN IF NOT EXISTS price NUMERIC`,
     `CREATE TABLE IF NOT EXISTS stock_movements (
       id TEXT PRIMARY KEY,
       product_id TEXT REFERENCES products(id),

--- a/nerin_final_updated/backend/index.js
+++ b/nerin_final_updated/backend/index.js
@@ -209,6 +209,7 @@ app.post("/api/orders", async (req, res) => {
       try {
         const pref = {
           items: productos.map((p) => ({
+            id: String(p.sku || ''),
             title: p.name,
             quantity: Number(p.quantity),
             unit_price: Number(p.price),
@@ -222,6 +223,15 @@ app.post("/api/orders", async (req, res) => {
           auto_return: "approved",
           external_reference: id,
           notification_url: `https://nerinparts.com.ar/api/webhooks/mp`,
+          metadata: {
+            items: productos.map((p) => ({
+              sku: p.sku,
+              name: p.name,
+              price: p.price,
+              qty: p.quantity,
+            })),
+            email: cliente?.email || null,
+          },
         };
         const prefRes = await mpPreference.create({ body: pref });
         initPoint = prefRes.init_point;

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -2181,12 +2181,15 @@ const server = http.createServer((req, res) => {
             .toLowerCase()
             .trim();
 
-        const items = carrito.map(({ titulo, precio, cantidad, currency_id }) => ({
-          title: String(titulo),
-          unit_price: Number(precio),
-          quantity: Number(cantidad),
-          currency_id: currency_id || "ARS",
-        }));
+        const items = carrito.map(
+          ({ titulo, precio, cantidad, currency_id, sku }) => ({
+            id: String(sku || ''),
+            title: String(titulo),
+            unit_price: Number(precio),
+            quantity: Number(cantidad),
+            currency_id: currency_id || "ARS",
+          })
+        );
 
         const itemsForOrder = carrito.map(
           ({ titulo, precio, cantidad, id, productId, sku }) => {
@@ -2227,6 +2230,15 @@ const server = http.createServer((req, res) => {
           },
           auto_return: "approved",
           notification_url: `${DOMAIN}/api/webhooks/mp`,
+          metadata: {
+            items: itemsForOrder.map((it) => ({
+              sku: it.sku,
+              name: it.name,
+              price: it.price,
+              qty: it.quantity,
+            })),
+            email: usuario?.email || null,
+          },
         };
         console.log("Preferencia enviada a Mercado Pago:", preferenceBody);
         if (!mpPreference) {

--- a/nerin_final_updated/backend/services/mercadoPago.js
+++ b/nerin_final_updated/backend/services/mercadoPago.js
@@ -1,0 +1,110 @@
+const ACCESS_TOKEN = process.env.MP_ACCESS_TOKEN || '';
+const fetchFn =
+  globalThis.fetch ||
+  ((...a) => import('node-fetch').then(({ default: f }) => f(...a)));
+
+async function fetchPayment(id) {
+  if (!id) throw new Error('payment id requerido');
+  const res = await fetchFn(`https://api.mercadopago.com/v1/payments/${id}`, {
+    headers: { Authorization: `Bearer ${ACCESS_TOKEN}` },
+  });
+  if (!res.ok) throw new Error(`payment fetch ${res.status}`);
+  return res.json();
+}
+
+async function fetchMerchantOrder(id) {
+  if (!id) throw new Error('merchant order id requerido');
+  const res = await fetchFn(
+    `https://api.mercadopago.com/merchant_orders/${id}`,
+    { headers: { Authorization: `Bearer ${ACCESS_TOKEN}` } }
+  );
+  if (!res.ok) throw new Error(`mo fetch ${res.status}`);
+  return res.json();
+}
+
+function mapItems(mpItems = []) {
+  return mpItems.map((it) => ({
+    sku: it.sku || it.id || '',
+    name: it.name || it.title || '',
+    price: Number(it.price || it.unit_price || 0),
+    qty: Number(it.qty || it.quantity || 0),
+  }));
+}
+
+async function resolveFromWebhook({ topic, id, body = {}, query = {} }) {
+  const resource = query.resource || body.resource;
+  const info = {
+    externalRef: null,
+    preferenceId: null,
+    paymentId: null,
+    merchantOrderId: null,
+    status: null,
+    items: null,
+    email: null,
+    source: null,
+  };
+
+  try {
+    if (resource && /\/v1\/payments\//.test(resource)) {
+      id = resource.split('/').pop();
+      topic = 'payment';
+    } else if (resource && /merchant_orders\//.test(resource)) {
+      id = resource.split('/').pop();
+      topic = 'merchant_order';
+    }
+
+    if (topic === 'payment' || /^[0-9]+$/.test(String(id))) {
+      info.paymentId = id;
+      const p = await fetchPayment(id);
+      info.status = p.status || null;
+      info.externalRef = p.external_reference || null;
+      info.preferenceId = p.preference_id || null;
+      info.merchantOrderId = p.order?.id || null;
+      info.items = mapItems(
+        p.metadata?.items ||
+          p.additional_info?.items ||
+          p.items ||
+          []
+      );
+      info.email = p.metadata?.email || p.payer?.email || null;
+      if (!info.items?.length && info.merchantOrderId) {
+        try {
+          const mo = await fetchMerchantOrder(info.merchantOrderId);
+          info.items = mapItems(mo.items || []);
+          info.source = 'mo';
+        } catch {}
+      } else {
+        info.source = 'metadata';
+      }
+      return info;
+    }
+
+    if (topic === 'merchant_order') {
+      info.merchantOrderId = id;
+      const mo = await fetchMerchantOrder(id);
+      info.preferenceId = mo.preference_id || null;
+      info.externalRef = mo.external_reference || null;
+      info.items = mapItems(mo.items || []);
+      info.source = 'mo';
+      const pay = mo.payments?.[0];
+      if (pay) {
+        info.paymentId = pay.id;
+        info.status = pay.status || null;
+      }
+      if (!info.status && info.paymentId) {
+        try {
+          const p = await fetchPayment(info.paymentId);
+          info.status = p.status || null;
+          if (!info.externalRef)
+            info.externalRef = p.external_reference || null;
+        } catch {}
+      }
+      return info;
+    }
+  } catch (e) {
+    return info;
+  }
+  return info;
+}
+
+module.exports = { fetchPayment, fetchMerchantOrder, resolveFromWebhook };


### PR DESCRIPTION
## Summary
- capture Mercado Pago items and metadata when creating preferences
- resolve webhook events, persist order_items and apply inventory idempotently
- add repository helpers and migrations for order totals and inventory flag
- cover Mercado Pago webhook flow with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a22d0ecdd0833190a7dc421376f797