### PR TITLE
docs: document project structure and add build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Ecommerce 3.0
+
+Este repositorio organiza el código en dos áreas principales:
+
+## Estructura
+
+- **`apps/`** – contiene los módulos activos del proyecto:
+  - `backend`: API Express y utilidades de servidor.
+  - `frontend`: página de checkout y ejemplo de integración.
+  - `nerin`: módulo ERP + E‑commerce de NERIN.
+- **`legacy/`** – conserva el código original para referencia histórica:
+  - `backend_orig`
+  - `frontend_orig`
+  - `nerin_orig`
+
+## Dependencias y scripts
+
+Todas las dependencias están unificadas en la raíz mediante un único `package.json`.
+Desde la raíz se pueden ejecutar los siguientes comandos:
+
+```bash
+npm install        # instala las dependencias
+npm start          # inicia el backend principal
+npm run nerin:start  # inicia el módulo NERIN
+npm run build      # paso de compilación (actualmente no realiza ninguna acción)
+npm test           # ejecuta las pruebas automatizadas
+```
+
+Para instrucciones de uso detalladas, consultar `README.txt`.
+
+

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "start": "node apps/backend/server.js",
     "test": "jest apps",
+    "build": "echo 'No build step necessary'",
     "list:webhooks": "node scripts/listMpWebhooks.js",
     "mp:trace": "node scripts/mpTrace.js",
     "nerin:start": "node apps/nerin/backend/index.js",


### PR DESCRIPTION
## Summary
- document repository structure and scripts in a new README
- add placeholder build script for root package

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bac87f240883319b18a29be12cfa62