### PR TITLE
Implement order listing filters and soft delete

### DIFF
--- a/nerin_final_updated/backend/__tests__/orders-payment-status.test.js
+++ b/nerin_final_updated/backend/__tests__/orders-payment-status.test.js
@@ -84,10 +84,12 @@ describe('Orders API payment status localization', () => {
   test('GET /api/orders returns spanish payment_status and normalized code', async () => {
     const res = await request(server).get('/api/orders');
     expect(res.status).toBe(200);
-    expect(res.body.orders).toHaveLength(1);
-    const order = res.body.orders[0];
+    expect(Array.isArray(res.body.items)).toBe(true);
+    expect(res.body.items).toHaveLength(1);
+    const order = res.body.items[0];
     expect(order.payment_status).toBe('pagado');
     expect(order.payment_status_code).toBe('approved');
+    expect(res.body.summary).toMatchObject({ total: 1, paid: 1 });
   });
 
   test('GET /api/orders/:id normalizes legacy "paid" values', async () => {


### PR DESCRIPTION
## Summary
- normalize stored order snapshots with customer and address helpers, extend creation/update logic, and add list/find/soft delete utilities
- expose summarized order listings with date, status, and query filters plus soft delete endpoint responses
- adjust payment status test expectations to the new response structure

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd9bcd989c83319959878604f9e458