### PR TITLE
Add in-memory lock to prevent duplicate Mercado Pago confirmation emails

### DIFF
--- a/nerin_final_updated/backend/utils/inflightLock.js
+++ b/nerin_final_updated/backend/utils/inflightLock.js
@@ -1,0 +1,3 @@
+const inflight = new Set();
+
+module.exports = inflight;


### PR DESCRIPTION
## Summary
- add a shared in-memory inflight set for Mercado Pago webhook processing
- guard confirmation emails behind already-sent and in-flight checks and only mark the flag after a successful send

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d686a5491883319e19ffc00ead6ee0