### PR TITLE
Wrap product image in centered square container

### DIFF
--- a/nerin_final_updated/frontend/js/product.js
+++ b/nerin_final_updated/frontend/js/product.js
@@ -477,7 +477,10 @@ function buildGallery(root, urls, alts = []) {
     img.alt = normalizedAlts[index];
     img.draggable = false;
     picture.appendChild(img);
-    slide.appendChild(picture);
+    const wrapper = document.createElement("div");
+    wrapper.className = "product-image-wrapper";
+    wrapper.appendChild(picture);
+    slide.appendChild(wrapper);
     track.appendChild(slide);
 
     img.addEventListener("click", () =>

--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -1306,6 +1306,21 @@ footer .legal {
   position: relative;
 }
 
+.product-page .product-image-wrapper {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #fff;
+}
+
+.product-page .product-image-wrapper .product-gallery__image {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+}
+
 .product-page .product-gallery__image {
   max-width: 100%;
   max-height: 100%;


### PR DESCRIPTION
## Summary
- wrap each product gallery image in a `.product-image-wrapper` container to constrain the main product visual
- style the new wrapper for a square aspect ratio with centered content and ensure images scale within it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d73eb0c7fc833184bc9c51c03f6ba3