### PR TITLE
Adjust product hero image framing

### DIFF
--- a/nerin_final_updated/frontend/js/product.js
+++ b/nerin_final_updated/frontend/js/product.js
@@ -556,7 +556,7 @@ function buildGallery(root, urls, alts = []) {
     });
 
     const img = new Image();
-    img.className = "product-gallery__image";
+    img.className = "product-gallery__image product-hero-img";
     img.decoding = "async";
     img.loading = index === 0 ? "eager" : "lazy";
     img.fetchPriority = index === 0 ? "high" : "auto";
@@ -569,9 +569,12 @@ function buildGallery(root, urls, alts = []) {
     img.alt = normalizedAlts[index];
     img.draggable = false;
     picture.appendChild(img);
+    const frame = document.createElement("div");
+    frame.className = "product-hero-frame";
+    frame.appendChild(picture);
     const wrapper = document.createElement("div");
     wrapper.className = "product-image-wrapper";
-    wrapper.appendChild(picture);
+    wrapper.appendChild(frame);
     slide.appendChild(wrapper);
     track.appendChild(slide);
 

--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -1308,17 +1308,9 @@ footer .legal {
 
 .product-page .product-image-wrapper {
   width: 100%;
-  aspect-ratio: 1 / 1;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #fff;
-}
-
-.product-page .product-image-wrapper .product-gallery__image {
-  max-width: 100%;
-  max-height: 100%;
-  object-fit: contain;
 }
 
 .product-page .product-gallery__image {
@@ -2171,4 +2163,25 @@ html, body{ max-width:100%; overflow-x:hidden; }
   to {
     transform: rotate(360deg);
   }
+}
+
+.product-page .product-hero-frame {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #fff;
+  border-radius: 16px;
+  min-height: clamp(260px, 42vh, 560px);
+  overflow: hidden;
+}
+
+.product-page img.product-hero-img {
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  object-position: center;
+  display: block;
 }


### PR DESCRIPTION
## Summary
- wrap product gallery hero images in a scoped frame container so they center and scale correctly without affecting the lightbox
- add scoped product-page styles for the new hero frame and image classes while removing the old square aspect-ratio constraint
- keep lightbox markup untouched while ensuring the hero image sizing stays responsive and visually balanced

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d97da16c888331a5cf666399c999a7