### PR TITLE
Refine footer styling and admin visibility

### DIFF
--- a/nerin_final_updated/frontend/admin-footer.js
+++ b/nerin_final_updated/frontend/admin-footer.js
@@ -15,7 +15,16 @@ const defaultConfig = {
   newsletter: { enabled: false, placeholder: "", successMsg: "" },
   legal: { cuit: "", iibb: "", terms: "", privacy: "" },
   show: { cta: true, branding: true, columns: true, contact: true, social: true, badges: true, newsletter: false, legal: true },
-  theme: { accentFrom: "#FFD54F", accentTo: "#FFC107", border: "rgba(255,255,255,.08)", bg: "#0B0B0C", fg: "#EDEDEF", muted: "#B8B8BC" },
+  theme: {
+    accentFrom: "#FFD54F",
+    accentTo: "#FFC107",
+    border: "rgba(0,0,0,.08)",
+    bg: "#ffffff",
+    fg: "#111827",
+    muted: "#A9ABB2",
+    dark: false,
+    accentBar: true,
+  },
 };
 
 const form = document.getElementById('footerForm');
@@ -53,6 +62,8 @@ function fillForm(cfg) {
   form.accentTo.value = cfg.theme.accentTo;
   form.bg.value = cfg.theme.bg;
   form.fg.value = cfg.theme.fg;
+  form.themeDark.checked = cfg.theme.dark;
+  form.accentBar.checked = cfg.theme.accentBar !== false;
   form.newsEnabled.checked = cfg.newsletter.enabled;
   form.newsPlaceholder.value = cfg.newsletter.placeholder;
   form.newsSuccess.value = cfg.newsletter.successMsg;
@@ -86,10 +97,17 @@ function collectForm() {
     email: form.email.value.trim(),
     address: form.address.value.trim(),
   };
+  const sanitizeUrl = (url) => {
+    try {
+      const u = new URL(url);
+      if (u.protocol === 'http:' || u.protocol === 'https:') return url;
+    } catch {}
+    return '';
+  };
   cfg.social = {
-    instagram: form.instagram.value.trim(),
-    linkedin: form.linkedin.value.trim(),
-    youtube: form.youtube.value.trim(),
+    instagram: sanitizeUrl(form.instagram.value.trim()),
+    linkedin: sanitizeUrl(form.linkedin.value.trim()),
+    youtube: sanitizeUrl(form.youtube.value.trim()),
   };
   cfg.legal = {
     cuit: form.cuit.value.trim(),
@@ -104,6 +122,8 @@ function collectForm() {
     bg: form.bg.value,
     fg: form.fg.value,
     muted: defaultConfig.theme.muted,
+    dark: form.themeDark.checked,
+    accentBar: form.accentBar.checked,
   };
   cfg.newsletter = {
     enabled: form.newsEnabled.checked,

--- a/nerin_final_updated/frontend/admin.html
+++ b/nerin_final_updated/frontend/admin.html
@@ -12,8 +12,6 @@
       href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css"
     />
       <link rel="stylesheet" href="style.css?v=mobfix-1" />
-      <link rel="stylesheet" href="/components/np-footer.css" />
-      <script src="/components/np-footer.js" defer></script>
   </head>
   <body>
     <header>
@@ -345,8 +343,10 @@
           <label><input type="checkbox" name="badge_authenticity" /> Autenticidad</label>
           <input type="color" name="accentFrom" value="#FFD54F" />
           <input type="color" name="accentTo" value="#FFC107" />
-          <input type="color" name="bg" value="#0B0B0C" />
-          <input type="color" name="fg" value="#EDEDEF" />
+          <input type="color" name="bg" value="#ffffff" />
+          <input type="color" name="fg" value="#111827" />
+          <label><input type="checkbox" name="themeDark" /> Modo oscuro</label>
+          <label><input type="checkbox" name="accentBar" checked /> Barra de acento</label>
           <label><input type="checkbox" name="newsEnabled" /> Newsletter habilitado</label>
           <input type="text" name="newsPlaceholder" placeholder="Placeholder newsletter" />
           <input type="text" name="newsSuccess" placeholder="Mensaje éxito" />

--- a/nerin_final_updated/frontend/components/np-footer.css
+++ b/nerin_final_updated/frontend/components/np-footer.css
@@ -1,98 +1,138 @@
-/* NERIN PARTS ultra-pro footer styles */
+/* NERIN PARTS footer styles aligned with site aesthetics */
+
 :root {
   --np-accent-from: #FFD54F;
   --np-accent-to: #FFC107;
-  --np-border: rgba(255,255,255,.08);
-  --np-bg: #0B0B0C;
-  --np-fg: #EDEDEF;
-  --np-muted: #B8B8BC;
+  /* default dark palette */
+  --np-bg-dark: color-mix(in srgb, #0E0F10 92%, white);
+  --np-fg-dark: #EDEDEF;
+  --np-muted-dark: #A9ABB2;
+  --np-border-dark: rgba(0, 0, 0, 0.08);
 }
 
 .np-footer {
+  --np-bg: var(--color-bg, #fff);
+  --np-fg: var(--color-secondary, #111827);
+  --np-muted: var(--color-muted, #6b7280);
+  --np-border: var(--color-border, #e5e7eb);
+
   background: var(--np-bg);
   color: var(--np-fg);
-  font-size: clamp(0.9rem, 0.28vw + 0.9rem, 1.05rem);
-  padding-block: 2rem;
+  border-top: 1px solid var(--np-border);
+  font-size: clamp(0.9rem, 0.4vw + 0.85rem, 1rem);
+  line-height: 1.5;
+  margin-top: 0;
+  -webkit-tap-highlight-color: transparent;
+  padding-bottom: max(24px, env(safe-area-inset-bottom, 0px));
+}
+
+.np-footer--dark {
+  --np-bg: var(--np-bg-dark);
+  --np-fg: var(--np-fg-dark);
+  --np-muted: var(--np-muted-dark);
+  --np-border: var(--np-border-dark);
 }
 
 .np-footer-accent {
-  height: 4px;
-  background: linear-gradient(to right,var(--np-accent-from),var(--np-accent-to));
+  height: 2px;
+  background: linear-gradient(to right, var(--np-accent-from), var(--np-accent-to));
+  opacity: 0.75;
 }
 
-.np-footer-inner {
-  max-width: min(1280px, 92vw);
-  margin-inline: auto;
+.np-footer__inner {
+  max-width: min(1200px, 92vw);
+  margin: 0 auto;
+  padding: clamp(20px, 3vw, 32px) 0;
   display: grid;
   gap: 2rem;
 }
 
-.np-footer-link {
-  color: inherit;
-  text-decoration: none;
-  padding: 0.25rem 0;
-  transition: transform 180ms ease, opacity 180ms ease;
+.np-footer-cta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
-.np-footer-link:hover,
-.np-footer-link:focus {
-  transform: translateY(-1px);
-  opacity: 0.9;
-  outline: 2px solid var(--np-accent-to);
-  outline-offset: 2px;
+@media (min-width: 640px) {
+  .np-footer-cta {
+    flex-direction: row;
+    align-items: center;
+  }
 }
 
 .np-footer-columns {
   display: grid;
-  gap: 1rem 3rem;
+  gap: 1.25rem 2rem;
 }
 
-@media (min-width: 600px) {
+@media (min-width: 640px) {
   .np-footer-columns {
-    grid-template-columns: repeat(auto-fit, minmax(150px,1fr));
+    grid-template-columns: repeat(2, 1fr);
   }
+}
+
+@media (min-width: 1024px) {
+  .np-footer-columns {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.np-footer-nav h3 {
+  font-weight: 600;
+  font-size: clamp(0.95rem, 0.4vw + 0.9rem, 1.05rem);
+  margin: 0 0 0.25rem;
+}
+
+.np-footer a {
+  text-decoration: none;
+  color: inherit;
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  padding-inline: 0.25rem;
+  transition: opacity var(--transition, 0.2s), transform var(--transition, 0.2s);
+}
+
+.np-footer a:hover {
+  opacity: 0.9;
+  transform: translateY(-1px);
+}
+
+.np-footer a:focus-visible {
+  outline: 2px solid var(--color-primary, var(--np-accent-to));
+  outline-offset: 3px;
 }
 
 .np-footer-contact,
 .np-footer-social,
 .np-footer-badges,
+.np-footer-newsletter,
 .np-footer-legal {
   border-top: 1px solid var(--np-border);
-  padding-top: 1rem;
+  padding-block: 0.75rem;
 }
 
-.np-footer-social svg,
-.np-footer-badges svg {
+.np-footer-social {
+  display: flex;
+  gap: 1rem;
+}
+
+.np-footer-social svg {
   width: 24px;
   height: 24px;
   fill: currentColor;
 }
 
-.np-footer-news-form {
+.np-footer-badges {
   display: flex;
-  gap: 0.5rem;
-}
-
-.np-footer-news-input {
-  flex: 1;
-  padding: 0.5rem;
-  background: var(--np-bg);
-  color: var(--np-fg);
-  border: 1px solid var(--np-border);
-  border-radius: 4px;
-}
-
-.np-footer-news-btn {
-  padding: 0.5rem 1rem;
-  background: var(--np-accent-to);
-  color: #000;
-  border-radius: 4px;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
 }
 
 .np-footer-legal {
   font-size: 0.875rem;
-  color: var(--np-muted);
   text-align: center;
+  color: var(--np-muted);
 }
 
 .sr-only {
@@ -102,6 +142,7 @@
   padding: 0;
   margin: -1px;
   overflow: hidden;
-  clip: rect(0,0,0,0);
+  clip: rect(0, 0, 0, 0);
   border: 0;
 }
+

--- a/nerin_final_updated/frontend/components/np-footer.html
+++ b/nerin_final_updated/frontend/components/np-footer.html
@@ -2,34 +2,36 @@
 <template id="np-footer-template">
   <footer class="np-footer" role="contentinfo">
     <div class="np-footer-accent" aria-hidden="true"></div>
-    <div class="np-footer-cta" hidden>
-      <p class="np-footer-cta-text"></p>
-      <a class="np-footer-cta-btn np-footer-link"></a>
-    </div>
-    <div class="np-footer-branding" hidden>
-      <div class="np-footer-logo" aria-hidden="true"></div>
-      <div class="np-footer-brand-text">
-        <span class="np-footer-brand"></span>
-        <span class="np-footer-slogan"></span>
+    <div class="np-footer__inner">
+      <div class="np-footer-cta" hidden>
+        <p class="np-footer-cta-text"></p>
+        <a class="np-footer-cta-btn np-footer-link"></a>
       </div>
+      <div class="np-footer-branding" hidden>
+        <div class="np-footer-logo" aria-hidden="true"></div>
+        <div class="np-footer-brand-text">
+          <span class="np-footer-brand"></span>
+          <span class="np-footer-slogan"></span>
+        </div>
+      </div>
+      <nav class="np-footer-nav" aria-labelledby="np-footer-nav-title" hidden>
+        <h2 id="np-footer-nav-title" class="sr-only">Navegación de pie de página</h2>
+        <div class="np-footer-columns"></div>
+      </nav>
+      <div class="np-footer-contact" hidden></div>
+      <div class="np-footer-social" hidden></div>
+      <div class="np-footer-badges" hidden></div>
+      <div class="np-footer-newsletter" hidden>
+        <form class="np-footer-news-form" novalidate>
+          <label>
+            <span class="sr-only">Email</span>
+            <input type="email" class="np-footer-news-input" required />
+          </label>
+          <button type="submit" class="np-footer-news-btn np-footer-link">OK</button>
+          <p class="np-footer-news-success" hidden></p>
+        </form>
+      </div>
+      <div class="np-footer-legal" hidden></div>
     </div>
-    <nav class="np-footer-nav" aria-labelledby="np-footer-nav-title" hidden>
-      <h2 id="np-footer-nav-title" class="sr-only">Navegación de pie de página</h2>
-      <div class="np-footer-columns"></div>
-    </nav>
-    <div class="np-footer-contact" hidden></div>
-    <div class="np-footer-social" hidden></div>
-    <div class="np-footer-badges" hidden></div>
-    <div class="np-footer-newsletter" hidden>
-      <form class="np-footer-news-form" novalidate>
-        <label>
-          <span class="sr-only">Email</span>
-          <input type="email" class="np-footer-news-input" required />
-        </label>
-        <button type="submit" class="np-footer-news-btn np-footer-link">OK</button>
-        <p class="np-footer-news-success" hidden></p>
-      </form>
-    </div>
-    <div class="np-footer-legal" hidden></div>
   </footer>
 </template>

--- a/nerin_final_updated/frontend/components/np-footer.js
+++ b/nerin_final_updated/frontend/components/np-footer.js
@@ -1,6 +1,7 @@
 // Render and mount NERIN PARTS footer
 (async () => {
   if (window.__npFooterLoaded) return;
+  if (location.pathname.includes('/admin.html') || document.querySelector('.admin-container')) return;
   window.__npFooterLoaded = true;
 
   let tpl = document.getElementById('np-footer-template');
@@ -27,11 +28,35 @@
   }
 
   const footer = tpl.content.firstElementChild.cloneNode(true);
+  footer.style.setProperty('-webkit-tap-highlight-color', 'transparent');
 
-  // Apply theme variables
   const theme = cfg.theme || {};
+  const rootStyles = getComputedStyle(document.documentElement);
+  const luminance = (hex) => {
+    if (!hex) return 1;
+    const c = hex.replace('#', '');
+    const full = c.length === 3 ? c.split('').map(ch => ch + ch).join('') : c;
+    const num = parseInt(full, 16);
+    const r = (num >> 16) & 255;
+    const g = (num >> 8) & 255;
+    const b = num & 255;
+    return (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
+  };
+  const isDark = theme.dark === true || luminance(theme.bg) < 0.35;
+  if (isDark) {
+    footer.classList.add('np-footer--dark');
+  } else {
+    footer.style.setProperty('--np-bg', rootStyles.getPropertyValue('--color-bg') || '#fff');
+    footer.style.setProperty('--np-fg', rootStyles.getPropertyValue('--color-secondary') || '#111827');
+    footer.style.setProperty('--np-border', rootStyles.getPropertyValue('--color-border') || '#e5e7eb');
+    footer.style.setProperty('--np-muted', rootStyles.getPropertyValue('--color-muted') || '#6b7280');
+  }
   for (const [k, v] of Object.entries(theme)) {
-    footer.style.setProperty(`--np-${k.replace(/([A-Z])/g,'-$1').toLowerCase()}`, v);
+    footer.style.setProperty(`--np-${k.replace(/([A-Z])/g, '-$1').toLowerCase()}`, v);
+  }
+  if (theme.accentBar === false) {
+    const acc = footer.querySelector('.np-footer-accent');
+    if (acc) acc.style.display = 'none';
   }
 
   const show = cfg.show || {};
@@ -83,9 +108,10 @@
   // Contact
   if (show.contact && cfg.contact) {
     const wrap = footer.querySelector('.np-footer-contact');
-    const parts = [];
     if (cfg.contact.whatsapp) {
-      parts.push(`WhatsApp: ${cfg.contact.whatsapp}`);
+      const span = document.createElement('span');
+      span.textContent = `WhatsApp: ${cfg.contact.whatsapp}`;
+      wrap.appendChild(span);
     }
     if (cfg.contact.email) {
       const a = document.createElement('a');
@@ -99,7 +125,7 @@
       span.textContent = cfg.contact.address;
       wrap.appendChild(span);
     }
-    wrap.hidden = false;
+    wrap.hidden = wrap.childNodes.length === 0;
   }
 
   // Social
@@ -164,21 +190,21 @@
     legal.hidden = false;
     const year = new Date().getFullYear();
     const span = document.createElement('span');
-    span.textContent = `© ${year} ${cfg.brand || ''} - CUIT ${cfg.legal.cuit} - IIBB ${cfg.legal.iibb}`;
+    span.textContent = `© ${year} ${cfg.brand || ''} – CUIT ${cfg.legal.cuit} – IIBB ${cfg.legal.iibb}`;
     legal.appendChild(span);
     if (cfg.legal.terms) {
       const a = document.createElement('a');
       a.className = 'np-footer-link';
       a.href = cfg.legal.terms;
       a.textContent = 'Términos';
-      legal.append(' - ', a);
+      legal.append(' – ', a);
     }
     if (cfg.legal.privacy) {
       const a = document.createElement('a');
       a.className = 'np-footer-link';
       a.href = cfg.legal.privacy;
       a.textContent = 'Privacidad';
-      legal.append(' - ', a);
+      legal.append(' – ', a);
     }
   }
 


### PR DESCRIPTION
## Summary
- Restyle modular footer to blend with site's clean palette, responsive grid and touch-friendly targets
- Prevent footer from loading in admin and add configuration toggles for dark mode and accent bar
- Remove incompatible binary screenshot assets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5c7fae06c8331b16c5cf20190f1bf