### PR TITLE
Improve checkout auto-fill with stored customer profile

### DIFF
--- a/nerin_final_updated/backend/index.js
+++ b/nerin_final_updated/backend/index.js
@@ -626,12 +626,54 @@ const USERS = [
     password: "admin123",
     role: "admin",
     name: "Valdir",
+    profile: {
+      nombre: "Valdir",
+      apellido: "Nerin",
+      email: "admin@nerin.com",
+      telefono: "+54 11 4555-1234",
+      provincia: "Ciudad Autónoma de Buenos Aires",
+      localidad: "Buenos Aires",
+      calle: "Av. Entre Ríos",
+      numero: "425",
+      piso: "7",
+      cp: "1080",
+      metodo: "retiro",
+      direccion: {
+        calle: "Av. Entre Ríos",
+        numero: "425",
+        piso: "7",
+        localidad: "Buenos Aires",
+        provincia: "Ciudad Autónoma de Buenos Aires",
+        cp: "1080",
+      },
+    },
   },
   {
     email: "mayorista@nerin.com",
     password: "clave123",
     role: "mayorista",
     name: "Cliente Mayorista",
+    profile: {
+      nombre: "Carolina",
+      apellido: "Gómez",
+      email: "mayorista@nerin.com",
+      telefono: "+54 11 6000-9988",
+      provincia: "Buenos Aires",
+      localidad: "Quilmes",
+      calle: "Hipólito Yrigoyen",
+      numero: "850",
+      piso: "2",
+      cp: "1878",
+      metodo: "estandar",
+      direccion: {
+        calle: "Hipólito Yrigoyen",
+        numero: "850",
+        piso: "2",
+        localidad: "Quilmes",
+        provincia: "Buenos Aires",
+        cp: "1878",
+      },
+    },
   },
 ];
 
@@ -642,7 +684,13 @@ app.post("/api/login", (req, res) => {
   if (user) {
     // Generar un token simple (no seguro, solo para demostración)
     const token = Buffer.from(`${user.email}:${Date.now()}`).toString("base64");
-    res.json({ success: true, token, role: user.role, name: user.name });
+    res.json({
+      success: true,
+      token,
+      role: user.role,
+      name: user.name,
+      profile: user.profile || null,
+    });
   } else {
     res
       .status(401)

--- a/nerin_final_updated/frontend/js/api.js
+++ b/nerin_final_updated/frontend/js/api.js
@@ -46,6 +46,13 @@ export async function login(email, password) {
     // También guardamos el nombre y correo del usuario para futuras operaciones
     localStorage.setItem("nerinUserName", data.name);
     localStorage.setItem("nerinUserEmail", email);
+    if (data.profile && typeof data.profile === "object") {
+      try {
+        localStorage.setItem("nerinUserProfile", JSON.stringify(data.profile));
+      } catch (storageError) {
+        console.warn("No se pudo guardar el perfil del usuario", storageError);
+      }
+    }
     // Registrar la fecha y hora del último inicio de sesión
     localStorage.setItem("nerinLastLogin", new Date().toISOString());
     return data;

--- a/nerin_final_updated/frontend/js/register.js
+++ b/nerin_final_updated/frontend/js/register.js
@@ -99,6 +99,25 @@ if (retailForm) {
       localStorage.setItem("nerinUserRole", data.role);
       localStorage.setItem("nerinUserName", name || "Cliente");
       localStorage.setItem("nerinUserEmail", email);
+      try {
+        const [firstName = "", ...rest] = (name || "").trim().split(/\s+/);
+        const baseProfile = {
+          nombre: firstName || name || "",
+          apellido: rest.join(" ") || "",
+          email,
+          telefono: "",
+          provincia: "",
+          localidad: "",
+          calle: "",
+          numero: "",
+          piso: "",
+          cp: "",
+          metodo: "",
+        };
+        localStorage.setItem("nerinUserProfile", JSON.stringify(baseProfile));
+      } catch (profileError) {
+        console.warn("No se pudo inicializar el perfil del usuario", profileError);
+      }
 
       showFormStatus(
         retailStatus,


### PR DESCRIPTION
## Summary
- add profile information to the demo users returned by the backend login endpoint
- persist the customer profile in localStorage during login/registro and reuse it to prefill checkout forms
- sync checkout flows to update the stored profile after a purchase so future checkouts already know the buyer details

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da861e35d88331a47791ed0f871a46