### PR TITLE
Add SSR product page with SEO metadata and tests

### DIFF
--- a/nerin_final_updated/backend/__tests__/features.test.js
+++ b/nerin_final_updated/backend/__tests__/features.test.js
@@ -53,7 +53,8 @@ describe('Ecommerce features', () => {
     fs.writeFileSync(configPath, '{}');
     fs.writeFileSync(uploadsPath, JSON.stringify({ uploads: [{ orderId: 'ORDER123', fileName: 'fact.pdf' }] }));
     process.env.MP_ACCESS_TOKEN = '';
-    server = require('../server');
+    const { createServer } = require('../server');
+    server = createServer();
   });
 
   afterAll((done) => {

--- a/nerin_final_updated/backend/__tests__/footer.test.js
+++ b/nerin_final_updated/backend/__tests__/footer.test.js
@@ -20,7 +20,8 @@ jest.mock('fs', () => {
   };
 });
 
-const server = require('../server');
+const { createServer } = require('../server');
+const server = createServer();
 
 afterAll((done) => {
   if (server.listening) server.close(done);

--- a/nerin_final_updated/backend/__tests__/product-ssr.test.js
+++ b/nerin_final_updated/backend/__tests__/product-ssr.test.js
@@ -1,0 +1,84 @@
+const path = require('path');
+const request = require('supertest');
+
+process.env.DATA_DIR = path.join(__dirname, '..', '..', 'data');
+
+const { createServer } = require('../server');
+const productsData = require('../../data/products.json').products;
+
+function esc(s=''){return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');}
+
+describe('product SSR', () => {
+  let server;
+  beforeAll(() => {
+    server = createServer();
+  });
+  afterAll((done) => {
+    if (server.listening) server.close(done);
+    else done();
+  });
+
+  test('renders SEO data for existing product', async () => {
+    const product = productsData[0];
+    const slug = product.slug;
+    const res = await request(server).get(`/p/${slug}`);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/text\/html/);
+    const canonical = `http://localhost:${process.env.PORT || 3000}/p/${slug}`;
+    const nameEsc = esc(product.name);
+    expect(res.text).toContain(`<title>${nameEsc}</title>`);
+    expect(res.text).toContain('<meta name="description"');
+    expect(res.text).toContain(`<link rel="canonical" href="${canonical}">`);
+    expect(res.text).toContain(`<meta property="og:title" content="${nameEsc}">`);
+    expect(res.text).toContain(`<meta property="og:description"`);
+    expect(res.text).toContain(`<meta property="og:url" content="${canonical}">`);
+    expect(res.text).toContain('<meta property="og:type" content="product">');
+    if (product.image) {
+      const abs = new URL(product.image, `http://localhost:${process.env.PORT || 3000}`).href;
+      expect(res.text).toContain(`<meta property="og:image" content="${abs}">`);
+    }
+    expect(res.text).toContain('<script type="application/ld+json">');
+    expect(res.text).toContain('"@type":"Product"');
+    expect(res.text).toContain('"@type":"Offer"');
+  });
+
+  test('returns 404 for unknown product', async () => {
+    const res = await request(server).get('/p/not-found');
+    expect(res.status).toBe(404);
+    expect(res.text).toContain('<meta name="robots" content="noindex">');
+  });
+});
+
+describe('data dir autodetection for SSR', () => {
+  let orig; beforeAll(() => { orig = process.env.DATA_DIR; delete process.env.DATA_DIR; jest.resetModules(); });
+  afterAll(() => { process.env.DATA_DIR = orig; });
+
+  test('uses utils/dataDir when DATA_DIR is not set', async () => {
+    const fs = require('fs'); const path = require('path'); const request = require('supertest');
+    const tmp = path.join(__dirname, '__tmp__'); fs.mkdirSync(tmp, { recursive: true });
+    fs.writeFileSync(path.join(tmp, 'products.json'), JSON.stringify({ products: [{ slug: 'tmp', name:'Tmp', price: 1, stock:1 }] }), 'utf8');
+
+    let createServer;
+    jest.isolateModules(() => {
+      jest.doMock('../utils/dataDir.js', () => ({ DATA_DIR: tmp, dataPath: (p) => path.join(tmp, p) }), { virtual: true });
+      ({ createServer } = require('../server'));
+    });
+    const server = createServer();
+    const res = await request(server).get('/p/tmp');
+    expect(res.status).toBe(200);
+    if (server.close) server.close();
+  });
+});
+
+test('malformed percent-encoding in slug does not crash', async () => {
+  const request = require('supertest');
+  const { createServer } = require('../server');
+  const server = createServer();
+  const res = await request(server).get('/p/%E0'); // inválido
+  expect([400, 404]).toContain(res.status);
+  expect(res.headers['content-type']).toMatch(/text\/html/);
+  if (res.status === 400) {
+    expect(res.text).toContain('noindex'); // meta para que no indexe
+  }
+  if (server.close) server.close();
+});

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -13,7 +13,39 @@ const http = require("http");
 const fs = require("fs");
 const path = require("path");
 const url = require("url");
-const { DATA_DIR: dataDir } = require("./utils/dataDir");
+const { DATA_DIR: dataDir, dataPath } = require("./utils/dataDir");
+
+// ENV > utils/dataDir > fallback local
+const DATA_DIR = process.env.DATA_DIR || dataDir || path.join(__dirname, 'data');
+const BASE_URL = process.env.PUBLIC_URL || `http://localhost:${process.env.PORT || 3000}`;
+const PRODUCTS_TTL = parseInt(process.env.PRODUCTS_TTL_MS, 10) || 60000;
+
+let _cache = { t: 0, data: null };
+async function loadProducts() {
+  const now = Date.now();
+  if (_cache.data && now - _cache.t < PRODUCTS_TTL) return _cache.data;
+  const p = typeof dataPath === 'function'
+    ? dataPath('products.json')
+    : path.join(DATA_DIR, 'products.json');
+  try {
+    const json = JSON.parse(fs.readFileSync(p, 'utf8'));
+    const arr = Array.isArray(json?.products) ? json.products : json;
+    _cache = { t: now, data: arr };
+    return arr;
+  } catch {
+    _cache = { t: now, data: [] };
+    return _cache.data;
+  }
+}
+
+function esc(s = '') {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
 
 // === Directorios persistentes para archivos subidos ===
 // UPLOADS_DIR guarda archivos genéricos
@@ -64,10 +96,6 @@ const ORIGIN = process.env.PUBLIC_URL || "*";
 const fetchFn =
   globalThis.fetch ||
   ((...a) => import("node-fetch").then(({ default: f }) => f(...a)));
-
-function dataPath(file) {
-  return path.join(dataDir, file);
-}
 
 const FOOTER_FILE = dataPath("footer.json");
 const DEFAULT_FOOTER = {
@@ -909,7 +937,7 @@ function serveStatic(filePath, res, headers = {}) {
 }
 
 // Crear servidor HTTP
-const server = http.createServer((req, res) => {
+async function requestHandler(req, res) {
   const parsedUrl = url.parse(req.url, true);
   const pathname = parsedUrl.pathname;
 
@@ -2929,6 +2957,85 @@ const server = http.createServer((req, res) => {
     return;
   }
 
+  // SSR de productos
+  if (pathname.startsWith("/p/") && req.method === "GET") {
+    // Decodificar slug con guardas para evitar URIError (e.g. /p/%E0)
+    let raw = pathname.slice(3);
+    if (raw.endsWith("/")) raw = raw.slice(0, -1);
+    let slug;
+    try {
+      slug = decodeURIComponent(raw);
+    } catch (e) {
+      const html = '<!DOCTYPE html><html lang="es"><head>' +
+        '<meta charset="utf-8"><meta name="robots" content="noindex">' +
+        '<title>Solicitud inválida</title></head>' +
+        '<body><h1>Solicitud inválida</h1></body></html>';
+      res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" });
+      res.end(html);
+      return;
+    }
+    const products = await loadProducts();
+    const product = Array.isArray(products)
+      ? products.find((p) => p.slug === slug)
+      : null;
+    if (!product) {
+      const html =
+        "<!DOCTYPE html><html lang=\"es\"><head><meta charset=\"utf-8\"><meta name=\"robots\" content=\"noindex\"><title>Producto no encontrado</title></head><body><h1>Producto no encontrado</h1></body></html>";
+      res.writeHead(404, { "Content-Type": "text/html; charset=utf-8" });
+      res.end(html);
+      return;
+    }
+    const name = product.name || "";
+    const desc =
+      product.meta_description || product.description || `Compra ${name}`;
+    const canonical = `${BASE_URL}/p/${slug}`;
+    const image = product.image
+      ? new URL(product.image, BASE_URL).href
+      : null;
+    const ld = {
+      "@context": "https://schema.org",
+      "@type": "Product",
+      name,
+      ...(product.description ? { description: product.description } : {}),
+      ...(product.sku ? { sku: product.sku } : {}),
+      ...(product.mpn ? { mpn: product.mpn } : {}),
+      ...(product.gtin13 ? { gtin13: product.gtin13 } : {}),
+      brand: { "@type": "Brand", name: product.brand || "Samsung" },
+      offers: {
+        "@type": "Offer",
+        priceCurrency: "ARS",
+        price:
+          product.price ||
+          product.price_minorista ||
+          product.price_mayorista ||
+          0,
+        availability: "https://schema.org/InStock",
+        url: canonical,
+      },
+    };
+    const head = [
+      '<meta charset="utf-8">',
+      `<title>${esc(name)}</title>`,
+      `<meta name="description" content="${esc(desc)}">`,
+      `<link rel="canonical" href="${esc(canonical)}">`,
+      `<meta property="og:title" content="${esc(name)}">`,
+      `<meta property="og:description" content="${esc(desc)}">`,
+      `<meta property="og:url" content="${esc(canonical)}">`,
+      '<meta property="og:type" content="product">',
+      image ? `<meta property="og:image" content="${esc(image)}">` : "",
+      `<script type="application/ld+json">${JSON.stringify(ld)}</script>`,
+    ]
+      .filter(Boolean)
+      .join("");
+    const body = `<h1>${esc(name)}</h1><div>Precio: $${esc(
+      product.price || product.price_minorista || product.price_mayorista || ""
+    )}</div><div>${product.stock > 0 ? "En stock" : "Sin stock"}</div>`;
+    const html = `<!DOCTYPE html><html lang="es"><head>${head}</head><body>${body}</body></html>`;
+    res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+    res.end(html);
+    return;
+  }
+
   // Servir componentes del frontend: /components/* -> /frontend/components/*
   if (pathname.startsWith("/components/") && req.method === "GET") {
     const compPath = path.join(__dirname, "..", "frontend", pathname.slice(1));
@@ -2970,12 +3077,17 @@ const server = http.createServer((req, res) => {
     }
     serveStatic(filePath, res);
   });
-});
+}
+
+function createServer() {
+  return http.createServer(requestHandler);
+}
+
+module.exports = { createServer };
 
 if (require.main === module) {
+  const server = createServer();
   server.listen(APP_PORT, () => {
     console.log(`Servidor de NERIN corriendo en http://localhost:${APP_PORT}`);
   });
-} else {
-  module.exports = server;
 }

--- a/nerin_final_updated/package.json
+++ b/nerin_final_updated/package.json
@@ -4,7 +4,8 @@
   "description": "Sistema ERP + E‑commerce para NERIN Repuestos",
   "main": "backend/index.js",
   "scripts": {
-    "start": "node backend/server.js"
+    "start": "node backend/server.js",
+    "test": "jest"
   },
   "dependencies": {
     "afip.ts": "^3.2.2",
@@ -18,6 +19,8 @@
     "pg": "^8.13.0"
   },
   "devDependencies": {
-    "prettier": "^3.6.2"
+    "prettier": "^3.6.2",
+    "jest": "^30.0.5",
+    "supertest": "^7.1.4"
   }
 }


### PR DESCRIPTION
## Summary
- implement `/p/:slug` SSR endpoint with SEO, Open Graph and JSON-LD
- add product cache with TTL and HTML escape helper
- expose `createServer` for tests and add Jest/Supertest coverage
- unify DATA_DIR handling with `utils/dataDir` and test autodetection
- handle malformed percent-encoding in `/p/:slug` without crashing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7055b5e088331b1fe05c1487a6a28