### PR TITLE
fix: unify orders repository and startup logging

### DIFF
--- a/nerin_final_updated/backend/index.js
+++ b/nerin_final_updated/backend/index.js
@@ -65,6 +65,12 @@ const { processNotification, processPayment, traceRef } = require("./routes/merc
 const verifySignature = require("./middleware/verifySignature");
 const { mapMpStatus, MP_STATUS_MAP } = require("../frontend/js/mpStatusMap");
 const logger = require("./logger");
+const dataDir = require("./utils/dataDir");
+
+const ordersFilePath = path.join(dataDir, "orders.json");
+logger.info(
+  `Startup paths cwd=${process.cwd()} ordersRepo=${require.resolve("./data/ordersRepo")} ordersFile=${ordersFilePath}`
+);
 
 let autoElevateCount = 0;
 

--- a/nerin_final_updated/backend/routes/mercadoPago.js
+++ b/nerin_final_updated/backend/routes/mercadoPago.js
@@ -109,28 +109,13 @@ function traceRef(ref, step, info) {
   }
 }
 
-function ordersPath() {
-  return path.join(dataDir, 'orders.json');
-}
-
-async function getOrders() {
-  if (db.getPool()) return ordersRepo.getAll();
-  try {
-    const file = fs.readFileSync(ordersPath(), 'utf8');
-    return JSON.parse(file).orders || [];
-  } catch {
-    return [];
+  async function getOrders() {
+    return ordersRepo.getAll();
   }
-}
 
-async function saveOrders(orders) {
-  if (db.getPool()) return ordersRepo.saveAll(orders);
-  await fs.promises.writeFile(
-    ordersPath(),
-    JSON.stringify({ orders }, null, 2),
-    'utf8'
-  );
-}
+  async function saveOrders(orders) {
+    return ordersRepo.saveAll(orders);
+  }
 
 function productsPath() {
   return path.join(dataDir, 'products.json');

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "ecommerce-3.0",
   "version": "1.0.0",
-  "main": "backend/server.js",
+  "main": "nerin_final_updated/backend/index.js",
   "scripts": {
-    "start": "node backend/server.js",
+    "start": "node nerin_final_updated/backend/index.js",
     "test": "jest",
     "list:webhooks": "node scripts/listMpWebhooks.js",
     "mp:trace": "node scripts/mpTrace.js"


### PR DESCRIPTION
## Summary
- start backend using `nerin_final_updated` Express server
- log startup info including working directory, repo path and orders file
- ensure Mercado Pago webhook uses shared orders repository

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b597191eb88331a32f54aca2551c8f