### PR TITLE
Improve product SEO metadata generation

### DIFF
--- a/nerin_final_updated/frontend/product.html
+++ b/nerin_final_updated/frontend/product.html
@@ -1,15 +1,17 @@
 <!doctype html>
-<html lang="es">
+<html lang="es-AR">
   <head>
     <meta charset="UTF-8" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1.0, viewport-fit=cover"
     />
-    <title>Detalle de producto – NERIN</title>
+    <title data-product-meta="title">
+      Repuesto ORIGINAL Service Pack | NERIN Parts
+    </title>
     <meta
       name="description"
-      content="Descubrí el catálogo de pantallas y repuestos originales de NERIN."
+      content="Repuestos originales Service Pack con garantía en NERIN Parts."
       data-product-meta="description"
     />
     <meta


### PR DESCRIPTION
## Summary
- set the product layout language to es-AR and prepare head tags for dynamic metadata updates
- generate product titles from brand and model with the ORIGINAL Service Pack | NERIN Parts format
- build canonical URLs and descriptions capped at 160 characters for meta, Open Graph, and Twitter tags

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d809c7723c8331a21b35a6f61a486d