### PR TITLE
feat: centralize data directory

### DIFF
--- a/nerin_final_updated/backend/data/clientsRepo.js
+++ b/nerin_final_updated/backend/data/clientsRepo.js
@@ -1,8 +1,9 @@
 const fs = require('fs');
 const path = require('path');
 const db = require('../db');
+const dataDir = require('../utils/dataDir');
 
-const filePath = path.join(__dirname, '../../data/clients.json');
+const filePath = path.join(dataDir, 'clients.json');
 
 async function getAll() {
   const pool = db.getPool();

--- a/nerin_final_updated/backend/data/invoicesRepo.js
+++ b/nerin_final_updated/backend/data/invoicesRepo.js
@@ -1,8 +1,9 @@
 const fs = require('fs');
 const path = require('path');
 const db = require('../db');
+const dataDir = require('../utils/dataDir');
 
-const filePath = path.join(__dirname, '../../data/invoices.json');
+const filePath = path.join(dataDir, 'invoices.json');
 
 async function getAll() {
   const pool = db.getPool();

--- a/nerin_final_updated/backend/data/ordersRepo.js
+++ b/nerin_final_updated/backend/data/ordersRepo.js
@@ -2,8 +2,9 @@ const fs = require('fs');
 const path = require('path');
 const db = require('../db');
 const productsRepo = require('./productsRepo');
+const dataDir = require('../utils/dataDir');
 
-const filePath = path.join(__dirname, '../../data/orders.json');
+const filePath = path.join(dataDir, 'orders.json');
 
 async function getAll() {
   const pool = db.getPool();

--- a/nerin_final_updated/backend/data/productsRepo.js
+++ b/nerin_final_updated/backend/data/productsRepo.js
@@ -1,8 +1,9 @@
 const fs = require('fs');
 const path = require('path');
 const db = require('../db');
+const dataDir = require('../utils/dataDir');
 
-const filePath = path.join(__dirname, '../../data/products.json');
+const filePath = path.join(dataDir, 'products.json');
 
 async function getAll() {
   const pool = db.getPool();

--- a/nerin_final_updated/backend/utils/dataDir.js
+++ b/nerin_final_updated/backend/utils/dataDir.js
@@ -1,0 +1,11 @@
+const path = require('path');
+const fs = require('fs');
+
+const DISK_PATH = process.env.RENDER_DISK_PATH || path.join(__dirname, '..', '..');
+const DATA_DIR = path.join(DISK_PATH, 'data');
+
+if (!fs.existsSync(DATA_DIR)) {
+  fs.mkdirSync(DATA_DIR, { recursive: true });
+}
+
+module.exports = DATA_DIR;


### PR DESCRIPTION
## Summary
- centralize disk path resolution with new dataDir helper
- use shared data directory across product, order, client, and invoice repos

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8ae47c4d88331bdff7b75d10ce991