### PR TITLE
fix: enforce MP lookup and stub order

### DIFF
--- a/nerin_final_updated/backend/utils/envFlag.js
+++ b/nerin_final_updated/backend/utils/envFlag.js
@@ -1,0 +1,9 @@
+function envFlag(name, defaultValue = false) {
+  const val = process.env[name];
+  if (val == null) return defaultValue;
+  const str = String(val).trim().toLowerCase();
+  if (['1', 'true', 'yes'].includes(str)) return true;
+  if (['0', 'false', 'no', ''].includes(str)) return false;
+  return defaultValue;
+}
+module.exports = { envFlag };


### PR DESCRIPTION
## Summary
- normalize env toggles and disable Mercado Pago bypass when running in production with credentials
- upsert stub orders and correlate using payment additional reference for inventory handling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `STORAGE_DIR=../data SKIP_MP_PAYMENT_FETCH=1 TRACE_REF=NRN-290825-6967 node backend/scripts/mp_replay.js -- --payment 124159043940`

------
https://chatgpt.com/codex/tasks/task_e_68b213e198148331886809ad6267411f