### PR TITLE
Handle Mercado Pago refund/chargeback statuses and revert inventory

### DIFF
--- a/nerin_final_updated/backend/__tests__/mercado-pago-webhook.test.js
+++ b/nerin_final_updated/backend/__tests__/mercado-pago-webhook.test.js
@@ -1,0 +1,241 @@
+jest.mock('mercadopago', () => ({
+  MercadoPagoConfig: jest.fn(),
+  Preference: jest.fn().mockImplementation(() => ({})),
+  Payment: jest.fn().mockImplementation(() => ({ get: jest.fn() })),
+}));
+
+const request = require('supertest');
+jest.mock('../db', () => ({
+  getPool: () => null,
+  init: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../data/ordersRepo', () => ({
+  upsertByPayment: jest.fn(),
+  findByPaymentIdentifiers: jest.fn(),
+  getNormalizedItems: jest.fn(),
+}));
+
+jest.mock('../services/inventory', () => ({
+  applyInventoryForOrder: jest.fn().mockResolvedValue(undefined),
+  revertInventoryForOrder: jest.fn().mockResolvedValue(undefined),
+}));
+
+process.env.MP_ACCESS_TOKEN = 'test-token';
+
+global.fetch = jest.fn();
+
+const ordersRepo = require('../data/ordersRepo');
+const { createServer } = require('../server');
+const { processNotification } = require('../routes/mercadoPago');
+const inventory = require('../services/inventory');
+
+describe('Mercado Pago webhook', () => {
+  beforeEach(() => {
+    const order = {
+      id: 'ORDER-1',
+      items: [{ id: 'SKU', qty: 1, price: 1000 }],
+      totals: { grand_total: 1000 },
+      payment_status_code: 'pending',
+      status: 'pending',
+      inventoryApplied: false,
+      inventory_applied: false,
+    };
+    ordersRepo.findByPaymentIdentifiers.mockResolvedValue(order);
+    ordersRepo.getNormalizedItems.mockReturnValue(order.items);
+    ordersRepo.upsertByPayment.mockResolvedValue({
+      ...order,
+      payment_status_code: 'approved',
+      payment_status: 'pagado',
+      status: 'paid',
+      inventoryApplied: true,
+      inventory_applied: true,
+    });
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: '123',
+        status: 'approved',
+        transaction_amount: 1000,
+        currency_id: 'ARS',
+        external_reference: 'ORDER-1',
+        preference_id: 'PREF-1',
+        metadata: {},
+      }),
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    delete global.fetch;
+  });
+
+  test('processes query-only webhook (POST ?topic=payment&id=...)', async () => {
+    const server = createServer();
+    const res = await request(server).post(
+      '/api/mercado-pago/webhook?topic=payment&id=123'
+    );
+    expect(res.status).toBe(200);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(ordersRepo.upsertByPayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payment_id: '123',
+        patch: expect.objectContaining({
+          payment_status_code: 'approved',
+          payment_status: 'pagado',
+          estado_pago: 'pagado',
+        }),
+      })
+    );
+    expect(inventory.applyInventoryForOrder).toHaveBeenCalled();
+    if (server.close) server.close();
+  });
+
+  test('supports GET ?topic=payment&resource=/payments/123', async () => {
+    const server = createServer();
+    const res = await request(server).get(
+      '/api/mercado-pago/webhook?topic=payment&resource=/payments/123'
+    );
+    expect(res.status).toBe(200);
+    if (server.close) server.close();
+  });
+
+  test('POST body.resource=/payments/:id se procesa', async () => {
+    const server = createServer();
+    const res = await request(server)
+      .post('/api/mercado-pago/webhook')
+      .send({ resource: '/payments/123' })
+      .set('Content-Type', 'application/json');
+
+    expect(res.status).toBe(200);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(ordersRepo.upsertByPayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payment_id: '123',
+        patch: expect.objectContaining({
+          payment_status_code: 'approved',
+          payment_status: 'pagado',
+          estado_pago: 'pagado',
+        }),
+      })
+    );
+    expect(inventory.applyInventoryForOrder).toHaveBeenCalled();
+
+    if (server.close) server.close();
+  });
+
+  test('payment approved transitioning to refunded reverts inventory once', async () => {
+    ordersRepo.findByPaymentIdentifiers.mockResolvedValue({
+      id: 'ORDER-1',
+      items: [{ id: 'SKU', qty: 1, price: 1000 }],
+      totals: { grand_total: 1000 },
+      currency: 'ARS',
+      payment_status_code: 'approved',
+      status: 'paid',
+      inventoryApplied: true,
+      inventory_applied: true,
+      paid_at: '2023-01-01T00:00:00.000Z',
+      paid_amount: 1000,
+      paid_currency: 'ARS',
+    });
+    ordersRepo.getNormalizedItems.mockReturnValue([
+      { id: 'SKU', qty: 1, price: 1000 },
+    ]);
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: '123',
+        status: 'refunded',
+        transaction_amount: 1000,
+        currency_id: 'ARS',
+        external_reference: 'ORDER-1',
+        preference_id: 'PREF-1',
+        metadata: {},
+      }),
+    });
+    await expect(
+      processNotification({
+        body: { type: 'payment', action: 'payment.updated', data: { id: '123' } },
+        query: {},
+      })
+    ).resolves.toBe('ok');
+
+    expect(inventory.revertInventoryForOrder).toHaveBeenCalledTimes(1);
+    expect(inventory.applyInventoryForOrder).not.toHaveBeenCalled();
+    expect(ordersRepo.upsertByPayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payment_id: '123',
+        patch: expect.objectContaining({
+          payment_status_code: 'refunded',
+          payment_status: 'rechazado',
+          estado_pago: 'rechazado',
+          status: 'canceled',
+          inventoryApplied: false,
+          inventory_applied: false,
+          inventory_applied_at: null,
+        }),
+      })
+    );
+  });
+
+  test('payment approved transitioning to charged_back reverts inventory once', async () => {
+    ordersRepo.findByPaymentIdentifiers.mockResolvedValue({
+      id: 'ORDER-1',
+      items: [{ id: 'SKU', qty: 1, price: 1000 }],
+      totals: { grand_total: 1000 },
+      currency: 'ARS',
+      payment_status_code: 'approved',
+      status: 'paid',
+      inventoryApplied: true,
+      inventory_applied: true,
+      paid_at: '2023-01-01T00:00:00.000Z',
+      paid_amount: 1000,
+      paid_currency: 'ARS',
+    });
+    ordersRepo.getNormalizedItems.mockReturnValue([
+      { id: 'SKU', qty: 1, price: 1000 },
+    ]);
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: '123',
+        status: 'charged_back',
+        transaction_amount: 1000,
+        currency_id: 'ARS',
+        external_reference: 'ORDER-1',
+        preference_id: 'PREF-1',
+        metadata: {},
+      }),
+    });
+    await expect(
+      processNotification({
+        body: { type: 'payment', action: 'payment.updated', data: { id: '123' } },
+        query: {},
+      })
+    ).resolves.toBe('ok');
+
+    expect(inventory.revertInventoryForOrder).toHaveBeenCalledTimes(1);
+    expect(inventory.applyInventoryForOrder).not.toHaveBeenCalled();
+    expect(ordersRepo.upsertByPayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payment_id: '123',
+        patch: expect.objectContaining({
+          payment_status_code: 'charged_back',
+          payment_status: 'rechazado',
+          estado_pago: 'rechazado',
+          status: 'canceled',
+          inventoryApplied: false,
+          inventory_applied: false,
+          inventory_applied_at: null,
+        }),
+      })
+    );
+  });
+});

--- a/nerin_final_updated/backend/__tests__/orders-payment-status.test.js
+++ b/nerin_final_updated/backend/__tests__/orders-payment-status.test.js
@@ -1,0 +1,99 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const request = require('supertest');
+
+jest.mock('mercadopago', () => ({
+  MercadoPagoConfig: jest.fn(),
+  Preference: jest.fn().mockImplementation(() => ({})),
+  Payment: jest.fn().mockImplementation(() => ({ get: jest.fn() })),
+}));
+
+jest.mock('../db', () => ({
+  getPool: () => null,
+  init: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe('Orders API payment status localization', () => {
+  let server;
+  let tmpDir;
+  let previousDataDir;
+  let previousAccessToken;
+
+  beforeEach(() => {
+    jest.resetModules();
+    previousDataDir = process.env.DATA_DIR;
+    previousAccessToken = process.env.MP_ACCESS_TOKEN;
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nerin-orders-'));
+    const now = new Date().toISOString();
+    const ordersPayload = {
+      orders: [
+        {
+          id: 'ORDER-1',
+          order_number: 'ORDER-1',
+          external_reference: 'ORDER-1',
+          payment_status: 'paid',
+          estado_pago: 'paid',
+          payment_status_code: 'paid',
+          total: 100,
+          productos: [
+            { id: 'SKU-1', name: 'Display', quantity: 1, price: 100 },
+          ],
+          items_summary: 'Display x1',
+          created_at: now,
+          fecha: now,
+        },
+      ],
+    };
+    fs.writeFileSync(
+      path.join(tmpDir, 'orders.json'),
+      JSON.stringify(ordersPayload, null, 2)
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'products.json'),
+      JSON.stringify({ products: [] }, null, 2)
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'order_items.json'),
+      JSON.stringify({ order_items: [] }, null, 2)
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'clients.json'),
+      JSON.stringify({ clients: [] }, null, 2)
+    );
+    process.env.DATA_DIR = tmpDir;
+    process.env.MP_ACCESS_TOKEN = 'test-token';
+    // Re-require server with fresh environment/mocks
+    // eslint-disable-next-line global-require
+    const { createServer } = require('../server');
+    server = createServer();
+  });
+
+  afterEach(() => {
+    if (server && server.close) server.close();
+    process.env.DATA_DIR = previousDataDir;
+    if (previousAccessToken === undefined) {
+      delete process.env.MP_ACCESS_TOKEN;
+    } else {
+      process.env.MP_ACCESS_TOKEN = previousAccessToken;
+    }
+    jest.resetModules();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('GET /api/orders returns spanish payment_status and normalized code', async () => {
+    const res = await request(server).get('/api/orders');
+    expect(res.status).toBe(200);
+    expect(res.body.orders).toHaveLength(1);
+    const order = res.body.orders[0];
+    expect(order.payment_status).toBe('pagado');
+    expect(order.payment_status_code).toBe('approved');
+  });
+
+  test('GET /api/orders/:id normalizes legacy "paid" values', async () => {
+    const res = await request(server).get('/api/orders/ORDER-1');
+    expect(res.status).toBe(200);
+    expect(res.body.order.payment_status).toBe('pagado');
+    expect(res.body.order.payment_status_code).toBe('approved');
+  });
+});

--- a/nerin_final_updated/backend/__tests__/orders-repo.test.js
+++ b/nerin_final_updated/backend/__tests__/orders-repo.test.js
@@ -1,0 +1,49 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+describe('ordersRepo legacy support', () => {
+  let originalDataDir;
+
+  beforeEach(() => {
+    jest.resetModules();
+    originalDataDir = process.env.DATA_DIR;
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'orders-repo-'));
+    process.env.DATA_DIR = tmpDir;
+    const localDataDir = path.join(__dirname, '..', '..', 'data');
+    const sampleSrc = path.join(localDataDir, 'products.json');
+    const sampleDest = path.join(tmpDir, 'products.json');
+    fs.copyFileSync(sampleSrc, sampleDest);
+  });
+
+  afterEach(() => {
+    if (originalDataDir === undefined) {
+      delete process.env.DATA_DIR;
+    } else {
+      process.env.DATA_DIR = originalDataDir;
+    }
+    jest.resetModules();
+  });
+
+  test('upsertByPayment actualiza una orden legacy con "productos"', async () => {
+    const repo = require('../data/ordersRepo');
+    const existing = await repo.create({
+      id: 'O-1',
+      productos: [{ titulo: 'Item A', cantidad: 2, precio: 100 }],
+      totals: { items: 200, shipping: 0, grand_total: 200 },
+    });
+
+    expect(existing.items).toBeDefined();
+
+    const out = await repo.upsertByPayment({
+      payment_id: 'P-123',
+      preference_id: 'PF-1',
+      external_reference: 'O-1',
+      patch: { payment_status: 'approved', status: 'paid' },
+    });
+
+    expect(out.status).toBe('paid');
+    expect(Array.isArray(out.items)).toBe(true);
+    expect(out.items.length).toBeGreaterThan(0);
+  });
+});

--- a/nerin_final_updated/backend/data/ordersRepo.js
+++ b/nerin_final_updated/backend/data/ordersRepo.js
@@ -62,7 +62,39 @@ async function saveAll(orders) {
   }
 }
 
+// Devuelve siempre un array de líneas; acepta 'items' o 'productos'.
+function normalizeItems(order = {}) {
+  const it = Array.isArray(order.items) ? order.items : null;
+  if (it && it.length) return it;
+  const prods = Array.isArray(order.productos) ? order.productos : [];
+  return prods
+    .map((p) => ({
+      id: p.id ?? p.product_id ?? p.codigo ?? undefined,
+      sku: p.sku ?? p.codigo ?? undefined,
+      name: p.name ?? p.titulo ?? p.descripcion ?? '',
+      qty: Number(p.qty ?? p.cantidad ?? p.cant ?? 1),
+      price: Number(p.price ?? p.precio ?? 0),
+      total:
+        Number(
+          p.total ??
+            Number(p.price ?? p.precio ?? 0) *
+              Number(p.qty ?? p.cantidad ?? p.cant ?? 1)
+        ),
+    }))
+    .filter((x) => x.qty > 0);
+}
+
+function validateOrder(order) {
+  const lines = normalizeItems(order);
+  if (!order || lines.length === 0) throw new Error('ORDER_WITHOUT_ITEMS');
+}
+
 async function create(order) {
+  if (!Array.isArray(order.items) || order.items.length === 0) {
+    const lines = normalizeItems(order);
+    if (lines.length) order.items = lines;
+  }
+  validateOrder(order);
   const pool = db.getPool();
   if (!pool) {
     const orders = await getAll();
@@ -88,6 +120,218 @@ async function create(order) {
     await pool.query('ROLLBACK');
     throw e;
   }
+}
+
+async function update(order) {
+  if (!Array.isArray(order.items) || order.items.length === 0) {
+    const lines = normalizeItems(order);
+    if (lines.length) order.items = lines;
+  }
+  validateOrder(order);
+  const pool = db.getPool();
+  if (!pool) {
+    const orders = await getAll();
+    const idx = orders.findIndex((o) => String(o.id) === String(order.id));
+    if (idx === -1) throw new Error('ORDER_NOT_FOUND');
+    const items = Array.isArray(order.items)
+      ? order.items.map((it) => ({ ...it }))
+      : [];
+    const next = { ...orders[idx], ...order, items };
+    orders[idx] = next;
+    await saveAll(orders);
+    return next;
+  }
+  await pool.query('BEGIN');
+  try {
+    await pool.query(
+      'UPDATE orders SET customer_email=$2, status=$3, total=$4 WHERE id=$1',
+      [order.id, order.customer_email || null, order.status || 'pendiente', order.total || 0]
+    );
+    await pool.query('DELETE FROM order_items WHERE order_id=$1', [order.id]);
+    for (const it of order.items) {
+      const pid = it.product_id || it.id || it.productId;
+      const qty = Number(it.qty || it.quantity || it.cantidad || 0);
+      if (!pid || !qty) continue;
+      const price = Number(it.price || it.unit_price || 0);
+      await pool.query(
+        'INSERT INTO order_items (order_id, product_id, qty, price) VALUES ($1,$2,$3,$4)',
+        [order.id, pid, qty, price]
+      );
+    }
+    await pool.query('COMMIT');
+    return order;
+  } catch (e) {
+    await pool.query('ROLLBACK');
+    throw e;
+  }
+}
+
+function normalizeKey(value) {
+  if (value == null) return null;
+  const str = String(value).trim();
+  return str ? str : null;
+}
+
+function normalizePaymentIdentifiers({
+  payment_id,
+  preference_id,
+  external_reference,
+} = {}) {
+  const normalizedPaymentId = normalizeKey(payment_id);
+  const normalizedPreferenceId = normalizeKey(preference_id);
+  const normalizedExternalRef = normalizeKey(external_reference);
+  const key =
+    normalizedPaymentId || normalizedPreferenceId || normalizedExternalRef;
+  return {
+    payment_id: normalizedPaymentId,
+    preference_id: normalizedPreferenceId,
+    external_reference: normalizedExternalRef,
+    key,
+  };
+}
+
+function orderMatches(order, candidate) {
+  if (!order || !candidate) return false;
+  const values = [
+    order.id,
+    order.order_id,
+    order.orderId,
+    order.order_number,
+    order.orderNumber,
+    order.external_reference,
+    order.externalReference,
+    order.preference_id,
+    order.preferenceId,
+    order.payment_id,
+    order.paymentId,
+    order.metadata?.order_id,
+  ];
+  return values.some((val) => normalizeKey(val) === candidate);
+}
+
+async function findByKey(key, identifiers = {}) {
+  const candidates = new Set();
+  const keys = [
+    key,
+    identifiers.payment_id,
+    identifiers.preference_id,
+    identifiers.external_reference,
+  ];
+  for (const value of keys) {
+    const normalized = normalizeKey(value);
+    if (normalized) candidates.add(normalized);
+  }
+  if (!candidates.size) return null;
+
+  const pool = db.getPool();
+  if (!pool) {
+    const orders = await getAll();
+    for (const candidate of candidates) {
+      const match = orders.find((o) => orderMatches(o, candidate));
+      if (match) return match;
+    }
+    return null;
+  }
+
+  for (const candidate of candidates) {
+    const found = await getById(candidate);
+    if (found) return found;
+  }
+  return null;
+}
+
+function computeOrderTotal(order) {
+  const total = Number(order?.total);
+  if (!Number.isFinite(total) || total <= 0) {
+    if (Array.isArray(order?.items)) {
+      return order.items.reduce((acc, it) => {
+        const price = Number(it.price || it.unit_price || 0);
+        const qty = Number(it.qty || it.quantity || it.cantidad || 0);
+        return acc + price * qty;
+      }, 0);
+    }
+    return 0;
+  }
+  return total;
+}
+
+function getOrderCurrency(order) {
+  if (!order) return null;
+  const itemWithCurrency = Array.isArray(order.items)
+    ? order.items.find((it) => it.currency || it.currency_id)
+    : null;
+  return (
+    order.currency ||
+    order.currency_id ||
+    order.currencyId ||
+    order.moneda ||
+    order.paid_currency ||
+    (itemWithCurrency ? itemWithCurrency.currency || itemWithCurrency.currency_id : null)
+  );
+}
+
+async function upsertByPayment({
+  payment_id,
+  preference_id,
+  external_reference,
+  patch = {},
+  amount,
+  currency,
+}) {
+  const identifiers = normalizePaymentIdentifiers({
+    payment_id,
+    preference_id,
+    external_reference,
+  });
+  if (!identifiers.key) return null;
+
+  const existing = await findByKey(identifiers.key, identifiers);
+  if (!existing) return null;
+
+  if (typeof amount === 'number' && Number.isFinite(amount)) {
+    const total = computeOrderTotal(existing);
+    if (Number.isFinite(total) && Math.abs(total - amount) > 0.01) {
+      const err = new Error('AMOUNT_MISMATCH');
+      err.code = 'AMOUNT_MISMATCH';
+      throw err;
+    }
+  }
+
+  if (currency) {
+    const orderCurrency = getOrderCurrency(existing);
+    if (orderCurrency && String(orderCurrency) !== String(currency)) {
+      const err = new Error('CURRENCY_MISMATCH');
+      err.code = 'CURRENCY_MISMATCH';
+      throw err;
+    }
+  }
+
+  const merged = {
+    ...existing,
+    ...patch,
+  };
+  if (identifiers.payment_id) merged.payment_id = identifiers.payment_id;
+  if (identifiers.preference_id) merged.preference_id = identifiers.preference_id;
+  if (identifiers.external_reference) {
+    merged.external_reference = identifiers.external_reference;
+    if (!merged.id) merged.id = identifiers.external_reference;
+  }
+  if (!Array.isArray(merged.items) || merged.items.length === 0) {
+    const lines = normalizeItems(existing);
+    if (lines.length) merged.items = lines;
+  }
+
+  return update(merged);
+}
+
+async function findByPaymentIdentifiers(params = {}) {
+  const identifiers = normalizePaymentIdentifiers(params);
+  if (!identifiers.key) return null;
+  return findByKey(identifiers.key, identifiers);
+}
+
+function getNormalizedItems(order = {}) {
+  return normalizeItems(order);
 }
 
 async function createOrder({ id, customer_email, items }) {
@@ -189,7 +433,11 @@ module.exports = {
   getById,
   saveAll,
   create,
+  update,
   createOrder,
   markInventoryApplied,
   clearInventoryApplied,
+  upsertByPayment,
+  findByPaymentIdentifiers,
+  getNormalizedItems,
 };

--- a/nerin_final_updated/backend/index.js
+++ b/nerin_final_updated/backend/index.js
@@ -307,7 +307,7 @@ async function getOrderStatus(id) {
   }
   const raw = String(order.status || order.estado_pago || order.payment_status || "").toLowerCase();
   let status = "pending";
-  if (["approved", "aprobado", "pagado"].includes(raw)) status = "approved";
+  if (["approved", "aprobado", "pagado", "paid"].includes(raw)) status = "approved";
   else if (["rejected", "rechazado"].includes(raw)) status = "rejected";
   return {
     status,

--- a/nerin_final_updated/backend/routes/mercadoPago.js
+++ b/nerin_final_updated/backend/routes/mercadoPago.js
@@ -1,285 +1,354 @@
-const fs = require('fs');
-const path = require('path');
-const { DATA_DIR: dataDir } = require('../utils/dataDir');
-const ACCESS_TOKEN = process.env.MP_ACCESS_TOKEN || '';
-const fetchFn =
-  globalThis.fetch ||
-  ((...a) => import('node-fetch').then(({ default: f }) => f(...a)));
-const db = require('../db');
 const ordersRepo = require('../data/ordersRepo');
-const productsRepo = require('../data/productsRepo');
-
-const logger = {
-  info: console.log,
-  warn: console.warn,
-  error: console.error,
-};
+const {
+  STATUS_CODE_TO_ES: BASE_STATUS_CODE_TO_ES,
+} = require('../utils/paymentStatus');
 const {
   applyInventoryForOrder,
   revertInventoryForOrder,
 } = require('../services/inventory');
 
-function mapStatus(mpStatus) {
-  const s = String(mpStatus || '').toLowerCase();
-  if (s === 'approved') return 'pagado';
-  if (['rejected', 'cancelled', 'refunded', 'charged_back'].includes(s))
-    return 'rechazado';
-  return 'pendiente';
-}
+const ACCESS_TOKEN = process.env.MP_ACCESS_TOKEN || '';
+const fetchFn =
+  globalThis.fetch ||
+  ((...args) => import('node-fetch').then(({ default: f }) => f(...args)));
 
-function ordersPath() {
-  return path.join(dataDir, 'orders.json');
-}
+const logger = {
+  info: (...args) => console.log(...args),
+  warn: (...args) => console.warn(...args),
+  error: (...args) => console.error(...args),
+};
 
-async function getOrders() {
-  if (db.getPool()) return ordersRepo.getAll();
-  try {
-    const file = fs.readFileSync(ordersPath(), 'utf8');
-    return JSON.parse(file).orders || [];
-  } catch {
-    return [];
+const STATUS_CODE_TO_ES = {
+  ...BASE_STATUS_CODE_TO_ES,
+  refunded: 'rechazado',
+  charged_back: 'rechazado',
+  cancelled: 'rechazado',
+  canceled: 'rechazado',
+};
+
+const VALID_ACTIONS = new Set(['payment.created', 'payment.updated']);
+
+function normalizeMpStatus(status = '') {
+  const key = String(status).toLowerCase();
+  if (key === 'approved') return 'approved';
+  if (key === 'pending' || key === 'in_process' || key === 'in process') {
+    return 'pending';
   }
-}
-
-async function saveOrders(orders) {
-  if (db.getPool()) return ordersRepo.saveAll(orders);
-  fs.writeFileSync(ordersPath(), JSON.stringify({ orders }, null, 2), 'utf8');
-}
-
-function productsPath() {
-  return path.join(dataDir, 'products.json');
-}
-
-async function getProducts() {
-  if (db.getPool()) return productsRepo.getAll();
-  try {
-    const file = fs.readFileSync(productsPath(), 'utf8');
-    return JSON.parse(file).products || [];
-  } catch {
-    return [];
+  if (key === 'refunded') return 'refunded';
+  if (key === 'charged_back' || key === 'charged-back' || key === 'chargeback') {
+    return 'charged_back';
   }
-}
-
-async function saveProducts(products) {
-  if (db.getPool()) return productsRepo.saveAll(products);
-  fs.writeFileSync(
-    productsPath(),
-    JSON.stringify({ products }, null, 2),
-    'utf8'
-  );
-}
-
-
-async function upsertOrder({
-  externalRef,
-  prefId,
-  status,
-  statusRaw,
-  paymentId,
-  total,
-}) {
-  const identifier = prefId || externalRef;
-  if (!identifier) return;
-  const orders = await getOrders();
-  const idx = orders.findIndex(
-    (o) =>
-      o.id === identifier ||
-      o.external_reference === identifier ||
-      o.order_number === identifier ||
-      String(o.preference_id) === String(identifier)
-  );
-  if (idx !== -1) {
-    const row = orders[idx];
-    if (paymentId != null) row.payment_id = String(paymentId);
-    if (status) {
-      row.payment_status = status;
-      row.estado_pago = status;
-    }
-    if (statusRaw) row.payment_status_raw = statusRaw;
-    if (total && !row.total) row.total = total;
-    if (!row.created_at) row.created_at = new Date().toISOString();
-    if (prefId != null) row.preference_id = prefId;
-    if (externalRef != null) row.external_reference = externalRef;
-  } else {
-    const row = { id: externalRef || prefId };
-    if (prefId != null) row.preference_id = prefId;
-    if (externalRef != null) row.external_reference = externalRef;
-    row.payment_status = status || 'pendiente';
-    row.estado_pago = status || 'pendiente';
-    if (statusRaw) row.payment_status_raw = statusRaw;
-    if (paymentId != null) row.payment_id = String(paymentId);
-    row.total = total || 0;
-    row.created_at = new Date().toISOString();
-    orders.push(row);
+  if (key === 'cancelled' || key === 'canceled' || key === 'rejected') {
+    return 'rejected';
   }
+  return 'pending';
+}
 
-  const row = orders[idx !== -1 ? idx : orders.length - 1];
-  const inventoryApplied = row.inventoryApplied || row.inventory_applied;
-
-  await saveOrders(orders);
-
-  if (statusRaw === 'approved') {
-    if (db.getPool()) {
-      await ordersRepo.createOrder({
-        id: row.external_reference || row.id,
-        customer_email: row.cliente?.email || null,
-        items: row.productos || row.items || [],
-      });
-    } else if (!inventoryApplied) {
-      await applyInventoryForOrder(row);
-    }
-  } else if (['rejected', 'cancelled', 'refunded', 'charged_back'].includes(statusRaw)) {
-    if (db.getPool()) {
-      const oid = row.external_reference || row.id;
-      if (oid) {
-        const dbOrder = await ordersRepo.getById(oid);
-        if (dbOrder && dbOrder.inventory_applied) {
-          await revertInventoryForOrder(dbOrder);
+function getMpClient() {
+  if (!ACCESS_TOKEN) {
+    throw new Error('MP_ACCESS_TOKEN not configured');
+  }
+  return {
+    payment: {
+      findById: async (id) => {
+        const res = await fetchFn(`https://api.mercadopago.com/v1/payments/${id}`, {
+          headers: { Authorization: `Bearer ${ACCESS_TOKEN}` },
+        });
+        if (!res.ok) {
+          const error = new Error(`payment fetch failed (${res.status})`);
+          error.status = res.status;
+          throw error;
         }
-      }
-    } else if (inventoryApplied) {
-      await revertInventoryForOrder(row);
-    }
+        return res.json();
+      },
+    },
+  };
+}
+
+function normalizePaymentResponse(res) {
+  if (res && res.body && typeof res.body === 'object') return res.body;
+  return res;
+}
+
+function extractAmount(payment) {
+  if (!payment) return null;
+  const rawAmount =
+    payment.transaction_amount ??
+    payment.transaction_details?.total_paid_amount ??
+    payment.amount ??
+    null;
+  if (rawAmount == null) return null;
+  const amount = Number(rawAmount);
+  return Number.isFinite(amount) ? amount : null;
+}
+
+function extractCurrency(payment) {
+  if (!payment) return null;
+  return (
+    payment.currency_id ||
+    payment.currency ||
+    payment.transaction_details?.currency_id ||
+    null
+  );
+}
+
+function extractIdFromResource(resource) {
+  try {
+    const last = String(resource)
+      .split('?')[0]
+      .split('/')
+      .filter(Boolean)
+      .pop();
+    return last && /^\d+$/.test(last) ? last : null;
+  } catch {
+    return null;
   }
 }
 
-async function processPayment(id, hints = {}) {
-  try {
-    const res = await fetchFn(`https://api.mercadopago.com/v1/payments/${id}`, {
-      headers: { Authorization: `Bearer ${ACCESS_TOKEN}` },
-    });
-    const p = await res.json();
-    const statusRaw = p.status;
-    const mapped = mapStatus(statusRaw);
-    const externalRef = p.external_reference || hints.externalRef || null;
-    const prefId = p.preference_id || hints.prefId || null;
-    const total = Number(
-      p.transaction_amount ||
-        p.transaction_details?.total_paid_amount ||
-        p.amount ||
-        0
-    );
-
-    await upsertOrder({
-      externalRef,
-      prefId,
-      status: mapped,
-      statusRaw,
-      paymentId: p.id,
-      total,
-    });
-
-    logger.info('mp-webhook OK', {
-      topic: 'payment',
-      paymentId: p.id,
-      externalRef,
-      prefId,
-      status: mapped,
-    });
-  } catch (e) {
-    logger.warn('mp-webhook payment fetch omitido', {
-      paymentId: id,
-      msg: e?.message,
-    });
+function extractPaymentEvent(req = {}) {
+  const b = req.body || {};
+  const q = req.query || {};
+  const resUrl = b.resource || q.resource || null;
+  let type = b.type || b.topic || q.type || q.topic || null;
+  const action = b.action || b.event || null;
+  let id =
+    (b.data && (b.data.id || b.data.payment_id)) ||
+    b.payment_id ||
+    b.id ||
+    q.id ||
+    null;
+  if (!id && resUrl) {
+    id = extractIdFromResource(resUrl);
   }
+  if (!type && id) {
+    type = 'payment';
+  }
+  return { type, action, id };
+}
+
+async function handlePayment(paymentId, hints = {}) {
+  if (!paymentId) return 'ignored';
+  let payment;
+  try {
+    const client = getMpClient();
+    const res = await client.payment.findById(paymentId);
+    payment = normalizePaymentResponse(res);
+  } catch (error) {
+    logger.warn('mp-webhook payment fetch failed', {
+      paymentId,
+      msg: error?.message,
+    });
+    return 'error';
+  }
+
+  if (!payment) {
+    logger.info('mp-webhook missing payment', { paymentId });
+    return 'ignored';
+  }
+
+  const nextCode = normalizeMpStatus(payment.status);
+  const nextEs = STATUS_CODE_TO_ES[nextCode] || 'pendiente';
+  const amount = extractAmount(payment);
+  const currency = extractCurrency(payment);
+  const reference =
+    payment.external_reference ||
+    hints.external_reference ||
+    payment.metadata?.order_id ||
+    null;
+  const preferenceId = payment.preference_id || hints.preference_id || null;
+
+  try {
+    const order = await ordersRepo.findByPaymentIdentifiers({
+      payment_id: paymentId,
+      preference_id: preferenceId,
+      external_reference: reference,
+    });
+
+    if (!order) {
+      logger.warn('mp-webhook order not found', {
+        paymentId,
+        reference,
+        preferenceId,
+      });
+      return 'no-order';
+    }
+
+    const previousCode = normalizeMpStatus(
+      order.payment_status_code || order.payment_status || order.estado_pago || ''
+    );
+    const wasApproved = previousCode === 'approved';
+    const willBeApproved = nextCode === 'approved';
+
+    const normalizedItems =
+      typeof ordersRepo.getNormalizedItems === 'function'
+        ? ordersRepo.getNormalizedItems(order)
+        : Array.isArray(order.items)
+        ? order.items
+        : [];
+    const orderForInventory =
+      normalizedItems && normalizedItems.length
+        ? { ...order, items: normalizedItems }
+        : order;
+
+    const inventoryAppliedPrev =
+      order.inventoryApplied === true || order.inventory_applied === true;
+    let inventoryAppliedNext = inventoryAppliedPrev;
+
+    if (willBeApproved && !inventoryAppliedPrev && normalizedItems.length) {
+      try {
+        await applyInventoryForOrder(orderForInventory);
+        inventoryAppliedNext = true;
+      } catch (err) {
+        logger.error('mp-webhook inventory apply failed', {
+          paymentId,
+          msg: err?.message,
+        });
+      }
+    } else if (wasApproved && !willBeApproved && inventoryAppliedPrev) {
+      try {
+        await revertInventoryForOrder(orderForInventory);
+        inventoryAppliedNext = false;
+      } catch (err) {
+        logger.error('mp-webhook inventory revert failed', {
+          paymentId,
+          msg: err?.message,
+        });
+      }
+    }
+
+    const now = new Date().toISOString();
+    const patch = {
+      payment_status_code: nextCode,
+      payment_status: nextEs,
+      estado_pago: nextEs,
+      status: willBeApproved
+        ? 'paid'
+        : nextCode === 'pending'
+        ? order.status || 'pending'
+        : 'canceled',
+      paid_at: willBeApproved ? now : order.paid_at ?? null,
+      paid_amount: willBeApproved ? amount : order.paid_amount ?? null,
+      paid_currency: willBeApproved ? currency : order.paid_currency ?? null,
+      mp_payment: { id: paymentId, status: payment.status },
+    };
+
+    if (inventoryAppliedNext !== inventoryAppliedPrev) {
+      patch.inventoryApplied = inventoryAppliedNext;
+      patch.inventory_applied = inventoryAppliedNext;
+      patch.inventory_applied_at = inventoryAppliedNext ? now : null;
+    }
+
+    const upsertArgs = {
+      payment_id: paymentId,
+      preference_id: preferenceId,
+      external_reference: reference,
+      patch,
+    };
+
+    if (willBeApproved) {
+      if (typeof amount === 'number' && Number.isFinite(amount)) {
+        upsertArgs.amount = amount;
+      }
+      if (currency) {
+        upsertArgs.currency = currency;
+      }
+    }
+
+    const updated = await ordersRepo.upsertByPayment(upsertArgs);
+    if (!updated) {
+      logger.warn('mp-webhook order not found', {
+        paymentId,
+        reference,
+        preferenceId,
+      });
+      return 'no-order';
+    }
+
+    logger.info('mp-webhook order updated', {
+      paymentId,
+      reference,
+      preferenceId,
+      status: nextCode,
+    });
+    return 'ok';
+  } catch (error) {
+    if (error && error.code === 'AMOUNT_MISMATCH') {
+      logger.warn('mp-webhook amount mismatch', {
+        paymentId,
+        amount,
+      });
+      return 'amount-mismatch';
+    }
+    if (error && error.code === 'CURRENCY_MISMATCH') {
+      logger.warn('mp-webhook currency mismatch', {
+        paymentId,
+        currency,
+      });
+      return 'currency-mismatch';
+    }
+    if (error && error.message === 'ORDER_WITHOUT_ITEMS') {
+      logger.warn('mp-webhook missing items', { paymentId });
+      return 'no-order';
+    }
+    logger.error('mp-webhook unexpected error', {
+      paymentId,
+      msg: error?.message,
+    });
+    throw error;
+  }
+}
+
+function extractFromBody(body = {}, query = {}) {
+  const { type, action, id } = extractPaymentEvent({ body, query });
+  const data = body.data || {};
+  const paymentId =
+    id ||
+    data.id ||
+    data.payment_id ||
+    body.payment_id ||
+    body.id ||
+    query.id ||
+    null;
+  const external_reference = data.external_reference || body.external_reference || null;
+  const preference_id = data.preference_id || body.preference_id || null;
+  return { type, action, paymentId, external_reference, preference_id };
 }
 
 async function processNotification(reqOrTopic, maybeId) {
-  const body = reqOrTopic?.body || {};
-  const query = reqOrTopic?.query || {};
-  const topic =
-    query.topic ||
-    query.type ||
-    body.type ||
-    body.topic ||
-    (typeof reqOrTopic === 'string' ? reqOrTopic : undefined);
-  const rawId =
-    query.id ||
-    body?.payment_id ||
-    body?.data?.id ||
-    body?.id ||
-    (typeof reqOrTopic === 'string' ? maybeId : undefined) ||
-    maybeId;
-  const resource = query.resource || body?.resource;
-
-  logger.info('mp-webhook recibido', { topic, id: rawId });
-
-  try {
-    if (resource) {
-      try {
-        const res = await fetchFn(resource, {
-          headers: { Authorization: `Bearer ${ACCESS_TOKEN}` },
-        });
-        const data = await res.json();
-        if (data?.payments) {
-          const paymentId = data.payments?.[0]?.id || null;
-          const prefId = data.preference_id || null;
-          const externalRef = data.external_reference || null;
-          if (!paymentId) {
-            await upsertOrder({ externalRef, prefId, status: 'pending' });
-            logger.info('mp-webhook merchant_order sin payment (pending)', {
-              externalRef,
-              prefId,
-            });
-            return;
-          }
-          await processPayment(paymentId, { externalRef, prefId });
-          return;
-        }
-        if (data?.status && data?.external_reference) {
-          await processPayment(data.id, {
-            externalRef: data.external_reference,
-            prefId: data.preference_id,
-          });
-          return;
-        }
-      } catch (e) {
-        logger.warn('mp-webhook resource fetch omitido', {
-          resource,
-          msg: e?.message,
-        });
-        return;
-      }
+  if (reqOrTopic && typeof reqOrTopic === 'object' && 'body' in reqOrTopic) {
+    const { body = {}, query = {} } = reqOrTopic;
+    const { type, action, paymentId, external_reference, preference_id } =
+      extractFromBody(body, query);
+    if (type !== 'payment') {
+      logger.info('mp-webhook ignored', { type, action });
+      return 'ignored';
     }
-
-    if (topic === 'merchant_order') {
-      const moId = Number(rawId) || rawId;
-      try {
-        const res = await fetchFn(
-          `https://api.mercadopago.com/merchant_orders/${moId}`,
-          { headers: { Authorization: `Bearer ${ACCESS_TOKEN}` } }
-        );
-        const mo = await res.json();
-        const paymentId = mo?.payments?.[0]?.id || null;
-        const prefId = mo?.preference_id || null;
-        const externalRef = mo?.external_reference || null;
-        if (!paymentId) {
-          await upsertOrder({ externalRef, prefId, status: 'pending' });
-          logger.info('mp-webhook merchant_order sin payment (pending)', {
-            externalRef,
-            prefId,
-          });
-          return;
-        }
-        await processPayment(paymentId, { externalRef, prefId });
-        return;
-      } catch (e) {
-        logger.info('mp-webhook merchant_order fetch omitido', {
-          moId,
-          msg: e?.message,
-        });
-        return;
-      }
+    const effectiveAction = action || 'payment.updated';
+    if (!VALID_ACTIONS.has(effectiveAction)) {
+      logger.info('mp-webhook ignored', { type, action: effectiveAction });
+      return 'ignored';
     }
-
-    if (topic === 'payment' || /^[0-9]+$/.test(String(rawId))) {
-      await processPayment(rawId);
-      return;
+    if (!paymentId) {
+      logger.warn('mp-webhook missing payment id');
+      return 'ignored';
     }
-  } catch (error) {
-    logger.error(`mp-webhook error inesperado: ${error.message}`);
+    return handlePayment(paymentId, {
+      external_reference,
+      preference_id,
+    });
   }
+
+  const topic = typeof reqOrTopic === 'string' ? reqOrTopic : null;
+  const paymentId = maybeId || (topic && /^[0-9]+$/.test(topic) ? topic : null);
+  if (topic && topic !== 'payment') {
+    logger.info('mp-webhook ignored legacy call', { topic });
+    return 'ignored';
+  }
+  if (!paymentId) {
+    logger.warn('mp-webhook legacy call without id');
+    return 'ignored';
+  }
+  return handlePayment(paymentId);
 }
 
-module.exports = { processNotification };
-
+module.exports = { processNotification, getMpClient };

--- a/nerin_final_updated/backend/utils/paymentStatus.js
+++ b/nerin_final_updated/backend/utils/paymentStatus.js
@@ -1,0 +1,59 @@
+const STATUS_CODE_TO_ES = {
+  approved: 'pagado',
+  pending: 'pendiente',
+  rejected: 'rechazado',
+  refunded: 'rechazado',
+  charged_back: 'rechazado',
+  cancelled: 'rechazado',
+  canceled: 'rechazado',
+};
+
+const STATUS_ES_TO_CODE = {
+  pagado: 'approved',
+  pendiente: 'pending',
+  rechazado: 'rejected',
+  aprobado: 'approved',
+  paid: 'approved',
+  approved: 'approved',
+  pending: 'pending',
+  rejected: 'rejected',
+  in_process: 'pending',
+  inprocess: 'pending',
+  refunded: 'refunded',
+  refund: 'refunded',
+  charged_back: 'charged_back',
+  'charged-back': 'charged_back',
+  chargeback: 'charged_back',
+  cancelled: 'rejected',
+  canceled: 'rejected',
+};
+
+function mapPaymentStatusCode(status) {
+  if (!status) return 'pending';
+  const key = String(status).toLowerCase();
+  if (STATUS_ES_TO_CODE[key]) return STATUS_ES_TO_CODE[key];
+  if (
+    key === 'approved' ||
+    key === 'pending' ||
+    key === 'rejected' ||
+    key === 'refunded' ||
+    key === 'charged_back'
+  ) {
+    return key;
+  }
+  if (key === 'cancelled' || key === 'canceled') return 'rejected';
+  if (key === 'in process') return 'pending';
+  return 'pending';
+}
+
+function localizePaymentStatus(esOrCode) {
+  const code = mapPaymentStatusCode(esOrCode);
+  return STATUS_CODE_TO_ES[code] || 'pendiente';
+}
+
+module.exports = {
+  STATUS_CODE_TO_ES,
+  STATUS_ES_TO_CODE,
+  mapPaymentStatusCode,
+  localizePaymentStatus,
+};


### PR DESCRIPTION
## Summary
- extend payment status normalization utilities to cover refunded, chargeback, and canceled outcomes while preserving the Spanish labels returned to the admin
- reuse shared order lookup helpers so webhook handling can compute transitions, apply or revert inventory once, and persist both payment_status_code and localized payment_status values
- update the Mercado Pago webhook tests to cover query-only flows plus approved->refunded and approved->charged_back transitions that verify inventory rollback and status mapping

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68cc107241848331a7e451d09e87db49