### PR TITLE
fix: prioritize payment ID from Mercado Pago webhook

### DIFF
--- a/backend/routes/mercadoPago.js
+++ b/backend/routes/mercadoPago.js
@@ -150,12 +150,12 @@ router.post(
 
   validateWebhook,
   (req, res) => {
-    const topic = req.query.topic || req.body.topic;
+    const topic = req.query.topic || req.body.topic || req.body.type;
     const id =
       req.query.id ||
-      req.body.id ||
       req.body.payment_id ||
-      (req.body.data && req.body.data.id);
+      (req.body.data && req.body.data.id) ||
+      req.body.id;
 
     console.log('📥 mp-webhook recibido:', { topic, id });
     logger.info(`mp-webhook recibido: ${JSON.stringify({ topic, id })}`);

--- a/nerin_final_updated/backend/routes/mercadoPago.js
+++ b/nerin_final_updated/backend/routes/mercadoPago.js
@@ -194,6 +194,7 @@ async function processNotification(reqOrTopic, maybeId) {
     (typeof reqOrTopic === 'string' ? reqOrTopic : undefined);
   const rawId =
     query.id ||
+    body?.payment_id ||
     body?.data?.id ||
     body?.id ||
     (typeof reqOrTopic === 'string' ? maybeId : undefined) ||


### PR DESCRIPTION
## Summary
- ensure Mercado Pago webhook uses payment ID from `data.id` or `payment_id`
- test webhook processing when body contains event id and payment id
- handle `payment_id` in legacy Mercado Pago route

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5b99dd5e4833192b1219da20d4749