### PR TITLE
Center product gallery slides

### DIFF
--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -1291,6 +1291,7 @@ footer .legal {
 .product-page .product-gallery__slide {
   min-width: 100%;
   height: 100%;
+  margin: 0;
   padding: 0.75rem;
   display: grid;
   place-items: center;


### PR DESCRIPTION
## Summary
- reset the default figure margin on product gallery slides so hero images stay centered within the carousel viewport

## Testing
- Manual verification by running `npm run start --prefix nerin_final_updated` and checking `product.html?id=1`


------
https://chatgpt.com/codex/tasks/task_e_68d9aca0ff0c83318c60bf50f2534df3