### PR TITLE
refactor: adjust hero and footer for tablet layouts

### DIFF
--- a/nerin_final_updated/frontend/components/np-footer.css
+++ b/nerin_final_updated/frontend/components/np-footer.css
@@ -22,8 +22,8 @@
   align-items: center;
   justify-content: space-between;
   gap: var(--space-12);
-  min-height: 64px;
-  z-index: 970;
+  min-height: 56px;
+  z-index: 960;
   transform: translateZ(0);
   transition: transform 0.18s ease, opacity 0.18s ease;
   will-change: transform;
@@ -51,7 +51,7 @@
   align-items: center;
   justify-content: center;
   text-decoration: none;
-  z-index: 980;
+  z-index: 990;
 }
 
 .wa-fab:focus-visible {
@@ -105,11 +105,12 @@ body.hide-cta main {
 .site-footer {
   background: #fff;
   color: var(--color-text);
-  font-size: clamp(14px, 1.5vw, 16px);
+  font-size: clamp(14px, 1.6vw, 16px);
+  line-height: 1.5;
   border-top: 1px solid var(--color-border);
   max-width: 1200px;
   margin: 0 auto;
-  padding: var(--space-12);
+  padding: var(--space-12) 16px;
   padding-bottom: calc(var(--space-12) + env(safe-area-inset-bottom));
   display: flex;
   flex-direction: column;
@@ -187,6 +188,9 @@ body.hide-cta main {
 }
 
 @media (min-width: 600px) and (max-width: 1024px) {
+  [data-sticky-cta] .button {
+    min-height: 40px;
+  }
   .site-footer {
     padding: var(--space-16);
     padding-bottom: calc(var(--space-16) + env(safe-area-inset-bottom));

--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -215,24 +215,28 @@ nav a:hover {
   backdrop-filter: blur(2px);
 }
 
-.hero .content {
+.hero .content,
+.hero__content {
   position: relative;
   z-index: 1;
   max-width: 650px;
 }
 
-.hero h1 {
+.hero h1,
+.hero__title {
   font-size: 2rem;
   margin-bottom: 0.5rem;
 }
 
-.hero p {
+.hero p,
+.hero__subtitle {
   margin-bottom: 1.5rem;
   font-size: 1.1rem;
   color: #444;
 }
 
-.buttons {
+.buttons,
+.hero__actions {
   display: flex;
   gap: 1rem;
   justify-content: center;
@@ -676,8 +680,56 @@ nav a:hover {
     padding: 0.5rem 1rem;
     gap: 0.75rem;
   }
-  .hero h1 {
+  .hero h1,
+  .hero__title {
     font-size: 1.6rem;
+  }
+}
+
+@media (min-width: 600px) and (max-width: 1024px) {
+  .hero {
+    padding-block: 32px;
+  }
+  .hero .content,
+  .hero__content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+  }
+  .hero h1,
+  .hero__title {
+    font-size: clamp(22px, 3.2vw, 32px);
+    line-height: 1.2;
+    margin: 0;
+  }
+  .hero p,
+  .hero__subtitle {
+    font-size: clamp(14px, 1.6vw, 16px);
+    line-height: 1.5;
+    margin: 0;
+  }
+  .buttons,
+  .hero__actions {
+    gap: 12px;
+  }
+  .buttons .button,
+  .hero__actions .button {
+    min-height: 40px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .hero {
+    padding-block: 48px;
+  }
+  .buttons,
+  .hero__actions {
+    gap: 16px;
+  }
+  .buttons .button,
+  .hero__actions .button {
+    min-height: 44px;
   }
 }
 


### PR DESCRIPTION
## Summary
- reduce hero spacing and typography on tablets using clamp and responsive gap
- align site footer layout with admin footer and avoid sticky/FAB overlap

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ada48a51588331ac7ad18f94cd0d82