### PR TITLE
Add email notification when orders enter preparation

### DIFF
--- a/nerin_final_updated/emails/orderPreparing.html
+++ b/nerin_final_updated/emails/orderPreparing.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+  <body style="font-family: Arial, sans-serif">
+    <h2>Tu pedido está en preparación</h2>
+    <p>Estamos preparando tu pedido Nº {{ORDER_ID}}.</p>
+    <p>Podés revisar el estado y próximos pasos en el siguiente enlace:</p>
+    <p>
+      <a
+        href="{{ORDER_URL}}"
+        style="
+          background: #0070f3;
+          color: #fff;
+          padding: 10px 15px;
+          border-radius: 4px;
+          text-decoration: none;
+        "
+        >Ver estado del pedido</a
+      >
+    </p>
+    <p>
+      Te avisaremos por este medio cuando tu pedido sea despachado. Si tenés
+      dudas podés responder a este correo.
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add reusable helpers for filling order email templates
- send a preparation notification email when an order's shipping status transitions to "preparing"
- create a dedicated HTML template for the preparation email content

## Testing
- npm test --prefix nerin_final_updated

------
https://chatgpt.com/codex/tasks/task_e_68d982d2fb1c8331a18e7dfcb16fee4a