### PR TITLE
Add payment status email templates

### DIFF
--- a/nerin_final_updated/src/emails/PaymentPendingEmail.tsx
+++ b/nerin_final_updated/src/emails/PaymentPendingEmail.tsx
@@ -1,0 +1,97 @@
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Link,
+  Preview,
+  Section,
+  Text,
+} from "@react-email/components";
+import * as React from "react";
+
+type PaymentPendingEmailProps = {
+  orderNumber: string | number;
+  customerName: string;
+  supportEmail: string;
+};
+
+const containerStyle: React.CSSProperties = {
+  width: "100%",
+  maxWidth: "640px",
+  margin: "0 auto",
+  padding: "40px 32px",
+  backgroundColor: "#ffffff",
+  borderRadius: "12px",
+  boxShadow: "0 8px 24px rgba(15, 23, 42, 0.08)",
+};
+
+const bodyStyle: React.CSSProperties = {
+  backgroundColor: "#ffffff",
+  margin: 0,
+  fontFamily:
+    "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+  color: "#0f172a",
+};
+
+const headingStyle: React.CSSProperties = {
+  fontSize: "24px",
+  fontWeight: 700,
+  margin: "0 0 16px",
+};
+
+const paragraphStyle: React.CSSProperties = {
+  fontSize: "16px",
+  lineHeight: "24px",
+  margin: "0 0 16px",
+};
+
+const linkStyle: React.CSSProperties = {
+  color: "#2563eb",
+  textDecoration: "none",
+  fontWeight: 600,
+};
+
+const PaymentPendingEmail: React.FC<PaymentPendingEmailProps> = ({
+  orderNumber,
+  customerName,
+  supportEmail,
+}) => (
+  <Html>
+    <Head />
+    <Preview>{`Pago pendiente para la orden #${orderNumber}`}</Preview>
+    <Body style={bodyStyle}>
+      <Container style={containerStyle}>
+        <Section>
+          <Heading style={headingStyle}>{`¡Gracias por tu compra, ${customerName}!`}</Heading>
+          <Text style={paragraphStyle}>
+            Recibimos tu pedido #{orderNumber} y actualmente estamos revisando el
+            estado del pago. Este proceso puede demorar unos minutos.
+          </Text>
+          <Text style={paragraphStyle}>
+            Te avisaremos por correo cuando la transacción se confirme. Si
+            necesitás continuar con tu compra de manera inmediata, podés seguir
+            revisando tus productos mientras aguardás la confirmación.
+          </Text>
+        </Section>
+
+        <Hr style={{ borderColor: "#e2e8f0", margin: "32px 0" }} />
+
+        <Section>
+          <Text style={paragraphStyle}>
+            Si tenés alguna consulta, no dudes en escribirnos a {" "}
+            <Link href={`mailto:${supportEmail}`} style={linkStyle}>
+              {supportEmail}
+            </Link>
+            .
+          </Text>
+          <Text style={{ ...paragraphStyle, marginBottom: 0 }}>— Equipo NERIN</Text>
+        </Section>
+      </Container>
+    </Body>
+  </Html>
+);
+
+export default PaymentPendingEmail;

--- a/nerin_final_updated/src/emails/PaymentRejectedEmail.tsx
+++ b/nerin_final_updated/src/emails/PaymentRejectedEmail.tsx
@@ -1,0 +1,110 @@
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Link,
+  Preview,
+  Section,
+  Text,
+} from "@react-email/components";
+import * as React from "react";
+
+type PaymentRejectedEmailProps = {
+  orderNumber: string | number;
+  customerName: string;
+  supportEmail: string;
+};
+
+const containerStyle: React.CSSProperties = {
+  width: "100%",
+  maxWidth: "640px",
+  margin: "0 auto",
+  padding: "40px 32px",
+  backgroundColor: "#ffffff",
+  borderRadius: "12px",
+  boxShadow: "0 8px 24px rgba(15, 23, 42, 0.08)",
+};
+
+const bodyStyle: React.CSSProperties = {
+  backgroundColor: "#ffffff",
+  margin: 0,
+  fontFamily:
+    "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+  color: "#0f172a",
+};
+
+const headingStyle: React.CSSProperties = {
+  fontSize: "24px",
+  fontWeight: 700,
+  margin: "0 0 16px",
+};
+
+const paragraphStyle: React.CSSProperties = {
+  fontSize: "16px",
+  lineHeight: "24px",
+  margin: "0 0 16px",
+};
+
+const linkStyle: React.CSSProperties = {
+  color: "#2563eb",
+  textDecoration: "none",
+  fontWeight: 600,
+};
+
+const ctaStyle: React.CSSProperties = {
+  display: "inline-block",
+  padding: "12px 24px",
+  backgroundColor: "#2563eb",
+  color: "#ffffff",
+  borderRadius: "9999px",
+  textDecoration: "none",
+  fontWeight: 600,
+  fontSize: "16px",
+};
+
+const PaymentRejectedEmail: React.FC<PaymentRejectedEmailProps> = ({
+  orderNumber,
+  customerName,
+  supportEmail,
+}) => (
+  <Html>
+    <Head />
+    <Preview>{`Pago rechazado para la orden #${orderNumber}`}</Preview>
+    <Body style={bodyStyle}>
+      <Container style={containerStyle}>
+        <Section>
+          <Heading style={headingStyle}>{`Hola ${customerName}, hubo un problema con tu pago`}</Heading>
+          <Text style={paragraphStyle}>
+            Intentamos procesar el pago del pedido #{orderNumber}, pero la
+            transacción fue rechazada por la entidad emisora.
+          </Text>
+          <Text style={paragraphStyle}>
+            Podés reintentar el pago haciendo clic en el siguiente enlace o bien
+            utilizando otro método de pago en el checkout.
+          </Text>
+          <Link href="#/checkout" style={ctaStyle}>
+            Reintentar pago
+          </Link>
+        </Section>
+
+        <Hr style={{ borderColor: "#e2e8f0", margin: "32px 0" }} />
+
+        <Section>
+          <Text style={paragraphStyle}>
+            Si necesitás ayuda, escribinos a {" "}
+            <Link href={`mailto:${supportEmail}`} style={linkStyle}>
+              {supportEmail}
+            </Link>
+            . Nuestro equipo está disponible para asistirte.
+          </Text>
+          <Text style={{ ...paragraphStyle, marginBottom: 0 }}>— Equipo NERIN</Text>
+        </Section>
+      </Container>
+    </Body>
+  </Html>
+);
+
+export default PaymentRejectedEmail;


### PR DESCRIPTION
## Summary
- add a payment pending email template consistent with the existing order confirmation design
- add a payment rejected email template including a checkout retry call to action

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4793e66a08331928ff8c5ca088a13