### PR TITLE
Harden Mercado Pago webhook order updates

### DIFF
--- a/nerin_final_updated/backend/__tests__/mercado-pago-webhook.test.js
+++ b/nerin_final_updated/backend/__tests__/mercado-pago-webhook.test.js
@@ -1,0 +1,80 @@
+jest.mock('mercadopago', () => ({
+  MercadoPagoConfig: jest.fn(),
+  Preference: jest.fn().mockImplementation(() => ({})),
+  Payment: jest.fn().mockImplementation(() => ({ get: jest.fn() })),
+}));
+
+const request = require('supertest');
+jest.mock('../db', () => ({
+  getPool: () => null,
+  init: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../data/ordersRepo', () => ({
+  upsertByPayment: jest.fn(),
+}));
+
+jest.mock('../services/inventory', () => ({
+  applyInventoryForOrder: jest.fn().mockResolvedValue(undefined),
+}));
+
+process.env.MP_ACCESS_TOKEN = 'test-token';
+
+global.fetch = jest.fn();
+
+const ordersRepo = require('../data/ordersRepo');
+const { createServer } = require('../server');
+
+describe('Mercado Pago webhook', () => {
+  beforeEach(() => {
+    ordersRepo.upsertByPayment.mockResolvedValue({
+      id: 'ORDER-1',
+      items: [{ id: 'SKU', qty: 1 }],
+      inventoryApplied: true,
+    });
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: '123',
+        status: 'approved',
+        transaction_amount: 1000,
+        currency_id: 'ARS',
+        external_reference: 'ORDER-1',
+        preference_id: 'PREF-1',
+        metadata: {},
+      }),
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    delete global.fetch;
+  });
+
+  test('processes query-only webhook (POST ?topic=payment&id=...)', async () => {
+    const server = createServer();
+    const res = await request(server).post(
+      '/api/mercado-pago/webhook?topic=payment&id=123'
+    );
+    expect(res.status).toBe(200);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(ordersRepo.upsertByPayment).toHaveBeenCalledWith(
+      expect.objectContaining({ payment_id: '123' })
+    );
+    if (server.close) server.close();
+  });
+
+  test('supports GET ?topic=payment&resource=/payments/123', async () => {
+    const server = createServer();
+    const res = await request(server).get(
+      '/api/mercado-pago/webhook?topic=payment&resource=/payments/123'
+    );
+    expect(res.status).toBe(200);
+    if (server.close) server.close();
+  });
+});

--- a/nerin_final_updated/backend/data/ordersRepo.js
+++ b/nerin_final_updated/backend/data/ordersRepo.js
@@ -62,7 +62,14 @@ async function saveAll(orders) {
   }
 }
 
+function validateOrder(order) {
+  if (!order || !Array.isArray(order.items) || order.items.length === 0) {
+    throw new Error('ORDER_WITHOUT_ITEMS');
+  }
+}
+
 async function create(order) {
+  validateOrder(order);
   const pool = db.getPool();
   if (!pool) {
     const orders = await getAll();
@@ -88,6 +95,196 @@ async function create(order) {
     await pool.query('ROLLBACK');
     throw e;
   }
+}
+
+async function update(order) {
+  validateOrder(order);
+  const pool = db.getPool();
+  if (!pool) {
+    const orders = await getAll();
+    const idx = orders.findIndex((o) => String(o.id) === String(order.id));
+    if (idx === -1) throw new Error('ORDER_NOT_FOUND');
+    const items = Array.isArray(order.items)
+      ? order.items.map((it) => ({ ...it }))
+      : [];
+    const next = { ...orders[idx], ...order, items };
+    orders[idx] = next;
+    await saveAll(orders);
+    return next;
+  }
+  await pool.query('BEGIN');
+  try {
+    await pool.query(
+      'UPDATE orders SET customer_email=$2, status=$3, total=$4 WHERE id=$1',
+      [order.id, order.customer_email || null, order.status || 'pendiente', order.total || 0]
+    );
+    await pool.query('DELETE FROM order_items WHERE order_id=$1', [order.id]);
+    for (const it of order.items) {
+      const pid = it.product_id || it.id || it.productId;
+      const qty = Number(it.qty || it.quantity || it.cantidad || 0);
+      if (!pid || !qty) continue;
+      const price = Number(it.price || it.unit_price || 0);
+      await pool.query(
+        'INSERT INTO order_items (order_id, product_id, qty, price) VALUES ($1,$2,$3,$4)',
+        [order.id, pid, qty, price]
+      );
+    }
+    await pool.query('COMMIT');
+    return order;
+  } catch (e) {
+    await pool.query('ROLLBACK');
+    throw e;
+  }
+}
+
+function normalizeKey(value) {
+  if (value == null) return null;
+  const str = String(value).trim();
+  return str ? str : null;
+}
+
+function orderMatches(order, candidate) {
+  if (!order || !candidate) return false;
+  const values = [
+    order.id,
+    order.order_id,
+    order.orderId,
+    order.order_number,
+    order.orderNumber,
+    order.external_reference,
+    order.externalReference,
+    order.preference_id,
+    order.preferenceId,
+    order.payment_id,
+    order.paymentId,
+    order.metadata?.order_id,
+  ];
+  return values.some((val) => normalizeKey(val) === candidate);
+}
+
+async function findByKey(key, identifiers = {}) {
+  const candidates = new Set();
+  const keys = [
+    key,
+    identifiers.payment_id,
+    identifiers.preference_id,
+    identifiers.external_reference,
+  ];
+  for (const value of keys) {
+    const normalized = normalizeKey(value);
+    if (normalized) candidates.add(normalized);
+  }
+  if (!candidates.size) return null;
+
+  const pool = db.getPool();
+  if (!pool) {
+    const orders = await getAll();
+    for (const candidate of candidates) {
+      const match = orders.find((o) => orderMatches(o, candidate));
+      if (match) return match;
+    }
+    return null;
+  }
+
+  for (const candidate of candidates) {
+    const found = await getById(candidate);
+    if (found) return found;
+  }
+  return null;
+}
+
+function computeOrderTotal(order) {
+  const total = Number(order?.total);
+  if (!Number.isFinite(total) || total <= 0) {
+    if (Array.isArray(order?.items)) {
+      return order.items.reduce((acc, it) => {
+        const price = Number(it.price || it.unit_price || 0);
+        const qty = Number(it.qty || it.quantity || it.cantidad || 0);
+        return acc + price * qty;
+      }, 0);
+    }
+    return 0;
+  }
+  return total;
+}
+
+function getOrderCurrency(order) {
+  if (!order) return null;
+  const itemWithCurrency = Array.isArray(order.items)
+    ? order.items.find((it) => it.currency || it.currency_id)
+    : null;
+  return (
+    order.currency ||
+    order.currency_id ||
+    order.currencyId ||
+    order.moneda ||
+    order.paid_currency ||
+    (itemWithCurrency ? itemWithCurrency.currency || itemWithCurrency.currency_id : null)
+  );
+}
+
+async function upsertByPayment({
+  payment_id,
+  preference_id,
+  external_reference,
+  patch = {},
+  amount,
+  currency,
+}) {
+  const normalizedPaymentId = normalizeKey(payment_id);
+  const normalizedPreferenceId = normalizeKey(preference_id);
+  const normalizedExternalRef = normalizeKey(external_reference);
+  const key = normalizedPaymentId || normalizedPreferenceId || normalizedExternalRef;
+  if (!key) return null;
+
+  const existing = await findByKey(key, {
+    payment_id: normalizedPaymentId,
+    preference_id: normalizedPreferenceId,
+    external_reference: normalizedExternalRef,
+  });
+  if (!existing) return null;
+
+  if (
+    normalizedPaymentId &&
+    existing.payment_id &&
+    normalizeKey(existing.payment_id) === normalizedPaymentId
+  ) {
+    return existing;
+  }
+
+  if (typeof amount === 'number' && Number.isFinite(amount)) {
+    const total = computeOrderTotal(existing);
+    if (Number.isFinite(total) && Math.abs(total - amount) > 0.01) {
+      const err = new Error('AMOUNT_MISMATCH');
+      err.code = 'AMOUNT_MISMATCH';
+      throw err;
+    }
+  }
+
+  if (currency) {
+    const orderCurrency = getOrderCurrency(existing);
+    if (orderCurrency && String(orderCurrency) !== String(currency)) {
+      const err = new Error('CURRENCY_MISMATCH');
+      err.code = 'CURRENCY_MISMATCH';
+      throw err;
+    }
+  }
+
+  const merged = {
+    ...existing,
+    ...patch,
+  };
+  if (normalizedPaymentId) merged.payment_id = normalizedPaymentId;
+  if (normalizedPreferenceId) merged.preference_id = normalizedPreferenceId;
+  if (normalizedExternalRef) {
+    merged.external_reference = normalizedExternalRef;
+    if (!merged.id) merged.id = normalizedExternalRef;
+  }
+  if (!Array.isArray(merged.items) || merged.items.length === 0) {
+    merged.items = existing.items;
+  }
+
+  return update(merged);
 }
 
 async function createOrder({ id, customer_email, items }) {
@@ -189,7 +386,9 @@ module.exports = {
   getById,
   saveAll,
   create,
+  update,
   createOrder,
   markInventoryApplied,
   clearInventoryApplied,
+  upsertByPayment,
 };

--- a/nerin_final_updated/backend/index.js
+++ b/nerin_final_updated/backend/index.js
@@ -307,7 +307,7 @@ async function getOrderStatus(id) {
   }
   const raw = String(order.status || order.estado_pago || order.payment_status || "").toLowerCase();
   let status = "pending";
-  if (["approved", "aprobado", "pagado"].includes(raw)) status = "approved";
+  if (["approved", "aprobado", "pagado", "paid"].includes(raw)) status = "approved";
   else if (["rejected", "rechazado"].includes(raw)) status = "rejected";
   return {
     status,


### PR DESCRIPTION
## Summary
- block order creation/update when no items are present and add an idempotent upsert helper keyed by Mercado Pago identifiers
- refactor the Mercado Pago webhook handler to process only approved payment events, validate amount/currency, and update existing orders without creating new ones
- ensure inventory is applied once in file-mode storage after successful payment updates
- accept Mercado Pago webhook notifications delivered via query parameters (topic/id/resource) over POST or GET while maintaining idempotent paid-order updates
- normalize payment status persistence to use the approved value and translate legacy "paid" entries for backward compatibility

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc107241848331a7e451d09e87db49