### PR TITLE
Include shipping address in admin orders

### DIFF
--- a/nerin_final_updated/backend/index.js
+++ b/nerin_final_updated/backend/index.js
@@ -258,15 +258,24 @@ app.get("/api/orders", async (req, res) => {
         return ps === status;
       });
     }
-    const rows = orders.map((o) => ({
-      order_number: o.order_number || o.id || o.external_reference || "",
-      date: o.fecha || o.date || o.created_at || "",
-      client: o.cliente?.nombre || o.cliente?.name || "",
-      phone: o.cliente?.telefono || "",
-      shipping_province: o.provincia_envio || "",
-      payment_status: o.payment_status || o.estado_pago || "pending",
-      total: o.total || 0,
-    }));
+    const rows = orders.map((o) => {
+      const cliente = o.cliente || {};
+      const direccion = cliente.direccion || {};
+      return {
+        ...o,
+        order_number: o.order_number || o.id || o.external_reference || "",
+        created_at: o.fecha || o.date || o.created_at || "",
+        cliente,
+        productos: o.productos || o.items || [],
+        provincia_envio: o.provincia_envio || direccion.provincia || "",
+        costo_envio: Number(o.costo_envio || 0),
+        total_amount: Number(o.total_amount || o.total || 0),
+        payment_status: o.payment_status || o.estado_pago || "pending",
+        shipping_status: o.shipping_status || o.estado_envio || "pendiente",
+        seguimiento: o.seguimiento || o.tracking || "",
+        transportista: o.transportista || o.carrier || "",
+      };
+    });
     res.json({ orders: rows });
   } catch (err) {
     console.error(err);

--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -919,7 +919,7 @@ async function loadOrders() {
           ? `${direccion.calle} ${direccion.numero || ""}, ${direccion.localidad || ""}, ${
               direccion.provincia || ""
             } ${direccion.cp || ""}`
-          : "";
+          : order.address || "";
         // Crear celdas manualmente para añadir listeners
         const idTd = document.createElement("td");
         idTd.textContent = order.order_number;


### PR DESCRIPTION
## Summary
- Return full order details including customer addresses and shipping info in `/api/orders`
- Display order address in admin panel with fallback to provided string

## Testing
- `npm test`
- `npm run verify:overrides`


------
https://chatgpt.com/codex/tasks/task_e_68aee96b00ec83319258afea14130717