### PR TITLE
Persist wholesale verification requests before sending email

### DIFF
--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -2234,12 +2234,21 @@ async function requestHandler(req, res) {
         }
 
         try {
+          saveWholesaleRequests(nextRequests);
+        } catch (error) {
+          console.error("wholesale send-code save", error);
+          return sendJson(res, 500, {
+            error:
+              "No pudimos registrar la solicitud en este momento. Intentá nuevamente más tarde.",
+          });
+        }
+
+        try {
           await sendWholesaleVerificationEmail({
             to: email,
             code,
             contactName: updatedEntry.contactName,
           });
-          saveWholesaleRequests(nextRequests);
           console.log(`[wholesale] Código de verificación enviado a ${email}`);
         } catch (error) {
           const rawMessage =
@@ -2256,7 +2265,10 @@ async function requestHandler(req, res) {
             friendlyMessage =
               "No pudimos enviar el código de verificación. Verificá tu correo o intentá nuevamente en unos minutos.";
           }
-          return sendJson(res, 502, { error: friendlyMessage });
+          return sendJson(res, 502, {
+            error: friendlyMessage,
+            saved: true,
+          });
         }
 
         return sendJson(res, 200, {


### PR DESCRIPTION
## Summary
- save wholesale verification requests before attempting email delivery so the admin can see pending entries
- return an explicit error when the request cannot be stored and mark email failures while keeping the record

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9d9a4ba848331a8fdf6c5fb7be868