### PR TITLE
Add Order type and annotate email senders

### DIFF
--- a/nerin_final_updated/src/routes/test-email.js
+++ b/nerin_final_updated/src/routes/test-email.js
@@ -72,7 +72,7 @@ router.get("/", async (req, res) => {
 
   try {
     const order = buildTestOrder();
-    await sender({ to: recipients, order });
+    await Promise.all(recipients.map((recipient) => sender({ to: recipient, order })));
     return res.json({ ok: true });
   } catch (error) {
     console.error("test-email route failed", error);

--- a/nerin_final_updated/src/services/send-email.js
+++ b/nerin_final_updated/src/services/send-email.js
@@ -4,6 +4,11 @@ import OrderConfirmedEmail from "../emails/OrderConfirmedEmail.tsx";
 import PaymentPendingEmail from "../emails/PaymentPendingEmail.tsx";
 import PaymentRejectedEmail from "../emails/PaymentRejectedEmail.tsx";
 
+/**
+ * @typedef {import("../types/order").Order} Order
+ * @typedef {{ to: string; order: Order }} SendEmailParams
+ */
+
 const RETRIABLE_STATUS = new Set([429, 500, 502, 503]);
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -205,7 +210,10 @@ export async function withRetries(fn, { retries = 3, base = 500 } = {}) {
 
 const SUPPORT_EMAIL = process.env.SUPPORT_EMAIL;
 
-export const sendOrderConfirmed = async ({ to, order } = {}) => {
+/**
+ * @param {SendEmailParams} params
+ */
+export const sendOrderConfirmed = async ({ to, order }) => {
   const recipients = ensureArray(to);
   const items = normalizeItems(order);
   const total = computeOrderTotal(order, items);
@@ -242,7 +250,10 @@ export const sendOrderConfirmed = async ({ to, order } = {}) => {
   );
 };
 
-export const sendPaymentPending = async ({ to, order } = {}) => {
+/**
+ * @param {SendEmailParams} params
+ */
+export const sendPaymentPending = async ({ to, order }) => {
   const recipients = ensureArray(to);
   const orderNumber = resolveOrderNumber(order);
   const customerName = resolveCustomerName(order);
@@ -271,7 +282,10 @@ export const sendPaymentPending = async ({ to, order } = {}) => {
   );
 };
 
-export const sendPaymentRejected = async ({ to, order } = {}) => {
+/**
+ * @param {SendEmailParams} params
+ */
+export const sendPaymentRejected = async ({ to, order }) => {
   const recipients = ensureArray(to);
   const orderNumber = resolveOrderNumber(order);
   const customerName = resolveCustomerName(order);

--- a/nerin_final_updated/src/types/order.d.ts
+++ b/nerin_final_updated/src/types/order.d.ts
@@ -1,0 +1,19 @@
+export interface OrderItem {
+  name: string;
+  quantity: number;
+  price: number;
+}
+
+export interface Order {
+  id: string | number;
+  number: string | number;
+  customerEmail: string;
+  customerName: string;
+  total: number;
+  items: OrderItem[];
+  emails?: {
+    confirmedSent?: boolean;
+    pendingSent?: boolean;
+    rejectedSent?: boolean;
+  };
+}


### PR DESCRIPTION
## Summary
- define a reusable Order interface in src/types/order.d.ts
- annotate the Resend sender helpers with the Order type and stricter parameter typing
- update the test email route to send individual emails per recipient under the new contract

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5a0cab3d48331b5d476f390a1649f