### PR TITLE
Add email notification service configuration and test endpoints

### DIFF
--- a/nerin_final_updated/backend/routes/mercadoPago.js
+++ b/nerin_final_updated/backend/routes/mercadoPago.js
@@ -248,16 +248,6 @@ async function notifyCustomerStatus({ order, status, paymentId }) {
     });
     return;
   }
-  const resendApiKey = String(process.env.RESEND_API_KEY || '').trim();
-  const fromEmail = String(process.env.FROM_EMAIL || '').trim();
-  if (!resendApiKey || !fromEmail) {
-    logger.info('email service not configured', {
-      paymentId,
-      status,
-      flag: config.flag,
-    });
-    return;
-  }
   try {
     await config.sender({ to, order });
     const orderId = resolveOrderIdentifier(order);
@@ -271,12 +261,11 @@ async function notifyCustomerStatus({ order, status, paymentId }) {
       orderId: resolveOrderIdentifier(order),
     });
   } catch (error) {
-    const errorPayload = error?.response?.data;
+    const errorPayload = error?.response?.data || error?.message;
     logger.error('mp-webhook email send failed', {
       paymentId,
       status,
-      msg: error?.message,
-      response: errorPayload,
+      error: errorPayload,
     });
   }
 }

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -1494,6 +1494,31 @@ async function requestHandler(req, res) {
     return sendJson(res, 200, { build: BUILD_ID });
   }
 
+  if (pathname === "/api/ping" && req.method === "GET") {
+    return sendJson(res, 200, { ok: true, ts: Date.now() });
+  }
+
+  if (pathname === "/api/test-email" && req.method === "GET") {
+    const query = parsedUrl.query || {};
+    const to =
+      (typeof query.to === "string" && query.to.trim()) ||
+      "test@nerin.com.ar";
+    const { sendEmail } = require("./services/emailNotifications");
+    try {
+      const result = await sendEmail({
+        to,
+        subject: "Test email",
+        html: "<p>Este es un correo de prueba.</p>",
+        type: "no-reply",
+        replyTo: process.env.SUPPORT_EMAIL,
+      });
+      const id = (result && result.data && result.data.id) || true;
+      return sendJson(res, 200, { ok: true, id });
+    } catch (error) {
+      return sendJson(res, 500, { ok: false, error });
+    }
+  }
+
   if (pathname === "/health/db") {
     (async () => {
       const pool = db.getPool();

--- a/nerin_final_updated/backend/services/emailNotifications.js
+++ b/nerin_final_updated/backend/services/emailNotifications.js
@@ -1,10 +1,64 @@
 const { Resend } = require('resend');
 
-const resendApiKey = process.env.RESEND_API_KEY || '';
-const FROM = process.env.FROM_EMAIL || 'NERIN <no-reply@nerin.com.ar>';
-const SUPPORT_EMAIL = process.env.SUPPORT_EMAIL || '';
+let fileConfig = null;
+try {
+  // eslint-disable-next-line import/no-dynamic-require, global-require
+  fileConfig = require('../../data/config.json');
+} catch (err) {
+  fileConfig = null;
+}
 
-const resend = resendApiKey ? new Resend(resendApiKey) : null;
+const apiKey = process.env.RESEND_API_KEY || fileConfig?.resendApiKey || null;
+
+function getFrom(type = 'no-reply') {
+  const key = typeof type === 'string' ? type.trim().toLowerCase() : 'no-reply';
+  const { FROM_EMAIL_NO_REPLY, FROM_EMAIL_VENTAS, FROM_EMAIL_CONTACTO } =
+    process.env;
+
+  let from;
+  if (key === 'no-reply') {
+    from = FROM_EMAIL_NO_REPLY;
+  } else if (key === 'ventas') {
+    from = FROM_EMAIL_VENTAS;
+  } else if (key === 'contacto') {
+    from = FROM_EMAIL_CONTACTO;
+  }
+
+  if (!from) {
+    from = FROM_EMAIL_NO_REPLY;
+  }
+
+  if (!from) {
+    throw new Error('FROM_EMAIL not configured');
+  }
+
+  return from;
+}
+
+let defaultFrom;
+try {
+  defaultFrom = getFrom('no-reply');
+} catch (err) {
+  defaultFrom = null;
+}
+
+console.log('email-config', { hasKey: !!apiKey, from: defaultFrom });
+
+async function sendEmail({ to, subject, html, type = 'no-reply', replyTo }) {
+  if (!apiKey) {
+    throw new Error('email service not configured');
+  }
+
+  const client = new Resend(apiKey);
+  const from = getFrom(type);
+  const reply_to = replyTo || process.env.SUPPORT_EMAIL;
+
+  try {
+    return await client.emails.send({ from, to, subject, html, reply_to });
+  } catch (e) {
+    throw e.response?.data || e.message;
+  }
+}
 
 function ensureArray(value) {
   if (Array.isArray(value)) {
@@ -46,11 +100,15 @@ function resolveCustomerName(order = {}) {
   return (
     normalizeString(order.customer?.name) ||
     normalizeString(order.customer?.fullName) ||
-    normalizeString(order.customer?.nombre &&
-      `${order.customer.nombre} ${order.customer.apellido || ''}`) ||
+    normalizeString(
+      order.customer?.nombre &&
+        `${order.customer.nombre} ${order.customer.apellido || ''}`,
+    ) ||
     normalizeString(order.cliente?.name) ||
-    normalizeString(order.cliente?.nombre &&
-      `${order.cliente.nombre} ${order.cliente.apellido || ''}`) ||
+    normalizeString(
+      order.cliente?.nombre &&
+        `${order.cliente.nombre} ${order.cliente.apellido || ''}`,
+    ) ||
     normalizeString(order.customer_name) ||
     normalizeString(order.client_name) ||
     normalizeString(order.nombre) ||
@@ -137,79 +195,78 @@ function buildHtmlTemplate({ heading, message, footer, order }) {
   `;
 }
 
-async function sendEmail({ to, subject, heading, message, footer, order }) {
+async function sendOrderConfirmed({ to, order } = {}) {
   const recipients = ensureArray(to);
   if (!recipients.length) return null;
-  if (!resend) {
-    console.info('email service not configured, skipping send', { subject });
-    return null;
-  }
-  const html = buildHtmlTemplate({ heading, message, footer, order });
-  try {
-    return await resend.emails.send({
-      from: FROM,
-      to: recipients,
-      subject,
-      html,
-      reply_to: SUPPORT_EMAIL || undefined,
-    });
-  } catch (error) {
-    throw error;
-  }
-}
-
-async function sendOrderConfirmed({ to, order } = {}) {
   const customer = resolveCustomerName(order);
   const orderNumber = resolveOrderNumber(order);
-  return sendEmail({
-    to,
-    order,
-    subject: `Confirmación de compra #${orderNumber}`,
+  const html = buildHtmlTemplate({
     heading: `¡Gracias por tu compra, ${customer}!`,
     message:
       'Tu pago fue acreditado correctamente y comenzaremos a preparar tu pedido en breve.',
     footer:
-      SUPPORT_EMAIL
-        ? `<p style="font-size: 14px; line-height: 20px; margin: 16px 0 0;">Si necesitás ayuda, escribinos a <a href="mailto:${SUPPORT_EMAIL}">${SUPPORT_EMAIL}</a>.</p>`
+      process.env.SUPPORT_EMAIL
+        ? `<p style="font-size: 14px; line-height: 20px; margin: 16px 0 0;">Si necesitás ayuda, escribinos a <a href="mailto:${process.env.SUPPORT_EMAIL}">${process.env.SUPPORT_EMAIL}</a>.</p>`
         : '',
+    order,
+  });
+  return sendEmail({
+    to: recipients,
+    subject: `Confirmación de compra #${orderNumber}`,
+    html,
+    replyTo: process.env.SUPPORT_EMAIL,
   });
 }
 
 async function sendPaymentPending({ to, order } = {}) {
+  const recipients = ensureArray(to);
+  if (!recipients.length) return null;
   const customer = resolveCustomerName(order);
   const orderNumber = resolveOrderNumber(order);
-  return sendEmail({
-    to,
-    order,
-    subject: `Pago pendiente - Orden #${orderNumber}`,
+  const html = buildHtmlTemplate({
     heading: `Tu pago está en proceso, ${customer}`,
     message:
       'Estamos esperando la confirmación de Mercado Pago. Te avisaremos apenas se acredite.',
     footer:
-      SUPPORT_EMAIL
-        ? `<p style="font-size: 14px; line-height: 20px; margin: 16px 0 0;">Ante cualquier consulta, respondé este correo o escribinos a <a href="mailto:${SUPPORT_EMAIL}">${SUPPORT_EMAIL}</a>.</p>`
+      process.env.SUPPORT_EMAIL
+        ? `<p style="font-size: 14px; line-height: 20px; margin: 16px 0 0;">Ante cualquier consulta, respondé este correo o escribinos a <a href="mailto:${process.env.SUPPORT_EMAIL}">${process.env.SUPPORT_EMAIL}</a>.</p>`
         : '',
+    order,
+  });
+  return sendEmail({
+    to: recipients,
+    subject: `Pago pendiente - Orden #${orderNumber}`,
+    html,
+    replyTo: process.env.SUPPORT_EMAIL,
   });
 }
 
 async function sendPaymentRejected({ to, order } = {}) {
+  const recipients = ensureArray(to);
+  if (!recipients.length) return null;
   const customer = resolveCustomerName(order);
   const orderNumber = resolveOrderNumber(order);
-  return sendEmail({
-    to,
-    order,
-    subject: `Pago rechazado - Orden #${orderNumber}`,
+  const html = buildHtmlTemplate({
     heading: `Necesitamos que revises tu pago, ${customer}`,
     message:
       'El intento de pago fue rechazado. Podés volver a intentar con otra tarjeta o medio de pago en tu cuenta de Mercado Pago.',
     footer:
-      SUPPORT_EMAIL
-        ? `<p style="font-size: 14px; line-height: 20px; margin: 16px 0 0;">Si creés que es un error, contactanos en <a href="mailto:${SUPPORT_EMAIL}">${SUPPORT_EMAIL}</a>.</p>`
+      process.env.SUPPORT_EMAIL
+        ? `<p style="font-size: 14px; line-height: 20px; margin: 16px 0 0;">Si creés que es un error, contactanos en <a href="mailto:${process.env.SUPPORT_EMAIL}">${process.env.SUPPORT_EMAIL}</a>.</p>`
         : '',
+    order,
+  });
+  return sendEmail({
+    to: recipients,
+    subject: `Pago rechazado - Orden #${orderNumber}`,
+    html,
+    replyTo: process.env.SUPPORT_EMAIL,
   });
 }
 
 module.exports = {
+  getFrom,
+  sendEmail,
   sendOrderConfirmed,
   sendPaymentPending,
   sendPaymentRejected,


### PR DESCRIPTION
## Summary
- add configurable Resend email helper with sender mapping
- expose /api/ping and /api/test-email endpoints on the HTTP server
- rely on email send success before marking Mercado Pago notifications as delivered

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5ecc6ddfc8331be353766fa9a0238