### PR TITLE
Handle Mercado Pago webhook email failures

### DIFF
--- a/nerin_final_updated/backend/__tests__/mercado-pago-webhook.test.js
+++ b/nerin_final_updated/backend/__tests__/mercado-pago-webhook.test.js
@@ -29,6 +29,8 @@ jest.mock('../services/emailNotifications', () => ({
 }));
 
 process.env.MP_ACCESS_TOKEN = 'test-token';
+process.env.RESEND_API_KEY = 'test-resend';
+process.env.FROM_EMAIL = 'tester@example.com';
 
 global.fetch = jest.fn();
 

--- a/nerin_final_updated/backend/routes/mercadoPago.js
+++ b/nerin_final_updated/backend/routes/mercadoPago.js
@@ -248,6 +248,16 @@ async function notifyCustomerStatus({ order, status, paymentId }) {
     });
     return;
   }
+  const resendApiKey = String(process.env.RESEND_API_KEY || '').trim();
+  const fromEmail = String(process.env.FROM_EMAIL || '').trim();
+  if (!resendApiKey || !fromEmail) {
+    logger.info('email service not configured', {
+      paymentId,
+      status,
+      flag: config.flag,
+    });
+    return;
+  }
   try {
     await config.sender({ to, order });
     const orderId = resolveOrderIdentifier(order);
@@ -261,10 +271,12 @@ async function notifyCustomerStatus({ order, status, paymentId }) {
       orderId: resolveOrderIdentifier(order),
     });
   } catch (error) {
+    const errorPayload = error?.response?.data;
     logger.error('mp-webhook email send failed', {
       paymentId,
       status,
       msg: error?.message,
+      response: errorPayload,
     });
   }
 }

--- a/nerin_final_updated/backend/services/emailNotifications.js
+++ b/nerin_final_updated/backend/services/emailNotifications.js
@@ -145,13 +145,17 @@ async function sendEmail({ to, subject, heading, message, footer, order }) {
     return null;
   }
   const html = buildHtmlTemplate({ heading, message, footer, order });
-  return resend.emails.send({
-    from: FROM,
-    to: recipients,
-    subject,
-    html,
-    reply_to: SUPPORT_EMAIL || undefined,
-  });
+  try {
+    return await resend.emails.send({
+      from: FROM,
+      to: recipients,
+      subject,
+      html,
+      reply_to: SUPPORT_EMAIL || undefined,
+    });
+  } catch (error) {
+    throw error;
+  }
 }
 
 async function sendOrderConfirmed({ to, order } = {}) {


### PR DESCRIPTION
## Summary
- skip Mercado Pago webhook email delivery when the resend API key or from address are missing
- log resend response payloads on failures and only mark notification flags after a successful send
- wrap resend email calls in try/catch and configure tests with email env vars

## Testing
- npm test -- --runTestsByPath nerin_final_updated/backend/__tests__/mercado-pago-webhook.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d5d68bff20833188c11bbfa55f4259