### PR TITLE
Tighten product detail image wrapper centering

### DIFF
--- a/nerin_final_updated/frontend/js/product.js
+++ b/nerin_final_updated/frontend/js/product.js
@@ -465,6 +465,8 @@ function buildGallery(root, urls, alts = []) {
     slide.setAttribute("aria-hidden", index === 0 ? "false" : "true");
     slide.dataset.index = String(index);
 
+    const wrapper = document.createElement("div");
+    wrapper.className = "product-image-wrapper";
     const picture = document.createElement("picture");
     const img = new Image();
     img.className = "product-gallery__image";
@@ -477,7 +479,8 @@ function buildGallery(root, urls, alts = []) {
     img.alt = normalizedAlts[index];
     img.draggable = false;
     picture.appendChild(img);
-    slide.appendChild(picture);
+    wrapper.appendChild(picture);
+    slide.appendChild(wrapper);
     track.appendChild(slide);
 
     img.addEventListener("click", () =>

--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -1306,6 +1306,21 @@ footer .legal {
   position: relative;
 }
 
+.product-page .product-image-wrapper {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #fff;
+}
+
+.product-page .product-image-wrapper img {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+}
+
 .product-page .product-gallery__image {
   max-width: 100%;
   max-height: 100%;


### PR DESCRIPTION
## Summary
- simplify the product detail `.product-image-wrapper` styles to only apply the requested square ratio, flex centering, and white background
- limit the nested image styles to max dimensions with `object-fit: contain` so the main photo stays centered within the wrapper

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d731770f28833180dc6128fcfc76d5