### PR TITLE
Improve Mercado Pago webhook diagnostics

### DIFF
--- a/backend/routes/mercadoPagoPreference.js
+++ b/backend/routes/mercadoPagoPreference.js
@@ -70,6 +70,8 @@ router.post('/crear-preferencia', async (req, res) => {
       if (id || sku) {
         it.id = id || sku;
         it.sku = sku || id;
+      } else {
+        it.id = it.sku = String(titulo);
       }
       return it;
     },
@@ -77,7 +79,7 @@ router.post('/crear-preferencia', async (req, res) => {
 
   const numeroOrden = generarNumeroOrden();
 
-  const PUBLIC_URL = getPublicUrl(req);
+  const PUBLIC_URL = process.env.PUBLIC_URL || getPublicUrl(req);
   const body = {
     items,
     payer: { email: usuario.email },

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -2443,6 +2443,34 @@ const server = http.createServer((req, res) => {
 
   // === Integración con Mercado Pago ===
   if (
+    pathname.startsWith('/api/debug/mp/payments/') &&
+    req.method === 'GET'
+  ) {
+    const id = decodeURIComponent(pathname.split('/').pop());
+    const url = `https://api.mercadopago.com/v1/payments/${id}`;
+    (async () => {
+      try {
+        const r = await fetchFn(url, {
+          headers: { Authorization: `Bearer ${MP_TOKEN}` },
+        });
+        const text = await r.text();
+        logger.info('mp-debug payment fetch', { id, status: r.status });
+        let parsed;
+        try {
+          parsed = JSON.parse(text);
+        } catch {
+          parsed = text;
+        }
+        sendJson(res, r.status, { status: r.status, body: parsed });
+      } catch (e) {
+        logger.error('mp-debug payment error', { id, msg: e?.message });
+        sendJson(res, 500, { error: 'fetch_failed' });
+      }
+    })();
+    return;
+  }
+
+  if (
     (pathname === "/api/mercadopago/preference" ||
       pathname === "/api/mercado-pago/crear-preferencia") &&
     req.method === "POST"


### PR DESCRIPTION
## Summary
- add safeTrunc helper and robust fetch/error logging for Mercado Pago lookups
- expose payment fetch debug route and avoid order stubs when references exist
- ensure preference items carry IDs and always send webhook notifications

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b39087bae0833181d06e66a82bdbfc