### PR TITLE
Enable product slug URLs and SSR template

### DIFF
--- a/nerin_final_updated/frontend/js/index.js
+++ b/nerin_final_updated/frontend/js/index.js
@@ -2,6 +2,15 @@
 
 import { fetchProducts, isWholesale } from "./api.js";
 
+function buildProductUrl(product) {
+  if (product && typeof product.slug === "string") {
+    const slug = product.slug.trim();
+    if (slug) return `/p/${encodeURIComponent(slug)}`;
+  }
+  const id = product?.id != null ? String(product.id) : "";
+  return `/product.html?id=${encodeURIComponent(id)}`;
+}
+
 function getPrimaryImage(product) {
   if (Array.isArray(product.images) && product.images.length) {
     return product.images[0];
@@ -52,7 +61,7 @@ function createFeaturedCard(product) {
   const actions = document.createElement("div");
   actions.className = "product-actions";
   const more = document.createElement("a");
-  more.href = `/product.html?id=${product.id}`;
+  more.href = buildProductUrl(product);
   more.className = "button secondary";
   more.textContent = "Ver más";
   actions.appendChild(more);

--- a/nerin_final_updated/frontend/js/shop.js
+++ b/nerin_final_updated/frontend/js/shop.js
@@ -1,5 +1,14 @@
 import { fetchProducts, isWholesale, getUserRole } from "./api.js";
 
+function buildProductUrl(product) {
+  if (product && typeof product.slug === "string") {
+    const slug = product.slug.trim();
+    if (slug) return `/p/${encodeURIComponent(slug)}`;
+  }
+  const id = product?.id != null ? String(product.id) : "";
+  return `/product.html?id=${encodeURIComponent(id)}`;
+}
+
 function getPrimaryImage(product) {
   if (Array.isArray(product.images) && product.images.length) {
     return product.images[0];
@@ -262,7 +271,7 @@ function createProductCard(product) {
   infoBtn.textContent = "Más info";
   infoBtn.addEventListener("click", (ev) => {
     ev.stopPropagation();
-    window.location.href = `/product.html?id=${product.id}`;
+    window.location.href = buildProductUrl(product);
   });
   actionsDiv.appendChild(infoBtn);
   card.appendChild(actionsDiv);
@@ -273,7 +282,7 @@ function createProductCard(product) {
     if (evt.target.tagName === "BUTTON" || evt.target.tagName === "INPUT") {
       return;
     }
-    window.location.href = `/product.html?id=${product.id}`;
+    window.location.href = buildProductUrl(product);
   });
   return card;
 }


### PR DESCRIPTION
## Summary
- point storefront links to the canonical /p/{slug} route while falling back to legacy IDs when necessary
- enhance the product detail script to resolve slugs from the path/query, refresh SEO metadata, and normalize the browser URL
- render /p/{slug} with the product template and dynamic head tags, updating SSR tests to match the configured public URL

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d15d5596688331884de894e57add3c