### PR TITLE
Add missing products endpoint

### DIFF
--- a/backend/data/products.json
+++ b/backend/data/products.json
@@ -1,0 +1,22 @@
+{
+  "products": [
+    {
+      "id": "1",
+      "name": "Pantalla iPhone 12",
+      "price": 25000,
+      "image": "/assets/product1.png"
+    },
+    {
+      "id": "2",
+      "name": "Pantalla Samsung S21",
+      "price": 23000,
+      "image": "/assets/product2.png"
+    },
+    {
+      "id": "3",
+      "name": "Pantalla Xiaomi Mi 11",
+      "price": 21000,
+      "image": "/assets/product3.png"
+    }
+  ]
+}

--- a/backend/routes/products.js
+++ b/backend/routes/products.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+
+const router = express.Router();
+const PRODUCTS_FILE = path.join(__dirname, '..', 'data', 'products.json');
+
+router.get('/products', (_req, res) => {
+  fs.readFile(PRODUCTS_FILE, 'utf8', (err, data) => {
+    if (err) {
+      return res.status(500).json({ error: 'No se pudieron cargar los productos' });
+    }
+    try {
+      const json = JSON.parse(data);
+      res.json({ products: json.products || [] });
+    } catch (e) {
+      res.status(500).json({ error: 'No se pudieron cargar los productos' });
+    }
+  });
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,4 +1,3 @@
-// Minor change to trigger redeploy
 const express = require('express');
 const cors = require('cors');
 const helmet = require('helmet');
@@ -12,6 +11,7 @@ const webhookRoutes = require('./routes/mercadoPago');
 const mercadoPagoPreferenceRoutes = require('./routes/mercadoPagoPreference');
 const orderRoutes = require('./routes/orders');
 const shippingRoutes = require('./routes/shipping');
+const productRoutes = require('./routes/products');
 const { getShippingCost } = require('./utils/shippingCosts');
 const verifyEmail = require('./emailValidator');
 const sendEmail = require('./utils/sendEmail');
@@ -150,6 +150,7 @@ app.use('/api/webhooks/mp', webhookRoutes);
 app.use('/api/orders', orderRoutes);
 // Specific Mercado Pago routes before generic /api routes
 app.use('/api/mercado-pago', mercadoPagoPreferenceRoutes);
+app.use('/api', productRoutes);
 app.use('/api', shippingRoutes);
 app.use('/api', (req, res) => {
   res.status(404).json({ error: 'Not found' });

--- a/nerin_final_updated/backend/utils/dataDir.js
+++ b/nerin_final_updated/backend/utils/dataDir.js
@@ -27,6 +27,23 @@ const BASE = ENV_DIR || RENDER_DIR || LOCAL_DIR;
 // Asegurar que exista
 try { fs.mkdirSync(BASE, { recursive: true }); } catch {}
 
+// Si estamos usando un directorio distinto al local y faltan datos,
+// copiar el contenido de la carpeta de ejemplo para evitar errores.
+if (BASE !== LOCAL_DIR) {
+  try {
+    const sample = path.join(BASE, 'products.json');
+    if (!fs.existsSync(sample)) {
+      for (const f of fs.readdirSync(LOCAL_DIR)) {
+        const src = path.join(LOCAL_DIR, f);
+        const dest = path.join(BASE, f);
+        if (!fs.existsSync(dest)) fs.copyFileSync(src, dest);
+      }
+    }
+  } catch (e) {
+    console.error('cannot seed data dir', e);
+  }
+}
+
 // API
 module.exports = {
   DATA_DIR: BASE,


### PR DESCRIPTION
## Summary
- serve sample products from `/api/products`
- seed Render data directory with default dataset when empty
- remove leftover redeploy comment from server header

## Testing
- `npm test`
- `curl -s http://localhost:3000/api/products`


------
https://chatgpt.com/codex/tasks/task_e_68c476bed2d88331bff60599401e4e67