### PR TITLE
Handle footer storage errors

### DIFF
--- a/nerin_final_updated/backend/__tests__/features.test.js
+++ b/nerin_final_updated/backend/__tests__/features.test.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const request = require('supertest');
-const dataDir = require('../utils/dataDir');
+const { DATA_DIR: dataDir } = require('../utils/dataDir');
 
 jest.mock('../emailValidator');
 jest.mock('afip.ts', () => ({ Afip: class {} }), { virtual: true });

--- a/nerin_final_updated/backend/__tests__/footer.test.js
+++ b/nerin_final_updated/backend/__tests__/footer.test.js
@@ -1,0 +1,34 @@
+const request = require('supertest');
+
+jest.mock('../emailValidator');
+jest.mock('afip.ts', () => ({ Afip: class {} }), { virtual: true });
+jest.mock('resend', () => ({ Resend: class { constructor(){ this.emails={ send: jest.fn() }; } } }), { virtual: true });
+jest.mock('multer', () => {
+  const m = () => ({ single: jest.fn() });
+  m.diskStorage = () => ({});
+  return m;
+}, { virtual: true });
+
+jest.mock('fs', () => {
+  const path = require('path');
+  return {
+    readFileSync: jest.fn(() => { throw new Error('read'); }),
+    writeFileSync: jest.fn(() => { throw new Error('write'); }),
+    existsSync: jest.fn(() => true),
+    mkdirSync: jest.fn(),
+    stat: jest.fn((p, cb) => cb(null, { isDirectory: () => false })),
+  };
+});
+
+const server = require('../server');
+
+afterAll((done) => {
+  if (server.listening) server.close(done);
+  else done();
+});
+
+test('returns default footer when file system is read-only', async () => {
+  const res = await request(server).get('/api/footer');
+  expect(res.status).toBe(200);
+  expect(res.body.brand).toBe('NERIN PARTS');
+});

--- a/nerin_final_updated/backend/data/clientsRepo.js
+++ b/nerin_final_updated/backend/data/clientsRepo.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const db = require('../db');
-const dataDir = require('../utils/dataDir');
+const { DATA_DIR: dataDir } = require('../utils/dataDir');
 
 const filePath = path.join(dataDir, 'clients.json');
 

--- a/nerin_final_updated/backend/data/invoicesRepo.js
+++ b/nerin_final_updated/backend/data/invoicesRepo.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const db = require('../db');
-const dataDir = require('../utils/dataDir');
+const { DATA_DIR: dataDir } = require('../utils/dataDir');
 
 const filePath = path.join(dataDir, 'invoices.json');
 

--- a/nerin_final_updated/backend/data/ordersRepo.js
+++ b/nerin_final_updated/backend/data/ordersRepo.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const db = require('../db');
 const productsRepo = require('./productsRepo');
-const dataDir = require('../utils/dataDir');
+const { DATA_DIR: dataDir } = require('../utils/dataDir');
 
 const filePath = path.join(dataDir, 'orders.json');
 

--- a/nerin_final_updated/backend/data/productsRepo.js
+++ b/nerin_final_updated/backend/data/productsRepo.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const db = require('../db');
-const dataDir = require('../utils/dataDir');
+const { DATA_DIR: dataDir } = require('../utils/dataDir');
 
 const filePath = path.join(dataDir, 'products.json');
 

--- a/nerin_final_updated/backend/routes/mercadoPago.js
+++ b/nerin_final_updated/backend/routes/mercadoPago.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const dataDir = require('../utils/dataDir');
+const { DATA_DIR: dataDir } = require('../utils/dataDir');
 const ACCESS_TOKEN = process.env.MP_ACCESS_TOKEN || '';
 const fetchFn =
   globalThis.fetch ||

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -13,7 +13,7 @@ const http = require("http");
 const fs = require("fs");
 const path = require("path");
 const url = require("url");
-const dataDir = require("./utils/dataDir");
+const { DATA_DIR: dataDir } = require("./utils/dataDir");
 
 // === Directorios persistentes para archivos subidos ===
 // Facturas y comprobantes de pago se guardan en INVOICES_DIR
@@ -703,13 +703,21 @@ function readFooter() {
     const txt = fs.readFileSync(FOOTER_FILE, "utf8");
     return JSON.parse(txt);
   } catch {
-    fs.writeFileSync(FOOTER_FILE, JSON.stringify(DEFAULT_FOOTER, null, 2));
+    try {
+      fs.writeFileSync(FOOTER_FILE, JSON.stringify(DEFAULT_FOOTER, null, 2));
+    } catch (e) {
+      console.error("Cannot write default footer", e);
+    }
     return { ...DEFAULT_FOOTER };
   }
 }
 
 function saveFooter(cfg) {
-  fs.writeFileSync(FOOTER_FILE, JSON.stringify(cfg, null, 2));
+  try {
+    fs.writeFileSync(FOOTER_FILE, JSON.stringify(cfg, null, 2));
+  } catch (e) {
+    console.error("Cannot save footer", e);
+  }
 }
 
 function normalizeFooter(data) {

--- a/nerin_final_updated/backend/services/inventory.js
+++ b/nerin_final_updated/backend/services/inventory.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const dataDir = require('../utils/dataDir');
+const { DATA_DIR: dataDir } = require('../utils/dataDir');
 
 const logger = {
   info: console.log,


### PR DESCRIPTION
## Summary
- avoid crashing when footer.json can't be written by catching write errors
- normalize DATA_DIR usage across backend modules
- add test covering default footer fallback on read-only filesystems

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c227dceae48331a9bbea45cb29ed9f