### PR TITLE
Fix admin orders filter and editing

### DIFF
--- a/backend/routes/orders.js
+++ b/backend/routes/orders.js
@@ -202,7 +202,7 @@ function computeSummary(orders, dateIso) {
 
 function normalizeStatusFilter(value) {
   const normalized = String(value || '').trim().toLowerCase();
-  if (!normalized || normalized === 'all') return 'all';
+  if (!normalized || normalized === 'all' || normalized === 'todos') return 'all';
   if (
     normalized === 'pagado' ||
     normalized === 'paid' ||


### PR DESCRIPTION
## Summary
- ensure the orders API treats "todos" like "all" so the filter does not exclude every order
- normalize status values on the admin orders screen and localize the display while reworking the detail pane with editable fields
- hook the detail save action to the existing update endpoint to persist payment, shipping, tracking, carrier, and notes without losing selection

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce005ad08483319a476bf51eaaf81c