### PR TITLE
feat: migrate backend to apps module

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,25 +1,22 @@
 INSTRUCCIONES RÁPIDAS
 =====================
 
-1. Entrá en la carpeta `backend`:
-
-   ```bash
-   cd backend
-   ```
-
-2. Las credenciales de Mercado Pago ya están definidas en `frontend/config.js`
-   y `backend/.env`. Si necesitás otras, editá esos archivos. Instalá las
-   dependencias y ejecutá el servidor:
+1. Instalá las dependencias del proyecto y levantá el backend desde la raíz:
 
    ```bash
    npm install
-   node server.js
+   npm start
    ```
 
-3. Abrí `frontend/index.html` en tu navegador y presioná el botón para pagar.
+2. Las credenciales de Mercado Pago ya están definidas en
+   `legacy/frontend_orig/config.js` y en un archivo `.env` en la raíz.
+   Si necesitás otras, editá esos archivos.
+
+3. Abrí `legacy/frontend_orig/index.html` en tu navegador y presioná el botón
+   para pagar.
 
 El backend quedará disponible en `http://localhost:3000` y podés cambiar los
-datos del producto directamente en `frontend/index.html`.
+datos del producto directamente en `legacy/frontend_orig/index.html`.
 
 VARIABLES DE ENTORNO
 -------------------

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -1,0 +1,24 @@
+# Backend
+
+Servidor Express que expone las API necesarias para el flujo de pago.
+
+## Desarrollo
+
+Desde la raíz del proyecto:
+
+```bash
+npm start
+```
+
+Las pruebas automatizadas se ejecutan con:
+
+```bash
+npm test
+```
+
+## Variables de entorno
+
+- `MP_ACCESS_TOKEN`
+- `WEBHOOK_SECRET`
+- `DB_HOST`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`, `DB_PORT`
+- `PUBLIC_URL`

--- a/apps/backend/__tests__/webhook.test.js
+++ b/apps/backend/__tests__/webhook.test.js
@@ -1,0 +1,112 @@
+const request = require('supertest');
+const express = require('express');
+const crypto = require('crypto');
+
+jest.mock('../db', () => ({
+  query: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('mercadopago', () => {
+  return {
+    MercadoPagoConfig: jest.fn().mockImplementation(() => ({})),
+    Payment: jest.fn().mockImplementation(() => ({
+      get: jest.fn().mockResolvedValue({
+        status: 'approved',
+        external_reference: 'pref123',
+        order: { id: 1 },
+      }),
+    })),
+    MerchantOrder: jest.fn().mockImplementation(() => ({
+      get: jest.fn().mockResolvedValue({
+        preference_id: 'pref123',
+        payments: [{ id: 987 }],
+      }),
+    })),
+  };
+});
+
+const { Payment, MerchantOrder } = require('mercadopago');
+const router = require('../routes/mercadoPago');
+
+describe('Mercado Pago Webhook', () => {
+  let app;
+  beforeAll(() => {
+    process.env.MP_ACCESS_TOKEN = 'test';
+    process.env.WEBHOOK_SECRET = 'secret';
+    process.env.NODE_ENV = 'test';
+    app = express();
+    app.use(express.urlencoded({ extended: false }));
+    app.use(
+      express.json({
+        verify: (req, res, buf) => {
+          req.rawBody = buf;
+        },
+      })
+    );
+    app.use('/api/webhooks/mp', router);
+  });
+
+  test('returns 200 for valid webhook', async () => {
+    const body = { id: 999, data: { id: 123 } };
+    const raw = JSON.stringify(body);
+    const signature = crypto
+      .createHmac('sha256', process.env.WEBHOOK_SECRET)
+      .update(raw)
+      .digest('hex');
+
+    await request(app)
+      .post('/api/webhooks/mp')
+      .set('Content-Type', 'application/json')
+      .set('x-signature', signature)
+      .send(body)
+      .expect(200);
+
+    const paymentInstance = Payment.mock.results[0].value;
+    expect(paymentInstance.get).toHaveBeenCalledWith({ id: 123 });
+  });
+
+  test('uses payment_id over event or data id', async () => {
+    const paymentInstance = Payment.mock.results[0].value;
+    paymentInstance.get.mockClear();
+    const body = { id: 999, data: { id: 123 }, payment_id: 456 };
+    const raw = JSON.stringify(body);
+    const signature = crypto
+      .createHmac('sha256', process.env.WEBHOOK_SECRET)
+      .update(raw)
+      .digest('hex');
+
+    await request(app)
+      .post('/api/webhooks/mp')
+      .set('Content-Type', 'application/json')
+      .set('x-signature', signature)
+      .send(body)
+      .expect(200);
+
+    expect(paymentInstance.get).toHaveBeenCalledWith({ id: 456 });
+  });
+
+  test('mapStatus maps cancelled-type statuses to cancelled', () => {
+    expect(router.mapStatus('cancelled')).toBe('cancelled');
+    expect(router.mapStatus('refunded')).toBe('cancelled');
+    expect(router.mapStatus('charged_back')).toBe('cancelled');
+  });
+
+  test('handles merchant_order webhook with resource only', async () => {
+    const merchantInstance = MerchantOrder.mock.results[0].value;
+    merchantInstance.get.mockClear();
+    const paymentInstance = Payment.mock.results[0].value;
+    paymentInstance.get.mockClear();
+
+    await request(app)
+      .post('/api/webhooks/mp?topic=merchant_order')
+      .type('form')
+      .send({ resource: 'https://api.mercadolibre.com/merchant_orders/777' })
+      .expect(200);
+
+    // allow async processing to complete
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(merchantInstance.get).toHaveBeenCalledWith({ id: '777' });
+    expect(paymentInstance.get).toHaveBeenCalledWith({ id: 987 });
+  });
+});

--- a/apps/backend/data/shipping.json
+++ b/apps/backend/data/shipping.json
@@ -1,0 +1,9 @@
+{
+  "costos": [
+    {"provincia": "CABA", "costo": 1500},
+    {"provincia": "Buenos Aires", "costo": 2000},
+    {"provincia": "Córdoba", "costo": 2500},
+    {"provincia": "Santa Fe", "costo": 2200},
+    {"provincia": "Otras", "costo": 3000}
+  ]
+}

--- a/apps/backend/db.js
+++ b/apps/backend/db.js
@@ -1,0 +1,15 @@
+const { Pool } = require('pg');
+require('dotenv').config();
+
+const pool = new Pool({
+  host: process.env.DB_HOST,
+  database: process.env.DB_NAME,
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  port: process.env.DB_PORT ? Number(process.env.DB_PORT) : undefined,
+  ssl: process.env.DB_SSL ? { rejectUnauthorized: false } : undefined,
+});
+
+module.exports = {
+  query: (text, params) => pool.query(text, params),
+};

--- a/apps/backend/emailValidator.js
+++ b/apps/backend/emailValidator.js
@@ -1,0 +1,14 @@
+async function verifyEmail(email) {
+  const apiKey = process.env.EMAIL_VERIFICATION_API_KEY;
+  if (!apiKey) return true;
+  const url = `https://emailvalidation.abstractapi.com/v1/?api_key=${apiKey}&email=${encodeURIComponent(email)}`;
+  try {
+    const res = await fetch(url);
+    const data = await res.json();
+    return data.deliverability === 'DELIVERABLE';
+  } catch {
+    return false;
+  }
+}
+
+module.exports = verifyEmail;

--- a/apps/backend/logger.js
+++ b/apps/backend/logger.js
@@ -1,0 +1,14 @@
+const { createLogger, format, transports } = require('winston');
+
+const logger = createLogger({
+  level: 'info',
+  format: format.combine(
+    format.timestamp(),
+    format.printf(({ timestamp, level, message }) => {
+      return `${timestamp} [${level}]: ${message}`;
+    })
+  ),
+  transports: [new transports.Console()],
+});
+
+module.exports = logger;

--- a/apps/backend/middleware/enforcePostJson.js
+++ b/apps/backend/middleware/enforcePostJson.js
@@ -1,0 +1,11 @@
+module.exports = function enforcePostJson(req, res, next) {
+  if (req.method !== 'POST') {
+    return res.status(405).end();
+  }
+  const isJson = req.is('application/json');
+  const isForm = req.is('application/x-www-form-urlencoded');
+  if (!isJson && !isForm) {
+    return res.status(415).json({ error: 'Unsupported content type' });
+  }
+  next();
+};

--- a/apps/backend/middleware/requireHttps.js
+++ b/apps/backend/middleware/requireHttps.js
@@ -1,0 +1,6 @@
+module.exports = function requireHttps(req, res, next) {
+  if (process.env.NODE_ENV === 'production' && !req.secure) {
+    return res.status(403).json({ error: 'HTTPS required' });
+  }
+  next();
+};

--- a/apps/backend/middleware/validateWebhook.js
+++ b/apps/backend/middleware/validateWebhook.js
@@ -1,0 +1,24 @@
+const Joi = require('joi');
+const logger = require('../logger');
+
+// Joi schema for webhook payload. It accepts an empty body so that
+// topic/id can also arrive via query parameters. Additional keys are
+// allowed beyond the ones explicitly listed here.
+const schema = Joi.object({
+  payment_id: Joi.alternatives().try(Joi.string(), Joi.number()).optional(),
+  id: Joi.alternatives().try(Joi.string(), Joi.number()).optional(),
+  topic: Joi.string().optional(),
+  data: Joi.object({
+    id: Joi.alternatives().try(Joi.string(), Joi.number()).required(),
+  }).optional(),
+}).unknown(true);
+
+module.exports = function validateWebhook(req, res, next) {
+  const { error, value } = schema.validate(req.body, { abortEarly: false });
+  if (error) {
+    logger.warn(`invalid body: ${error.message}`);
+    return res.status(400).json({ error: 'Invalid payload' });
+  }
+  req.body = value;
+  next();
+};

--- a/apps/backend/middleware/verifySignature.js
+++ b/apps/backend/middleware/verifySignature.js
@@ -1,0 +1,25 @@
+const crypto = require('crypto');
+const logger = require('../logger');
+
+module.exports = function verifySignature(req, res, next) {
+  const secret = process.env.WEBHOOK_SECRET;
+  if (!secret) {
+    return next();
+  }
+  const signature = req.headers['x-signature'];
+  if (!signature || !req.rawBody) {
+    return res.status(400).json({ error: 'Invalid signature' });
+  }
+  const expected = crypto
+    .createHmac('sha256', secret)
+    .update(req.rawBody)
+    .digest('hex');
+
+  const sigBuf = Buffer.from(signature, 'utf8');
+  const expBuf = Buffer.from(expected, 'utf8');
+  if (sigBuf.length !== expBuf.length || !crypto.timingSafeEqual(sigBuf, expBuf)) {
+    logger.warn('signature mismatch');
+    return res.status(403).json({ error: 'Invalid signature' });
+  }
+  next();
+};

--- a/apps/backend/middleware/webhookRateLimit.js
+++ b/apps/backend/middleware/webhookRateLimit.js
@@ -1,0 +1,8 @@
+const rateLimit = require('express-rate-limit');
+
+module.exports = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+});

--- a/apps/backend/routes/mercadoPago.js
+++ b/apps/backend/routes/mercadoPago.js
@@ -1,0 +1,184 @@
+const express = require('express');
+const router = express.Router();
+const db = require('../db');
+//co/st verifySignature = require('../middleware/verifySignature');
+const validateWebhook = require('../middleware/validateWebhook');
+const webhookRateLimit = require('../middleware/webhookRateLimit');
+const enforcePostJson = require('../middleware/enforcePostJson');
+const requireHttps = require('../middleware/requireHttps');
+const logger = require('../logger');
+const { MercadoPagoConfig, Payment, MerchantOrder } = require('mercadopago');
+const ACCESS_TOKEN = process.env.MP_ACCESS_TOKEN;
+const mpClient = new MercadoPagoConfig({ accessToken: ACCESS_TOKEN });
+const paymentClient = new Payment(mpClient);
+const merchantClient = new MerchantOrder(mpClient);
+
+router.post('/test', (req, res) => {
+  console.log('📥 mp-webhook test:', req.body);
+  logger.info(`mp-webhook test: ${JSON.stringify(req.body)}`);
+  res.sendStatus(200);
+});
+
+function mapStatus(mpStatus) {
+  switch (mpStatus) {
+    case 'approved':
+      return 'approved';
+    case 'rejected':
+      return 'rejected';
+    case 'cancelled':
+    case 'refunded':
+    case 'charged_back':
+      return 'cancelled';
+    default:
+      return 'pending';
+  }
+}
+
+async function processNotification(topic, id) {
+  try {
+    let paymentId = null;
+    let merchantOrder;
+    let preferenceId = null;
+    let externalRef = null;
+    let status = 'pending';
+
+    if (topic && topic.startsWith('merchant_order')) {
+      merchantOrder = await merchantClient.get({ id });
+      const payments = merchantOrder.payments || [];
+      preferenceId = merchantOrder.preference_id || null;
+      externalRef = merchantOrder.external_reference || null;
+      if (!payments.length) {
+        const identifier = preferenceId || externalRef;
+        if (identifier) {
+          const whereField = preferenceId ? 'preference_id' : 'order_number';
+          const existing = await db.query(
+            `SELECT id FROM orders WHERE ${whereField} = $1`,
+            [identifier]
+          );
+          if (existing.rowCount > 0) {
+            await db.query(
+              `UPDATE orders SET payment_status = $1 WHERE ${whereField} = $2`,
+              ['pending', identifier]
+            );
+          } else {
+            await db.query(
+              `INSERT INTO orders (${whereField}, payment_status) VALUES ($1,$2)`,
+              [identifier, 'pending']
+            );
+          }
+        }
+        logger.info(
+          `mp-webhook OK paymentId=null externalRef=${externalRef} prefId=${preferenceId} status=pending`
+        );
+        return;
+      }
+      paymentId = payments[0].id;
+    } else {
+      paymentId = id;
+    }
+
+    const payment = await paymentClient.get({ id: paymentId });
+    status = mapStatus(payment.status);
+    externalRef = payment.external_reference || externalRef;
+
+    if (payment.order && payment.order.id) {
+      merchantOrder = await merchantClient.get({ id: payment.order.id });
+      preferenceId = merchantOrder.preference_id || preferenceId;
+      externalRef = externalRef || merchantOrder.external_reference || null;
+    }
+
+    const identifier = preferenceId || externalRef;
+    if (!identifier) {
+      logger.error('No se pudieron determinar identificadores del pago');
+      return;
+    }
+    const whereField = preferenceId ? 'preference_id' : 'order_number';
+    const existing = await db.query(
+      `SELECT id FROM orders WHERE ${whereField} = $1`,
+      [identifier]
+    );
+
+    if (existing.rowCount > 0) {
+      await db.query(
+        `UPDATE orders SET payment_status = $1, payment_id = $2 WHERE ${whereField} = $3`,
+        [status, String(paymentId), identifier]
+      );
+    } else {
+      const item = merchantOrder?.items?.[0] || {};
+      const payer = payment.payer || {};
+      const shipment = merchantOrder?.shipments?.[0] || {};
+      const address = shipment.receiver_address || {};
+      const shippingOption = shipment.shipping_option || {};
+      const shippingCost = shippingOption.cost || shipment.shipping_cost || 0;
+      const shippingMethod =
+        shippingOption.name || shipment.shipping_mode || null;
+      const totalAmount =
+        merchantOrder?.total_amount ||
+        (payment.transaction_amount + shippingCost);
+
+      await db.query(
+        'INSERT INTO orders (order_number, preference_id, payment_status, payment_id, product_title, unit_price, quantity, user_email, first_name, last_name, phone, shipping_province, shipping_city, shipping_address, shipping_zip, shipping_method, shipping_cost, total_amount) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18)',
+        [
+          externalRef,
+          preferenceId,
+          status,
+          String(paymentId),
+          item.title || null,
+          item.unit_price || null,
+          item.quantity || null,
+          payer.email || null,
+          payer.first_name || null,
+          payer.last_name || null,
+          (payer.phone && payer.phone.number) || null,
+          address.state_name || null,
+          address.city_name || null,
+          address.street_name || null,
+          address.zip_code || null,
+          shippingMethod,
+          shippingCost,
+          totalAmount,
+        ]
+      );
+    }
+
+    logger.info(
+      `mp-webhook OK paymentId=${paymentId} externalRef=${externalRef} prefId=${preferenceId} status=${status}`
+    );
+  } catch (error) {
+    logger.error(`Error al procesar webhook: ${error.message}`);
+  }
+}
+
+router.post(
+  '/',
+  requireHttps,
+  webhookRateLimit,
+  enforcePostJson,
+
+  validateWebhook,
+  (req, res) => {
+    const topic = req.query.topic || req.body.topic || req.body.type;
+    const resource = req.query.resource || req.body.resource;
+    const id =
+      req.query.id ||
+      req.body.payment_id ||
+      (req.body.data && req.body.data.id) ||
+      req.body.id ||
+      (resource && String(resource).split('/').pop());
+
+    console.log('📥 mp-webhook recibido:', { topic, id });
+    logger.info(`mp-webhook recibido: ${JSON.stringify({ topic, id })}`);
+
+    res.sendStatus(200);
+
+    if (!id) {
+      logger.warn('id requerido');
+      return;
+    }
+
+    processNotification(topic, id);
+  }
+);
+
+module.exports = router;
+module.exports.mapStatus = mapStatus;

--- a/apps/backend/routes/mercadoPagoPreference.js
+++ b/apps/backend/routes/mercadoPagoPreference.js
@@ -1,0 +1,140 @@
+const express = require('express');
+const { MercadoPagoConfig, Preference } = require('mercadopago');
+const generarNumeroOrden = require('../utils/generarNumeroOrden');
+const logger = require('../logger');
+const db = require('../db');
+
+const router = express.Router();
+
+const ACCESS_TOKEN = process.env.MP_ACCESS_TOKEN;
+
+// Determina la URL pública a utilizar. Si no está configurada la variable de
+// entorno PUBLIC_URL (por ejemplo en entornos de producción con dominios
+// personalizados), se usa el dominio de la propia petición.
+function getPublicUrl(req) {
+  if (process.env.PUBLIC_URL) return process.env.PUBLIC_URL;
+  return `${req.protocol}://${req.get('host')}`;
+}
+
+router.post('/crear-preferencia', async (req, res) => {
+  logger.info(`➡️ ${req.method} ${req.originalUrl}`);
+  const { carrito, usuario } = req.body || {};
+  logger.info(`📥 body recibido: ${JSON.stringify(req.body)}`);
+
+  if (!usuario || !usuario.email) {
+    const payload = { error: 'email requerido' };
+    logger.info(`⬅️ 400 ${JSON.stringify(payload)}`);
+    return res.status(400).json(payload);
+  }
+
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(usuario.email)) {
+    const payload = { error: 'email inválido' };
+    logger.info(`⬅️ 400 ${JSON.stringify(payload)}`);
+    return res.status(400).json(payload);
+  }
+
+  const hasValidItems =
+    Array.isArray(carrito) &&
+    carrito.length > 0 &&
+    carrito.every((i) => {
+      return (
+        i &&
+        typeof i.titulo === 'string' &&
+        i.titulo.trim() !== '' &&
+        !isNaN(Number(i.precio)) &&
+        Number(i.precio) > 0 &&
+        Number.isInteger(Number(i.cantidad)) &&
+        Number(i.cantidad) > 0 &&
+        (typeof i.currency_id === 'undefined' || typeof i.currency_id === 'string')
+      );
+    });
+
+  if (!hasValidItems) {
+    const payload = {
+      error:
+        'Faltan datos en los ítems del carrito. Verificá que todos los productos tengan título, precio y cantidad.',
+    };
+    logger.info(`⬅️ 400 ${JSON.stringify(payload)}`);
+    return res.status(400).json(payload);
+  }
+
+  const items = carrito.map(
+    ({ titulo, precio, cantidad, currency_id, id, sku }) => {
+      const it = {
+        title: String(titulo),
+        unit_price: Number(precio),
+        quantity: Number(cantidad),
+        currency_id: currency_id || 'ARS',
+      };
+      if (id || sku) {
+        it.id = id || sku;
+        it.sku = sku || id;
+      } else {
+        it.id = it.sku = String(titulo);
+      }
+      return it;
+    },
+  );
+
+  const numeroOrden = generarNumeroOrden();
+
+  const PUBLIC_URL = process.env.PUBLIC_URL || getPublicUrl(req);
+  const body = {
+    items,
+    payer: { email: usuario.email },
+    external_reference: numeroOrden,
+    notification_url: `${PUBLIC_URL}/api/webhooks/mp`,
+    back_urls: {
+      success: `${PUBLIC_URL}/success`,
+      failure: `${PUBLIC_URL}/failure`,
+      pending: `${PUBLIC_URL}/pending`,
+    },
+    auto_return: 'approved',
+  };
+
+  try {
+    const client = new MercadoPagoConfig({ accessToken: ACCESS_TOKEN });
+    const preference = new Preference(client);
+    logger.info(`📦 preference.body: ${JSON.stringify(body)}`);
+    const response = await preference.create({ body });
+    const prefId = response.id || response.body?.id || response.preference_id;
+    if (prefId) {
+      const result = await db.query(
+        'UPDATE orders SET preference_id = $1 WHERE order_number = $2',
+        [String(prefId), String(numeroOrden)]
+      );
+      if (result.rowCount === 0) {
+        await db.query(
+          'INSERT INTO orders (order_number, preference_id, payment_status, user_email) VALUES ($1,$2,$3,$4)',
+          [
+            String(numeroOrden),
+            String(prefId),
+            'pending',
+            usuario.email || null,
+          ]
+        );
+      }
+    }
+    // Log completo de la respuesta de Mercado Pago para facilitar el debug
+    logger.info(`📝 response.body: ${JSON.stringify(response.body)}`);
+    console.log('Respuesta completa de Mercado Pago:', response.body);
+
+    const { id, init_point } = response.body || {};
+    if (init_point) {
+      const payload = { id, init_point };
+      logger.info(`⬅️ 200 ${JSON.stringify(payload)}`);
+      return res.json(payload);
+    }
+    const payload = { error: 'init_point no recibido' };
+    logger.info(`⬅️ 500 ${JSON.stringify(payload)}`);
+    return res.status(500).json(payload);
+  } catch (error) {
+    logger.error(`Error al crear preferencia: ${error.message}`);
+    const payload = { error: 'Error al crear preferencia' };
+    logger.info(`⬅️ 500 ${JSON.stringify(payload)}`);
+    return res.status(500).json(payload);
+  }
+});
+
+module.exports = router;

--- a/apps/backend/routes/orders.js
+++ b/apps/backend/routes/orders.js
@@ -1,0 +1,108 @@
+const express = require('express');
+const router = express.Router();
+const db = require('../db');
+const logger = require('../logger');
+
+router.get('/', async (_req, res) => {
+  try {
+    const { rows } = await db.query('SELECT * FROM orders ORDER BY created_at DESC');
+    res.json(rows);
+  } catch (error) {
+    logger.error(`Error al obtener pedidos: ${error.message}`);
+    res.status(500).json({ error: 'Error interno' });
+  }
+});
+
+router.get('/pending', async (_req, res) => {
+  try {
+    const { rows } = await db.query(
+      "SELECT * FROM orders WHERE payment_status = 'pendiente_transferencia' OR payment_status = 'pendiente_pago_local' ORDER BY created_at DESC"
+    );
+    res.json(rows);
+  } catch (error) {
+    logger.error(`Error al obtener pedidos pendientes: ${error.message}`);
+    res.status(500).json({ error: 'Error interno' });
+  }
+});
+
+async function findOrder(id) {
+  if (id.startsWith('pref_')) {
+    return (
+      await db.query(
+        'SELECT payment_status, order_number FROM orders WHERE preference_id = $1',
+        [id]
+      )
+    ).rows;
+  }
+  if (id.startsWith('NRN-')) {
+    return (
+      await db.query(
+        'SELECT payment_status, order_number FROM orders WHERE order_number = $1',
+        [id]
+      )
+    ).rows;
+  }
+  let rows = (
+    await db.query(
+      'SELECT payment_status, order_number FROM orders WHERE preference_id = $1',
+      [id]
+    )
+  ).rows;
+  if (rows.length === 0) {
+    rows = (
+      await db.query(
+        'SELECT payment_status, order_number FROM orders WHERE order_number = $1',
+        [id]
+      )
+    ).rows;
+  }
+  return rows;
+}
+
+router.get('/test/:id/status', async (req, res) => {
+  try {
+    const rows = await findOrder(req.params.id);
+    if (rows.length === 0) {
+      return res.json({ status: 'pending', numeroOrden: null });
+    }
+    res.json({ status: rows[0].payment_status, numeroOrden: rows[0].order_number });
+  } catch (error) {
+    logger.error(`Error al obtener estado del pedido (test): ${error.message}`);
+    res.status(500).json({ error: 'Error interno' });
+  }
+});
+
+router.get('/:id/status', async (req, res) => {
+  try {
+    const rows = await findOrder(req.params.id);
+    if (rows.length === 0) {
+      return res.json({ status: 'pending', numeroOrden: null });
+    }
+    res.json({ status: rows[0].payment_status, numeroOrden: rows[0].order_number });
+  } catch (error) {
+    logger.error(`Error al obtener estado del pedido: ${error.message}`);
+    res.status(500).json({ error: 'Error interno' });
+  }
+});
+
+router.post('/:orderNumber/mark-paid', async (req, res) => {
+  try {
+    const { rows } = await db.query(
+      'UPDATE orders SET payment_status = $1 WHERE order_number = $2 RETURNING user_email',
+      ['pagado', req.params.orderNumber]
+    );
+    if (rows.length > 0) {
+      const email = rows[0].user_email;
+      if (email) {
+        const sendEmail = require('../utils/sendEmail');
+        await sendEmail(email, 'Pago confirmado', 'Tu pago fue confirmado y tu pedido está en preparación.');
+      }
+    }
+    res.json({ success: true });
+  } catch (error) {
+    logger.error(`Error al actualizar pedido: ${error.message}`);
+    res.status(500).json({ error: 'Error interno' });
+  }
+});
+
+module.exports = router;

--- a/apps/backend/routes/shipping.js
+++ b/apps/backend/routes/shipping.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+const { getShippingCost } = require('../utils/shippingCosts');
+
+router.get('/shipping-cost', (req, res) => {
+  const provincia = req.query.provincia || '';
+  const costo = getShippingCost(provincia);
+  res.json({ costo });
+});
+
+module.exports = router;

--- a/apps/backend/server.js
+++ b/apps/backend/server.js
@@ -1,0 +1,175 @@
+// Minor change to trigger redeploy
+const express = require('express');
+const cors = require('cors');
+const helmet = require('helmet');
+const path = require('path');
+const db = require('./db');
+const generarNumeroOrden = require('./utils/generarNumeroOrden');
+const logger = require('./logger');
+require('dotenv').config();
+
+const webhookRoutes = require('./routes/mercadoPago');
+const mercadoPagoPreferenceRoutes = require('./routes/mercadoPagoPreference');
+const orderRoutes = require('./routes/orders');
+const shippingRoutes = require('./routes/shipping');
+const { getShippingCost } = require('./utils/shippingCosts');
+const verifyEmail = require('./emailValidator');
+const sendEmail = require('./utils/sendEmail');
+
+const ACCESS_TOKEN = process.env.MP_ACCESS_TOKEN;
+if (!ACCESS_TOKEN) {
+  throw new Error('MP_ACCESS_TOKEN no configurado');
+}
+if (ACCESS_TOKEN.startsWith('TEST-')) {
+  console.warn(
+    '⚠️ Advertencia: usando access_token de prueba de Mercado Pago'
+  );
+}
+
+const PUBLIC_URL =
+  process.env.PUBLIC_URL || 'http://localhost:3000';
+
+const app = express();
+app.enable('trust proxy');
+app.disable('x-powered-by');
+app.use(helmet());
+const allowedOrigins = ['https://nerinparts.com.ar'];
+if (PUBLIC_URL) allowedOrigins.push(PUBLIC_URL);
+app.use(
+  cors({
+    origin: allowedOrigins,
+  })
+);
+app.use(express.urlencoded({ extended: false }));
+app.use(
+  express.json({
+    verify: (req, res, buf) => {
+      req.rawBody = buf;
+    },
+    limit: '100kb',
+  })
+);
+
+app.get('/success', (req, res) => {
+  const { preference_id } = req.query;
+  res.redirect(`/confirmacion/${preference_id}`);
+});
+app.get('/failure', (req, res) => {
+  const { preference_id } = req.query;
+  res.redirect(`/estado-pedido/${preference_id}`);
+});
+app.get('/pending', (req, res) => {
+  const { preference_id } = req.query;
+  res.redirect(`/estado-pedido/${preference_id}`);
+});
+
+app.get('/estado-pedido/:id', (_req, res) => {
+  res.sendFile(
+    path.join(__dirname, '../../legacy/frontend_orig/estado-pedido.html')
+  );
+});
+
+app.get('/confirmacion/:id', (_req, res) => {
+  res.sendFile(
+    path.join(__dirname, '../../legacy/frontend_orig/confirmacion.html')
+  );
+});
+
+app.use((req, res, next) => {
+  if (req.path.startsWith('/api/')) {
+    logger.info(`[API] ${req.method} ${req.path}`);
+  }
+  next();
+});
+
+app.get('/api/health', (req, res) => {
+  res.json({ ok: true, service: 'backend', ts: Date.now() });
+});
+
+app.get('/api/validate-email', async (req, res) => {
+  const email = req.query.email || '';
+  try {
+    const valid = await verifyEmail(String(email).trim());
+    res.json({ valid: !!valid });
+  } catch (e) {
+    logger.error(`Error validar email: ${e.message}`);
+    res.status(500).json({ error: 'Error al validar' });
+  }
+});
+
+app.post('/orden-manual', async (req, res) => {
+  logger.info(`Orden manual body: ${JSON.stringify(req.body)}`);
+  logger.debug(`orden-manual req.body ${JSON.stringify(req.body)}`);
+  const { titulo, precio, cantidad, datos, envio, metodo } = req.body;
+  if (datos && datos.email) {
+    try {
+      const valid = await verifyEmail(String(datos.email).trim());
+      if (!valid) {
+        return res.status(400).json({ error: 'El email ingresado no es válido' });
+      }
+    } catch (e) {
+      logger.error(`Error al verificar email: ${e.message}`);
+      return res.status(500).json({ error: 'Error al verificar email' });
+    }
+  }
+  const numeroOrden = generarNumeroOrden();
+  const costoEnvio = getShippingCost(envio && envio.provincia);
+  const status = metodo === 'transferencia' ? 'pendiente_transferencia' : 'pendiente_pago_local';
+  try {
+    await db.query(
+      'INSERT INTO orders (order_number, preference_id, payment_status, product_title, unit_price, quantity, user_email, first_name, last_name, phone, shipping_province, shipping_city, shipping_address, shipping_zip, shipping_method, shipping_cost, total_amount) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17)',
+      [
+        numeroOrden,
+        numeroOrden,
+        status,
+        titulo,
+        precio,
+        cantidad,
+        datos && datos.email ? datos.email : null,
+        datos && datos.nombre ? datos.nombre : null,
+        datos && datos.apellido ? datos.apellido : null,
+        datos && datos.telefono ? datos.telefono : null,
+        envio && envio.provincia ? envio.provincia : null,
+        envio && envio.localidad ? envio.localidad : null,
+        envio && envio.direccion ? envio.direccion : null,
+        envio && envio.cp ? envio.cp : null,
+        envio && envio.metodo ? envio.metodo : null,
+        costoEnvio,
+        Number(precio) * Number(cantidad) + costoEnvio,
+      ]
+    );
+    await sendEmail(
+      datos.email,
+      'Pedido recibido',
+      'Tu pedido fue registrado. Está pendiente de pago. Una vez confirmado, recibirás el aviso de preparación/envío.'
+    );
+    res.json({ numeroOrden });
+  } catch (error) {
+    logger.error(`Error al crear orden manual: ${error.message}`);
+    res.status(400).json({ error: error.message });
+  }
+});
+
+app.use('/api/webhooks/mp', webhookRoutes);
+app.use('/api/orders', orderRoutes);
+// Specific Mercado Pago routes before generic /api routes
+app.use('/api/mercado-pago', mercadoPagoPreferenceRoutes);
+app.use('/api', shippingRoutes);
+app.use('/api', (req, res) => {
+  res.status(404).json({ error: 'Not found' });
+});
+
+app.use(
+  express.static(path.join(__dirname, '../../legacy/frontend_orig'))
+);
+
+app.get('*', (_req, res) => {
+  res.sendFile(
+    path.join(__dirname, '../../legacy/frontend_orig/index.html')
+  );
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  logger.info(`Servidor corriendo en http://localhost:${PORT}`);
+});

--- a/apps/backend/utils/generarNumeroOrden.js
+++ b/apps/backend/utils/generarNumeroOrden.js
@@ -1,0 +1,10 @@
+function generarNumeroOrden() {
+  const fecha = new Date();
+  const dia = String(fecha.getDate()).padStart(2, '0');
+  const mes = String(fecha.getMonth() + 1).padStart(2, '0');
+  const anio = fecha.getFullYear().toString().slice(-2);
+  const random = Math.floor(1000 + Math.random() * 9000);
+  return `NRN-${dia}${mes}${anio}-${random}`;
+}
+
+module.exports = generarNumeroOrden;

--- a/apps/backend/utils/sendEmail.js
+++ b/apps/backend/utils/sendEmail.js
@@ -1,0 +1,27 @@
+const nodemailer = require('nodemailer');
+const logger = require('../logger');
+
+async function sendEmail(to, subject, text) {
+  if (!process.env.SMTP_HOST) {
+    logger.info(`Mock email to ${to}: ${subject} - ${text}`);
+    return;
+  }
+  const transporter = nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: Number(process.env.SMTP_PORT) || 587,
+    secure: false,
+    auth: {
+      user: process.env.SMTP_USER,
+      pass: process.env.SMTP_PASS,
+    },
+  });
+
+  await transporter.sendMail({
+    from: process.env.SMTP_FROM || process.env.SMTP_USER,
+    to,
+    subject,
+    text,
+  });
+}
+
+module.exports = sendEmail;

--- a/apps/backend/utils/shippingCosts.js
+++ b/apps/backend/utils/shippingCosts.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+const path = require('path');
+
+const dataPath = path.join(__dirname, '../data/shipping.json');
+
+function getTable() {
+  try {
+    const content = fs.readFileSync(dataPath, 'utf8');
+    return JSON.parse(content);
+  } catch {
+    return { costos: [] };
+  }
+}
+
+function getShippingCost(provincia) {
+  const table = getTable();
+  const match = table.costos.find(c => c.provincia.toLowerCase() === String(provincia || '').toLowerCase());
+  if (match) return match.costo;
+  const other = table.costos.find(c => c.provincia === 'Otras');
+  return other ? other.costo : 0;
+}
+
+module.exports = { getShippingCost };

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "ecommerce-3.0",
   "version": "1.0.0",
-  "main": "nerin_final_updated/backend/index.js",
+  "main": "apps/backend/server.js",
   "scripts": {
-    "start": "node nerin_final_updated/backend/index.js",
-    "test": "jest",
+    "start": "node apps/backend/server.js",
+    "test": "jest apps/backend",
     "list:webhooks": "node scripts/listMpWebhooks.js",
     "mp:trace": "node scripts/mpTrace.js"
   },


### PR DESCRIPTION
## Summary
- copy legacy backend into `apps/backend` and fix static file paths
- update package scripts and main entry to use the new backend
- document backend usage and add dedicated tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9813333fc8331a4ee46c9c1adfed9