### PR TITLE
Fix Mercado Pago status mapping and add reconciliation tool

### DIFF
--- a/nerin_final_updated/backend/README.md
+++ b/nerin_final_updated/backend/README.md
@@ -39,3 +39,21 @@ Esta actualización agrega persistencia básica de pedidos y soporte de seguimie
      -H 'Content-Type: application/json' \
      -d '{"email":"a@b.com","id":"<NRN>"}' | jq
    ```
+
+## Reconciliación de pagos
+
+Si un webhook final no llega, se puede reconciliar el estado y stock en forma
+idempotente:
+
+- Revisar las últimas 24 h:
+  ```bash
+  npm run mp:reconcile
+  ```
+- Reconciliar una orden específica por `payment_id` o `external_reference`:
+  ```bash
+  npm run mp:reconcile -- --payment 123456789
+  npm run mp:reconcile -- --order NRN-0001
+  ```
+
+El comando consulta la API de Mercado Pago y actualiza la orden aplicando o
+revirtiendo stock solo una vez.

--- a/nerin_final_updated/backend/middleware/verifySignature.js
+++ b/nerin_final_updated/backend/middleware/verifySignature.js
@@ -4,19 +4,23 @@ const logger = require('../logger');
 module.exports = function verifySignature(req, _res, next) {
   const secret = process.env.MP_WEBHOOK_SECRET || '';
   if (!secret || secret === 'dummy') {
-    logger.warn('mp-webhook signature check', {
-      signature_valid: false,
-      reason: secret ? 'placeholder' : 'no_secret',
-    });
+    logger.warn(
+      `mp-webhook signature check ${JSON.stringify({
+        signature_valid: false,
+        reason: secret ? 'placeholder' : 'no_secret',
+      })}`,
+    );
     req.validSignature = true;
     return next();
   }
   const signature = req.headers['x-signature'];
   if (!signature || !req.rawBody) {
-    logger.warn('mp-webhook signature check', {
-      signature_valid: false,
-      reason: 'missing',
-    });
+    logger.warn(
+      `mp-webhook signature check ${JSON.stringify({
+        signature_valid: false,
+        reason: 'missing',
+      })}`,
+    );
     req.validSignature = false;
     return next();
   }
@@ -31,21 +35,27 @@ module.exports = function verifySignature(req, _res, next) {
       sigBuf.length !== expBuf.length ||
       !crypto.timingSafeEqual(sigBuf, expBuf)
     ) {
-      logger.warn('mp-webhook signature check', {
-        signature_valid: false,
-        reason: 'mismatch',
-      });
+      logger.warn(
+        `mp-webhook signature check ${JSON.stringify({
+          signature_valid: false,
+          reason: 'mismatch',
+        })}`,
+      );
       req.validSignature = false;
       return next();
     }
-    logger.info('mp-webhook signature check', { signature_valid: true });
+    logger.info(
+      `mp-webhook signature check ${JSON.stringify({ signature_valid: true })}`,
+    );
     req.validSignature = true;
   } catch (e) {
-    logger.warn('mp-webhook signature check', {
-      signature_valid: false,
-      reason: 'error',
-      msg: e?.message,
-    });
+    logger.warn(
+      `mp-webhook signature check ${JSON.stringify({
+        signature_valid: false,
+        reason: 'error',
+        msg: e?.message,
+      })}`,
+    );
     req.validSignature = false;
   }
   next();

--- a/nerin_final_updated/backend/routes/mercadoPago.js
+++ b/nerin_final_updated/backend/routes/mercadoPago.js
@@ -166,14 +166,17 @@ async function processPayment(id, hints = {}) {
       total,
     });
 
-    logger.info('mp-webhook OK', {
-      topic: 'payment',
-      paymentId: p.id,
-      externalRef,
-      prefId,
-      status: mapped,
-      stock_delta: stockDelta,
-    });
+    logger.info(
+      `mp-webhook OK ${JSON.stringify({
+        topic: 'payment',
+        paymentId: p.id,
+        externalRef,
+        prefId,
+        status: mapped,
+        stock_delta: stockDelta,
+        idempotent: stockDelta === 0,
+      })}`,
+    );
 
     return {
       mp_lookup_ok: true,
@@ -213,7 +216,9 @@ async function processNotification(reqOrTopic, maybeId) {
     maybeId;
   const resource = query.resource || body?.resource;
 
-  logger.info('mp-webhook recibido', { topic, id: rawId });
+  logger.info(
+    `mp-webhook recibido ${JSON.stringify({ topic, id: rawId })}`,
+  );
 
   try {
     if (resource) {

--- a/nerin_final_updated/backend/scripts/mp_reconcile.js
+++ b/nerin_final_updated/backend/scripts/mp_reconcile.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+require('dotenv').config();
+const { processNotification } = require('../routes/mercadoPago');
+const ordersRepo = require('../data/ordersRepo');
+const fetchFn =
+  globalThis.fetch ||
+  ((...a) => import('node-fetch').then(({ default: f }) => f(...a)));
+
+async function reconcileRecent(hours = 24) {
+  const orders = await ordersRepo.getAll();
+  const cutoff = Date.now() - hours * 3600 * 1000;
+  for (const o of orders) {
+    const created = new Date(o.created_at || o.fecha || 0).getTime();
+    if (created && created < cutoff) continue;
+    const status = String(o.payment_status || o.estado_pago || '').toLowerCase();
+    if (['aprobado', 'rechazado'].includes(status)) continue;
+    const id = o.payment_id || o.preference_id || o.external_reference;
+    if (!id) continue;
+    const topic = o.payment_id ? 'payment' : 'merchant_order';
+    try {
+      await processNotification(topic, id);
+      console.log('reconciled', topic, id);
+    } catch (e) {
+      console.error('reconcile failed', topic, id, e.message);
+    }
+  }
+}
+
+async function reconcileOne(opts) {
+  const { payment, order } = opts;
+  if (!payment && !order) {
+    console.error('Usage: mp:reconcile -- --payment <id>|--order <external_ref>');
+    process.exit(1);
+  }
+  try {
+    if (payment) {
+      await processNotification('payment', payment);
+    } else {
+      let moId = order;
+      if (!/^\d+$/.test(String(order))) {
+        const res = await fetchFn(
+          `https://api.mercadopago.com/merchant_orders/search?external_reference=${encodeURIComponent(
+            order,
+          )}`,
+          { headers: { Authorization: `Bearer ${process.env.MP_ACCESS_TOKEN || ''}` } },
+        );
+        const data = await res.json();
+        moId = data?.elements?.[0]?.id;
+        if (!moId) throw new Error('order not found');
+      }
+      await processNotification('merchant_order', moId);
+    }
+    console.log('reconciled');
+  } catch (e) {
+    console.error('reconcile failed', e.message);
+    process.exit(1);
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  let payment = null;
+  let order = null;
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if ((a === '--payment' || a === '-p') && args[i + 1]) {
+      payment = args[++i];
+    } else if ((a === '--order' || a === '-o') && args[i + 1]) {
+      order = args[++i];
+    }
+  }
+  if (payment || order) await reconcileOne({ payment, order });
+  else await reconcileRecent();
+}
+
+main();

--- a/nerin_final_updated/frontend/js/mpStatusMap.js
+++ b/nerin_final_updated/frontend/js/mpStatusMap.js
@@ -6,6 +6,10 @@ const MP_STATUS_MAP = {
   charged_back: 'rechazado',
   in_process: 'pendiente',
   pending: 'pendiente',
+  // internal statuses
+  aprobado: 'aprobado',
+  rechazado: 'rechazado',
+  pendiente: 'pendiente',
 };
 
 function mapMpStatus(status) {

--- a/nerin_final_updated/package.json
+++ b/nerin_final_updated/package.json
@@ -11,6 +11,7 @@
     "verify:mp-prod": "node backend/scripts/mp_webhook_probe.js",
     "mp:replay": "node backend/scripts/mp_replay.js",
     "mp:self-probe": "node backend/scripts/mp_self_probe.js",
+    "mp:reconcile": "node backend/scripts/mp_reconcile.js",
     "device:qa": "node scripts/device-qa.js"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- handle internal Mercado Pago statuses in shared status map
- improve webhook logging including idempotent stock updates
- add mp:reconcile script and documentation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run mp:reconcile`
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b0ec4065f08331b20fcfe663ec11d8