### PR TITLE
Handle Mercado Pago cancellation statuses

### DIFF
--- a/backend/middleware/enforcePostJson.js
+++ b/backend/middleware/enforcePostJson.js
@@ -2,7 +2,9 @@ module.exports = function enforcePostJson(req, res, next) {
   if (req.method !== 'POST') {
     return res.status(405).end();
   }
-  if (!req.is('application/json')) {
+  const isJson = req.is('application/json');
+  const isForm = req.is('application/x-www-form-urlencoded');
+  if (!isJson && !isForm) {
     return res.status(415).json({ error: 'Unsupported content type' });
   }
   next();


### PR DESCRIPTION
## Summary
- map Mercado Pago `cancelled`, `refunded` and `charged_back` statuses to `cancelled`
- expose `mapStatus` for testing and add coverage
- accept form-encoded Mercado Pago webhooks, parse `resource` IDs and handle `merchant_order` topics

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a64c1bc6588331b189b18ea150cfc7