### PR TITLE
feat: improve sticky cta and whatsapp

### DIFF
--- a/nerin_final_updated/frontend/components/np-footer.css
+++ b/nerin_final_updated/frontend/components/np-footer.css
@@ -4,6 +4,8 @@
   --space-16: 16px;
   --color-text: #1a1a1a;
   --color-border: rgba(0, 0, 0, 0.08);
+  --cta-h: 0px;
+  --wa-bottom: 16px;
 }
 
 /* Sticky CTA */
@@ -22,11 +24,14 @@
   gap: var(--space-12);
   min-height: 64px;
   z-index: 970;
-  transition: transform 180ms ease;
+  transform: translateZ(0);
+  transition: transform 0.18s ease, opacity 0.18s ease;
+  will-change: transform;
 }
 
 [data-sticky-cta].is-hidden {
   transform: translateY(110%);
+  opacity: 0.98;
 }
 
 [data-sticky-cta] .button {
@@ -39,7 +44,7 @@
   width: 56px;
   height: 56px;
   right: 16px;
-  bottom: calc(16px + var(--cta-offset, 0px) + env(safe-area-inset-bottom));
+  bottom: calc(var(--wa-bottom) + env(safe-area-inset-bottom));
   border-radius: 50%;
   background: #25d366;
   display: flex;
@@ -51,6 +56,30 @@
 
 [data-wa]:focus-visible {
   outline: 2px auto;
+}
+
+main {
+  padding-bottom: calc(var(--cta-h) + env(safe-area-inset-bottom));
+}
+
+@media (max-width: 360px) {
+  [data-wa] {
+    width: 52px;
+    height: 52px;
+    right: 12px;
+  }
+}
+
+html.cta-visible [data-wa] {
+  bottom: calc(var(--wa-bottom) + var(--cta-h) + env(safe-area-inset-bottom));
+}
+
+body.hide-cta [data-sticky-cta] {
+  display: none;
+}
+
+body.hide-cta main {
+  padding-bottom: env(safe-area-inset-bottom);
 }
 
 /* Footer */

--- a/nerin_final_updated/frontend/components/np-footer.js
+++ b/nerin_final_updated/frontend/components/np-footer.js
@@ -25,37 +25,64 @@
       const cta = document.querySelector('[data-sticky-cta]');
       const main = document.querySelector('main');
       const wa = document.querySelector('[data-wa]');
+      const footer = document.querySelector('footer');
 
       function setOffsets() {
-        let h = 0;
-        if (cta && !document.body.classList.contains('hide-cta')) {
-          h = cta.offsetHeight;
-        }
-        document.documentElement.style.setProperty('--cta-offset', h + 'px');
+        const h = (cta?.offsetHeight || 0);
+        document.documentElement.style.setProperty('--cta-h', h + 'px');
         if (main) {
           main.style.paddingBottom = `calc(${h}px + env(safe-area-inset-bottom))`;
         }
+        document.documentElement.classList.toggle('cta-visible', h > 0 && isCTAOnScreen());
       }
-      setOffsets();
-      window.addEventListener('resize', setOffsets);
 
-      if (document.body.classList.contains('hide-cta')) {
-        cta && cta.classList.add('is-hidden');
+      function isCTAOnScreen() {
+        const r = cta?.getBoundingClientRect();
+        return r ? (window.innerHeight - r.bottom) <= 1 : false;
       }
 
       window.addEventListener('focusin', (e) => {
-        if (e.target.matches('input,select,textarea')) {
-          cta && cta.classList.add('is-hidden');
+        if (e.target.matches('input, select, textarea')) {
+          cta?.classList.add('is-hidden');
+          setOffsets();
         }
       });
-      window.addEventListener('focusout', () => cta && cta.classList.remove('is-hidden'));
+      window.addEventListener('focusout', () => {
+        cta?.classList.remove('is-hidden');
+        setOffsets();
+      });
+
+      if ('IntersectionObserver' in window && footer && cta) {
+        const io = new IntersectionObserver(
+          (entries) => {
+            entries.forEach((en) => {
+              if (en.isIntersecting) {
+                cta.classList.add('is-hidden');
+              } else {
+                cta.classList.remove('is-hidden');
+              }
+              setOffsets();
+            });
+          },
+          { rootMargin: '0px 0px -10% 0px', threshold: 0.01 }
+        );
+        io.observe(footer);
+      }
+
+      ['load', 'resize'].forEach((ev) =>
+        window.addEventListener(ev, setOffsets, { passive: true })
+      );
+      const ro = 'ResizeObserver' in window && cta ? new ResizeObserver(setOffsets) : null;
+      if (ro && cta) ro.observe(cta);
 
       const checkWa = () => {
-        const hide = window.innerWidth < 360 || document.body.classList.contains('hide-whatsapp');
+        const hide = document.body.classList.contains('hide-whatsapp');
         if (wa) wa.style.display = hide ? 'none' : 'flex';
       };
       checkWa();
       window.addEventListener('resize', checkWa);
+
+      setOffsets();
     } catch (e) {
       console.error('[np-footer]', e);
     }


### PR DESCRIPTION
## Summary
- adjust sticky CTA and WhatsApp button to respect safe areas and dynamic heights
- hide CTA when keyboard or footer visible and update WA offsets accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9088c63a08331822665cdab0af668