### PR TITLE
feat: redesign public footer

### DIFF
--- a/nerin_final_updated/data/footer.json
+++ b/nerin_final_updated/data/footer.json
@@ -63,6 +63,8 @@
     "border": "rgba(255,255,255,.08)",
     "bg": "#0B0B0C",
     "fg": "#EDEDEF",
-    "muted": "#B8B8BC"
+    "muted": "#B8B8BC",
+    "accentBar": true,
+    "mode": "auto"
   }
 }

--- a/nerin_final_updated/frontend/admin-footer.js
+++ b/nerin_final_updated/frontend/admin-footer.js
@@ -22,8 +22,8 @@ const defaultConfig = {
     bg: "#ffffff",
     fg: "#111827",
     muted: "#A9ABB2",
-    dark: false,
     accentBar: true,
+    mode: "auto",
   },
 };
 
@@ -62,7 +62,7 @@ function fillForm(cfg) {
   form.accentTo.value = cfg.theme.accentTo;
   form.bg.value = cfg.theme.bg;
   form.fg.value = cfg.theme.fg;
-  form.themeDark.checked = cfg.theme.dark;
+  form.themeMode.value = cfg.theme.mode || 'auto';
   form.accentBar.checked = cfg.theme.accentBar !== false;
   form.newsEnabled.checked = cfg.newsletter.enabled;
   form.newsPlaceholder.value = cfg.newsletter.placeholder;
@@ -122,8 +122,8 @@ function collectForm() {
     bg: form.bg.value,
     fg: form.fg.value,
     muted: defaultConfig.theme.muted,
-    dark: form.themeDark.checked,
     accentBar: form.accentBar.checked,
+    mode: form.themeMode.value,
   };
   cfg.newsletter = {
     enabled: form.newsEnabled.checked,

--- a/nerin_final_updated/frontend/admin.html
+++ b/nerin_final_updated/frontend/admin.html
@@ -345,7 +345,14 @@
           <input type="color" name="accentTo" value="#FFC107" />
           <input type="color" name="bg" value="#ffffff" />
           <input type="color" name="fg" value="#111827" />
-          <label><input type="checkbox" name="themeDark" /> Modo oscuro</label>
+          <label>
+            Modo
+            <select name="themeMode">
+              <option value="auto">Auto</option>
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+            </select>
+          </label>
           <label><input type="checkbox" name="accentBar" checked /> Barra de acento</label>
           <label><input type="checkbox" name="newsEnabled" /> Newsletter habilitado</label>
           <input type="text" name="newsPlaceholder" placeholder="Placeholder newsletter" />

--- a/nerin_final_updated/frontend/components/np-footer.css
+++ b/nerin_final_updated/frontend/components/np-footer.css
@@ -1,9 +1,4 @@
 /* NERIN Parts footer - light, minimal */
-:root {
-  --np-accent-from: #FFD54F;
-  --np-accent-to: #FFC107;
-}
-
 .np-footer {
   background: var(--color-bg, #fff);
   color: var(--color-secondary, #111827);
@@ -19,9 +14,15 @@
     var(--np-accent-to, #FFC107));
 }
 
+.np-footer[data-accent="off"] .np-footer__accent {
+  display: none;
+}
+
 .np-footer__inner {
   max-width: min(1200px, 92vw);
   margin: 0 auto;
+  display: grid;
+  gap: 24px;
 }
 
 .np-footer__columns {
@@ -29,7 +30,7 @@
   gap: 12px 28px;
 }
 
-@media (min-width: 600px) {
+@media (min-width: 640px) {
   .np-footer__columns {
     grid-template-columns: repeat(2, minmax(160px, 1fr));
   }
@@ -73,6 +74,27 @@
   text-align: center;
   color: #6b7280;
   font-size: .9rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.np-footer[data-theme="dark"] {
+  background: #0B0B0C;
+  color: #EDEDEF;
+  border-top: 1px solid rgba(255, 255, 255, .08);
+}
+
+.np-footer[data-theme="dark"] .np-footer__row {
+  border-top: 1px solid rgba(255, 255, 255, .08);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/nerin_final_updated/frontend/components/np-footer.html
+++ b/nerin_final_updated/frontend/components/np-footer.html
@@ -3,25 +3,16 @@
   <footer class="np-footer" role="contentinfo">
     <div class="np-footer__accent" aria-hidden="true"></div>
     <div class="np-footer__inner">
-      <div class="np-footer__cta" hidden>
-        <p class="np-footer__cta-text"></p>
-        <a class="np-footer__cta-btn"></a>
-      </div>
-      <div class="np-footer__branding" hidden>
-        <div class="np-footer__logo" aria-hidden="true"></div>
-        <div class="np-footer__brand-text">
-          <span class="np-footer__brand"></span>
-          <span class="np-footer__slogan"></span>
-        </div>
-      </div>
+      <div class="np-footer__cta" hidden></div>
+      <div class="np-footer__branding" hidden></div>
       <nav class="np-footer__nav" aria-labelledby="np-footer-nav-title" hidden>
-        <h2 id="np-footer-nav-title" class="sr-only">Navegación de pie de página</h2>
+        <h2 id="np-footer-nav-title" class="sr-only">Navegación</h2>
         <div class="np-footer__columns"></div>
       </nav>
-      <div class="np-footer__row np-footer__contact" hidden></div>
-      <div class="np-footer__row np-footer__social" hidden></div>
-      <div class="np-footer__row np-footer__badges" hidden></div>
-      <div class="np-footer__row np-footer__legal" hidden></div>
+      <div class="np-footer__contact np-footer__row" hidden></div>
+      <div class="np-footer__social  np-footer__row" hidden></div>
+      <div class="np-footer__badges  np-footer__row" hidden></div>
+      <div class="np-footer__legal   np-footer__row" hidden></div>
     </div>
   </footer>
 </template>


### PR DESCRIPTION
## Summary
- redesign np-footer component with light aesthetic layout and optional accent bar
- support dark mode and theme config flags
- expose footer theme options in admin editor and config JSON

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a60b1212808331a6588e6cc85ccfe7