### PR TITLE
Ensure JSON data files exist on Render

### DIFF
--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -27,6 +27,8 @@ const {
 } = require("./config/storage");
 const logger = require("./logger");
 const cleanup = require("./utils/cleanup");
+const { initializeData } = require("./utils/dataStore");
+initializeData();
 const dataDir = DATA_DIR;
 const { MercadoPagoConfig, Preference, Payment } = require("mercadopago");
 const { Afip } = require("afip.ts");

--- a/nerin_final_updated/backend/utils/dataStore.js
+++ b/nerin_final_updated/backend/utils/dataStore.js
@@ -1,0 +1,68 @@
+const fs = require('fs');
+const path = require('path');
+const { DATA_DIR } = require('../config/storage');
+
+function safeJoin(base, file) {
+  const target = path.resolve(base, file);
+  if (!target.startsWith(path.resolve(base))) {
+    throw new Error('Invalid path');
+  }
+  return target;
+}
+
+function pathFor(file) {
+  return safeJoin(DATA_DIR, file);
+}
+
+function readJSONSafe(file, defVal) {
+  try {
+    const content = fs.readFileSync(pathFor(file), 'utf8');
+    return JSON.parse(content);
+  } catch {
+    return defVal;
+  }
+}
+
+function writeJSON(file, data) {
+  fs.writeFileSync(pathFor(file), JSON.stringify(data, null, 2));
+}
+
+function ensureDataDir() {
+  try {
+    fs.mkdirSync(DATA_DIR, { recursive: true, mode: 0o750 });
+  } catch {}
+}
+
+function initializeData() {
+  ensureDataDir();
+  const defaults = {
+    'products.json': { products: [] },
+    'orders.json': { orders: [] },
+    'clients.json': { clients: [] },
+    'returns.json': { returns: [] },
+  };
+  const legacyDirs = [
+    path.resolve(__dirname, '../data'),
+    path.resolve(__dirname, '../../data'),
+  ];
+
+  for (const [file, def] of Object.entries(defaults)) {
+    const dest = pathFor(file);
+    if (fs.existsSync(dest)) continue;
+    let copied = false;
+    for (const dir of legacyDirs) {
+      const legacyPath = path.join(dir, file);
+      if (fs.existsSync(legacyPath)) {
+        fs.copyFileSync(legacyPath, dest);
+        copied = true;
+        break;
+      }
+    }
+    if (!copied) {
+      writeJSON(file, def);
+    }
+  }
+}
+
+module.exports = { pathFor, readJSONSafe, writeJSON, initializeData };
+


### PR DESCRIPTION
## Summary
- add `utils/dataStore` module to manage JSON files and bootstrap storage
- initialize required data files on server startup to avoid ENOENT errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad9c5e623883319a5b53dbe44cbb32