### PR TITLE
Fix product edit modal to load existing data

### DIFF
--- a/nerin_final_updated/backend/index.js
+++ b/nerin_final_updated/backend/index.js
@@ -166,6 +166,19 @@ app.get("/api/products", async (_req, res) => {
   }
 });
 
+// API: obtener un producto por ID
+app.get("/api/products/:id", async (req, res) => {
+  try {
+    const products = await getProducts();
+    const product = products.find((p) => String(p.id) === String(req.params.id));
+    if (!product) return res.status(404).json({ error: "Producto no encontrado" });
+    res.json(product);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: "No se pudo cargar el producto" });
+  }
+});
+
 // Crear un nuevo pedido y generar preferencia de Mercado Pago
 app.post("/api/orders", async (req, res) => {
   try {

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -896,6 +896,22 @@ const server = http.createServer((req, res) => {
     }
   }
 
+  // API: obtener un producto por ID
+  if (pathname.startsWith("/api/products/") && req.method === "GET") {
+    const id = pathname.split("/").pop();
+    try {
+      const products = getProducts();
+      const product = products.find((p) => p.id === id);
+      if (!product) {
+        return sendJson(res, 404, { error: "Producto no encontrado" });
+      }
+      return sendJson(res, 200, product);
+    } catch (err) {
+      console.error(err);
+      return sendJson(res, 500, { error: "No se pudo cargar el producto" });
+    }
+  }
+
   // API: login
   if (pathname === "/api/login" && req.method === "POST") {
     let body = "";

--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -315,17 +315,28 @@ async function openProductModal(id) {
     return;
   }
 
+  modalTitle.textContent = "Editar producto";
+  skuInput.readOnly = true;
+  const cached = productsCache.find((p) => String(p.id) === String(id));
+  if (cached) {
+    originalProduct = cached;
+    fillProductForm(cached);
+  } else {
+    productForm.reset();
+    imagePreview.innerHTML = "";
+    uploadedImagePath = "";
+    originalProduct = null;
+    renderSeoPreview();
+  }
+  productModal.classList.remove("hidden");
   try {
     setLoading(true);
-    modalTitle.textContent = "Editar producto";
     const p = await loadProduct(id);
     originalProduct = p;
     fillProductForm(p);
-    skuInput.readOnly = true;
-    productModal.classList.remove("hidden");
   } catch (err) {
     console.error("Failed to load product", err);
-    if (window.showToast) showToast("No se pudo cargar el producto.");
+    if (!cached && window.showToast) showToast("No se pudo cargar el producto.");
   } finally {
     setLoading(false);
   }


### PR DESCRIPTION
## Summary
- expose `/api/products/:id` to return a single product
- prefill edit modal using cached/remote product data so only changed fields are patched

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a757e0b2448331b0c301bd0d07f9ca