### PR TITLE
Documentar configuración de emails con Resend

### DIFF
--- a/nerin_final_updated/.env.example
+++ b/nerin_final_updated/.env.example
@@ -1,3 +1,6 @@
+# API key de Resend para enviar emails transaccionales
 RESEND_API_KEY=change_me
+# Dirección del remitente verificada en Resend (formato Nombre <email>)
 FROM_EMAIL="NERIN <ventas@send.nerinparts.com.ar>"
+# Correo que recibirá consultas de soporte
 SUPPORT_EMAIL=soporte@nerinparts.com.ar

--- a/nerin_final_updated/backend/README.md
+++ b/nerin_final_updated/backend/README.md
@@ -39,3 +39,12 @@ Esta actualización agrega persistencia básica de pedidos y soporte de seguimie
      -H 'Content-Type: application/json' \
      -d '{"email":"a@b.com","id":"<NRN>"}' | jq
    ```
+
+## Emails (Resend)
+
+- Configurá las variables en tu `.env`:
+  - `RESEND_API_KEY`: API key de Resend con permisos para enviar emails.
+  - `FROM_EMAIL`: remitente verificado que verán los clientes.
+  - `SUPPORT_EMAIL`: casilla que recibirá respuestas o consultas.
+- Verificá el dominio remitente en Resend (registros SPF y DKIM) antes de enviar correos en producción.
+- Probar envío local: `GET /test-email?to=TU_EMAIL&type=confirmed`.


### PR DESCRIPTION
## Summary
- añade comentarios aclaratorios a las variables de correo en `.env.example`
- documenta la configuración y prueba de emails con Resend en `backend/README.md`

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68d57beb35248331a8be309288ccb157