### PR TITLE
Update order tracking and invoice management

### DIFF
--- a/nerin_final_updated/backend/__tests__/orders-admin.test.js
+++ b/nerin_final_updated/backend/__tests__/orders-admin.test.js
@@ -1,0 +1,127 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const request = require('supertest');
+
+jest.mock('mercadopago', () => ({
+  MercadoPagoConfig: jest.fn(),
+  Preference: jest.fn().mockImplementation(() => ({})),
+  Payment: jest.fn().mockImplementation(() => ({ get: jest.fn() })),
+}));
+
+jest.mock('../db', () => ({
+  getPool: () => null,
+  init: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe('Orders admin endpoints', () => {
+  let server;
+  let tmpDir;
+  let previousDataDir;
+  let previousToken;
+
+  beforeEach(() => {
+    jest.resetModules();
+    previousDataDir = process.env.DATA_DIR;
+    previousToken = process.env.MP_ACCESS_TOKEN;
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nerin-orders-admin-'));
+
+    const now = new Date().toISOString();
+    const baseOrder = {
+      id: 'ORDER-123',
+      order_number: 'ORDER-123',
+      external_reference: 'ORDER-123',
+      payment_status: 'pendiente',
+      estado_pago: 'pendiente',
+      payment_status_code: 'pending',
+      shipping_status: 'Pendiente',
+      estado_envio: 'Pendiente',
+      shipping_status_code: 'received',
+      productos: [
+        { id: 'SKU-1', name: 'Producto demo', quantity: 1, price: 1000 },
+      ],
+      items_summary: 'Producto demo x1',
+      total: 1000,
+      created_at: now,
+      fecha: now,
+    };
+
+    fs.writeFileSync(
+      path.join(tmpDir, 'orders.json'),
+      JSON.stringify({ orders: [baseOrder] }, null, 2),
+      'utf8',
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'products.json'),
+      JSON.stringify({ products: [] }, null, 2),
+      'utf8',
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'order_items.json'),
+      JSON.stringify({ order_items: [] }, null, 2),
+      'utf8',
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'clients.json'),
+      JSON.stringify({ clients: [] }, null, 2),
+      'utf8',
+    );
+
+    process.env.DATA_DIR = tmpDir;
+    process.env.MP_ACCESS_TOKEN = 'test-token';
+
+    // eslint-disable-next-line global-require
+    const { createServer } = require('../server');
+    server = createServer();
+  });
+
+  afterEach(() => {
+    if (server && server.close) server.close();
+    if (previousDataDir === undefined) delete process.env.DATA_DIR;
+    else process.env.DATA_DIR = previousDataDir;
+    if (previousToken === undefined) delete process.env.MP_ACCESS_TOKEN;
+    else process.env.MP_ACCESS_TOKEN = previousToken;
+    jest.resetModules();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('PATCH /api/orders/:id actualiza el estado de envío', async () => {
+    const res = await request(server)
+      .patch('/api/orders/ORDER-123')
+      .send({ shipping_status: 'enviado' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('order');
+    expect(res.body.order.shipping_status_code).toBe('shipped');
+    expect(res.body.order.estado_envio).toBe('Enviado');
+  });
+
+  test('POST /api/orders/:id/invoices guarda y lista facturas', async () => {
+    const dummyPdfPath = path.join(tmpDir, 'factura.pdf');
+    fs.writeFileSync(
+      dummyPdfPath,
+      '%PDF-1.4\n1 0 obj\n<<>>\nendobj\ntrailer\n<<>>\n%%EOF\n',
+      'utf8',
+    );
+
+    const uploadRes = await request(server)
+      .post('/api/orders/ORDER-123/invoices')
+      .attach('file', dummyPdfPath);
+
+    expect(uploadRes.status).toBe(201);
+    expect(uploadRes.body).toHaveProperty('invoice');
+    expect(uploadRes.body.invoice.filename).toMatch(/^ORDER-123-/);
+    expect(uploadRes.body.invoice.url).toContain('/files/invoices/');
+
+    const listRes = await request(server).get(
+      '/api/orders/ORDER-123/invoices',
+    );
+
+    expect(listRes.status).toBe(200);
+    expect(Array.isArray(listRes.body.invoices)).toBe(true);
+    expect(listRes.body.invoices.length).toBeGreaterThan(0);
+    const active = listRes.body.invoices.find((inv) => !inv.deleted_at);
+    expect(active).toBeDefined();
+    expect(active.url).toContain('/files/invoices/');
+  });
+});

--- a/nerin_final_updated/frontend/seguimiento.html
+++ b/nerin_final_updated/frontend/seguimiento.html
@@ -54,7 +54,7 @@
       </div>
     </main>
 
-    <script type="module" src="/js/seguimiento.js"></script>
+    <script type="module" src="/js/seguimiento.js?v=20241002-nerin-01"></script>
     <script type="module" src="/js/config.js"></script>
   </body>
 </html>

--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -1329,7 +1329,7 @@ footer .legal {
 .order-progress {
   --c-done: #16a34a;
   --c-current: #2563eb;
-  --c-todo: #cbd5e1;
+  --c-todo: #9ca3af;
   --c-text: #0f172a;
   --progress: 0%;
   display: flex;
@@ -1376,6 +1376,7 @@ footer .legal {
   place-items: center;
   background: #fff;
   border: 2px solid var(--c-todo);
+  color: var(--c-todo);
   margin: 0 auto 6px;
   position: relative;
 }
@@ -1394,21 +1395,27 @@ footer .legal {
   color: var(--c-text);
 }
 
-.order-progress .step[data-state="done"] .icon {
+.order-progress .step[data-state="done"] .icon,
+.order-progress .step.done .icon {
   border-color: var(--c-done);
   background: var(--c-done);
+  color: var(--c-done);
 }
 
-.order-progress .step[data-state="done"] .icon svg {
+.order-progress .step[data-state="done"] .icon svg,
+.order-progress .step.done .icon svg {
   stroke: #fff;
 }
 
-.order-progress .step[data-state="current"] .icon {
+.order-progress .step[data-state="current"] .icon,
+.order-progress .step.current .icon {
   border-color: var(--c-current);
+  color: var(--c-current);
   box-shadow: 0 0 0 4px color-mix(in srgb, var(--c-current) 20%, transparent);
 }
 
-.order-progress .step[data-state="current"] .icon::after {
+.order-progress .step[data-state="current"] .icon::after,
+.order-progress .step.current .icon::after {
   content: "";
   position: absolute;
   inset: -6px;
@@ -1431,12 +1438,21 @@ footer .legal {
   }
 }
 
-.order-progress .step[data-state="current"] .icon svg {
+.order-progress .step[data-state="current"] .icon svg,
+.order-progress .step.current .icon svg {
   stroke: var(--c-current);
 }
 
-.order-progress .step[data-state="todo"] .icon {
+.order-progress .step[data-state="todo"] .icon,
+.order-progress .step.todo .icon {
   background: #fff;
+  color: var(--c-todo);
+}
+
+.order-progress .step[data-state="current"] .label,
+.order-progress .step.current .label {
+  color: var(--c-current);
+  font-weight: 600;
 }
 
 @media (max-width: 520px) {

--- a/nerin_final_updated/scripts/schema.sql
+++ b/nerin_final_updated/scripts/schema.sql
@@ -14,8 +14,16 @@ CREATE TABLE IF NOT EXISTS orders (
   customer_email TEXT,
   status TEXT,
   total NUMERIC,
-  inventory_applied BOOLEAN DEFAULT false
+  inventory_applied BOOLEAN DEFAULT false,
+  invoice_status TEXT,
+  invoices JSONB DEFAULT '[]'::jsonb
 );
+
+ALTER TABLE orders
+  ADD COLUMN IF NOT EXISTS invoice_status TEXT;
+
+ALTER TABLE orders
+  ADD COLUMN IF NOT EXISTS invoices JSONB DEFAULT '[]'::jsonb;
 
 CREATE TABLE IF NOT EXISTS order_items (
   id BIGSERIAL PRIMARY KEY,


### PR DESCRIPTION
## Summary
- normalizar el seguimiento del pedido en `seguimiento.js`, calculando los cinco pasos según payment_status y shipping_status con íconos accesibles y clases done/current/todo
- restaurar en el panel de administración la sección de facturas con listado, subida y eliminación, apoyada en nuevos endpoints de backend y persistencia tanto en archivos como en Postgres
- ajustar filtros de estado en `/api/orders`, servir facturas desde `/files/invoices/` y extender el esquema/almacenamiento para incluir `invoice_status` e `invoices`
- añadir pruebas de integración con supertest para PATCH del estado de envío y para la subida/listado de facturas

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cec3e38be48331bda38a1606211cc9