### PR TITLE
Add internal email alert for new wholesale requests

### DIFF
--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -21,6 +21,7 @@ const {
   sendOrderPreparing,
   sendWholesaleVerificationEmail,
   sendWholesaleApplicationReceived,
+  sendWholesaleInternalNotification,
 } = require("./services/emailNotifications");
 const {
   STATUS_ES_TO_CODE,
@@ -2376,6 +2377,15 @@ async function requestHandler(req, res) {
           });
         } catch (error) {
           console.warn("wholesale apply confirmation email", error?.message || error);
+        }
+
+        try {
+          await sendWholesaleInternalNotification({
+            request: sanitizeWholesaleRequestForResponse(requests[idx]),
+            baseUrl: getPublicBaseUrl(getConfig()),
+          });
+        } catch (error) {
+          console.warn("wholesale apply admin email", error?.message || error);
         }
 
         return sendJson(res, 201, {

--- a/nerin_final_updated/data/config.json
+++ b/nerin_final_updated/data/config.json
@@ -9,6 +9,7 @@
   "afipKey": "",
   "resendApiKey": "",
   "supportEmail": "",
+  "wholesaleNotificationEmails": [],
   "publicUrl": "https://nerinparts.com.ar",
   "apiBase": ""
 }


### PR DESCRIPTION
## Summary
- add support for configuring wholesale notification recipients and reuse it for internal alerts
- send an internal notification email with applicant details when a wholesale request is submitted
- extend the default config with a placeholder for wholesale notification recipients

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9d3f6f35c83318f9768b718fa24a5