### PR TITLE
Add preparing status email notification

### DIFF
--- a/nerin_final_updated/backend/services/emailNotifications.js
+++ b/nerin_final_updated/backend/services/emailNotifications.js
@@ -296,6 +296,30 @@ async function sendPaymentRejected({ to, order } = {}) {
   });
 }
 
+async function sendOrderPreparing({ to, order } = {}) {
+  const recipients = ensureArray(to);
+  if (!recipients.length) return null;
+  const customer = resolveCustomerName(order);
+  const orderNumber = resolveOrderNumber(order);
+  const supportEmail = getSupportEmail();
+  const footer = supportEmail
+    ? `<p style="font-size: 14px; line-height: 20px; margin: 16px 0 0;">Si necesitás más información, escribinos a <a href="mailto:${supportEmail}">${supportEmail}</a>.</p>`
+    : '';
+  const html = buildHtmlTemplate({
+    heading: `Estamos preparando tu pedido, ${customer}`,
+    message:
+      'Ya estamos armando tu compra con mucho cuidado. Te avisaremos apenas salga a despacho.',
+    footer,
+    order,
+  });
+  return sendEmail({
+    to: recipients,
+    subject: `Tu pedido está en preparación - Orden #${orderNumber}`,
+    html,
+    type: 'no-reply',
+  });
+}
+
 module.exports = {
   getFrom,
   getEmailConfig,
@@ -303,4 +327,5 @@ module.exports = {
   sendOrderConfirmed,
   sendPaymentPending,
   sendPaymentRejected,
+  sendOrderPreparing,
 };


### PR DESCRIPTION
## Summary
- send a templated "en preparación" notification email when admins move an order to the preparing shipping status
- add helper logic to resolve customer emails and cover the workflow with updated admin endpoint tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d982b8a2588331870fd55047b25a49