### PR TITLE
Wrap product image with square aspect container

### DIFF
--- a/nerin_final_updated/frontend/js/product.js
+++ b/nerin_final_updated/frontend/js/product.js
@@ -477,7 +477,10 @@ function buildGallery(root, urls, alts = []) {
     img.alt = normalizedAlts[index];
     img.draggable = false;
     picture.appendChild(img);
-    slide.appendChild(picture);
+    const imageWrapper = document.createElement("div");
+    imageWrapper.className = "product-image-wrapper";
+    imageWrapper.appendChild(picture);
+    slide.appendChild(imageWrapper);
     track.appendChild(slide);
 
     img.addEventListener("click", () =>

--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -1297,6 +1297,15 @@ footer .legal {
   background: var(--color-bg, #fff);
 }
 
+.product-page .product-image-wrapper {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #fff;
+}
+
 .product-page .product-gallery__slide picture {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
## Summary
- wrap each product gallery image in a dedicated `.product-image-wrapper` container to enable consistent presentation
- add styling to enforce a square aspect ratio with centered content while keeping images contained within the new wrapper

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7dc5a139c8331877dbe2d0299e7c1