### PR TITLE
Ensure product metadata handles missing brand and fallbacks

### DIFF
--- a/nerin_final_updated/frontend/js/product.js
+++ b/nerin_final_updated/frontend/js/product.js
@@ -96,18 +96,21 @@ function updateBreadcrumbJsonLd(product, productUrl) {
 
 function updateProductMeta(product, images) {
   if (!product) return { productUrl: resolveAbsoluteUrl(window.location.href) };
+  const fallbackName =
+    typeof product.name === "string" && product.name.trim()
+      ? product.name.trim()
+      : "Producto";
   const baseTitle =
     (typeof product.meta_title === "string" && product.meta_title.trim())
       ? product.meta_title.trim()
-      : product.name;
-  const title = baseTitle.includes("NERIN")
-    ? baseTitle
-    : `${baseTitle} | NERIN Repuestos`;
+      : fallbackName;
+  const hasBrand = typeof product.brand === "string" && product.brand.trim();
+  const title = hasBrand ? baseTitle : `${baseTitle} | NERIN Repuestos`;
   const description =
     (typeof product.meta_description === "string" &&
       product.meta_description.trim()) ||
     (typeof product.description === "string" && product.description.trim()) ||
-    `${product.name} disponible con garantía oficial en NERIN.`;
+    `${fallbackName} disponible con garantía oficial en NERIN.`;
   const productUrl = resolveAbsoluteUrl(
     `/product.html?id=${encodeURIComponent(product.id)}`,
   );
@@ -116,7 +119,7 @@ function updateProductMeta(product, images) {
   if (Array.isArray(product.tags) && product.tags.length) {
     setMetaContent("name", "keywords", product.tags.join(", "));
   } else {
-    const fallbackKeywords = [product.name, product.brand, product.category]
+    const fallbackKeywords = [fallbackName, product.brand, product.category]
       .filter((item) => typeof item === "string" && item.trim())
       .join(", ");
     if (fallbackKeywords) {


### PR DESCRIPTION
## Summary
- ensure product meta title falls back to meta_title or name and appends "| NERIN Repuestos" when no brand is available
- add resilient fallbacks for descriptions and keywords so SEO tags remain populated and consistent
- keep canonical and social meta tags in sync while returning the computed title, description, and product URL

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0716792ec83318bce7e0175b011f2