### PR TITLE
Use PUBLIC_URL for Mercado Pago notification webhook

### DIFF
--- a/nerin_final_updated/backend/index.js
+++ b/nerin_final_updated/backend/index.js
@@ -210,7 +210,7 @@ app.post("/api/orders", async (req, res) => {
           },
           auto_return: "approved",
           external_reference: id,
-          notification_url: `https://nerinparts.com.ar/api/webhooks/mp`,
+          notification_url: `${PUBLIC_URL}/api/webhooks/mp`,
         };
         const prefRes = await mpPreference.create({ body: pref });
         initPoint = prefRes.init_point;


### PR DESCRIPTION
## Summary
- use PUBLIC_URL when setting Mercado Pago notification URL in backend index
- ensure PUBLIC_URL defaults to `process.env.PUBLIC_URL || http://localhost:${PORT}`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5b0fb71908331beccb9e91b774b16