### PR TITLE
fix: enforce Mercado Pago webhook fetch and unify status mapping

### DIFF
--- a/nerin_final_updated/frontend/js/success.js
+++ b/nerin_final_updated/frontend/js/success.js
@@ -74,7 +74,7 @@ function render(info) {
       ? 'Pago aprobado'
       : status === 'rechazado'
       ? 'Pago rechazado'
-      : 'Pago en revisión';
+      : 'Pago pendiente';
   const guide =
     status === 'pendiente'
       ? '<p class="guide">Te avisamos por email. Podés seguir el estado con tu número de pedido.</p>'


### PR DESCRIPTION
## Summary
- log and enforce Mercado Pago webhook fetch in production when token is present
- create persistent order stubs and robustly resolve references
- align frontend status copy to use `pendiente` instead of `revisión`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run verify:overrides`
- `npm run verify:mp-webhook` *(fails: Webhook probe failed fetch failed ECONNREFUSED)*
- `NODE_ENV=production MP_ENV=production SKIP_MP_PAYMENT_FETCH=1 MP_ACCESS_TOKEN=dummy npm run mp:replay -- --payment 124173624736`
- `NODE_ENV=production MP_ENV=production SKIP_MP_PAYMENT_FETCH=1 MP_ACCESS_TOKEN=dummy npm run mp:replay -- --payment 123630053327`

------
https://chatgpt.com/codex/tasks/task_e_68b22c7109588331b091a6fb5a35edff