### PR TITLE
Allow configurable API base for frontend

### DIFF
--- a/nerin_final_updated/data/config.json
+++ b/nerin_final_updated/data/config.json
@@ -8,5 +8,6 @@
   "afipCert": "",
   "afipKey": "",
   "resendApiKey": "",
-  "publicUrl": ""
+  "publicUrl": "",
+  "apiBase": ""
 }

--- a/nerin_final_updated/frontend/components/np-footer.js
+++ b/nerin_final_updated/frontend/components/np-footer.js
@@ -154,7 +154,11 @@
 
       let remote = {};
       try {
-        const res = await fetch("/api/footer", { cache: "no-store" });
+        const base =
+          (window.NERIN_CONFIG && window.NERIN_CONFIG.apiBase) ||
+          window.API_BASE_URL ||
+          "";
+        const res = await fetch(`${base}/api/footer`, { cache: "no-store" });
         remote = await res.json();
       } catch (e) {
         console.warn("[NP-FOOTER] /api/footer failed", e);

--- a/nerin_final_updated/frontend/js/api.js
+++ b/nerin_final_updated/frontend/js/api.js
@@ -6,9 +6,13 @@
  * en localStorage.
  */
 
-// Base URL del backend. Cuando se despliegue en producción, ajustar según
-// corresponda. Para desarrollo local suele ser la misma URL de origen.
-const API_BASE = "";
+// Base URL del backend. Permite ser configurada desde el servidor a través
+// de `window.NERIN_CONFIG.apiBase` o por una variable global `API_BASE_URL`.
+// Si no se define, se usa la misma URL de origen del frontend.
+const API_BASE =
+  (window.NERIN_CONFIG && window.NERIN_CONFIG.apiBase) ||
+  window.API_BASE_URL ||
+  "";
 
 // Obtener la lista de productos desde el backend
 export async function fetchProducts() {

--- a/nerin_final_updated/frontend/js/config.js
+++ b/nerin_final_updated/frontend/js/config.js
@@ -12,6 +12,10 @@ async function loadConfig() {
     const cfg = await res.json();
     // Exponer a nivel global
     window.NERIN_CONFIG = cfg;
+    // Permitir que otros módulos conozcan la URL base del backend si está definida
+    if (cfg.apiBase) {
+      window.API_BASE_URL = cfg.apiBase;
+    }
     // Actualizar enlace de WhatsApp flotante si existe
     if (cfg.whatsappNumber) {
       const waBtn = document.querySelector("#whatsapp-button a");


### PR DESCRIPTION
## Summary
- allow API base URL to be provided by backend config
- propagate base URL to footer component to load remote configuration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c458110dac83318ff0d914ee9cd78b