### PR TITLE
Add Resend client configuration

### DIFF
--- a/nerin_final_updated/src/lib/resend.js
+++ b/nerin_final_updated/src/lib/resend.js
@@ -1,0 +1,6 @@
+import { Resend } from "resend";
+
+export const resend = new Resend(process.env.RESEND_API_KEY);
+
+export const FROM =
+  process.env.FROM_EMAIL || "NERIN <no-reply@send.nerinparts.com.ar>";


### PR DESCRIPTION
## Summary
- add a Resend client helper under src/lib to centralize initialization
- expose the default FROM email fallback when an environment value is not set

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d432eaebb88331b995eddb20563100