### PR TITLE
Ensure overrides stylesheet loads last with responsive tweaks

### DIFF
--- a/nerin_final_updated/backend/scripts/verifyOverrides.js
+++ b/nerin_final_updated/backend/scripts/verifyOverrides.js
@@ -1,0 +1,45 @@
+const { spawn } = require('child_process');
+const http = require('http');
+const path = require('path');
+
+const PORT = process.env.PORT || 3100;
+
+const server = spawn('node', [path.join(__dirname, '..', 'index.js')], {
+  env: { ...process.env, NODE_ENV: 'test', PORT: PORT.toString() },
+  stdio: ['ignore', 'inherit', 'inherit'],
+});
+
+function shutdown(code) {
+  server.kill();
+  setTimeout(() => process.exit(code), 100);
+}
+
+function check(retries = 10) {
+  http
+    .get(`http://localhost:${PORT}/css/overrides.css`, (res) => {
+      let data = '';
+      res.on('data', (chunk) => (data += chunk));
+      res.on('end', () => {
+        if (res.statusCode !== 200) {
+          console.error(`Expected status 200, got ${res.statusCode}`);
+          return shutdown(1);
+        }
+        if (!/\.product-card/.test(data)) {
+          console.error('overrides.css missing .product-card rule');
+          return shutdown(1);
+        }
+        console.log('overrides.css served with .product-card rule');
+        shutdown(0);
+      });
+    })
+    .on('error', (err) => {
+      if (retries > 0) {
+        setTimeout(() => check(retries - 1), 500);
+      } else {
+        console.error('Request failed', err.message);
+        shutdown(1);
+      }
+    });
+}
+
+setTimeout(() => check(), 1000);

--- a/nerin_final_updated/frontend/account.html
+++ b/nerin_final_updated/frontend/account.html
@@ -14,7 +14,7 @@
       <link rel="stylesheet" href="style.css?v=mobfix-1" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
-  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1459">
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/admin.html
+++ b/nerin_final_updated/frontend/admin.html
@@ -12,7 +12,7 @@
       href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css"
     />
       <link rel="stylesheet" href="style.css?v=mobfix-1" />
-  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1459">
   </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/cart.html
+++ b/nerin_final_updated/frontend/cart.html
@@ -20,7 +20,7 @@
       <link rel="stylesheet" href="style.css?v=mobfix-1" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
-  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1459">
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/checkout-form.html
+++ b/nerin_final_updated/frontend/checkout-form.html
@@ -6,7 +6,7 @@
     <script>window.location.replace('/checkout-steps.html');</script>
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
-  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1459">
 </head>
   <body>
     <p>Redirigiendo al nuevo checkout...</p>

--- a/nerin_final_updated/frontend/checkout-steps.html
+++ b/nerin_final_updated/frontend/checkout-steps.html
@@ -8,7 +8,7 @@
       <link rel="stylesheet" href="style.css?v=mobfix-1" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
-  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1459">
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/checkout.html
+++ b/nerin_final_updated/frontend/checkout.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css" />
   <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
-  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1459">
 </head>
 <body>
   <div class="contenedor">

--- a/nerin_final_updated/frontend/contact.html
+++ b/nerin_final_updated/frontend/contact.html
@@ -14,7 +14,7 @@
       <link rel="stylesheet" href="style.css?v=mobfix-1" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
-  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1459">
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/css/overrides.css
+++ b/nerin_final_updated/frontend/css/overrides.css
@@ -5,11 +5,20 @@
   padding-block: 24px;
 }
 .hero h1 {
-  font-size: clamp(24px, 5vw, 32px);
+  font-size: clamp(22px, 5.2vw, 32px);
+}
+.hero p {
+  font-size: clamp(14px, 4vw, 16px);
+}
+.hero .button {
+  min-height: 44px;
 }
 @media (min-width: 600px) {
   .hero {
     padding-block: 32px;
+  }
+  .hero .button {
+    min-height: 40px;
   }
 }
 @media (min-width: 1024px) {
@@ -19,8 +28,12 @@
 }
 
 /* Product cards */
+.product-grid {
+  display: grid;
+  gap: 12px;
+}
 .product-card img {
-  height: clamp(160px, 38vw, 220px);
+  height: clamp(140px, 37vw, 220px);
   object-fit: cover;
 }
 .product-card h3 {
@@ -34,6 +47,9 @@
   min-height: 44px;
 }
 @media (min-width: 600px) {
+  .product-grid {
+    gap: 16px;
+  }
   .product-card .product-actions .button,
   .product-card .add-to-cart button {
     min-height: 40px;
@@ -41,11 +57,13 @@
 }
 
 /* Footer layout */
+body .site-footer,
 .site-footer {
   padding: 12px 16px;
   gap: 12px;
 }
 @media (min-width: 600px) {
+  body .site-footer,
   .site-footer {
     display: grid;
     grid-template-columns: 1fr 1fr;
@@ -57,16 +75,36 @@
   }
 }
 @media (min-width: 1024px) {
+  body .site-footer,
   .site-footer {
     padding: 24px;
   }
 }
+body .site-footer .contact-chips,
+.site-footer .contact-chips {
+  grid-area: chips;
+}
+body .site-footer .footer-nav,
+.site-footer .footer-nav {
+  grid-area: nav;
+}
+body .site-footer .footer-social,
+.site-footer .footer-social {
+  grid-area: social;
+}
+body .site-footer .legal,
+.site-footer .legal {
+  grid-area: legal;
+}
 
 /* Anti-overlap for sticky footer and FAB */
+:root {
+  --sticky: 56px;
+}
 body {
-  padding-bottom: calc(var(--cta-h, 0px) + 72px);
+  padding-bottom: calc(var(--sticky) + 72px);
 }
 .wa-fab,
 html.cta-visible .wa-fab {
-  bottom: calc(16px + var(--cta-h, 0px));
+  bottom: calc(16px + var(--sticky));
 }

--- a/nerin_final_updated/frontend/failure.html
+++ b/nerin_final_updated/frontend/failure.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="css/success.css" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
-  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1459">
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/index.html
+++ b/nerin_final_updated/frontend/index.html
@@ -14,7 +14,7 @@
       <link rel="stylesheet" href="style.css?v=mobfix-1" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r2">
     <script src="/components/np-footer.js?v=np-r2" defer></script>
-  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1459">
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/invoice.html
+++ b/nerin_final_updated/frontend/invoice.html
@@ -51,7 +51,7 @@
       <link rel="stylesheet" href="style.css?v=mobfix-1" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
-  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1459">
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/login.html
+++ b/nerin_final_updated/frontend/login.html
@@ -14,7 +14,7 @@
       <link rel="stylesheet" href="style.css?v=mobfix-1" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
-  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1459">
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/pending.html
+++ b/nerin_final_updated/frontend/pending.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="css/success.css" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
-  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1459">
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/product.html
+++ b/nerin_final_updated/frontend/product.html
@@ -14,7 +14,7 @@
       <link rel="stylesheet" href="style.css?v=mobfix-1" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
-  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1459">
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/register.html
+++ b/nerin_final_updated/frontend/register.html
@@ -14,7 +14,7 @@
       <link rel="stylesheet" href="style.css?v=mobfix-1" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
-  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1459">
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/seguimiento.html
+++ b/nerin_final_updated/frontend/seguimiento.html
@@ -7,7 +7,7 @@
           <link rel="stylesheet" href="style.css?v=mobfix-1" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
-  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1459">
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/shop.html
+++ b/nerin_final_updated/frontend/shop.html
@@ -14,7 +14,7 @@
       <link rel="stylesheet" href="style.css?v=mobfix-1" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
-  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1459">
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/success.html
+++ b/nerin_final_updated/frontend/success.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="css/success.css" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
   <script src="/components/np-footer.js?v=np-r1" defer></script>
-  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1427">
+  <link rel="stylesheet" href="/css/overrides.css?v=nerin-20250826-1459">
 </head>
   <body>
     <header>

--- a/nerin_final_updated/package.json
+++ b/nerin_final_updated/package.json
@@ -5,7 +5,8 @@
   "main": "backend/index.js",
   "scripts": {
     "start": "node backend/index.js",
-    "cleanup": "node backend/scripts/cleanup.js"
+    "cleanup": "node backend/scripts/cleanup.js",
+    "verify:overrides": "node backend/scripts/verifyOverrides.js"
   },
   "dependencies": {
     "afip.ts": "^3.2.2",


### PR DESCRIPTION
## Summary
- append cache-busted `/css/overrides.css` link to the end of every public HTML template
- tighten hero, product card, and footer styles with real selectors for consistent sizing
- add anti-overlap spacing using `--sticky` variable for sticky CTA and WhatsApp button
- add `verify:overrides` npm script to confirm the override stylesheet is served

## Testing
- `npm test` *(fails: Missing script "test" as no tests are defined)*
- `npm run verify:overrides`


------
https://chatgpt.com/codex/tasks/task_e_68adcb65543883319a720157f2b59449