### PR TITLE
chore: instrument order persistence paths

### DIFF
--- a/nerin_final_updated/backend/routes/mercadoPago.js
+++ b/nerin_final_updated/backend/routes/mercadoPago.js
@@ -114,7 +114,10 @@ function traceRef(ref, step, info) {
   }
 
   async function saveOrders(orders) {
-    return ordersRepo.saveAll(orders);
+    const r = await ordersRepo.saveAll(orders);
+    const { ORDERS_FILE } = ordersRepo.getPaths();
+    logger.info('order_persist_target', { ORDERS_FILE });
+    return r;
   }
 
 function productsPath() {
@@ -576,6 +579,10 @@ async function processPayment(id, hints = {}, webhookInfo = null) {
       items,
       rawData: { payment: p, merchant_order: mo },
     });
+    {
+      const { ORDERS_FILE } = ordersRepo.getPaths();
+      logger.info('order_persist_target', { ORDERS_FILE });
+    }
 
     const persistInfo = {
       status: mapped,
@@ -621,6 +628,7 @@ async function processPayment(id, hints = {}, webhookInfo = null) {
 }
 
 async function processNotification(reqOrTopic, maybeId) {
+  logger.info('mp-webhook begin', { file: __filename });
   const body = reqOrTopic?.body || {};
   const query = reqOrTopic?.query || {};
   const topic =
@@ -717,6 +725,10 @@ async function processNotification(reqOrTopic, maybeId) {
               items: data.items || [],
               rawData: { resource: data },
             });
+            {
+              const { ORDERS_FILE } = ordersRepo.getPaths();
+              logger.info('order_persist_target', { ORDERS_FILE });
+            }
             logger.info('mp-webhook merchant_order sin payment (pending)', {
               externalRef,
               prefId,
@@ -803,6 +815,10 @@ async function processNotification(reqOrTopic, maybeId) {
             items: mo.items || [],
             rawData: { merchant_order: mo },
           });
+          {
+            const { ORDERS_FILE } = ordersRepo.getPaths();
+            logger.info('order_persist_target', { ORDERS_FILE });
+          }
           logger.info('mp-webhook merchant_order sin payment (pending)', {
             externalRef,
             prefId,

--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -967,8 +967,17 @@ if (orderStatusFilter) {
 
 async function loadOrders() {
   try {
-    const res = await fetch("/api/orders");
+    const url = "/api/orders";
+    console.info('admin-orders fetch', { url });
+    const res = await fetch(url);
     const data = await res.json();
+    console.info('admin-orders result', {
+      count: Array.isArray(data?.orders)
+        ? data.orders.length
+        : Array.isArray(data)
+        ? data.length
+        : null,
+    });
     ordersTableBody.innerHTML = "";
     const filter = document.getElementById("orderStatusFilter");
     const statusFilter = filter ? filter.value : "todos";


### PR DESCRIPTION
## Summary
- log repo paths in orders repo
- add duplicate ordersRepo detection
- trace order persistence from MercadoPago webhook and admin list
- expose debug endpoints and console traces for admin orders

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5a46421c08331be7a478986b710fb