### PR TITLE
Add missing joi dependency

### DIFF
--- a/nerin_final_updated/package.json
+++ b/nerin_final_updated/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "afip.ts": "^3.2.2",
     "dotenv": "^16.4.5",
+    "joi": "^17.11.0",
     "mercadopago": "^2.2.10",
     "multer": "^1.4.5-lts.1",
     "node-fetch": "^3.3.2",


### PR DESCRIPTION
## Summary
- add joi 17.11.0 to nerin_final_updated dependencies

## Testing
- `cd nerin_final_updated && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3790359608331804a3b51154c8e5b