### PR TITLE
Add dev-only email testing endpoint

### DIFF
--- a/nerin_final_updated/src/app.js
+++ b/nerin_final_updated/src/app.js
@@ -1,0 +1,10 @@
+const express = require("express");
+
+const app = express();
+
+if (process.env.NODE_ENV !== "production") {
+  const testEmailRouter = require("./routes/test-email.js");
+  app.use("/test-email", testEmailRouter);
+}
+
+module.exports = app;

--- a/nerin_final_updated/src/routes/test-email.js
+++ b/nerin_final_updated/src/routes/test-email.js
@@ -1,0 +1,72 @@
+const express = require("express");
+
+let sendersPromise;
+const loadSenders = async () => {
+  if (!sendersPromise) {
+    sendersPromise = import("../services/send-email.js");
+  }
+  return sendersPromise;
+};
+
+const router = express.Router();
+
+const buildTestOrder = () => ({
+  orderNumber: "DEV-TEST-1001",
+  customer: { name: "Juan Pérez" },
+  total: 185000,
+  items: [
+    { name: "Pantalla OLED iPhone 13", quantity: 1, price: 150000 },
+    { name: "Pegamento B-7000", quantity: 2, price: 17500 },
+  ],
+});
+
+const normalizeRecipients = (value) => {
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => (typeof item === "string" ? item.trim() : ""))
+      .filter(Boolean);
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed ? [trimmed] : [];
+  }
+  return [];
+};
+
+router.get("/", async (req, res) => {
+  const { to, type } = req.query;
+  const recipients = normalizeRecipients(to);
+
+  if (!recipients.length) {
+    return res.status(400).json({ ok: false, error: "Missing 'to' query" });
+  }
+
+  const { sendOrderConfirmed, sendPaymentPending, sendPaymentRejected } =
+    await loadSenders();
+  const senderMap = {
+    confirmed: sendOrderConfirmed,
+    pending: sendPaymentPending,
+    rejected: sendPaymentRejected,
+  };
+
+  const sender = typeof type === "string" ? senderMap[type] : null;
+  if (!sender) {
+    return res
+      .status(400)
+      .json({ ok: false, error: "Invalid 'type' query. Use confirmed|pending|rejected." });
+  }
+
+  try {
+    const order = buildTestOrder();
+    await sender({ to: recipients, order });
+    return res.json({ ok: true });
+  } catch (error) {
+    console.error("test-email route failed", error);
+    return res.status(500).json({
+      ok: false,
+      error: error?.message || "Unable to send test email",
+    });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add an Express router to trigger sample transactional emails
- mount the router under /test-email when the app runs outside production

## Testing
- npm test --prefix nerin_final_updated

------
https://chatgpt.com/codex/tasks/task_e_68d54f72cef083318006e2728951f9d1