### PR TITLE
feat: modern responsive order progress stepper

### DIFF
--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -1323,114 +1323,145 @@ footer .legal {
 }
 
 .order-progress-container {
-  position: relative;
+  margin: clamp(1.25rem, 2.5vw, 2.25rem) 0 clamp(1.5rem, 3vw, 2.75rem);
 }
 
 .order-progress {
+  --node-size: clamp(2.4rem, 4vw, 3.2rem);
+  --label-size: clamp(0.78rem, 1vw + 0.55rem, 0.95rem);
   --c-done: #16a34a;
   --c-current: #2563eb;
-  --c-todo: #9ca3af;
-  --c-text: #0f172a;
-  --progress: 0%;
-  display: flex;
-  gap: 1rem;
-  align-items: flex-start;
-  counter-reset: step;
+  --c-pending: #9ca3af;
+  --progress: 0;
   position: relative;
-  padding: 0.5rem 0;
-  margin: 1.5rem 0 0.75rem;
+  margin: 0;
+  padding: clamp(0.75rem, 1vw, 1rem) clamp(0.5rem, 2vw, 1.25rem);
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: clamp(0.5rem, 2.5vw, 1.6rem);
+  color: #0f172a;
+  border-radius: clamp(0.5rem, 1vw, 0.85rem);
 }
 
-.order-progress::before {
-  content: "";
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: 18px;
-  height: 2px;
-  background: var(--c-todo);
-}
-
+.order-progress::before,
 .order-progress::after {
   content: "";
   position: absolute;
-  left: 0;
-  top: 18px;
-  height: 2px;
-  width: var(--progress);
-  background: var(--c-current);
-  transition: width 0.3s ease;
+  top: calc(var(--node-size) / 2);
+  left: calc(var(--node-size) / 2);
+  height: 3px;
+  border-radius: 999px;
+  transform: translateY(-50%);
 }
 
-.order-progress .step {
-  flex: 1;
+.order-progress::before {
+  right: calc(var(--node-size) / 2);
+  background: var(--c-pending);
+  opacity: 0.35;
+}
+
+.order-progress::after {
+  right: auto;
+  width: calc((100% - var(--node-size)) * var(--progress));
+  max-width: calc(100% - var(--node-size));
+  background: linear-gradient(90deg, var(--c-done) 0%, var(--c-current) 100%);
+  transform-origin: left center;
+  transition: width 0.35s ease;
+}
+
+.order-step {
+  position: relative;
   text-align: center;
-  position: relative;
+  display: grid;
+  gap: clamp(0.45rem, 1vw, 0.7rem);
+  justify-items: center;
+  scroll-snap-align: center;
 }
 
-.order-progress .icon {
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  display: inline-grid;
+.order-step__icon {
+  width: var(--node-size);
+  height: var(--node-size);
+  border-radius: 999px;
+  display: grid;
   place-items: center;
+  border: 2px solid var(--c-pending);
   background: #fff;
-  border: 2px solid var(--c-todo);
-  color: var(--c-todo);
-  margin: 0 auto 6px;
+  color: var(--c-pending);
   position: relative;
+  transition:
+    border-color 0.25s ease,
+    color 0.25s ease,
+    box-shadow 0.25s ease,
+    background 0.25s ease;
 }
 
-.order-progress .icon svg {
-  width: 20px;
-  height: 20px;
-  fill: none;
-  stroke: var(--c-todo);
-  stroke-width: 2;
-}
-
-.order-progress .label {
+.order-step__icon svg {
+  width: calc(var(--node-size) * 0.55);
+  height: calc(var(--node-size) * 0.55);
   display: block;
-  font-size: 0.85rem;
-  color: var(--c-text);
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.75;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
-.order-progress .step[data-state="done"] .icon,
-.order-progress .step.done .icon {
+.order-step__label {
+  font-size: var(--label-size);
+  line-height: 1.3;
+  font-weight: 500;
+  color: #1f2937;
+  text-wrap: balance;
+}
+
+.order-step.is-done .order-step__icon {
   border-color: var(--c-done);
   background: var(--c-done);
-  color: var(--c-done);
+  color: #fff;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--c-done) 20%, transparent);
 }
 
-.order-progress .step[data-state="done"] .icon svg,
-.order-progress .step.done .icon svg {
+.order-step.is-done .order-step__icon svg {
   stroke: #fff;
 }
 
-.order-progress .step[data-state="current"] .icon,
-.order-progress .step.current .icon {
-  border-color: var(--c-current);
-  color: var(--c-current);
-  box-shadow: 0 0 0 4px color-mix(in srgb, var(--c-current) 20%, transparent);
+.order-step.is-done .order-step__label {
+  color: var(--c-done);
+  font-weight: 600;
 }
 
-.order-progress .step[data-state="current"] .icon::after,
-.order-progress .step.current .icon::after {
+.order-step.is-current .order-step__icon {
+  border-color: var(--c-current);
+  color: var(--c-current);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--c-current) 18%, transparent);
+}
+
+.order-step.is-current .order-step__icon::after {
   content: "";
   position: absolute;
-  inset: -6px;
-  border-radius: 50%;
-  animation: pulse 1.6s infinite;
-  border: 2px solid color-mix(in srgb, var(--c-current) 40%, transparent);
+  inset: -8px;
+  border-radius: inherit;
+  border: 2px solid color-mix(in srgb, var(--c-current) 45%, transparent);
+  animation: pulse 1.8s infinite;
+}
+
+.order-step.is-current .order-step__label {
+  color: var(--c-current);
+  font-weight: 650;
+}
+
+.order-step:not(.is-done):not(.is-current) .order-step__label {
+  color: #374151;
 }
 
 @keyframes pulse {
   0% {
     transform: scale(0.9);
-    opacity: 0.8;
+    opacity: 0.85;
   }
-  70% {
-    transform: scale(1.15);
+  65% {
+    transform: scale(1.18);
     opacity: 0;
   }
   100% {
@@ -1438,26 +1469,47 @@ footer .legal {
   }
 }
 
-.order-progress .step[data-state="current"] .icon svg,
-.order-progress .step.current .icon svg {
-  stroke: var(--c-current);
+@media (max-width: 639px) {
+  .order-progress {
+    display: flex;
+    gap: clamp(0.75rem, 4vw, 1.5rem);
+    overflow-x: auto;
+    padding-inline: clamp(0.75rem, 5vw, 1.75rem);
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch;
+    min-width: max-content;
+  }
+
+  .order-progress::before,
+  .order-progress::after {
+    right: auto;
+  }
+
+  .order-progress::-webkit-scrollbar {
+    height: 6px;
+  }
+
+  .order-progress::-webkit-scrollbar-thumb {
+    background: rgba(15, 23, 42, 0.2);
+    border-radius: 999px;
+  }
+
+  .order-progress::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .order-step {
+    flex: 0 0 clamp(9.25rem, 62vw, 12rem);
+  }
 }
 
-.order-progress .step[data-state="todo"] .icon,
-.order-progress .step.todo .icon {
-  background: #fff;
-  color: var(--c-todo);
-}
+@media (max-width: 480px) {
+  .order-progress {
+    gap: clamp(0.65rem, 4vw, 1.25rem);
+  }
 
-.order-progress .step[data-state="current"] .label,
-.order-progress .step.current .label {
-  color: var(--c-current);
-  font-weight: 600;
-}
-
-@media (max-width: 520px) {
-  .order-progress .label {
-    font-size: 0.78rem;
+  .order-step__label {
+    font-size: clamp(0.75rem, 3.5vw, 0.88rem);
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the order tracking progress bar with a responsive, accessible stepper that uses inline SVG icons and supports horizontal scroll on small screens
- add a reusable `renderOrderSteps` helper that maps payment and shipping status synonyms to the correct step and drives CSS progress updates
- hook the helper into the tracking flow so refreshed data automatically advances the current step and preserves cancellation alerts

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf02c7d5b0833184f76cbcb4ab7167