### PR TITLE
feat: centralize data directory

### DIFF
--- a/nerin_final_updated/backend/__tests__/features.test.js
+++ b/nerin_final_updated/backend/__tests__/features.test.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const request = require('supertest');
+const dataDir = require('../utils/dataDir');
 
 jest.mock('../emailValidator');
 jest.mock('afip.ts', () => ({ Afip: class {} }), { virtual: true });
@@ -29,9 +30,9 @@ jest.mock('fs', () => {
 const verifyEmailMock = require('../emailValidator');
 const fs = require('fs');
 
-const ordersPath = path.join(__dirname, '../../data/orders.json');
-const configPath = path.join(__dirname, '../../data/config.json');
-const uploadsPath = path.join(__dirname, '../../data/invoice_uploads.json');
+const ordersPath = path.join(dataDir, 'orders.json');
+const configPath = path.join(dataDir, 'config.json');
+const uploadsPath = path.join(dataDir, 'invoice_uploads.json');
 
 describe('Ecommerce features', () => {
   let server;

--- a/nerin_final_updated/backend/data/clientsRepo.js
+++ b/nerin_final_updated/backend/data/clientsRepo.js
@@ -1,8 +1,9 @@
 const fs = require('fs');
 const path = require('path');
 const db = require('../db');
+const dataDir = require('../utils/dataDir');
 
-const filePath = path.join(__dirname, '../../data/clients.json');
+const filePath = path.join(dataDir, 'clients.json');
 
 async function getAll() {
   const pool = db.getPool();

--- a/nerin_final_updated/backend/data/invoicesRepo.js
+++ b/nerin_final_updated/backend/data/invoicesRepo.js
@@ -1,8 +1,9 @@
 const fs = require('fs');
 const path = require('path');
 const db = require('../db');
+const dataDir = require('../utils/dataDir');
 
-const filePath = path.join(__dirname, '../../data/invoices.json');
+const filePath = path.join(dataDir, 'invoices.json');
 
 async function getAll() {
   const pool = db.getPool();

--- a/nerin_final_updated/backend/data/ordersRepo.js
+++ b/nerin_final_updated/backend/data/ordersRepo.js
@@ -2,8 +2,9 @@ const fs = require('fs');
 const path = require('path');
 const db = require('../db');
 const productsRepo = require('./productsRepo');
+const dataDir = require('../utils/dataDir');
 
-const filePath = path.join(__dirname, '../../data/orders.json');
+const filePath = path.join(dataDir, 'orders.json');
 
 async function getAll() {
   const pool = db.getPool();

--- a/nerin_final_updated/backend/data/productsRepo.js
+++ b/nerin_final_updated/backend/data/productsRepo.js
@@ -1,8 +1,9 @@
 const fs = require('fs');
 const path = require('path');
 const db = require('../db');
+const dataDir = require('../utils/dataDir');
 
-const filePath = path.join(__dirname, '../../data/products.json');
+const filePath = path.join(dataDir, 'products.json');
 
 async function getAll() {
   const pool = db.getPool();

--- a/nerin_final_updated/backend/routes/mercadoPago.js
+++ b/nerin_final_updated/backend/routes/mercadoPago.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const dataDir = require('../utils/dataDir');
 const ACCESS_TOKEN = process.env.MP_ACCESS_TOKEN || '';
 const fetchFn =
   globalThis.fetch ||
@@ -27,7 +28,7 @@ function mapStatus(mpStatus) {
 }
 
 function ordersPath() {
-  return path.join(__dirname, '../../data/orders.json');
+  return path.join(dataDir, 'orders.json');
 }
 
 async function getOrders() {
@@ -46,7 +47,7 @@ async function saveOrders(orders) {
 }
 
 function productsPath() {
-  return path.join(__dirname, '../../data/products.json');
+  return path.join(dataDir, 'products.json');
 }
 
 async function getProducts() {

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -13,6 +13,7 @@ const http = require("http");
 const fs = require("fs");
 const path = require("path");
 const url = require("url");
+const dataDir = require("./utils/dataDir");
 const { MercadoPagoConfig, Preference, Payment } = require("mercadopago");
 const { Afip } = require("afip.ts");
 const { Resend } = require("resend");
@@ -48,7 +49,11 @@ const fetchFn =
   globalThis.fetch ||
   ((...a) => import("node-fetch").then(({ default: f }) => f(...a)));
 
-const FOOTER_FILE = path.join(__dirname, "../data/footer.json");
+function dataPath(file) {
+  return path.join(dataDir, file);
+}
+
+const FOOTER_FILE = dataPath("footer.json");
 const DEFAULT_FOOTER = {
   brand: "NERIN PARTS",
   slogan: "Samsung Service Pack Original",
@@ -263,9 +268,9 @@ const USERS = [
  * { email, password, role, name }. Si no existe, devuelve un array vacío.
  */
 function getUsers() {
-  const dataPath = path.join(__dirname, "../data/users.json");
+  const filePath = dataPath("users.json");
   try {
-    const file = fs.readFileSync(dataPath, "utf8");
+    const file = fs.readFileSync(filePath, "utf8");
     return JSON.parse(file).users || [];
   } catch (e) {
     return [];
@@ -276,8 +281,8 @@ function getUsers() {
  * Guardar usuarios registrados. Se almacena bajo la clave "users".
  */
 function saveUsers(users) {
-  const dataPath = path.join(__dirname, "../data/users.json");
-  fs.writeFileSync(dataPath, JSON.stringify({ users }, null, 2), "utf8");
+  const filePath = dataPath("users.json");
+  fs.writeFileSync(filePath, JSON.stringify({ users }, null, 2), "utf8");
 }
 
 // ========================= NUEVAS UTILIDADES PARA MÓDULOS AVANZADOS =========================
@@ -288,9 +293,9 @@ function saveUsers(users) {
  * adicional como dirección, email y tiempo de entrega.
  */
 function getSuppliers() {
-  const dataPath = path.join(__dirname, "../data/suppliers.json");
+  const filePath = dataPath("suppliers.json");
   try {
-    const file = fs.readFileSync(dataPath, "utf8");
+    const file = fs.readFileSync(filePath, "utf8");
     return JSON.parse(file).suppliers;
   } catch (e) {
     // Si el archivo no existe, devolver lista vacía
@@ -303,8 +308,8 @@ function getSuppliers() {
  * { "suppliers": [ ... ] } para que sea similar a otros ficheros del sistema.
  */
 function saveSuppliers(suppliers) {
-  const dataPath = path.join(__dirname, "../data/suppliers.json");
-  fs.writeFileSync(dataPath, JSON.stringify({ suppliers }, null, 2), "utf8");
+  const filePath = dataPath("suppliers.json");
+  fs.writeFileSync(filePath, JSON.stringify({ suppliers }, null, 2), "utf8");
 }
 
 /**
@@ -313,9 +318,9 @@ function saveSuppliers(suppliers) {
  * creación, estado (pendiente, aprobada, recibida) y fecha estimada de llegada.
  */
 function getPurchaseOrders() {
-  const dataPath = path.join(__dirname, "../data/purchase_orders.json");
+  const filePath = dataPath("purchase_orders.json");
   try {
-    const file = fs.readFileSync(dataPath, "utf8");
+    const file = fs.readFileSync(filePath, "utf8");
     return JSON.parse(file).purchaseOrders;
   } catch (e) {
     return [];
@@ -326,9 +331,9 @@ function getPurchaseOrders() {
  * Guardar órdenes de compra en el archivo JSON.
  */
 function savePurchaseOrders(purchaseOrders) {
-  const dataPath = path.join(__dirname, "../data/purchase_orders.json");
+  const filePath = dataPath("purchase_orders.json");
   fs.writeFileSync(
-    dataPath,
+    filePath,
     JSON.stringify({ purchaseOrders }, null, 2),
     "utf8",
   );
@@ -415,35 +420,35 @@ function calculateDetailedAnalytics() {
 
 // Leer productos desde el archivo JSON
 function getProducts() {
-  const dataPath = path.join(__dirname, "../data/products.json");
-  const file = fs.readFileSync(dataPath, "utf8");
+  const filePath = dataPath("products.json");
+  const file = fs.readFileSync(filePath, "utf8");
   return JSON.parse(file).products;
 }
 
 // Guardar productos en el archivo JSON
 function saveProducts(products) {
-  const dataPath = path.join(__dirname, "../data/products.json");
-  fs.writeFileSync(dataPath, JSON.stringify({ products }, null, 2), "utf8");
+  const filePath = dataPath("products.json");
+  fs.writeFileSync(filePath, JSON.stringify({ products }, null, 2), "utf8");
 }
 
 // Leer pedidos desde el archivo JSON
 function getOrders() {
-  const dataPath = path.join(__dirname, "../data/orders.json");
-  const file = fs.readFileSync(dataPath, "utf8");
+  const filePath = dataPath("orders.json");
+  const file = fs.readFileSync(filePath, "utf8");
   return JSON.parse(file).orders;
 }
 
 // Guardar pedidos en el archivo JSON
 function saveOrders(orders) {
-  const dataPath = path.join(__dirname, "../data/orders.json");
-  fs.writeFileSync(dataPath, JSON.stringify({ orders }, null, 2), "utf8");
+  const filePath = dataPath("orders.json");
+  fs.writeFileSync(filePath, JSON.stringify({ orders }, null, 2), "utf8");
 }
 
 // Leer líneas de pedidos
 function getOrderItems() {
-  const dataPath = path.join(__dirname, "../data/order_items.json");
+  const filePath = dataPath("order_items.json");
   try {
-    const file = fs.readFileSync(dataPath, "utf8");
+    const file = fs.readFileSync(filePath, "utf8");
     return JSON.parse(file).order_items || [];
   } catch {
     return [];
@@ -452,9 +457,9 @@ function getOrderItems() {
 
 // Guardar líneas de pedidos
 function saveOrderItems(items) {
-  const dataPath = path.join(__dirname, "../data/order_items.json");
+  const filePath = dataPath("order_items.json");
   fs.writeFileSync(
-    dataPath,
+    filePath,
     JSON.stringify({ order_items: items }, null, 2),
     "utf8",
   );
@@ -553,29 +558,29 @@ function getOrderStatus(id) {
 
 // Leer clientes desde el archivo JSON
 function getClients() {
-  const dataPath = path.join(__dirname, "../data/clients.json");
-  const file = fs.readFileSync(dataPath, "utf8");
+  const filePath = dataPath("clients.json");
+  const file = fs.readFileSync(filePath, "utf8");
   return JSON.parse(file).clients;
 }
 
 // Guardar clientes en el archivo JSON
 function saveClients(clients) {
-  const dataPath = path.join(__dirname, "../data/clients.json");
-  fs.writeFileSync(dataPath, JSON.stringify({ clients }, null, 2), "utf8");
+  const filePath = dataPath("clients.json");
+  fs.writeFileSync(filePath, JSON.stringify({ clients }, null, 2), "utf8");
 }
 
 // Leer facturas desde el archivo JSON
 function getInvoices() {
-  const dataPath = path.join(__dirname, "../data/invoices.json");
-  const file = fs.readFileSync(dataPath, "utf8");
+  const filePath = dataPath("invoices.json");
+  const file = fs.readFileSync(filePath, "utf8");
   return JSON.parse(file).invoices;
 }
 
 // Leer configuración general (ID de Google Analytics, Meta Pixel, WhatsApp, etc.)
 function getConfig() {
-  const dataPath = path.join(__dirname, "../data/config.json");
+  const filePath = dataPath("config.json");
   try {
-    const file = fs.readFileSync(dataPath, "utf8");
+    const file = fs.readFileSync(filePath, "utf8");
     return JSON.parse(file);
   } catch (e) {
     // Si el archivo no existe o está corrupto, devolver configuración vacía
@@ -585,34 +590,34 @@ function getConfig() {
 
 // Guardar configuración general
 function saveConfig(cfg) {
-  const dataPath = path.join(__dirname, "../data/config.json");
-  fs.writeFileSync(dataPath, JSON.stringify(cfg, null, 2), "utf8");
+  const filePath = dataPath("config.json");
+  fs.writeFileSync(filePath, JSON.stringify(cfg, null, 2), "utf8");
 }
 
 // Leer devoluciones desde el archivo JSON
 function getReturns() {
-  const dataPath = path.join(__dirname, "../data/returns.json");
-  const file = fs.readFileSync(dataPath, "utf8");
+  const filePath = dataPath("returns.json");
+  const file = fs.readFileSync(filePath, "utf8");
   return JSON.parse(file).returns;
 }
 
 // Guardar devoluciones en el archivo JSON
 function saveReturns(returns) {
-  const dataPath = path.join(__dirname, "../data/returns.json");
-  fs.writeFileSync(dataPath, JSON.stringify({ returns }, null, 2), "utf8");
+  const filePath = dataPath("returns.json");
+  fs.writeFileSync(filePath, JSON.stringify({ returns }, null, 2), "utf8");
 }
 
 // Guardar facturas en el archivo JSON
 function saveInvoices(invoices) {
-  const dataPath = path.join(__dirname, "../data/invoices.json");
-  fs.writeFileSync(dataPath, JSON.stringify({ invoices }, null, 2), "utf8");
+  const filePath = dataPath("invoices.json");
+  fs.writeFileSync(filePath, JSON.stringify({ invoices }, null, 2), "utf8");
 }
 
 // Leer registros de archivos de factura
 function getInvoiceUploads() {
-  const dataPath = path.join(__dirname, "../data/invoice_uploads.json");
+  const filePath = dataPath("invoice_uploads.json");
   try {
-    const file = fs.readFileSync(dataPath, "utf8");
+    const file = fs.readFileSync(filePath, "utf8");
     return JSON.parse(file).uploads || [];
   } catch {
     return [];
@@ -621,13 +626,13 @@ function getInvoiceUploads() {
 
 // Guardar registros de archivos de factura
 function saveInvoiceUploads(uploads) {
-  const dataPath = path.join(__dirname, "../data/invoice_uploads.json");
-  fs.writeFileSync(dataPath, JSON.stringify({ uploads }, null, 2), "utf8");
+  const filePath = dataPath("invoice_uploads.json");
+  fs.writeFileSync(filePath, JSON.stringify({ uploads }, null, 2), "utf8");
 }
 
 // Obtener el siguiente número de factura (persistente)
 function getNextInvoiceNumber() {
-  const filePath = path.join(__dirname, "../data/invoice_counter.txt");
+  const filePath = dataPath("invoice_counter.txt");
   let counter = 0;
   try {
     counter = parseInt(fs.readFileSync(filePath, "utf8"), 10);
@@ -756,9 +761,9 @@ function normalizeFooter(data) {
 
 // Leer tabla de costos de envío por provincia
 function getShippingTable() {
-  const dataPath = path.join(__dirname, "../data/shipping.json");
+  const filePath = dataPath("shipping.json");
   try {
-    const file = fs.readFileSync(dataPath, "utf8");
+    const file = fs.readFileSync(filePath, "utf8");
     return JSON.parse(file);
   } catch (e) {
     return { costos: [] };
@@ -766,8 +771,8 @@ function getShippingTable() {
 }
 
 function saveShippingTable(table) {
-  const dataPath = path.join(__dirname, "../data/shipping.json");
-  fs.writeFileSync(dataPath, JSON.stringify(table, null, 2), "utf8");
+  const filePath = dataPath("shipping.json");
+  fs.writeFileSync(filePath, JSON.stringify(table, null, 2), "utf8");
 }
 
 function validateShippingTable(table) {

--- a/nerin_final_updated/backend/services/inventory.js
+++ b/nerin_final_updated/backend/services/inventory.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const dataDir = require('../utils/dataDir');
 
 const logger = {
   info: console.log,
@@ -10,7 +11,7 @@ const db = require('../db');
 const inventoryRepo = require('../data/inventoryRepo');
 
 function dataPath(file) {
-  return path.join(__dirname, '../../data', file);
+  return path.join(dataDir, file);
 }
 
 function readJSON(file) {

--- a/nerin_final_updated/backend/utils/dataDir.js
+++ b/nerin_final_updated/backend/utils/dataDir.js
@@ -1,0 +1,11 @@
+const path = require('path');
+const fs = require('fs');
+
+const DISK_PATH = process.env.RENDER_DISK_PATH || path.join(__dirname, '..', '..');
+const DATA_DIR = path.join(DISK_PATH, 'data');
+
+if (!fs.existsSync(DATA_DIR)) {
+  fs.mkdirSync(DATA_DIR, { recursive: true });
+}
+
+module.exports = DATA_DIR;

--- a/nerin_final_updated/scripts/importFromJson.js
+++ b/nerin_final_updated/scripts/importFromJson.js
@@ -1,9 +1,10 @@
 const fs = require('fs');
 const path = require('path');
 const db = require('../backend/db');
+const dataDir = require('../backend/utils/dataDir');
 
 async function importProducts(pool) {
-  const file = path.join(__dirname, '../data/products.json');
+  const file = path.join(dataDir, 'products.json');
   let products = [];
   try {
     products = JSON.parse(fs.readFileSync(file, 'utf8')).products || [];
@@ -32,7 +33,7 @@ async function importProducts(pool) {
 }
 
 async function importOrders(pool) {
-  const file = path.join(__dirname, '../data/orders.json');
+  const file = path.join(dataDir, 'orders.json');
   let orders = [];
   try {
     orders = JSON.parse(fs.readFileSync(file, 'utf8')).orders || [];


### PR DESCRIPTION
## Summary
- centralize disk path resolution with new dataDir helper
- use shared data directory across product, order, client, and invoice repos
- route remaining code paths through dataDir to respect persistent disk

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8ae47c4d88331bdff7b75d10ce991