### PR TITLE
Use API_BASE_URL for Mercado Pago webhooks

### DIFF
--- a/nerin_final_updated/.env.example
+++ b/nerin_final_updated/.env.example
@@ -6,3 +6,5 @@ FROM_EMAIL="NERIN <ventas@send.nerinparts.com.ar>"
 SUPPORT_EMAIL=soporte@nerinparts.com.ar
 # Clave para habilitar el endpoint /test-email en producción
 ENV_TEST_KEY=
+# URL base pública de la API (ej: https://api.nerinparts.com.ar)
+API_BASE_URL=https://api.nerinparts.com.ar

--- a/nerin_final_updated/backend/index.js
+++ b/nerin_final_updated/backend/index.js
@@ -64,6 +64,9 @@ const mpPreference = mpClient ? new Preference(mpClient) : null;
 const resendApiKey = process.env.RESEND_API_KEY || "";
 const resend = Resend && resendApiKey ? new Resend(resendApiKey) : null;
 const PUBLIC_URL = process.env.PUBLIC_URL || `http://localhost:${PORT}`;
+const API_BASE_URL = (
+  process.env.API_BASE_URL || `${PUBLIC_URL}/api`
+).replace(/\/+$/, "");
 const ADMIN_EMAIL = process.env.ADMIN_EMAIL || "";
 const DEFAULT_TEST_EMAIL_TO =
   process.env.TEST_EMAIL_TO || ADMIN_EMAIL || process.env.FROM_EMAIL || "";
@@ -281,7 +284,7 @@ app.post("/api/orders", async (req, res) => {
           },
           auto_return: "approved",
           external_reference: id,
-          notification_url: `${PUBLIC_URL}/api/webhooks/mp`,
+          notification_url: `${API_BASE_URL}/webhooks/mp`,
         };
         const prefRes = await mpPreference.create({ body: pref });
         initPoint = prefRes.init_point;

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -348,6 +348,9 @@ const APP_PORT = process.env.PORT || 3000;
 // Dominio público para redirecciones de Mercado Pago
 // configurable mediante la variable de entorno PUBLIC_URL
 const DOMAIN = process.env.PUBLIC_URL || "http://localhost:3000";
+const API_BASE_URL = (
+  process.env.API_BASE_URL || `${DOMAIN}/api`
+).replace(/\/+$/, "");
 const resend = CONFIG.resendApiKey ? new Resend(CONFIG.resendApiKey) : null;
 const MP_TOKEN = process.env.MP_ACCESS_TOKEN;
 let mpPreference = null;
@@ -3371,7 +3374,7 @@ async function requestHandler(req, res) {
             pending: `${DOMAIN}/pending`,
           },
           auto_return: "approved",
-          notification_url: `${DOMAIN}/api/webhooks/mp`,
+          notification_url: `${API_BASE_URL}/webhooks/mp`,
         };
         console.log("Preferencia enviada a Mercado Pago:", preferenceBody);
         if (!mpPreference) {


### PR DESCRIPTION
## Summary
- derive a sanitized API base URL with a fallback to PUBLIC_URL for both backend entry points
- send Mercado Pago webhook notifications to the API_BASE_URL/webhooks/mp endpoint
- document the new API_BASE_URL variable in the example environment file

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5d8c8708c8331bca8b69817f5864c