### PR TITLE
feat: unify footer offsets for safe-area

### DIFF
--- a/nerin_final_updated/frontend/components/np-footer.css
+++ b/nerin_final_updated/frontend/components/np-footer.css
@@ -6,6 +6,7 @@
   --color-border: rgba(0, 0, 0, 0.08);
   --cta-h: 0px;
   --fab-safe-offset: 0px;
+  --safe-area: env(safe-area-inset-bottom);
 }
 
 /* Sticky CTA */
@@ -13,7 +14,7 @@
   position: fixed;
   left: 0;
   right: 0;
-  bottom: env(safe-area-inset-bottom);
+  bottom: var(--safe-area);
   padding: 12px 16px;
   background: #fff;
   border-top: 1px solid var(--color-border);
@@ -44,7 +45,7 @@
   width: 56px;
   height: 56px;
   right: 16px;
-  bottom: calc(16px + var(--fab-safe-offset) + env(safe-area-inset-bottom));
+  bottom: calc(16px + var(--fab-safe-offset) + var(--safe-area));
   border-radius: 50%;
   background: #25d366;
   display: flex;
@@ -71,7 +72,7 @@ html.footer-visible [data-wa] {
 }
 
 main {
-  padding-bottom: calc(var(--cta-h) + env(safe-area-inset-bottom));
+  padding-bottom: calc(var(--cta-h) + var(--safe-area));
 }
 
 body {
@@ -91,7 +92,7 @@ body.hide-cta [data-sticky-cta] {
 }
 
 body.hide-cta main {
-  padding-bottom: env(safe-area-inset-bottom);
+  padding-bottom: var(--safe-area);
 }
 
 /* Footer */
@@ -104,7 +105,7 @@ body.hide-cta main {
   max-width: 1200px;
   margin: 0 auto;
   padding: var(--space-12) 16px;
-  padding-bottom: calc(var(--space-12) + env(safe-area-inset-bottom));
+  padding-bottom: calc(var(--space-12) + var(--safe-area));
   display: flex;
   flex-direction: column;
   gap: var(--space-12);
@@ -183,7 +184,7 @@ body.hide-cta main {
   }
   .site-footer {
     padding: var(--space-16);
-    padding-bottom: calc(var(--space-16) + env(safe-area-inset-bottom));
+    padding-bottom: calc(var(--space-16) + var(--safe-area));
     gap: var(--space-16);
     display: grid;
     grid-template-columns: 1fr 1fr;
@@ -206,6 +207,6 @@ body.hide-cta main {
 @media (min-width: 1024px) {
   .site-footer {
     padding: 24px;
-    padding-bottom: calc(24px + env(safe-area-inset-bottom));
+    padding-bottom: calc(24px + var(--safe-area));
   }
 }

--- a/nerin_final_updated/frontend/components/np-footer.js
+++ b/nerin_final_updated/frontend/components/np-footer.js
@@ -32,7 +32,7 @@
         const h = (cta?.offsetHeight || 0);
         document.documentElement.style.setProperty('--cta-h', h + 'px');
         if (main) {
-          main.style.paddingBottom = `calc(${h}px + env(safe-area-inset-bottom))`;
+          main.style.paddingBottom = `calc(${h}px + var(--safe-area))`;
         }
         document.documentElement.classList.toggle('cta-visible', h > 0 && isCTAOnScreen());
       }

--- a/nerin_final_updated/frontend/js/fab-offset.js
+++ b/nerin_final_updated/frontend/js/fab-offset.js
@@ -2,16 +2,22 @@
   const selectors = '[data-wa], a[href*="wa.me"], .whatsapp-fab, [class*="whatsapp"]';
   const fab = document.querySelector(selectors);
 
+  const getSafe = () =>
+    parseFloat(
+      getComputedStyle(document.documentElement).getPropertyValue('--safe-area')
+    ) || 0;
+
   function update() {
     let offset = 0;
     const vp = window.innerHeight;
+    const safe = getSafe();
     document.querySelectorAll('body *').forEach((el) => {
       if (!el || el === fab || (fab && fab.contains(el))) return;
       if (el.offsetParent === null) return;
       const style = getComputedStyle(el);
       if (style.position === 'fixed' || style.position === 'sticky') {
         const rect = el.getBoundingClientRect();
-        if (rect.bottom >= vp - 1 && rect.top < vp) {
+        if (rect.bottom >= vp - safe - 1 && rect.top < vp) {
           offset += rect.height;
         }
       }
@@ -19,8 +25,8 @@
     const footer = document.querySelector('footer');
     if (footer) {
       const r = footer.getBoundingClientRect();
-      if (r.top < vp) {
-        const overlap = vp - r.top;
+      if (r.top < vp - safe) {
+        const overlap = vp - safe - r.top;
         if (overlap > offset) offset = overlap;
       }
     }


### PR DESCRIPTION
## Summary
- add `--safe-area` token and reuse it across footer styles
- make FAB offset calculation aware of safe-area to keep WhatsApp button clear of CTA and footer
- update footer script to honour shared safe-area variable

## Testing
- `npm test`

## QA
- [ ] index
- [ ] shop
- [ ] product
- [ ] checkout
- [ ] success/failure
- [ ] admin
- [ ] 360px viewport
- [ ] 768px viewport
- [ ] 1024px viewport
- [x] 1280px viewport
- [x] Keyboard focus reaches CTA and FAB
- [x] CTA and FAB do not overlap and stay above footer


------
https://chatgpt.com/codex/tasks/task_e_68af0c531e64833195d0cb816598bd5d