### PR TITLE
fix: prioritize payment IDs for Mercado Pago webhook

### DIFF
--- a/nerin_final_updated/backend/routes/mercadoPago.js
+++ b/nerin_final_updated/backend/routes/mercadoPago.js
@@ -553,10 +553,10 @@ async function processNotification(reqOrTopic, maybeId) {
     body.topic ||
     (typeof reqOrTopic === 'string' ? reqOrTopic : undefined);
   const rawId =
-    query.id ||
     body?.payment_id ||
     body?.data?.id ||
     body?.id ||
+    query.id ||
     (typeof reqOrTopic === 'string' ? maybeId : undefined) ||
     maybeId;
   const resource = query.resource || body?.resource;


### PR DESCRIPTION
## Summary
- ensure Mercado Pago webhook prioritizes payment_id and data.id when resolving notification IDs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b23b16dfa08331b4c711fee72e861e