### PR TITLE
Add admin support for product descriptions

### DIFF
--- a/nerin_final_updated/frontend/admin.html
+++ b/nerin_final_updated/frontend/admin.html
@@ -331,6 +331,12 @@
               name="slug"
               placeholder="Slug"
             />
+            <textarea
+              id="productDescription"
+              name="description"
+              placeholder="Descripción del producto"
+              rows="3"
+            ></textarea>
             <input
               type="text"
               id="productMetaTitle"

--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -354,16 +354,24 @@ function slugify(str) {
 
 const nameInput = document.getElementById("productName");
 const slugInput = document.getElementById("productSlug");
+const descriptionInput = document.getElementById("productDescription");
 const metaTitleInput = document.getElementById("productMetaTitle");
 const metaDescInput = document.getElementById("productMetaDesc");
 const seoSlugPreview = document.getElementById("seoSlugPreview");
 const seoTitlePreview = document.getElementById("seoTitlePreview");
 const seoDescPreview = document.getElementById("seoDescPreview");
 
+function resolveDescriptionPreview() {
+  const meta = metaDescInput?.value?.trim();
+  if (meta) return meta;
+  const desc = descriptionInput?.value?.trim();
+  return desc || "";
+}
+
 function renderSeoPreview() {
   seoSlugPreview.textContent = `/productos/${slugInput.value}`;
   seoTitlePreview.textContent = metaTitleInput.value || nameInput.value;
-  seoDescPreview.textContent = metaDescInput.value;
+  seoDescPreview.textContent = resolveDescriptionPreview();
 }
 
 nameInput.addEventListener("input", () => {
@@ -375,6 +383,7 @@ nameInput.addEventListener("input", () => {
 slugInput.addEventListener("input", renderSeoPreview);
 metaTitleInput.addEventListener("input", renderSeoPreview);
 metaDescInput.addEventListener("input", renderSeoPreview);
+if (descriptionInput) descriptionInput.addEventListener("input", renderSeoPreview);
 
 function setLoading(state) {
   productForm
@@ -408,6 +417,7 @@ function fillProductForm(p) {
   set("cost", p.cost);
   set("supplier_id", p.supplier_id);
   set("slug", p.slug);
+  set("description", p.description);
   set("meta_title", p.meta_title);
   set("meta_description", p.meta_description);
   set("dimensions", p.dimensions);

--- a/nerin_final_updated/frontend/js/product.js
+++ b/nerin_final_updated/frontend/js/product.js
@@ -34,6 +34,20 @@ function resolveAbsoluteUrl(url) {
   }
 }
 
+function getProductDescription(product, { preferMeta = false } = {}) {
+  if (!product) return "";
+  const primary = preferMeta
+    ? [product.meta_description, product.description, product.short_description]
+    : [product.description, product.meta_description, product.short_description];
+  for (const value of primary) {
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed) return trimmed;
+    }
+  }
+  return "";
+}
+
 function setMetaContent(attr, key, value) {
   const head = document.head;
   if (!head || !key) return;
@@ -107,9 +121,7 @@ function updateProductMeta(product, images) {
   const hasBrand = typeof product.brand === "string" && product.brand.trim();
   const title = hasBrand ? baseTitle : `${baseTitle} | NERIN Repuestos`;
   const description =
-    (typeof product.meta_description === "string" &&
-      product.meta_description.trim()) ||
-    (typeof product.description === "string" && product.description.trim()) ||
+    getProductDescription(product, { preferMeta: true }) ||
     `${fallbackName} disponible con garantía oficial en NERIN.`;
   const productUrl = resolveAbsoluteUrl(
     `/product.html?id=${encodeURIComponent(product.id)}`,
@@ -233,7 +245,7 @@ function updateJsonLd(product, images, productUrl) {
     url: productUrl,
     name: product.name,
     image: absoluteImages,
-    description: product.meta_description || product.description || "",
+    description: getProductDescription(product, { preferMeta: true }),
     sku: product.sku || product.id || "",
     mpn: product.sku || undefined,
     category: product.category || undefined,
@@ -733,12 +745,12 @@ function renderProduct(product) {
   detailsHeading.textContent = "Descripción y detalles";
   detailsPanel.appendChild(detailsHeading);
 
-  if (product.description) {
-    const desc = document.createElement("p");
-    desc.className = "product-detail-desc";
-    desc.textContent = product.description;
-    detailsPanel.appendChild(desc);
-  }
+  const descriptionText =
+    getProductDescription(product) || "Descripción no disponible por el momento.";
+  const desc = document.createElement("p");
+  desc.className = "product-detail-desc";
+  desc.textContent = descriptionText;
+  detailsPanel.appendChild(desc);
 
   const attrs = buildAttributes(product);
   if (attrs.children.length) {

--- a/nerin_final_updated/frontend/js/shop.js
+++ b/nerin_final_updated/frontend/js/shop.js
@@ -7,6 +7,22 @@ function getPrimaryImage(product) {
   return product.image;
 }
 
+function getProductDescription(product) {
+  if (!product) return "";
+  const candidates = [
+    product.description,
+    product.meta_description,
+    product.short_description,
+  ];
+  for (const value of candidates) {
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed) return trimmed;
+    }
+  }
+  return "";
+}
+
 const PLACEHOLDER_IMAGE =
   "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
 
@@ -55,7 +71,9 @@ function createProductCard(product) {
 
   const desc = document.createElement("p");
   desc.className = "description";
-  desc.textContent = product.description;
+  const descriptionText =
+    getProductDescription(product) || "Descripción no disponible.";
+  desc.textContent = descriptionText;
   card.appendChild(desc);
 
   // Mostrar atributos adicionales (categoría, peso, dimensiones, color)


### PR DESCRIPTION
## Summary
- add a dedicated description textarea to the product modal in the admin and wire it into the form serialization
- update the admin SEO preview to fall back to the main description when no meta description is provided
- surface product descriptions (with sensible fallbacks) on the public product grid and detail pages

## Testing
- npm test --prefix nerin_final_updated

------
https://chatgpt.com/codex/tasks/task_e_68d14e7b2a8c83319a10208cc2bf25a7