### PR TITLE
Ensure SEO tags render with public domain before hydration

### DIFF
--- a/nerin_final_updated/frontend/contact.html
+++ b/nerin_final_updated/frontend/contact.html
@@ -12,7 +12,11 @@
       content="Contactá a NERIN para solicitar cotizaciones de pantallas Samsung originales, soporte técnico inmediato y envíos a todo el país."
     />
     <meta name="robots" content="index,follow" />
-    <link rel="canonical" href="/contact.html" data-seo-absolute="href" />
+    <link
+      rel="canonical"
+      href="__BASE_URL__/contact.html"
+      data-seo-absolute="href"
+    />
     <meta property="og:locale" content="es_AR" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="NERIN Repuestos" />
@@ -23,12 +27,12 @@
     />
     <meta
       property="og:url"
-      content="/contact.html"
+      content="__BASE_URL__/contact.html"
       data-seo-absolute="content"
     />
     <meta
       property="og:image"
-      content="/assets/hero.png"
+      content="__BASE_URL__/assets/hero.png"
       data-seo-absolute="content"
     />
     <meta
@@ -43,12 +47,12 @@
     />
     <meta
       name="twitter:url"
-      content="/contact.html"
+      content="__BASE_URL__/contact.html"
       data-seo-absolute="content"
     />
     <meta
       name="twitter:image"
-      content="/assets/hero.png"
+      content="__BASE_URL__/assets/hero.png"
       data-seo-absolute="content"
     />
     <meta

--- a/nerin_final_updated/frontend/index.html
+++ b/nerin_final_updated/frontend/index.html
@@ -18,7 +18,11 @@
     <meta name="robots" content="index,follow" />
     <meta name="author" content="NERIN Repuestos" />
     <meta name="theme-color" content="#101935" />
-    <link rel="canonical" href="/index.html" data-seo-absolute="href" />
+    <link
+      rel="canonical"
+      href="__BASE_URL__/index.html"
+      data-seo-absolute="href"
+    />
     <meta property="og:locale" content="es_AR" />
     <meta property="og:type" content="website" />
     <meta
@@ -32,12 +36,12 @@
     <meta property="og:site_name" content="NERIN Repuestos" />
     <meta
       property="og:url"
-      content="/index.html"
+      content="__BASE_URL__/index.html"
       data-seo-absolute="content"
     />
     <meta
       property="og:image"
-      content="/assets/hero.png"
+      content="__BASE_URL__/assets/hero.png"
       data-seo-absolute="content"
     />
     <meta
@@ -55,12 +59,12 @@
     />
     <meta
       name="twitter:url"
-      content="/index.html"
+      content="__BASE_URL__/index.html"
       data-seo-absolute="content"
     />
     <meta
       name="twitter:image"
-      content="/assets/hero.png"
+      content="__BASE_URL__/assets/hero.png"
       data-seo-absolute="content"
     />
     <meta

--- a/nerin_final_updated/frontend/product.html
+++ b/nerin_final_updated/frontend/product.html
@@ -33,7 +33,7 @@
     />
     <meta
       property="og:url"
-      content="/product.html"
+      content="__BASE_URL__/product.html"
       data-seo-absolute="content"
       data-product-meta="og:url"
     />
@@ -50,13 +50,13 @@
     />
     <meta
       name="twitter:url"
-      content="/product.html"
+      content="__BASE_URL__/product.html"
       data-seo-absolute="content"
       data-product-meta="twitter:url"
     />
     <link
       rel="canonical"
-      href="/product.html"
+      href="__BASE_URL__/product.html"
       data-seo-absolute="href"
       data-product-meta="canonical"
     />

--- a/nerin_final_updated/frontend/shop.html
+++ b/nerin_final_updated/frontend/shop.html
@@ -16,7 +16,11 @@
       content="catalogo pantallas samsung, tienda repuestos celulares, service pack argentina"
     />
     <meta name="robots" content="index,follow" />
-    <link rel="canonical" href="/shop.html" data-seo-absolute="href" />
+    <link
+      rel="canonical"
+      href="__BASE_URL__/shop.html"
+      data-seo-absolute="href"
+    />
     <meta property="og:locale" content="es_AR" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="NERIN Repuestos" />
@@ -27,12 +31,12 @@
     />
     <meta
       property="og:url"
-      content="/shop.html"
+      content="__BASE_URL__/shop.html"
       data-seo-absolute="content"
     />
     <meta
       property="og:image"
-      content="/assets/hero.png"
+      content="__BASE_URL__/assets/hero.png"
       data-seo-absolute="content"
     />
     <meta
@@ -47,12 +51,12 @@
     />
     <meta
       name="twitter:url"
-      content="/shop.html"
+      content="__BASE_URL__/shop.html"
       data-seo-absolute="content"
     />
     <meta
       name="twitter:image"
-      content="/assets/hero.png"
+      content="__BASE_URL__/assets/hero.png"
       data-seo-absolute="content"
     />
     <meta


### PR DESCRIPTION
## Summary
- replace relative canonical, Open Graph and Twitter meta URLs with __BASE_URL__ placeholders across public pages
- hydrate HTML responses on the Node server using the configured publicUrl so crawlers receive absolute links without running JS

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d1bf6703948331b6928e0c66492b69