### PR TITLE
Improve storefront SEO metadata and structured data

### DIFF
--- a/nerin_final_updated/frontend/contact.html
+++ b/nerin_final_updated/frontend/contact.html
@@ -7,13 +7,75 @@
       content="width=device-width, initial-scale=1.0, viewport-fit=cover"
     />
     <title>Contacto – NERIN</title>
-        <link
+    <meta
+      name="description"
+      content="Contactá a NERIN para solicitar cotizaciones de pantallas Samsung originales, soporte técnico inmediato y envíos a todo el país."
+    />
+    <meta name="robots" content="index,follow" />
+    <link rel="canonical" href="/contact.html" data-seo-absolute="href" />
+    <meta property="og:locale" content="es_AR" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="NERIN Repuestos" />
+    <meta property="og:title" content="Contacto directo | NERIN Repuestos" />
+    <meta
+      property="og:description"
+      content="Escribinos por WhatsApp o completá el formulario para recibir asesoramiento personalizado en pantallas originales."
+    />
+    <meta
+      property="og:url"
+      content="/contact.html"
+      data-seo-absolute="content"
+    />
+    <meta
+      property="og:image"
+      content="/assets/hero.png"
+      data-seo-absolute="content"
+    />
+    <meta
+      property="og:image:alt"
+      content="Equipo de soporte de NERIN listo para ayudar"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Contacto directo | NERIN Repuestos" />
+    <meta
+      name="twitter:description"
+      content="Solicitá cotizaciones y envíos de pantallas Samsung originales en minutos."
+    />
+    <meta
+      name="twitter:url"
+      content="/contact.html"
+      data-seo-absolute="content"
+    />
+    <meta
+      name="twitter:image"
+      content="/assets/hero.png"
+      data-seo-absolute="content"
+    />
+    <meta
+      name="twitter:image:alt"
+      content="Atención personalizada de NERIN"
+    />
+    <link rel="icon" type="image/png" href="/assets/IMG_3086.png" />
+    <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css"
     />
-      <link rel="stylesheet" href="/style.css?v=mobfix-1" />
-    <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
-  <script src="/components/np-footer.js?v=np-r1" defer></script>
+    <link rel="stylesheet" href="/style.css?v=mobfix-1" />
+    <link rel="stylesheet" href="/components/np-footer.css?v=np-r1" />
+    <script src="/components/np-footer.js?v=np-r1" defer></script>
+    <script
+      type="application/ld+json"
+      id="contact-schema"
+      data-seo-jsonld="contact"
+    >
+{
+  "@context": "https://schema.org",
+  "@type": "ContactPage",
+  "name": "Contacto NERIN",
+  "description": "Formulario y canales de contacto directo con NERIN Repuestos.",
+  "url": "__BASE_URL__/contact.html"
+}
+    </script>
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/index.html
+++ b/nerin_final_updated/frontend/index.html
@@ -7,13 +7,118 @@
       content="width=device-width, initial-scale=1.0, viewport-fit=cover"
     />
     <title>NERIN Repuestos – Pantallas originales</title>
-        <link
+    <meta
+      name="description"
+      content="NERIN Repuestos distribuye pantallas Samsung originales Service Pack con envíos a todo Argentina y soporte para técnicos, revendedores y particulares."
+    />
+    <meta
+      name="keywords"
+      content="pantallas samsung originales, service pack argentina, repuestos samsung, pantallas celulares mayorista"
+    />
+    <meta name="robots" content="index,follow" />
+    <meta name="author" content="NERIN Repuestos" />
+    <meta name="theme-color" content="#101935" />
+    <link rel="canonical" href="/index.html" data-seo-absolute="href" />
+    <meta property="og:locale" content="es_AR" />
+    <meta property="og:type" content="website" />
+    <meta
+      property="og:title"
+      content="Pantallas Samsung originales con garantía | NERIN Repuestos"
+    />
+    <meta
+      property="og:description"
+      content="Compra pantallas Samsung originales Service Pack con entrega inmediata, garantía técnica y asesoramiento real por WhatsApp."
+    />
+    <meta property="og:site_name" content="NERIN Repuestos" />
+    <meta
+      property="og:url"
+      content="/index.html"
+      data-seo-absolute="content"
+    />
+    <meta
+      property="og:image"
+      content="/assets/hero.png"
+      data-seo-absolute="content"
+    />
+    <meta
+      property="og:image:alt"
+      content="Pantallas Samsung originales con garantía en NERIN Repuestos"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta
+      name="twitter:title"
+      content="Pantallas Samsung originales con garantía | NERIN Repuestos"
+    />
+    <meta
+      name="twitter:description"
+      content="Descubrí pantallas Samsung originales con envío a todo el país, atención personalizada y stock real."
+    />
+    <meta
+      name="twitter:url"
+      content="/index.html"
+      data-seo-absolute="content"
+    />
+    <meta
+      name="twitter:image"
+      content="/assets/hero.png"
+      data-seo-absolute="content"
+    />
+    <meta
+      name="twitter:image:alt"
+      content="Pantallas Samsung originales listas para enviar"
+    />
+    <link rel="icon" type="image/png" href="/assets/IMG_3086.png" />
+    <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css"
     />
-      <link rel="stylesheet" href="/style.css?v=mobfix-1" />
-    <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
-  <script src="/components/np-footer.js?v=np-r1" defer></script>
+    <link rel="stylesheet" href="/style.css?v=mobfix-1" />
+    <link rel="stylesheet" href="/components/np-footer.css?v=np-r1" />
+    <script src="/components/np-footer.js?v=np-r1" defer></script>
+    <script
+      type="application/ld+json"
+      id="org-schema"
+      data-seo-jsonld="organization"
+    >
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "name": "NERIN Repuestos",
+  "url": "__BASE_URL__/",
+  "logo": "__BASE_URL__/assets/IMG_3086.png",
+  "sameAs": [
+    "https://www.instagram.com/nerin",
+    "https://www.facebook.com/nerin",
+    "https://wa.me/541112345678"
+  ],
+  "contactPoint": [
+    {
+      "@type": "ContactPoint",
+      "telephone": "+54 11 1234-5678",
+      "contactType": "customer service",
+      "areaServed": "AR",
+      "availableLanguage": ["es-AR"]
+    }
+  ]
+}
+    </script>
+    <script
+      type="application/ld+json"
+      id="website-schema"
+      data-seo-jsonld="website"
+    >
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": "NERIN Repuestos",
+  "url": "__BASE_URL__/",
+  "potentialAction": {
+    "@type": "SearchAction",
+    "target": "__BASE_URL__/shop.html?search={search_term_string}",
+    "query-input": "required name=search_term_string"
+  }
+}
+    </script>
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/product.html
+++ b/nerin_final_updated/frontend/product.html
@@ -7,13 +7,91 @@
       content="width=device-width, initial-scale=1.0, viewport-fit=cover"
     />
     <title>Detalle de producto – NERIN</title>
-        <link
+    <meta
+      name="description"
+      content="Descubrí el catálogo de pantallas y repuestos originales de NERIN."
+      data-product-meta="description"
+    />
+    <meta
+      name="keywords"
+      content="pantallas originales, repuestos samsung, service pack"
+      data-product-meta="keywords"
+    />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:locale" content="es_AR" />
+    <meta property="og:site_name" content="NERIN Repuestos" />
+    <meta property="og:type" content="product" />
+    <meta
+      property="og:title"
+      content="Pantallas originales con garantía | NERIN"
+      data-product-meta="og:title"
+    />
+    <meta
+      property="og:description"
+      content="Repuestos originales para técnicos y particulares en Argentina."
+      data-product-meta="og:description"
+    />
+    <meta
+      property="og:url"
+      content="/product.html"
+      data-seo-absolute="content"
+      data-product-meta="og:url"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta
+      name="twitter:title"
+      content="Pantallas originales con garantía | NERIN"
+      data-product-meta="twitter:title"
+    />
+    <meta
+      name="twitter:description"
+      content="Pantallas Samsung originales Service Pack con envío rápido."
+      data-product-meta="twitter:description"
+    />
+    <meta
+      name="twitter:url"
+      content="/product.html"
+      data-seo-absolute="content"
+      data-product-meta="twitter:url"
+    />
+    <link
+      rel="canonical"
+      href="/product.html"
+      data-seo-absolute="href"
+      data-product-meta="canonical"
+    />
+    <link rel="icon" type="image/png" href="/assets/IMG_3086.png" />
+    <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css"
     />
-      <link rel="stylesheet" href="/style.css?v=mobfix-1" />
-    <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
-  <script src="/components/np-footer.js?v=np-r1" defer></script>
+    <link rel="stylesheet" href="/style.css?v=mobfix-1" />
+    <link rel="stylesheet" href="/components/np-footer.css?v=np-r1" />
+    <script src="/components/np-footer.js?v=np-r1" defer></script>
+    <script
+      type="application/ld+json"
+      id="product-breadcrumbs"
+      data-product-breadcrumbs="true"
+    >
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Inicio",
+      "item": "__BASE_URL__/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Productos",
+      "item": "__BASE_URL__/shop.html"
+    }
+  ]
+}
+    </script>
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/shop.html
+++ b/nerin_final_updated/frontend/shop.html
@@ -7,13 +7,79 @@
       content="width=device-width, initial-scale=1.0, viewport-fit=cover"
     />
     <title>NERIN – Tienda</title>
-        <link
+    <meta
+      name="description"
+      content="Explorá el catálogo completo de pantallas Samsung originales Service Pack y repuestos premium de NERIN con filtros por modelo, marca y categoría."
+    />
+    <meta
+      name="keywords"
+      content="catalogo pantallas samsung, tienda repuestos celulares, service pack argentina"
+    />
+    <meta name="robots" content="index,follow" />
+    <link rel="canonical" href="/shop.html" data-seo-absolute="href" />
+    <meta property="og:locale" content="es_AR" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="NERIN Repuestos" />
+    <meta property="og:title" content="Catálogo de pantallas originales | NERIN" />
+    <meta
+      property="og:description"
+      content="Filtrá por modelo y encontrá pantallas Samsung originales listas para enviar con garantía técnica."
+    />
+    <meta
+      property="og:url"
+      content="/shop.html"
+      data-seo-absolute="content"
+    />
+    <meta
+      property="og:image"
+      content="/assets/hero.png"
+      data-seo-absolute="content"
+    />
+    <meta
+      property="og:image:alt"
+      content="Catálogo de pantallas originales NERIN"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Catálogo de pantallas originales | NERIN" />
+    <meta
+      name="twitter:description"
+      content="Accedé al stock actualizado de pantallas Samsung originales Service Pack y solicitá asesoramiento inmediato."
+    />
+    <meta
+      name="twitter:url"
+      content="/shop.html"
+      data-seo-absolute="content"
+    />
+    <meta
+      name="twitter:image"
+      content="/assets/hero.png"
+      data-seo-absolute="content"
+    />
+    <meta
+      name="twitter:image:alt"
+      content="Catálogo completo de repuestos Samsung"
+    />
+    <link rel="icon" type="image/png" href="/assets/IMG_3086.png" />
+    <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css"
     />
-      <link rel="stylesheet" href="/style.css?v=mobfix-1" />
-    <link rel="stylesheet" href="/components/np-footer.css?v=np-r1">
-  <script src="/components/np-footer.js?v=np-r1" defer></script>
+    <link rel="stylesheet" href="/style.css?v=mobfix-1" />
+    <link rel="stylesheet" href="/components/np-footer.css?v=np-r1" />
+    <script src="/components/np-footer.js?v=np-r1" defer></script>
+    <script
+      type="application/ld+json"
+      id="shop-schema"
+      data-seo-jsonld="collection"
+    >
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "name": "Catálogo de pantallas originales NERIN",
+  "description": "Catálogo actualizado de pantallas Samsung originales con filtros por marca, modelo y categoría.",
+  "url": "__BASE_URL__/shop.html"
+}
+    </script>
 </head>
   <body>
     <header>


### PR DESCRIPTION
## Summary
- add rich SEO meta tags and structured data to the storefront home, shop, contact, and product templates
- hydrate canonical/absolute URLs from configuration when pages load
- update the product detail experience to emit dynamic metadata, breadcrumb JSON-LD, and refined offers schema

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68d0398aa7f4833191705680bb50372b