### PR TITLE
Centralize Resend configuration and add diagnostic endpoints

### DIFF
--- a/nerin_final_updated/data/config.json
+++ b/nerin_final_updated/data/config.json
@@ -8,6 +8,7 @@
   "afipCert": "",
   "afipKey": "",
   "resendApiKey": "",
+  "supportEmail": "",
   "publicUrl": "https://nerinparts.com.ar",
   "apiBase": ""
 }


### PR DESCRIPTION
## Summary
- centralize Resend configuration with multi-from support and config fallbacks in the email notification service
- expose plain HTTP diagnostics endpoints for ping and Resend email testing
- harden Mercado Pago webhook email delivery handling and extend local config defaults

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5ed9bc7708331a41e095f96687aed