### PR TITLE
Refresh admin orders panel and add version endpoint

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -1,47 +1,489 @@
 <!DOCTYPE html>
 <html lang="es">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Administración de pedidos</title>
-  <style>
-    body{font-family:Arial,Helvetica,sans-serif;padding:20px;}
-    table{width:100%;border-collapse:collapse;margin-top:20px;}
-    th,td{border:1px solid #ccc;padding:8px;text-align:left;}
-    button{padding:6px 12px;cursor:pointer;}
-  </style>
-</head>
-<body>
-  <h1>Pedidos pendientes de pago</h1>
-  <table id="tabla">
-    <thead>
-      <tr><th>Número</th><th>Email</th><th>Total</th><th>Estado</th><th></th></tr>
-    </thead>
-    <tbody></tbody>
-  </table>
-<script src="config.js"></script>
-<script>
-async function cargar(){
-  const res = await fetch(`${API_BASE_URL}/api/orders/pending`, { mode: 'cors' });
-  const datos = await res.json();
-  const tbody = document.querySelector('#tabla tbody');
-  tbody.innerHTML = '';
-  datos.forEach(o=>{
-    const tr = document.createElement('tr');
-    tr.innerHTML = `<td>${o.order_number}</td><td>${o.user_email||''}</td><td>${o.total_amount}</td><td>${o.payment_status}</td><td><button data-id="${o.order_number}">Marcar como pagado</button></td>`;
-    tbody.appendChild(tr);
-  });
-}
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Administración de pedidos</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg: #f5f5f7;
+        --surface: #ffffff;
+        --border: #d8dce1;
+        --text: #111827;
+        --text-muted: #4b5563;
+        --accent: #2563eb;
+        --accent-soft: rgba(37, 99, 235, 0.08);
+        --danger: #dc2626;
+      }
 
-document.addEventListener('click', async (e)=>{
-  if(e.target.dataset && e.target.dataset.id){
-    const id = e.target.dataset.id;
-    await fetch(`${API_BASE_URL}/api/orders/`+id+`/mark-paid`, {mode:'cors', method:'POST'});
-    cargar();
-  }
-});
+      * {
+        box-sizing: border-box;
+      }
 
-cargar();
-</script>
-</body>
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont,
+          'Segoe UI', sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        padding: 1.5rem;
+      }
+
+      h1 {
+        margin-top: 0;
+        font-size: 1.75rem;
+      }
+
+      .admin-layout {
+        display: grid;
+        grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+        gap: 1.5rem;
+        align-items: flex-start;
+      }
+
+      .orders-panel,
+      .order-detail {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        padding: 1.5rem;
+        box-shadow: 0 12px 24px rgba(15, 23, 42, 0.05);
+      }
+
+      .orders-filters {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1rem;
+        align-items: flex-end;
+        margin-bottom: 1.5rem;
+      }
+
+      .filter-group {
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+        min-width: 180px;
+      }
+
+      label {
+        font-weight: 600;
+        font-size: 0.85rem;
+      }
+
+      input,
+      select,
+      textarea {
+        font: inherit;
+        border-radius: 10px;
+        border: 1px solid var(--border);
+        padding: 0.45rem 0.65rem;
+        background: #fff;
+      }
+
+      textarea {
+        min-height: 90px;
+        resize: vertical;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        overflow: hidden;
+        border-radius: 12px;
+        border: 1px solid var(--border);
+      }
+
+      thead {
+        background: #f9fafb;
+      }
+
+      th,
+      td {
+        text-align: left;
+        padding: 0.65rem 0.85rem;
+        border-bottom: 1px solid var(--border);
+        font-size: 0.9rem;
+      }
+
+      tbody tr {
+        cursor: pointer;
+        transition: background 0.15s ease;
+      }
+
+      tbody tr:hover {
+        background: var(--accent-soft);
+      }
+
+      tbody tr.is-selected {
+        background: rgba(37, 99, 235, 0.14);
+      }
+
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        font-size: 0.75rem;
+        font-weight: 600;
+        padding: 0.25rem 0.6rem;
+        border-radius: 999px;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+
+      .badge.is-paid {
+        background: rgba(34, 197, 94, 0.16);
+        color: #047857;
+      }
+
+      .badge.is-pending {
+        background: rgba(245, 158, 11, 0.16);
+        color: #b45309;
+      }
+
+      .badge.is-rejected {
+        background: rgba(239, 68, 68, 0.16);
+        color: #b91c1c;
+      }
+
+      .badge.is-cancelled {
+        background: rgba(239, 68, 68, 0.16);
+        color: #b91c1c;
+      }
+
+      .badge.is-shipped {
+        background: rgba(59, 130, 246, 0.16);
+        color: #1d4ed8;
+      }
+
+      .badge.is-delivered {
+        background: rgba(16, 185, 129, 0.16);
+        color: #047857;
+      }
+
+      .orders-summary {
+        display: flex;
+        gap: 1rem;
+        flex-wrap: wrap;
+        margin-bottom: 1rem;
+      }
+
+      .summary-card {
+        flex: 1 1 160px;
+        border-radius: 12px;
+        border: 1px solid var(--border);
+        padding: 1rem;
+        background: #fff;
+      }
+
+      .summary-card strong {
+        display: block;
+        font-size: 1.35rem;
+        margin-bottom: 0.4rem;
+      }
+
+      .order-detail {
+        position: sticky;
+        top: 1.5rem;
+      }
+
+      .order-detail.hidden {
+        display: none;
+      }
+
+      .order-detail h2 {
+        margin-top: 0;
+        margin-bottom: 1rem;
+      }
+
+      .order-detail-section {
+        margin-bottom: 1.25rem;
+      }
+
+      .order-detail-section h3 {
+        margin-bottom: 0.5rem;
+        font-size: 1rem;
+      }
+
+      .order-detail-section p {
+        margin: 0.25rem 0;
+        color: var(--text-muted);
+      }
+
+      dl {
+        margin: 0;
+      }
+
+      dt {
+        font-weight: 600;
+        margin-top: 0.35rem;
+      }
+
+      dd {
+        margin: 0.1rem 0 0.35rem;
+        color: var(--text-muted);
+      }
+
+      .order-items {
+        border-top: 1px solid var(--border);
+        padding-top: 1rem;
+      }
+
+      .order-items ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+      }
+
+      .order-items li {
+        padding: 0.35rem 0;
+        border-bottom: 1px dashed rgba(148, 163, 184, 0.4);
+      }
+
+      .form-actions {
+        display: flex;
+        gap: 0.75rem;
+        align-items: center;
+        flex-wrap: wrap;
+        margin-top: 1rem;
+      }
+
+      button.primary {
+        background: var(--accent);
+        color: #fff;
+        border: none;
+        border-radius: 999px;
+        padding: 0.55rem 1.5rem;
+        font-size: 0.95rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: transform 0.15s ease, box-shadow 0.15s ease;
+      }
+
+      button.primary:disabled {
+        opacity: 0.6;
+        cursor: wait;
+      }
+
+      button.primary:not(:disabled):hover {
+        transform: translateY(-1px);
+        box-shadow: 0 12px 20px rgba(37, 99, 235, 0.2);
+      }
+
+      .status-text {
+        font-size: 0.85rem;
+        color: var(--text-muted);
+      }
+
+      .empty-state,
+      .error-state {
+        padding: 1.5rem;
+        text-align: center;
+        color: var(--text-muted);
+      }
+
+      @media (max-width: 1024px) {
+        body {
+          padding: 1rem;
+        }
+
+        .admin-layout {
+          grid-template-columns: 1fr;
+        }
+
+        .order-detail {
+          position: static;
+        }
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0f172a;
+          --surface: #111827;
+          --border: #1f2937;
+          --text: #f8fafc;
+          --text-muted: #cbd5f5;
+          --accent-soft: rgba(96, 165, 250, 0.12);
+        }
+
+        body {
+          background: var(--bg);
+          color: var(--text);
+        }
+
+        input,
+        select,
+        textarea {
+          background: rgba(15, 23, 42, 0.8);
+          color: var(--text);
+        }
+
+        thead {
+          background: rgba(148, 163, 184, 0.08);
+        }
+
+        .summary-card {
+          background: rgba(15, 23, 42, 0.85);
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Administración de pedidos</h1>
+    <p class="status-text" id="ordersFetchStatus"></p>
+    <div class="admin-layout">
+      <section class="orders-panel">
+        <div class="orders-filters">
+          <div class="filter-group">
+            <label for="ordersDate">Fecha</label>
+            <input type="date" id="ordersDate" />
+          </div>
+          <div class="filter-group">
+            <label for="ordersStatus">Estado de pago</label>
+            <select id="ordersStatus">
+              <option value="">Todos</option>
+              <option value="paid">Pagado</option>
+              <option value="pending">Pendiente</option>
+              <option value="canceled">Rechazado / Cancelado</option>
+            </select>
+          </div>
+          <div class="filter-group" style="flex: 1 1 220px; min-width: 220px">
+            <label for="ordersSearch">Buscar</label>
+            <input
+              type="search"
+              id="ordersSearch"
+              placeholder="Buscar por número, cliente, email o destino"
+            />
+          </div>
+          <div class="filter-group">
+            <label>&nbsp;</label>
+            <button type="button" class="primary" id="ordersRefreshBtn">
+              Actualizar
+            </button>
+          </div>
+        </div>
+        <div class="orders-summary" id="ordersSummary"></div>
+        <div class="table-wrapper">
+          <table id="ordersTable">
+            <thead>
+              <tr>
+                <th>Número</th>
+                <th>Fecha</th>
+                <th>Cliente</th>
+                <th>Total</th>
+                <th>Pago</th>
+                <th>Envío</th>
+              </tr>
+            </thead>
+            <tbody id="ordersTableBody">
+              <tr>
+                <td colspan="6" class="empty-state">
+                  Cargando pedidos...
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+      <aside class="order-detail hidden" id="orderDetail">
+        <h2>Detalle del pedido</h2>
+        <div class="order-detail-section">
+          <h3>Resumen</h3>
+          <p><strong>Número:</strong> <span id="detailOrderNumber">—</span></p>
+          <p><strong>Creado:</strong> <span id="detailCreatedAt">—</span></p>
+          <p><strong>Total:</strong> <span id="detailTotal">—</span></p>
+        </div>
+        <div class="order-detail-section">
+          <h3>Cliente</h3>
+          <dl>
+            <dt>Nombre</dt>
+            <dd id="detailCustomerName">—</dd>
+            <dt>Email</dt>
+            <dd id="detailCustomerEmail">—</dd>
+            <dt>Teléfono</dt>
+            <dd id="detailCustomerPhone">—</dd>
+          </dl>
+        </div>
+        <div class="order-detail-section">
+          <h3>Envío</h3>
+          <dl>
+            <dt>Dirección</dt>
+            <dd id="detailShippingAddress">—</dd>
+            <dt>Método</dt>
+            <dd id="detailShippingMethod">—</dd>
+          </dl>
+        </div>
+        <div class="order-items">
+          <h3>Productos</h3>
+          <ul id="detailItemsList"></ul>
+        </div>
+        <form id="orderEditForm">
+          <div class="order-detail-section">
+            <h3>Editar estado</h3>
+            <label for="orderPaymentStatus">Estado de pago</label>
+            <select id="orderPaymentStatus">
+              <option value="approved">Pagado</option>
+              <option value="pending">Pendiente</option>
+              <option value="rejected">Rechazado</option>
+            </select>
+          </div>
+          <div class="order-detail-section">
+            <label for="orderShippingStatus">Estado de envío</label>
+            <select id="orderShippingStatus">
+              <option value="preparing">En preparación</option>
+              <option value="shipped">Enviado</option>
+              <option value="delivered">Entregado</option>
+              <option value="cancelled">Cancelado</option>
+            </select>
+          </div>
+          <div class="order-detail-section">
+            <label for="orderTracking">Seguimiento</label>
+            <input type="text" id="orderTracking" placeholder="Código de seguimiento" />
+          </div>
+          <div class="order-detail-section">
+            <label for="orderCarrier">Transporte</label>
+            <input type="text" id="orderCarrier" placeholder="Correo, transporte, etc." />
+          </div>
+          <div class="order-detail-section">
+            <label for="orderShippingNote">Notas de envío</label>
+            <textarea id="orderShippingNote" placeholder="Notas visibles para el equipo"></textarea>
+          </div>
+          <div class="form-actions">
+            <button type="submit" class="primary" id="orderSaveBtn">Guardar cambios</button>
+            <span class="status-text" id="orderSaveStatus"></span>
+          </div>
+        </form>
+      </aside>
+    </div>
+
+    <script src="config.js"></script>
+    <script>
+      (async () => {
+        let buildId = 'dev';
+        try {
+          const response = await fetch('/api/version', { cache: 'no-store' });
+          if (response.ok) {
+            const data = await response.json();
+            if (data && data.build) {
+              buildId = data.build;
+            }
+          }
+        } catch (error) {
+          console.warn('No se pudo obtener la versión del backend', error);
+        }
+        window.__ADMIN_BUILD__ = buildId;
+        const script = document.createElement('script');
+        script.src = `js/admin.js?v=${encodeURIComponent(buildId)}`;
+        script.dataset.build = buildId;
+        document.body.appendChild(script);
+      })();
+    </script>
+  </body>
 </html>

--- a/frontend/js/admin.js
+++ b/frontend/js/admin.js
@@ -1,0 +1,714 @@
+(() => {
+  const currentScript = document.currentScript;
+  const buildId =
+    (currentScript && currentScript.dataset && currentScript.dataset.build) ||
+    (typeof window !== 'undefined' && window.__ADMIN_BUILD__) ||
+    'dev';
+  console.info('admin-js-version', buildId);
+
+  const ARG_TIMEZONE = 'America/Argentina/Buenos_Aires';
+  const SEARCH_DEBOUNCE = 250;
+
+  const PAYMENT_STATUS_MAP = {
+    pagado: 'approved',
+    pago: 'approved',
+    pagada: 'approved',
+    approved: 'approved',
+    paid: 'approved',
+    acreditado: 'approved',
+    accredited: 'approved',
+    pendiente: 'pending',
+    pending: 'pending',
+    pending_payment: 'pending',
+    'in process': 'pending',
+    'in_process': 'pending',
+    proceso: 'pending',
+    rechazado: 'rejected',
+    rechazada: 'rejected',
+    rejected: 'rejected',
+    cancelado: 'rejected',
+    cancelada: 'rejected',
+    cancelled: 'rejected',
+    canceled: 'rejected',
+    refunded: 'rejected',
+  };
+
+  const PAYMENT_LABELS = {
+    approved: { label: 'Pagado', badge: 'is-paid' },
+    pending: { label: 'Pendiente', badge: 'is-pending' },
+    rejected: { label: 'Rechazado / Cancelado', badge: 'is-rejected' },
+  };
+
+  const SHIPPING_STATUS_MAP = {
+    pendiente: 'preparing',
+    pending: 'preparing',
+    preparando: 'preparing',
+    'en preparación': 'preparing',
+    'en preparacion': 'preparing',
+    preparacion: 'preparing',
+    preparando_envio: 'preparing',
+    preparing: 'preparing',
+    listo: 'preparing',
+    ready: 'preparing',
+    enviado: 'shipped',
+    envio: 'shipped',
+    shipment: 'shipped',
+    shipped: 'shipped',
+    despachado: 'shipped',
+    entregado: 'delivered',
+    entregada: 'delivered',
+    delivered: 'delivered',
+    finalizado: 'delivered',
+    completado: 'delivered',
+    cancelado: 'cancelled',
+    cancelada: 'cancelled',
+    cancelled: 'cancelled',
+    canceled: 'cancelled',
+  };
+
+  const SHIPPING_LABELS = {
+    preparing: { label: 'En preparación', badge: 'is-pending' },
+    shipped: { label: 'Enviado', badge: 'is-shipped' },
+    delivered: { label: 'Entregado', badge: 'is-delivered' },
+    cancelled: { label: 'Cancelado', badge: 'is-cancelled' },
+  };
+
+  const elements = {};
+  const state = {
+    date: '',
+    status: '',
+    q: '',
+    orders: [],
+    summary: null,
+    selectedId: null,
+    selected: null,
+  };
+
+  let searchTimer = null;
+
+  function resolveApi(path) {
+    const base =
+      (typeof window !== 'undefined' && window.API_BASE_URL) || '';
+    if (!base) return path;
+    const normalizedBase = base.endsWith('/') ? base.slice(0, -1) : base;
+    return `${normalizedBase}${path}`;
+  }
+
+  function isAbsoluteUrl(url) {
+    return /^https?:\/\//i.test(url);
+  }
+
+  function formatCurrency(value) {
+    const number = Number(value ?? 0);
+    return new Intl.NumberFormat('es-AR', {
+      style: 'currency',
+      currency: 'ARS',
+      minimumFractionDigits: 2,
+    }).format(number);
+  }
+
+  function formatArgentinaDateInput(date) {
+    const formatter = new Intl.DateTimeFormat('en-CA', {
+      timeZone: ARG_TIMEZONE,
+    });
+    return formatter.format(date instanceof Date ? date : new Date(date));
+  }
+
+  function formatDateForQuery(inputValue) {
+    if (!inputValue) return '';
+    const [year, month, day] = String(inputValue).split('-');
+    if (!year || !month || !day) return '';
+    return `${day}/${month}/${year}`;
+  }
+
+  function normalizePaymentStatus(raw) {
+    if (raw == null) return 'pending';
+    const key = String(raw).trim().toLowerCase();
+    return PAYMENT_STATUS_MAP[key] ||
+      (key === 'approved' || key === 'pending' || key === 'rejected'
+        ? key
+        : 'pending');
+  }
+
+  function normalizeShippingStatus(raw) {
+    if (raw == null) return 'preparing';
+    const key = String(raw).trim().toLowerCase();
+    return SHIPPING_STATUS_MAP[key] ||
+      (key === 'preparing' ||
+      key === 'shipped' ||
+      key === 'delivered' ||
+      key === 'cancelled'
+        ? key
+        : 'preparing');
+  }
+
+  function formatDateTime(value) {
+    if (!value && value !== 0) return '—';
+    let date;
+    if (typeof value === 'string' && value.includes('T')) {
+      date = new Date(value);
+    } else if (typeof value === 'string' && value.includes('-')) {
+      date = new Date(`${value}T00:00:00`);
+    } else {
+      date = new Date(value);
+    }
+    if (!date || Number.isNaN(date.getTime())) return '—';
+    return date.toLocaleString('es-AR', {
+      timeZone: ARG_TIMEZONE,
+      dateStyle: 'short',
+      timeStyle: 'short',
+    });
+  }
+
+  function getOrderIdentifier(order) {
+    if (!order || typeof order !== 'object') return null;
+    if (order.id != null && order.id !== '') return String(order.id);
+    if (order.order_number) return String(order.order_number);
+    if (order.preference_id) return String(order.preference_id);
+    if (order.external_reference) return String(order.external_reference);
+    return null;
+  }
+
+  function getOrderCustomer(order) {
+    const customer = order.customer || order.cliente || {};
+    const name =
+      customer.name ||
+      [customer.first_name, customer.last_name].filter(Boolean).join(' ') ||
+      order.customer_name ||
+      order.client_name ||
+      '';
+    return {
+      name: name || '—',
+      email: customer.email || order.customer_email || order.user_email || '—',
+      phone:
+        customer.phone ||
+        customer.telefono ||
+        order.customer_phone ||
+        order.phone ||
+        '—',
+    };
+  }
+
+  function formatAddress(order) {
+    const shipping =
+      (order.shipping_address && typeof order.shipping_address === 'object'
+        ? order.shipping_address
+        : {}) || {};
+    const rawShippingAddress =
+      typeof order.shipping_address === 'string' ? order.shipping_address : '';
+    const envio = order.envio || {};
+    const cliente = order.customer || order.cliente || {};
+    const direccionCliente = cliente.direccion || {};
+    const parts = [];
+    const street =
+      shipping.street ||
+      rawShippingAddress ||
+      envio.calle ||
+      direccionCliente.calle ||
+      order.shipping_street ||
+      order.address ||
+      '';
+    const number =
+      shipping.number ||
+      envio.numero ||
+      direccionCliente.numero ||
+      order.shipping_number ||
+      '';
+    const streetLine = [street, number].filter(Boolean).join(' ').trim();
+    if (streetLine) parts.push(streetLine);
+    const city =
+      shipping.city ||
+      order.shipping_city ||
+      envio.localidad ||
+      direccionCliente.localidad ||
+      cliente.localidad ||
+      '';
+    const province =
+      shipping.province ||
+      order.shipping_province ||
+      envio.provincia ||
+      direccionCliente.provincia ||
+      cliente.provincia ||
+      '';
+    const cityLine = [city, province].filter(Boolean).join(', ').trim();
+    if (cityLine) parts.push(cityLine);
+    const zip =
+      shipping.zip ||
+      order.shipping_zip ||
+      envio.cp ||
+      direccionCliente.cp ||
+      cliente.cp ||
+      '';
+    if (zip) {
+      parts.push(`CP ${zip}`);
+    }
+    return parts.join(' · ') || '—';
+  }
+
+  function getOrderItems(order) {
+    if (Array.isArray(order.items) && order.items.length) return order.items;
+    if (Array.isArray(order.productos) && order.productos.length) {
+      return order.productos.map((item) => ({
+        title: item.title || item.titulo || item.descripcion || item.name || '',
+        name: item.name || item.titulo || item.descripcion || '',
+        quantity: item.quantity || item.qty || item.cantidad || item.cant || 0,
+        unit_price: item.unit_price || item.price || item.precio || 0,
+      }));
+    }
+    return [];
+  }
+
+  function computeSummary() {
+    if (state.summary) return state.summary;
+    const summary = { total: 0, paid: 0, pending: 0, canceled: 0 };
+    state.orders.forEach((order) => {
+      const status = normalizePaymentStatus(order.payment_status || order.status);
+      summary.total += 1;
+      if (status === 'approved') summary.paid += 1;
+      else if (status === 'rejected') summary.canceled += 1;
+      else summary.pending += 1;
+    });
+    return summary;
+  }
+
+  function setFetchStatus(message, isError = false) {
+    if (!elements.fetchStatus) return;
+    elements.fetchStatus.textContent = message || '';
+    elements.fetchStatus.style.color = isError ? '#dc2626' : 'var(--text-muted)';
+  }
+
+  function setSaveStatus(message, isError = false) {
+    if (!elements.saveStatus) return;
+    elements.saveStatus.textContent = message || '';
+    elements.saveStatus.style.color = isError ? '#dc2626' : 'var(--text-muted)';
+  }
+
+  function renderSummary() {
+    if (!elements.summary) return;
+    const summary = computeSummary();
+    elements.summary.innerHTML = '';
+    const cards = [
+      { label: 'Total pedidos', value: summary.total },
+      { label: 'Pagados', value: summary.paid },
+      { label: 'Pendientes', value: summary.pending },
+      { label: 'Rechazados / Cancelados', value: summary.canceled },
+    ];
+    cards.forEach((card) => {
+      const div = document.createElement('div');
+      div.className = 'summary-card';
+      const strong = document.createElement('strong');
+      strong.textContent = card.value;
+      const span = document.createElement('span');
+      span.className = 'status-text';
+      span.textContent = card.label;
+      div.appendChild(strong);
+      div.appendChild(span);
+      elements.summary.appendChild(div);
+    });
+  }
+
+  function createBadge(code, labels) {
+    const info = labels[code];
+    const span = document.createElement('span');
+    span.className = `badge ${info ? info.badge : ''}`.trim();
+    span.textContent = info ? info.label : code;
+    return span;
+  }
+
+  function renderOrders() {
+    if (!elements.tableBody) return;
+    elements.tableBody.innerHTML = '';
+    if (!state.orders.length) {
+      const row = document.createElement('tr');
+      const cell = document.createElement('td');
+      cell.colSpan = 6;
+      cell.className = 'empty-state';
+      cell.textContent = 'No hay pedidos para los filtros seleccionados.';
+      row.appendChild(cell);
+      elements.tableBody.appendChild(row);
+      return;
+    }
+    state.orders.forEach((order) => {
+      const row = document.createElement('tr');
+      const id = getOrderIdentifier(order);
+      if (state.selectedId && id && state.selectedId === id) {
+        row.classList.add('is-selected');
+      }
+      if (id) row.dataset.orderId = id;
+
+      const paymentCode = normalizePaymentStatus(order.payment_status || order.status);
+      const shippingCode = normalizeShippingStatus(
+        order.shipping_status || order.envio_estado,
+      );
+
+      const cells = [
+        order.order_number || order.numero_orden || order.id || '—',
+        formatDateTime(order.created_at || order.order_date || order.date),
+        getOrderCustomer(order).name,
+        formatCurrency(
+          (order.totals && (order.totals.total || order.totals.grand_total)) ||
+            order.total_amount ||
+            order.total ||
+            0,
+        ),
+      ];
+      cells.forEach((value) => {
+        const cell = document.createElement('td');
+        cell.textContent = value;
+        row.appendChild(cell);
+      });
+
+      const paymentCell = document.createElement('td');
+      paymentCell.appendChild(createBadge(paymentCode, PAYMENT_LABELS));
+      row.appendChild(paymentCell);
+
+      const shippingCell = document.createElement('td');
+      shippingCell.appendChild(createBadge(shippingCode, SHIPPING_LABELS));
+      row.appendChild(shippingCell);
+
+      elements.tableBody.appendChild(row);
+    });
+  }
+
+  function renderOrderDetail() {
+    if (!elements.detail) return;
+    if (!state.selected) {
+      elements.detail.classList.add('hidden');
+      setSaveStatus('Seleccioná un pedido para editar.');
+      return;
+    }
+    elements.detail.classList.remove('hidden');
+    setSaveStatus('');
+
+    const detail = state.selected;
+    const customer = getOrderCustomer(detail);
+    const paymentCode = normalizePaymentStatus(detail.payment_status || detail.status);
+    const shippingCode = normalizeShippingStatus(
+      detail.shipping_status || detail.envio_estado,
+    );
+    const items = getOrderItems(detail);
+
+    if (elements.detailNumber) {
+      elements.detailNumber.textContent =
+        detail.order_number || detail.numero_orden || detail.id || '—';
+    }
+    if (elements.detailCreatedAt) {
+      elements.detailCreatedAt.textContent = formatDateTime(
+        detail.created_at || detail.order_date || detail.date,
+      );
+    }
+    if (elements.detailTotal) {
+      elements.detailTotal.textContent = formatCurrency(
+        (detail.totals && (detail.totals.total || detail.totals.grand_total)) ||
+          detail.total_amount ||
+          detail.total ||
+          0,
+      );
+    }
+    if (elements.detailCustomerName) {
+      elements.detailCustomerName.textContent = customer.name || '—';
+    }
+    if (elements.detailCustomerEmail) {
+      elements.detailCustomerEmail.textContent = customer.email || '—';
+    }
+    if (elements.detailCustomerPhone) {
+      elements.detailCustomerPhone.textContent = customer.phone || '—';
+    }
+    if (elements.detailShippingAddress) {
+      elements.detailShippingAddress.textContent = formatAddress(detail);
+    }
+    const rawShippingInfo = detail.shipping || detail.shipping_info || {};
+    const rawEnvioInfo = detail.envio || {};
+    if (elements.detailShippingMethod) {
+      const method =
+        detail.shipping_method ||
+        rawShippingInfo.method ||
+        rawEnvioInfo.metodo ||
+        rawEnvioInfo.metodo_envio ||
+        rawEnvioInfo.envio ||
+        '';
+      elements.detailShippingMethod.textContent = method || '—';
+    }
+    if (elements.detailItems) {
+      elements.detailItems.innerHTML = '';
+      if (items.length) {
+        items.forEach((item) => {
+          const li = document.createElement('li');
+          const qty = Number(item.quantity ?? item.qty ?? 0);
+          const price = Number(item.unit_price ?? item.price ?? 0);
+          li.textContent = `${item.title || item.name || 'Producto'} × ${qty} — ${formatCurrency(
+            qty * price || price,
+          )}`;
+          elements.detailItems.appendChild(li);
+        });
+      } else if (detail.items_summary) {
+        const li = document.createElement('li');
+        li.textContent = detail.items_summary;
+        elements.detailItems.appendChild(li);
+      } else {
+        const li = document.createElement('li');
+        li.textContent = 'Sin ítems disponibles.';
+        elements.detailItems.appendChild(li);
+      }
+    }
+
+    if (elements.paymentSelect) {
+      const value = paymentCode;
+      elements.paymentSelect.value =
+        value === 'approved' || value === 'pending' || value === 'rejected'
+          ? value
+          : 'pending';
+    }
+    if (elements.shippingSelect) {
+      const value = shippingCode;
+      elements.shippingSelect.value =
+        value === 'preparing' || value === 'shipped' || value === 'delivered' || value === 'cancelled'
+          ? value
+          : 'preparing';
+    }
+    if (elements.trackingInput) {
+      elements.trackingInput.value =
+        detail.tracking ||
+        detail.tracking_number ||
+        detail.shipping_tracking ||
+        rawShippingInfo.tracking ||
+        rawEnvioInfo.tracking ||
+        '';
+    }
+    if (elements.carrierInput) {
+      elements.carrierInput.value =
+        detail.carrier || rawShippingInfo.carrier || rawEnvioInfo.carrier || '';
+    }
+    if (elements.shippingNoteInput) {
+      elements.shippingNoteInput.value =
+        detail.shipping_note ||
+        detail.shipping_notes ||
+        detail.shipping_note_text ||
+        rawShippingInfo.note ||
+        rawShippingInfo.notes ||
+        rawEnvioInfo.nota ||
+        rawEnvioInfo.notas ||
+        '';
+    }
+  }
+
+  function hydrateSelection() {
+    if (!state.selectedId) {
+      state.selected = null;
+      return;
+    }
+    const found = state.orders.find(
+      (order) => getOrderIdentifier(order) === state.selectedId,
+    );
+    state.selected = found || null;
+    if (!found) {
+      state.selectedId = null;
+    }
+  }
+
+  async function loadOrders() {
+    const params = new URLSearchParams();
+    if (state.date) {
+      params.set('date', formatDateForQuery(state.date));
+    }
+    if (state.status) {
+      params.set('status', state.status);
+    }
+    if (state.q) {
+      params.set('q', state.q);
+    }
+    const query = params.toString();
+    const url = resolveApi(`/api/orders${query ? `?${query}` : ''}`);
+    try {
+      setFetchStatus('Cargando pedidos...');
+      const response = await fetch(url, {
+        mode: isAbsoluteUrl(url) ? 'cors' : 'same-origin',
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const data = await response.json();
+      const items = Array.isArray(data.items)
+        ? data.items
+        : Array.isArray(data.orders)
+        ? data.orders
+        : [];
+      state.orders = items;
+      state.summary = data.summary || null;
+      hydrateSelection();
+      renderSummary();
+      renderOrders();
+      renderOrderDetail();
+      if (!items.length) {
+        setFetchStatus('No hay pedidos para los filtros seleccionados.');
+      } else {
+        setFetchStatus(`Pedidos cargados (${items.length}).`);
+      }
+    } catch (error) {
+      console.error('Error al cargar pedidos', error);
+      state.orders = [];
+      state.summary = null;
+      state.selectedId = null;
+      state.selected = null;
+      renderSummary();
+      renderOrders();
+      renderOrderDetail();
+      setFetchStatus('No se pudieron cargar los pedidos. Reintentá más tarde.', true);
+    }
+  }
+
+  async function handleSave(event) {
+    event.preventDefault();
+    if (!state.selected) return;
+    const identifier = state.selectedId || getOrderIdentifier(state.selected);
+    if (!identifier) {
+      setSaveStatus('No se encontró un identificador para la orden.', true);
+      return;
+    }
+    const payload = {
+      payment_status: elements.paymentSelect ? elements.paymentSelect.value : undefined,
+      shipping_status: elements.shippingSelect ? elements.shippingSelect.value : undefined,
+      tracking: elements.trackingInput ? elements.trackingInput.value.trim() : undefined,
+      carrier: elements.carrierInput ? elements.carrierInput.value.trim() : undefined,
+      shipping_note: elements.shippingNoteInput
+        ? elements.shippingNoteInput.value.trim()
+        : undefined,
+    };
+    if (payload.tracking === '') payload.tracking = null;
+    if (payload.carrier === '') payload.carrier = null;
+    if (payload.shipping_note === '') payload.shipping_note = null;
+
+    const url = resolveApi(`/api/orders/${encodeURIComponent(identifier)}`);
+    try {
+      setSaveStatus('Guardando cambios...');
+      if (elements.saveBtn) elements.saveBtn.disabled = true;
+      const response = await fetch(url, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+        mode: isAbsoluteUrl(url) ? 'cors' : 'same-origin',
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const data = await response.json();
+      if (!data || !data.order) {
+        throw new Error('Respuesta inválida');
+      }
+      const updated = data.order;
+      const updatedId = getOrderIdentifier(updated) || identifier;
+      state.orders = state.orders.map((order) =>
+        getOrderIdentifier(order) === updatedId ? updated : order,
+      );
+      state.summary = data.summary || state.summary;
+      state.selectedId = updatedId;
+      state.selected = updated;
+      renderSummary();
+      renderOrders();
+      renderOrderDetail();
+      setSaveStatus('Cambios guardados correctamente.');
+      setFetchStatus('Pedido actualizado correctamente.');
+    } catch (error) {
+      console.error('Error al guardar pedido', error);
+      setSaveStatus('No se pudieron guardar los cambios.', true);
+    } finally {
+      if (elements.saveBtn) elements.saveBtn.disabled = false;
+    }
+  }
+
+  function handleRowClick(event) {
+    const row = event.target.closest('tr[data-order-id]');
+    if (!row) return;
+    const id = row.dataset.orderId;
+    if (!id) return;
+    if (state.selectedId === id) {
+      return;
+    }
+    state.selectedId = id;
+    hydrateSelection();
+    renderOrders();
+    renderOrderDetail();
+  }
+
+  function init() {
+    elements.fetchStatus = document.getElementById('ordersFetchStatus');
+    elements.date = document.getElementById('ordersDate');
+    elements.status = document.getElementById('ordersStatus');
+    elements.search = document.getElementById('ordersSearch');
+    elements.refreshBtn = document.getElementById('ordersRefreshBtn');
+    elements.summary = document.getElementById('ordersSummary');
+    elements.tableBody = document.getElementById('ordersTableBody');
+    elements.detail = document.getElementById('orderDetail');
+    elements.detailNumber = document.getElementById('detailOrderNumber');
+    elements.detailCreatedAt = document.getElementById('detailCreatedAt');
+    elements.detailTotal = document.getElementById('detailTotal');
+    elements.detailCustomerName = document.getElementById('detailCustomerName');
+    elements.detailCustomerEmail = document.getElementById('detailCustomerEmail');
+    elements.detailCustomerPhone = document.getElementById('detailCustomerPhone');
+    elements.detailShippingAddress = document.getElementById('detailShippingAddress');
+    elements.detailShippingMethod = document.getElementById('detailShippingMethod');
+    elements.detailItems = document.getElementById('detailItemsList');
+    elements.form = document.getElementById('orderEditForm');
+    elements.paymentSelect = document.getElementById('orderPaymentStatus');
+    elements.shippingSelect = document.getElementById('orderShippingStatus');
+    elements.trackingInput = document.getElementById('orderTracking');
+    elements.carrierInput = document.getElementById('orderCarrier');
+    elements.shippingNoteInput = document.getElementById('orderShippingNote');
+    elements.saveBtn = document.getElementById('orderSaveBtn');
+    elements.saveStatus = document.getElementById('orderSaveStatus');
+
+    if (elements.date) {
+      const today = formatArgentinaDateInput(new Date());
+      state.date = elements.date.value || today;
+      elements.date.value = state.date;
+      elements.date.addEventListener('change', () => {
+        state.date = elements.date.value;
+        loadOrders();
+      });
+    }
+    if (!state.date) {
+      state.date = formatArgentinaDateInput(new Date());
+      if (elements.date) elements.date.value = state.date;
+    }
+
+    if (elements.status) {
+      elements.status.addEventListener('change', () => {
+        state.status = elements.status.value;
+        loadOrders();
+      });
+    }
+
+    if (elements.search) {
+      elements.search.addEventListener('input', () => {
+        const value = elements.search.value.trim();
+        clearTimeout(searchTimer);
+        searchTimer = window.setTimeout(() => {
+          state.q = value;
+          loadOrders();
+        }, SEARCH_DEBOUNCE);
+      });
+    }
+
+    if (elements.refreshBtn) {
+      elements.refreshBtn.addEventListener('click', () => {
+        loadOrders();
+      });
+    }
+
+    if (elements.tableBody) {
+      elements.tableBody.addEventListener('click', handleRowClick);
+    }
+
+    if (elements.form) {
+      elements.form.addEventListener('submit', handleSave);
+    }
+
+    loadOrders();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## Summary
- add `/api/version` endpoint with build detection to expose deployment versions
- extend orders router with PUT support and normalize filter handling
- rebuild the admin orders page to use the new API, add cache busting, and ship a full-featured admin.js

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce09b1c88c8331b5faba12a934bfcd