### PR TITLE
Harden Mercado Pago webhook order updates

### DIFF
--- a/nerin_final_updated/backend/__tests__/mercado-pago-webhook.test.js
+++ b/nerin_final_updated/backend/__tests__/mercado-pago-webhook.test.js
@@ -1,0 +1,80 @@
+jest.mock('mercadopago', () => ({
+  MercadoPagoConfig: jest.fn(),
+  Preference: jest.fn().mockImplementation(() => ({})),
+  Payment: jest.fn().mockImplementation(() => ({ get: jest.fn() })),
+}));
+
+const request = require('supertest');
+jest.mock('../db', () => ({
+  getPool: () => null,
+  init: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../data/ordersRepo', () => ({
+  upsertByPayment: jest.fn(),
+}));
+
+jest.mock('../services/inventory', () => ({
+  applyInventoryForOrder: jest.fn().mockResolvedValue(undefined),
+}));
+
+process.env.MP_ACCESS_TOKEN = 'test-token';
+
+global.fetch = jest.fn();
+
+const ordersRepo = require('../data/ordersRepo');
+const { createServer } = require('../server');
+
+describe('Mercado Pago webhook', () => {
+  beforeEach(() => {
+    ordersRepo.upsertByPayment.mockResolvedValue({
+      id: 'ORDER-1',
+      items: [{ id: 'SKU', qty: 1 }],
+      inventoryApplied: true,
+    });
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: '123',
+        status: 'approved',
+        transaction_amount: 1000,
+        currency_id: 'ARS',
+        external_reference: 'ORDER-1',
+        preference_id: 'PREF-1',
+        metadata: {},
+      }),
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    delete global.fetch;
+  });
+
+  test('processes query-only webhook (POST ?topic=payment&id=...)', async () => {
+    const server = createServer();
+    const res = await request(server).post(
+      '/api/mercado-pago/webhook?topic=payment&id=123'
+    );
+    expect(res.status).toBe(200);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(ordersRepo.upsertByPayment).toHaveBeenCalledWith(
+      expect.objectContaining({ payment_id: '123' })
+    );
+    if (server.close) server.close();
+  });
+
+  test('supports GET ?topic=payment&resource=/payments/123', async () => {
+    const server = createServer();
+    const res = await request(server).get(
+      '/api/mercado-pago/webhook?topic=payment&resource=/payments/123'
+    );
+    expect(res.status).toBe(200);
+    if (server.close) server.close();
+  });
+});

--- a/nerin_final_updated/backend/data/ordersRepo.js
+++ b/nerin_final_updated/backend/data/ordersRepo.js
@@ -62,7 +62,14 @@ async function saveAll(orders) {
   }
 }
 
+function validateOrder(order) {
+  if (!order || !Array.isArray(order.items) || order.items.length === 0) {
+    throw new Error('ORDER_WITHOUT_ITEMS');
+  }
+}
+
 async function create(order) {
+  validateOrder(order);
   const pool = db.getPool();
   if (!pool) {
     const orders = await getAll();
@@ -88,6 +95,196 @@ async function create(order) {
     await pool.query('ROLLBACK');
     throw e;
   }
+}
+
+async function update(order) {
+  validateOrder(order);
+  const pool = db.getPool();
+  if (!pool) {
+    const orders = await getAll();
+    const idx = orders.findIndex((o) => String(o.id) === String(order.id));
+    if (idx === -1) throw new Error('ORDER_NOT_FOUND');
+    const items = Array.isArray(order.items)
+      ? order.items.map((it) => ({ ...it }))
+      : [];
+    const next = { ...orders[idx], ...order, items };
+    orders[idx] = next;
+    await saveAll(orders);
+    return next;
+  }
+  await pool.query('BEGIN');
+  try {
+    await pool.query(
+      'UPDATE orders SET customer_email=$2, status=$3, total=$4 WHERE id=$1',
+      [order.id, order.customer_email || null, order.status || 'pendiente', order.total || 0]
+    );
+    await pool.query('DELETE FROM order_items WHERE order_id=$1', [order.id]);
+    for (const it of order.items) {
+      const pid = it.product_id || it.id || it.productId;
+      const qty = Number(it.qty || it.quantity || it.cantidad || 0);
+      if (!pid || !qty) continue;
+      const price = Number(it.price || it.unit_price || 0);
+      await pool.query(
+        'INSERT INTO order_items (order_id, product_id, qty, price) VALUES ($1,$2,$3,$4)',
+        [order.id, pid, qty, price]
+      );
+    }
+    await pool.query('COMMIT');
+    return order;
+  } catch (e) {
+    await pool.query('ROLLBACK');
+    throw e;
+  }
+}
+
+function normalizeKey(value) {
+  if (value == null) return null;
+  const str = String(value).trim();
+  return str ? str : null;
+}
+
+function orderMatches(order, candidate) {
+  if (!order || !candidate) return false;
+  const values = [
+    order.id,
+    order.order_id,
+    order.orderId,
+    order.order_number,
+    order.orderNumber,
+    order.external_reference,
+    order.externalReference,
+    order.preference_id,
+    order.preferenceId,
+    order.payment_id,
+    order.paymentId,
+    order.metadata?.order_id,
+  ];
+  return values.some((val) => normalizeKey(val) === candidate);
+}
+
+async function findByKey(key, identifiers = {}) {
+  const candidates = new Set();
+  const keys = [
+    key,
+    identifiers.payment_id,
+    identifiers.preference_id,
+    identifiers.external_reference,
+  ];
+  for (const value of keys) {
+    const normalized = normalizeKey(value);
+    if (normalized) candidates.add(normalized);
+  }
+  if (!candidates.size) return null;
+
+  const pool = db.getPool();
+  if (!pool) {
+    const orders = await getAll();
+    for (const candidate of candidates) {
+      const match = orders.find((o) => orderMatches(o, candidate));
+      if (match) return match;
+    }
+    return null;
+  }
+
+  for (const candidate of candidates) {
+    const found = await getById(candidate);
+    if (found) return found;
+  }
+  return null;
+}
+
+function computeOrderTotal(order) {
+  const total = Number(order?.total);
+  if (!Number.isFinite(total) || total <= 0) {
+    if (Array.isArray(order?.items)) {
+      return order.items.reduce((acc, it) => {
+        const price = Number(it.price || it.unit_price || 0);
+        const qty = Number(it.qty || it.quantity || it.cantidad || 0);
+        return acc + price * qty;
+      }, 0);
+    }
+    return 0;
+  }
+  return total;
+}
+
+function getOrderCurrency(order) {
+  if (!order) return null;
+  const itemWithCurrency = Array.isArray(order.items)
+    ? order.items.find((it) => it.currency || it.currency_id)
+    : null;
+  return (
+    order.currency ||
+    order.currency_id ||
+    order.currencyId ||
+    order.moneda ||
+    order.paid_currency ||
+    (itemWithCurrency ? itemWithCurrency.currency || itemWithCurrency.currency_id : null)
+  );
+}
+
+async function upsertByPayment({
+  payment_id,
+  preference_id,
+  external_reference,
+  patch = {},
+  amount,
+  currency,
+}) {
+  const normalizedPaymentId = normalizeKey(payment_id);
+  const normalizedPreferenceId = normalizeKey(preference_id);
+  const normalizedExternalRef = normalizeKey(external_reference);
+  const key = normalizedPaymentId || normalizedPreferenceId || normalizedExternalRef;
+  if (!key) return null;
+
+  const existing = await findByKey(key, {
+    payment_id: normalizedPaymentId,
+    preference_id: normalizedPreferenceId,
+    external_reference: normalizedExternalRef,
+  });
+  if (!existing) return null;
+
+  if (
+    normalizedPaymentId &&
+    existing.payment_id &&
+    normalizeKey(existing.payment_id) === normalizedPaymentId
+  ) {
+    return existing;
+  }
+
+  if (typeof amount === 'number' && Number.isFinite(amount)) {
+    const total = computeOrderTotal(existing);
+    if (Number.isFinite(total) && Math.abs(total - amount) > 0.01) {
+      const err = new Error('AMOUNT_MISMATCH');
+      err.code = 'AMOUNT_MISMATCH';
+      throw err;
+    }
+  }
+
+  if (currency) {
+    const orderCurrency = getOrderCurrency(existing);
+    if (orderCurrency && String(orderCurrency) !== String(currency)) {
+      const err = new Error('CURRENCY_MISMATCH');
+      err.code = 'CURRENCY_MISMATCH';
+      throw err;
+    }
+  }
+
+  const merged = {
+    ...existing,
+    ...patch,
+  };
+  if (normalizedPaymentId) merged.payment_id = normalizedPaymentId;
+  if (normalizedPreferenceId) merged.preference_id = normalizedPreferenceId;
+  if (normalizedExternalRef) {
+    merged.external_reference = normalizedExternalRef;
+    if (!merged.id) merged.id = normalizedExternalRef;
+  }
+  if (!Array.isArray(merged.items) || merged.items.length === 0) {
+    merged.items = existing.items;
+  }
+
+  return update(merged);
 }
 
 async function createOrder({ id, customer_email, items }) {
@@ -189,7 +386,9 @@ module.exports = {
   getById,
   saveAll,
   create,
+  update,
   createOrder,
   markInventoryApplied,
   clearInventoryApplied,
+  upsertByPayment,
 };

--- a/nerin_final_updated/backend/routes/mercadoPago.js
+++ b/nerin_final_updated/backend/routes/mercadoPago.js
@@ -1,285 +1,245 @@
-const fs = require('fs');
-const path = require('path');
-const { DATA_DIR: dataDir } = require('../utils/dataDir');
+const db = require('../db');
+const ordersRepo = require('../data/ordersRepo');
+
 const ACCESS_TOKEN = process.env.MP_ACCESS_TOKEN || '';
 const fetchFn =
   globalThis.fetch ||
-  ((...a) => import('node-fetch').then(({ default: f }) => f(...a)));
-const db = require('../db');
-const ordersRepo = require('../data/ordersRepo');
-const productsRepo = require('../data/productsRepo');
+  ((...args) => import('node-fetch').then(({ default: f }) => f(...args)));
 
 const logger = {
-  info: console.log,
-  warn: console.warn,
-  error: console.error,
+  info: (...args) => console.log(...args),
+  warn: (...args) => console.warn(...args),
+  error: (...args) => console.error(...args),
 };
-const {
-  applyInventoryForOrder,
-  revertInventoryForOrder,
-} = require('../services/inventory');
 
-function mapStatus(mpStatus) {
-  const s = String(mpStatus || '').toLowerCase();
-  if (s === 'approved') return 'pagado';
-  if (['rejected', 'cancelled', 'refunded', 'charged_back'].includes(s))
-    return 'rechazado';
-  return 'pendiente';
-}
+const VALID_ACTIONS = new Set(['payment.created', 'payment.updated']);
 
-function ordersPath() {
-  return path.join(dataDir, 'orders.json');
-}
-
-async function getOrders() {
-  if (db.getPool()) return ordersRepo.getAll();
-  try {
-    const file = fs.readFileSync(ordersPath(), 'utf8');
-    return JSON.parse(file).orders || [];
-  } catch {
-    return [];
+function getMpClient() {
+  if (!ACCESS_TOKEN) {
+    throw new Error('MP_ACCESS_TOKEN not configured');
   }
+  return {
+    payment: {
+      findById: async (id) => {
+        const res = await fetchFn(`https://api.mercadopago.com/v1/payments/${id}`, {
+          headers: { Authorization: `Bearer ${ACCESS_TOKEN}` },
+        });
+        if (!res.ok) {
+          const error = new Error(`payment fetch failed (${res.status})`);
+          error.status = res.status;
+          throw error;
+        }
+        return res.json();
+      },
+    },
+  };
 }
 
-async function saveOrders(orders) {
-  if (db.getPool()) return ordersRepo.saveAll(orders);
-  fs.writeFileSync(ordersPath(), JSON.stringify({ orders }, null, 2), 'utf8');
+function normalizePaymentResponse(res) {
+  if (res && res.body && typeof res.body === 'object') return res.body;
+  return res;
 }
 
-function productsPath() {
-  return path.join(dataDir, 'products.json');
+function extractAmount(payment) {
+  if (!payment) return null;
+  const rawAmount =
+    payment.transaction_amount ??
+    payment.transaction_details?.total_paid_amount ??
+    payment.amount ??
+    null;
+  if (rawAmount == null) return null;
+  const amount = Number(rawAmount);
+  return Number.isFinite(amount) ? amount : null;
 }
 
-async function getProducts() {
-  if (db.getPool()) return productsRepo.getAll();
-  try {
-    const file = fs.readFileSync(productsPath(), 'utf8');
-    return JSON.parse(file).products || [];
-  } catch {
-    return [];
-  }
-}
-
-async function saveProducts(products) {
-  if (db.getPool()) return productsRepo.saveAll(products);
-  fs.writeFileSync(
-    productsPath(),
-    JSON.stringify({ products }, null, 2),
-    'utf8'
+function extractCurrency(payment) {
+  if (!payment) return null;
+  return (
+    payment.currency_id ||
+    payment.currency ||
+    payment.transaction_details?.currency_id ||
+    null
   );
 }
 
+function extractPaymentEvent(req = {}) {
+  const b = req.body || {};
+  const q = req.query || {};
+  const type = b.type || b.topic || q.type || q.topic || null;
+  const action = b.action || b.event || null;
+  let id =
+    (b.data && (b.data.id || b.data.payment_id)) ||
+    b.payment_id ||
+    b.id ||
+    q.id ||
+    null;
+  if (!id && q.resource) {
+    const parts = String(q.resource).split('/');
+    id = parts[parts.length - 1] || null;
+  }
+  return { type, action, id };
+}
 
-async function upsertOrder({
-  externalRef,
-  prefId,
-  status,
-  statusRaw,
-  paymentId,
-  total,
-}) {
-  const identifier = prefId || externalRef;
-  if (!identifier) return;
-  const orders = await getOrders();
-  const idx = orders.findIndex(
-    (o) =>
-      o.id === identifier ||
-      o.external_reference === identifier ||
-      o.order_number === identifier ||
-      String(o.preference_id) === String(identifier)
-  );
-  if (idx !== -1) {
-    const row = orders[idx];
-    if (paymentId != null) row.payment_id = String(paymentId);
-    if (status) {
-      row.payment_status = status;
-      row.estado_pago = status;
-    }
-    if (statusRaw) row.payment_status_raw = statusRaw;
-    if (total && !row.total) row.total = total;
-    if (!row.created_at) row.created_at = new Date().toISOString();
-    if (prefId != null) row.preference_id = prefId;
-    if (externalRef != null) row.external_reference = externalRef;
-  } else {
-    const row = { id: externalRef || prefId };
-    if (prefId != null) row.preference_id = prefId;
-    if (externalRef != null) row.external_reference = externalRef;
-    row.payment_status = status || 'pendiente';
-    row.estado_pago = status || 'pendiente';
-    if (statusRaw) row.payment_status_raw = statusRaw;
-    if (paymentId != null) row.payment_id = String(paymentId);
-    row.total = total || 0;
-    row.created_at = new Date().toISOString();
-    orders.push(row);
+async function handlePayment(paymentId, hints = {}) {
+  if (!paymentId) return 'ignored';
+  let payment;
+  try {
+    const client = getMpClient();
+    const res = await client.payment.findById(paymentId);
+    payment = normalizePaymentResponse(res);
+  } catch (error) {
+    logger.warn('mp-webhook payment fetch failed', {
+      paymentId,
+      msg: error?.message,
+    });
+    return 'error';
   }
 
-  const row = orders[idx !== -1 ? idx : orders.length - 1];
-  const inventoryApplied = row.inventoryApplied || row.inventory_applied;
+  if (!payment || payment.status !== 'approved') {
+    logger.info('mp-webhook ignored (status)', {
+      paymentId,
+      status: payment?.status,
+    });
+    return 'ignored';
+  }
 
-  await saveOrders(orders);
+  const amount = extractAmount(payment);
+  const currency = extractCurrency(payment);
+  const reference =
+    payment.external_reference ||
+    hints.external_reference ||
+    payment.metadata?.order_id ||
+    null;
+  const preferenceId = payment.preference_id || hints.preference_id || null;
 
-  if (statusRaw === 'approved') {
-    if (db.getPool()) {
-      await ordersRepo.createOrder({
-        id: row.external_reference || row.id,
-        customer_email: row.cliente?.email || null,
-        items: row.productos || row.items || [],
+  try {
+    const updated = await ordersRepo.upsertByPayment({
+      payment_id: paymentId,
+      preference_id: preferenceId,
+      external_reference: reference,
+      amount,
+      currency,
+      patch: {
+        status: 'paid',
+        payment_status: 'paid',
+        estado_pago: 'pagado',
+        paid_at: new Date().toISOString(),
+        paid_amount: amount,
+        paid_currency: currency,
+        mp_payment: { id: paymentId, status: payment.status },
+      },
+    });
+    if (!updated) {
+      logger.warn('mp-webhook order not found', {
+        paymentId,
+        reference,
+        preferenceId,
       });
-    } else if (!inventoryApplied) {
-      await applyInventoryForOrder(row);
+      return 'no-order';
     }
-  } else if (['rejected', 'cancelled', 'refunded', 'charged_back'].includes(statusRaw)) {
-    if (db.getPool()) {
-      const oid = row.external_reference || row.id;
-      if (oid) {
-        const dbOrder = await ordersRepo.getById(oid);
-        if (dbOrder && dbOrder.inventory_applied) {
-          await revertInventoryForOrder(dbOrder);
+
+    // En modo archivo, asegurarnos de aplicar inventario si aún no se hizo.
+    if (!db.getPool()) {
+      const inventoryApplied =
+        updated.inventoryApplied === true ||
+        updated.inventory_applied === true;
+      if (!inventoryApplied && Array.isArray(updated.items) && updated.items.length) {
+        try {
+          const { applyInventoryForOrder } = require('../services/inventory');
+          await applyInventoryForOrder(updated);
+        } catch (err) {
+          logger.error('mp-webhook inventory apply failed', {
+            paymentId,
+            msg: err?.message,
+          });
         }
       }
-    } else if (inventoryApplied) {
-      await revertInventoryForOrder(row);
     }
+
+    logger.info('mp-webhook order updated', {
+      paymentId,
+      reference,
+      preferenceId,
+    });
+    return 'ok';
+  } catch (error) {
+    if (error && error.code === 'AMOUNT_MISMATCH') {
+      logger.warn('mp-webhook amount mismatch', {
+        paymentId,
+        amount,
+      });
+      return 'amount-mismatch';
+    }
+    if (error && error.code === 'CURRENCY_MISMATCH') {
+      logger.warn('mp-webhook currency mismatch', {
+        paymentId,
+        currency,
+      });
+      return 'currency-mismatch';
+    }
+    if (error && error.message === 'ORDER_WITHOUT_ITEMS') {
+      logger.warn('mp-webhook missing items', { paymentId });
+      return 'no-order';
+    }
+    logger.error('mp-webhook unexpected error', {
+      paymentId,
+      msg: error?.message,
+    });
+    throw error;
   }
 }
 
-async function processPayment(id, hints = {}) {
-  try {
-    const res = await fetchFn(`https://api.mercadopago.com/v1/payments/${id}`, {
-      headers: { Authorization: `Bearer ${ACCESS_TOKEN}` },
-    });
-    const p = await res.json();
-    const statusRaw = p.status;
-    const mapped = mapStatus(statusRaw);
-    const externalRef = p.external_reference || hints.externalRef || null;
-    const prefId = p.preference_id || hints.prefId || null;
-    const total = Number(
-      p.transaction_amount ||
-        p.transaction_details?.total_paid_amount ||
-        p.amount ||
-        0
-    );
-
-    await upsertOrder({
-      externalRef,
-      prefId,
-      status: mapped,
-      statusRaw,
-      paymentId: p.id,
-      total,
-    });
-
-    logger.info('mp-webhook OK', {
-      topic: 'payment',
-      paymentId: p.id,
-      externalRef,
-      prefId,
-      status: mapped,
-    });
-  } catch (e) {
-    logger.warn('mp-webhook payment fetch omitido', {
-      paymentId: id,
-      msg: e?.message,
-    });
-  }
+function extractFromBody(body = {}, query = {}) {
+  const { type, action, id } = extractPaymentEvent({ body, query });
+  const data = body.data || {};
+  const paymentId =
+    id ||
+    data.id ||
+    data.payment_id ||
+    body.payment_id ||
+    body.id ||
+    query.id ||
+    null;
+  const external_reference = data.external_reference || body.external_reference || null;
+  const preference_id = data.preference_id || body.preference_id || null;
+  return { type, action, paymentId, external_reference, preference_id };
 }
 
 async function processNotification(reqOrTopic, maybeId) {
-  const body = reqOrTopic?.body || {};
-  const query = reqOrTopic?.query || {};
-  const topic =
-    query.topic ||
-    query.type ||
-    body.type ||
-    body.topic ||
-    (typeof reqOrTopic === 'string' ? reqOrTopic : undefined);
-  const rawId =
-    query.id ||
-    body?.payment_id ||
-    body?.data?.id ||
-    body?.id ||
-    (typeof reqOrTopic === 'string' ? maybeId : undefined) ||
-    maybeId;
-  const resource = query.resource || body?.resource;
-
-  logger.info('mp-webhook recibido', { topic, id: rawId });
-
-  try {
-    if (resource) {
-      try {
-        const res = await fetchFn(resource, {
-          headers: { Authorization: `Bearer ${ACCESS_TOKEN}` },
-        });
-        const data = await res.json();
-        if (data?.payments) {
-          const paymentId = data.payments?.[0]?.id || null;
-          const prefId = data.preference_id || null;
-          const externalRef = data.external_reference || null;
-          if (!paymentId) {
-            await upsertOrder({ externalRef, prefId, status: 'pending' });
-            logger.info('mp-webhook merchant_order sin payment (pending)', {
-              externalRef,
-              prefId,
-            });
-            return;
-          }
-          await processPayment(paymentId, { externalRef, prefId });
-          return;
-        }
-        if (data?.status && data?.external_reference) {
-          await processPayment(data.id, {
-            externalRef: data.external_reference,
-            prefId: data.preference_id,
-          });
-          return;
-        }
-      } catch (e) {
-        logger.warn('mp-webhook resource fetch omitido', {
-          resource,
-          msg: e?.message,
-        });
-        return;
-      }
+  if (reqOrTopic && typeof reqOrTopic === 'object' && 'body' in reqOrTopic) {
+    const { body = {}, query = {} } = reqOrTopic;
+    const { type, action, paymentId, external_reference, preference_id } =
+      extractFromBody(body, query);
+    if (type !== 'payment') {
+      logger.info('mp-webhook ignored', { type, action });
+      return 'ignored';
     }
-
-    if (topic === 'merchant_order') {
-      const moId = Number(rawId) || rawId;
-      try {
-        const res = await fetchFn(
-          `https://api.mercadopago.com/merchant_orders/${moId}`,
-          { headers: { Authorization: `Bearer ${ACCESS_TOKEN}` } }
-        );
-        const mo = await res.json();
-        const paymentId = mo?.payments?.[0]?.id || null;
-        const prefId = mo?.preference_id || null;
-        const externalRef = mo?.external_reference || null;
-        if (!paymentId) {
-          await upsertOrder({ externalRef, prefId, status: 'pending' });
-          logger.info('mp-webhook merchant_order sin payment (pending)', {
-            externalRef,
-            prefId,
-          });
-          return;
-        }
-        await processPayment(paymentId, { externalRef, prefId });
-        return;
-      } catch (e) {
-        logger.info('mp-webhook merchant_order fetch omitido', {
-          moId,
-          msg: e?.message,
-        });
-        return;
-      }
+    const effectiveAction = action || 'payment.updated';
+    if (!VALID_ACTIONS.has(effectiveAction)) {
+      logger.info('mp-webhook ignored', { type, action: effectiveAction });
+      return 'ignored';
     }
-
-    if (topic === 'payment' || /^[0-9]+$/.test(String(rawId))) {
-      await processPayment(rawId);
-      return;
+    if (!paymentId) {
+      logger.warn('mp-webhook missing payment id');
+      return 'ignored';
     }
-  } catch (error) {
-    logger.error(`mp-webhook error inesperado: ${error.message}`);
+    return handlePayment(paymentId, {
+      external_reference,
+      preference_id,
+    });
   }
+
+  const topic = typeof reqOrTopic === 'string' ? reqOrTopic : null;
+  const paymentId = maybeId || (topic && /^[0-9]+$/.test(topic) ? topic : null);
+  if (topic && topic !== 'payment') {
+    logger.info('mp-webhook ignored legacy call', { topic });
+    return 'ignored';
+  }
+  if (!paymentId) {
+    logger.warn('mp-webhook legacy call without id');
+    return 'ignored';
+  }
+  return handlePayment(paymentId);
 }
 
-module.exports = { processNotification };
-
+module.exports = { processNotification, getMpClient };


### PR DESCRIPTION
## Summary
- block order creation/update when no items are present and add an idempotent upsert helper keyed by Mercado Pago identifiers
- refactor the Mercado Pago webhook handler to process only approved payment events, validate amount/currency, and update existing orders without creating new ones
- ensure inventory is applied once in file-mode storage after successful payment updates
- accept Mercado Pago webhook notifications delivered via query parameters (topic/id/resource) over POST or GET while maintaining idempotent paid-order updates

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc107241848331a7e451d09e87db49