### PR TITLE
Protect test-email route in production

### DIFF
--- a/nerin_final_updated/.env.example
+++ b/nerin_final_updated/.env.example
@@ -4,3 +4,5 @@ RESEND_API_KEY=change_me
 FROM_EMAIL="NERIN <ventas@send.nerinparts.com.ar>"
 # Correo que recibirá consultas de soporte
 SUPPORT_EMAIL=soporte@nerinparts.com.ar
+# Clave para habilitar el endpoint /test-email en producción
+ENV_TEST_KEY=

--- a/nerin_final_updated/src/routes/test-email.js
+++ b/nerin_final_updated/src/routes/test-email.js
@@ -10,6 +10,20 @@ const loadSenders = async () => {
 
 const router = express.Router();
 
+router.use((req, res, next) => {
+  const isProduction = process.env.NODE_ENV === "production";
+  if (!isProduction) {
+    return next();
+  }
+
+  const providedKey = req.query?.key;
+  if (typeof providedKey === "string" && providedKey === process.env.ENV_TEST_KEY) {
+    return next();
+  }
+
+  return res.status(403).json({ ok: false, error: "Unauthorized" });
+});
+
 const buildTestOrder = () => ({
   orderNumber: "DEV-TEST-1001",
   customer: { name: "Juan Pérez" },


### PR DESCRIPTION
## Summary
- add a simple security guard to the /test-email route that only allows usage in production when the ENV_TEST_KEY is provided
- document the new ENV_TEST_KEY variable in the environment example file

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d59ce48d8c8331836ae84589502bc5