### PR TITLE
feat: add responsive overrides

### DIFF
--- a/nerin_final_updated/frontend/account.html
+++ b/nerin_final_updated/frontend/account.html
@@ -14,6 +14,7 @@
       <link rel="stylesheet" href="style.css?v=mobfix-1" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/admin.html
+++ b/nerin_final_updated/frontend/admin.html
@@ -12,6 +12,7 @@
       href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css"
     />
       <link rel="stylesheet" href="style.css?v=mobfix-1" />
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
   </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/cart.html
+++ b/nerin_final_updated/frontend/cart.html
@@ -20,6 +20,7 @@
       <link rel="stylesheet" href="style.css?v=mobfix-1" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/checkout-form.html
+++ b/nerin_final_updated/frontend/checkout-form.html
@@ -6,6 +6,7 @@
     <script>window.location.replace('/checkout-steps.html');</script>
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
 </head>
   <body>
     <p>Redirigiendo al nuevo checkout...</p>

--- a/nerin_final_updated/frontend/checkout-steps.html
+++ b/nerin_final_updated/frontend/checkout-steps.html
@@ -8,6 +8,7 @@
       <link rel="stylesheet" href="style.css?v=mobfix-1" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/checkout.html
+++ b/nerin_final_updated/frontend/checkout.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css" />
   <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
 </head>
 <body>
   <div class="contenedor">

--- a/nerin_final_updated/frontend/contact.html
+++ b/nerin_final_updated/frontend/contact.html
@@ -14,6 +14,7 @@
       <link rel="stylesheet" href="style.css?v=mobfix-1" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/css/overrides.css
+++ b/nerin_final_updated/frontend/css/overrides.css
@@ -1,0 +1,72 @@
+/* Overrides for mobile responsiveness */
+
+/* Hero */
+.hero {
+  padding-block: 24px;
+}
+.hero h1 {
+  font-size: clamp(24px, 5vw, 32px);
+}
+@media (min-width: 600px) {
+  .hero {
+    padding-block: 32px;
+  }
+}
+@media (min-width: 1024px) {
+  .hero {
+    padding-block: 32px;
+  }
+}
+
+/* Product cards */
+.product-card img {
+  height: clamp(160px, 38vw, 220px);
+  object-fit: cover;
+}
+.product-card h3 {
+  font-size: clamp(16px, 4vw, 18px);
+}
+.product-card .price {
+  font-size: clamp(14px, 3.5vw, 16px);
+}
+.product-card .product-actions .button,
+.product-card .add-to-cart button {
+  min-height: 44px;
+}
+@media (min-width: 600px) {
+  .product-card .product-actions .button,
+  .product-card .add-to-cart button {
+    min-height: 40px;
+  }
+}
+
+/* Footer layout */
+.site-footer {
+  padding: 12px 16px;
+  gap: 12px;
+}
+@media (min-width: 600px) {
+  .site-footer {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas:
+      "chips nav"
+      "social legal";
+    padding: 16px;
+    gap: 16px;
+  }
+}
+@media (min-width: 1024px) {
+  .site-footer {
+    padding: 24px;
+  }
+}
+
+/* Anti-overlap for sticky footer and FAB */
+body {
+  padding-bottom: calc(var(--cta-h, 0px) + 72px);
+}
+.wa-fab,
+html.cta-visible .wa-fab {
+  bottom: calc(16px + var(--cta-h, 0px));
+}

--- a/nerin_final_updated/frontend/failure.html
+++ b/nerin_final_updated/frontend/failure.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="css/success.css" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/index.html
+++ b/nerin_final_updated/frontend/index.html
@@ -14,6 +14,7 @@
       <link rel="stylesheet" href="style.css?v=mobfix-1" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r2">
     <script src="/components/np-footer.js?v=np-r2" defer></script>
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/invoice.html
+++ b/nerin_final_updated/frontend/invoice.html
@@ -51,6 +51,7 @@
       <link rel="stylesheet" href="style.css?v=mobfix-1" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/login.html
+++ b/nerin_final_updated/frontend/login.html
@@ -14,6 +14,7 @@
       <link rel="stylesheet" href="style.css?v=mobfix-1" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/pages/confirmacion.html
+++ b/nerin_final_updated/frontend/pages/confirmacion.html
@@ -6,6 +6,7 @@
   <link rel="stylesheet" href="/css/style.css?v=mobfix-1" />
   <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
 </head>
 <body>
   <div class="contenedor">

--- a/nerin_final_updated/frontend/pages/error.html
+++ b/nerin_final_updated/frontend/pages/error.html
@@ -6,6 +6,7 @@
   <link rel="stylesheet" href="/css/style.css?v=mobfix-1" />
   <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
 </head>
 <body>
   <div class="contenedor">

--- a/nerin_final_updated/frontend/pages/pendiente.html
+++ b/nerin_final_updated/frontend/pages/pendiente.html
@@ -6,6 +6,7 @@
   <link rel="stylesheet" href="/css/style.css?v=mobfix-1" />
   <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
 </head>
 <body>
   <div class="contenedor">

--- a/nerin_final_updated/frontend/pages/precheckout.html
+++ b/nerin_final_updated/frontend/pages/precheckout.html
@@ -6,6 +6,7 @@
     <script>window.location.replace('/checkout-steps.html');</script>
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
 </head>
   <body>
     <p>Redirigiendo al nuevo checkout...</p>

--- a/nerin_final_updated/frontend/pages/terminos.html
+++ b/nerin_final_updated/frontend/pages/terminos.html
@@ -71,6 +71,7 @@
     <link rel="stylesheet" href="/css/style.css?v=mobfix-1" />
   <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
 </head>
 <body>
   <header class="simple-header">

--- a/nerin_final_updated/frontend/pending.html
+++ b/nerin_final_updated/frontend/pending.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="css/success.css" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/product.html
+++ b/nerin_final_updated/frontend/product.html
@@ -14,6 +14,7 @@
       <link rel="stylesheet" href="style.css?v=mobfix-1" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/register.html
+++ b/nerin_final_updated/frontend/register.html
@@ -14,6 +14,7 @@
       <link rel="stylesheet" href="style.css?v=mobfix-1" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/seguimiento.html
+++ b/nerin_final_updated/frontend/seguimiento.html
@@ -7,6 +7,7 @@
           <link rel="stylesheet" href="style.css?v=mobfix-1" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/shop.html
+++ b/nerin_final_updated/frontend/shop.html
@@ -14,6 +14,7 @@
       <link rel="stylesheet" href="style.css?v=mobfix-1" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/success.html
+++ b/nerin_final_updated/frontend/success.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="css/success.css" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
 </head>
   <body>
     <header>


### PR DESCRIPTION
## Summary
- add CSS overrides to compact hero, product cards and footer
- ensure overrides stylesheet loads last on all public pages

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68adc23001348331b715682761e10cf3