### PR TITLE
fix: enforce MP payment lookup and stock idempotency

### DIFF
--- a/nerin_final_updated/backend/data/inventoryRepo.js
+++ b/nerin_final_updated/backend/data/inventoryRepo.js
@@ -2,23 +2,33 @@ const productsRepo = require('./productsRepo');
 const ordersRepo = require('./ordersRepo');
 
 async function applyForOrder(order) {
+  const items = [];
+  let total = 0;
   for (const it of order.productos || order.items || []) {
     const id = it.product_id || it.productId || it.id;
     const qty = Number(it.quantity || it.qty || 0);
     if (id && qty) {
-      await productsRepo.adjustStock(id, -qty, 'order', order.id);
+      const before = (await productsRepo.getById(id))?.stock || 0;
+      const after = await productsRepo.adjustStock(id, -qty, 'order', order.id);
+      items.push({ sku: id, before: Number(before), after: Number(after) });
+      total += qty;
     }
   }
   if (order.id) await ordersRepo.markInventoryApplied(order.id);
-  return true;
+  return { total, items };
 }
 
 async function revertForOrder(order) {
+  const items = [];
+  let total = 0;
   for (const it of order.productos || order.items || []) {
     const id = it.product_id || it.productId || it.id;
     const qty = Number(it.quantity || it.qty || 0);
     if (id && qty) {
-      await productsRepo.adjustStock(id, qty, 'order-revert', order.id);
+      const before = (await productsRepo.getById(id))?.stock || 0;
+      const after = await productsRepo.adjustStock(id, qty, 'order-revert', order.id);
+      items.push({ sku: id, before: Number(before), after: Number(after) });
+      total += qty;
     }
   }
   if (order.id) {
@@ -26,7 +36,7 @@ async function revertForOrder(order) {
       await ordersRepo.clearInventoryApplied(order.id);
     } catch {}
   }
-  return true;
+  return { total, items };
 }
 
 module.exports = { applyForOrder, revertForOrder };


### PR DESCRIPTION
## Summary
- ensure Mercado Pago payment lookups always run in production
- apply inventory with before/after tracking and detect idempotent stock updates
- enrich MP webhook logs with order/payment IDs and item deltas

## Testing
- `npm test` *(fails: Missing script "test")*
- `STORAGE_DIR=/tmp/nerin-test node - <<'NODE'
// stub fetch before require
global.fetch = async (url, opts) => ({
  json: async () => ({
    id: 124100848004,
    status: 'approved',
    external_reference: 'NRN-TEST-0001',
    preference_id: null,
    order: { id: 999 },
    transaction_amount: 200
  })
});
const { processPayment } = require('./nerin_final_updated/backend/routes/mercadoPago');
processPayment(124100848004, {}, { topic:'payment', id:124100848004 }).then(r => {
  console.log('result', JSON.stringify(r));
});
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68b1a581afc08331aa3da7a8208d97d4