### PR TITLE
Add Mercado Pago webhook testing helpers

### DIFF
--- a/nerin_final_updated/backend/routes/mercadoPago.js
+++ b/nerin_final_updated/backend/routes/mercadoPago.js
@@ -167,6 +167,16 @@ function extractPaymentEvent(req = {}) {
 }
 
 async function fetchPaymentStatus(paymentId) {
+  if (String(paymentId).trim() === 'TEST123') {
+    return {
+      id: 'TEST123',
+      status: 'approved',
+      transaction_amount: 0,
+      currency_id: 'ARS',
+      external_reference: 'TEST-MOCK-ORDER',
+      payment_method_id: 'mock',
+    };
+  }
   const client = getMpClient();
   const res = await client.payment.findById(paymentId);
   return normalizePaymentResponse(res);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "node nerin_final_updated/backend/server.js",
     "test": "npm test --prefix nerin_final_updated",
-    "list:webhooks": "node scripts/listMpWebhooks.js"
+    "list:webhooks": "node scripts/listMpWebhooks.js",
+    "hit:mp-webhook": "curl -X POST -H 'Content-Type: application/json' -d '{\"data\":{\"id\":\"TEST123\"}}' http://localhost:3000/webhooks/mp"
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary
- add an npm helper script to simulate Mercado Pago webhook POSTs locally
- mock Mercado Pago payment fetches for the TEST123 id so the flow can run without the external API

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5a3b3b9788331ac84032cbec18dd2