### PR TITLE
Add helper emails for wholesale verification flow

### DIFF
--- a/nerin_final_updated/backend/services/emailNotifications.js
+++ b/nerin_final_updated/backend/services/emailNotifications.js
@@ -320,6 +320,46 @@ async function sendOrderPreparing({ to, order } = {}) {
   });
 }
 
+async function sendWholesaleVerificationEmail({ to, code, contactName } = {}) {
+  const recipients = ensureArray(to);
+  if (!recipients.length) return null;
+  const normalizedName = normalizeString(contactName);
+  const greeting = normalizedName ? `Hola ${normalizedName},` : 'Hola,';
+  const html = `
+    <p>${greeting}</p>
+    <p>Gracias por solicitar acceso mayorista en NERIN Parts.</p>
+    <p>Tu código de verificación es:</p>
+    <p style="font-size: 24px; font-weight: 700; letter-spacing: 4px;">${code}</p>
+    <p>Ingresalo en el formulario dentro de los próximos 30 minutos para continuar con la solicitud.</p>
+    <p>Si no solicitaste este código podés ignorar este mensaje.</p>
+  `;
+  return sendEmail({
+    to: recipients,
+    subject: 'Código de verificación mayorista – NERIN Parts',
+    html,
+    type: 'no-reply',
+  });
+}
+
+async function sendWholesaleApplicationReceived({ to, contactName } = {}) {
+  const recipients = ensureArray(to);
+  if (!recipients.length) return null;
+  const normalizedName = normalizeString(contactName);
+  const greeting = normalizedName ? `Hola ${normalizedName},` : 'Hola,';
+  const html = `
+    <p>${greeting}</p>
+    <p>Recibimos tu solicitud para acceder a nuestra tienda mayorista.</p>
+    <p>En un plazo de 24 a 48 hs hábiles nuestro equipo validará la información y te responderá por correo.</p>
+    <p>Gracias por confiar en NERIN Parts.</p>
+  `;
+  return sendEmail({
+    to: recipients,
+    subject: 'Solicitud mayorista recibida – NERIN Parts',
+    html,
+    type: 'no-reply',
+  });
+}
+
 module.exports = {
   getFrom,
   getEmailConfig,
@@ -328,4 +368,6 @@ module.exports = {
   sendPaymentPending,
   sendPaymentRejected,
   sendOrderPreparing,
+  sendWholesaleVerificationEmail,
+  sendWholesaleApplicationReceived,
 };


### PR DESCRIPTION
## Summary
- add dedicated helpers to deliver wholesale verification codes and submission confirmations via the shared email service
- reuse the new helpers in the wholesale endpoints so email delivery is explicit and failures surface to the caller

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9c982c2048331850784f4d8521ef4