### PR TITLE
Ocultar botón de WhatsApp cuando aparece el footer

### DIFF
--- a/nerin_final_updated/frontend/components/np-footer.css
+++ b/nerin_final_updated/frontend/components/np-footer.css
@@ -58,6 +58,25 @@
   outline: 2px auto;
 }
 
+/* transición suave para mostrar/ocultar WA */
+[data-wa] {
+  transition: transform 0.18s ease, opacity 0.18s ease;
+}
+
+/* opción A: ocultar WA cuando el footer está visible */
+html.footer-visible [data-wa] {
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(20%);
+}
+
+/* opción B (si NO querés ocultarlo): subirlo 96px cuando el footer entra */
+html.footer-visible.move-wa [data-wa] {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(-96px);
+}
+
 main {
   padding-bottom: calc(var(--cta-h) + env(safe-area-inset-bottom));
 }

--- a/nerin_final_updated/frontend/components/np-footer.js
+++ b/nerin_final_updated/frontend/components/np-footer.js
@@ -22,6 +22,7 @@
       if (!tpl) return;
       document.body.appendChild(tpl.content.cloneNode(true));
 
+      const html = document.documentElement;
       const cta = document.querySelector('[data-sticky-cta]');
       const main = document.querySelector('main');
       const wa = document.querySelector('[data-wa]');
@@ -67,6 +68,17 @@
           { rootMargin: '0px 0px -10% 0px', threshold: 0.01 }
         );
         io.observe(footer);
+      }
+
+      if ('IntersectionObserver' in window && footer) {
+        const footerIO = new IntersectionObserver(
+          (entries) => {
+            const visible = entries.some((en) => en.isIntersecting);
+            html.classList.toggle('footer-visible', visible);
+          },
+          { root: null, rootMargin: '0px 0px -10% 0px', threshold: 0.01 }
+        );
+        footerIO.observe(footer);
       }
 
       ['load', 'resize', 'orientationchange'].forEach((ev) =>


### PR DESCRIPTION
## Resumen
- Añade estilos para ocultar suavemente el botón de WhatsApp al entrar el footer en pantalla.
- Usa IntersectionObserver para marcar `footer-visible` en `<html>` y disparar la animación.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac4c90b1ac833194afe8e245ed1ea0