### PR TITLE
Add dedicated minorista account experience

### DIFF
--- a/nerin_final_updated/frontend/account-minorista.html
+++ b/nerin_final_updated/frontend/account-minorista.html
@@ -1,0 +1,230 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
+    <title>Mi cuenta minorista – NERIN</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css"
+    />
+    <link rel="stylesheet" href="/style.css?v=mobfix-1" />
+    <link rel="stylesheet" href="/components/np-footer.css?v=np-r1" />
+    <script src="/components/np-footer.js?v=np-r1" defer></script>
+  </head>
+  <body>
+    <header>
+      <div class="header-inner">
+        <div class="logo">
+          <a href="/index.html" class="brand"
+            ><img
+              src="../assets/IMG_3086.png"
+              alt="NERIN"
+              class="site-logo"
+          /></a>
+        </div>
+        <button class="menu-toggle" id="navToggle">☰</button>
+        <nav id="mainNav">
+          <ul>
+            <li><a href="/index.html">Inicio</a></li>
+            <li><a href="/shop.html">Productos</a></li>
+            <li><a href="/contact.html">Contacto</a></li>
+            <li><a href="/seguimiento.html">Seguir mi pedido</a></li>
+            <li><a href="/cart.html">Carrito</a></li>
+            <li><a href="/account-minorista.html" class="active">Mi cuenta</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+    <main class="container account-dashboard account-dashboard--minorista">
+      <section class="account-hero">
+        <div class="account-hero__content">
+          <p class="account-hero__tag">Canal minorista NERIN</p>
+          <h1>Mi cuenta minorista</h1>
+          <p id="heroSubtitle">
+            Accedé a tus pedidos, devoluciones y beneficios personalizados en un
+            mismo lugar.
+          </p>
+          <div class="account-hero__cta">
+            <a href="/shop.html" class="button primary">Seguir comprando</a>
+            <a href="/seguimiento.html" class="button outline">Seguir envío</a>
+          </div>
+        </div>
+        <div class="account-hero__stats">
+          <div class="hero-stat">
+            <span class="hero-stat__label">Cliente</span>
+            <span class="hero-stat__value" id="heroName">—</span>
+            <span class="hero-stat__meta" id="heroLevel">Nuevo cliente</span>
+          </div>
+          <div class="hero-stat">
+            <span class="hero-stat__label">Compras</span>
+            <span class="hero-stat__value" id="heroOrders">0</span>
+            <span class="hero-stat__meta" id="heroTotal">$0 acumulado</span>
+          </div>
+          <div class="hero-stat">
+            <span class="hero-stat__label">Último pedido</span>
+            <span class="hero-stat__value" id="heroLastOrder">—</span>
+            <span class="hero-stat__meta" id="heroLastStatus">Sin envíos</span>
+          </div>
+        </div>
+      </section>
+
+      <section class="account-section account-card" id="quickActionsSection">
+        <div class="section-header">
+          <div>
+            <p class="eyebrow">Gestioná tu cuenta</p>
+            <h2>Acciones rápidas</h2>
+          </div>
+        </div>
+        <div class="action-grid">
+          <button class="action-tile" type="button" data-action="orders">
+            <span class="action-icon">🧾</span>
+            <div>
+              <strong>Ver mis pedidos</strong>
+              <p>Repasá el detalle y descargas de tus compras.</p>
+            </div>
+          </button>
+          <button class="action-tile" type="button" data-action="track">
+            <span class="action-icon">🚚</span>
+            <div>
+              <strong>Seguir envíos</strong>
+              <p>Consultá el estado y estimado de entrega.</p>
+            </div>
+          </button>
+          <button class="action-tile" type="button" data-action="profile">
+            <span class="action-icon">👤</span>
+            <div>
+              <strong>Actualizar mis datos</strong>
+              <p>Mantené tu dirección y teléfono al día.</p>
+            </div>
+          </button>
+          <button class="action-tile" type="button" data-action="support">
+            <span class="action-icon">💬</span>
+            <div>
+              <strong>Contactar soporte</strong>
+              <p>Recibí ayuda inmediata de nuestro equipo.</p>
+            </div>
+          </button>
+        </div>
+      </section>
+
+      <section class="account-section account-card" id="purchaseSummary">
+        <div class="card-header">
+          <h3>Resumen de compras</h3>
+          <span class="badge" id="loyaltyBadge">Nuevo</span>
+        </div>
+        <div class="insight-grid">
+          <article class="insight-card">
+            <p class="insight-label">Total invertido</p>
+            <p class="insight-value" id="totalSpent">$0</p>
+            <p class="insight-meta" id="avgTicket">Ticket promedio $0</p>
+          </article>
+          <article class="insight-card">
+            <p class="insight-label">Compras concretadas</p>
+            <p class="insight-value" id="ordersCount">0</p>
+            <p class="insight-meta" id="ordersFrequency">Tu próxima compra desbloquea beneficios.</p>
+          </article>
+          <article class="insight-card">
+            <p class="insight-label">Entrega estimada</p>
+            <p class="insight-value" id="nextDelivery">—</p>
+            <p class="insight-meta" id="deliveryMeta">Aún no hay envíos en curso.</p>
+          </article>
+        </div>
+        <div class="progress-track">
+          <div class="progress-track__header">
+            <h4>Tu progreso como cliente</h4>
+            <span id="progressLabel">0% hacia nivel Frecuente</span>
+          </div>
+          <div class="progress-track__bar">
+            <div class="progress-track__fill" id="loyaltyProgress"></div>
+          </div>
+          <p class="microcopy" id="progressMessage">
+            Realizá tu primera compra para empezar a sumar beneficios.
+          </p>
+        </div>
+      </section>
+
+      <section class="account-section account-card" id="ordersSection">
+        <div class="card-header">
+          <h3>Pedidos recientes</h3>
+          <p class="helper-text">Descargá comprobantes y repetí tus compras favoritas.</p>
+        </div>
+        <div class="table-wrapper">
+          <table class="data-table" id="ordersTable">
+            <thead>
+              <tr>
+                <th>Pedido</th>
+                <th>Fecha</th>
+                <th>Estado</th>
+                <th>Total</th>
+                <th>Acciones</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td colspan="5">Cargando pedidos...</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="account-section account-card" id="benefitsSection">
+        <div class="card-header">
+          <h3>Beneficios para vos</h3>
+          <p class="helper-text">
+            Te acompañamos con envíos rápidos, soporte técnico y promociones
+            exclusivas.
+          </p>
+        </div>
+        <ul class="benefits-list" id="benefitsList">
+          <li>
+            <span class="benefit-icon">⚡</span>
+            <div>
+              <strong>Envío prioritario</strong>
+              <p>Despachamos pedidos minoristas en menos de 24 horas hábiles.</p>
+            </div>
+          </li>
+          <li>
+            <span class="benefit-icon">🎁</span>
+            <div>
+              <strong>Promos por volumen</strong>
+              <p>Sumá descuentos extra al comprar kits o repuestos combinados.</p>
+            </div>
+          </li>
+          <li>
+            <span class="benefit-icon">🛠️</span>
+            <div>
+              <strong>Asistencia técnica</strong>
+              <p>Recibí ayuda de nuestros especialistas para instalar repuestos.</p>
+            </div>
+          </li>
+        </ul>
+      </section>
+
+      <section class="account-section account-card" id="helpSection">
+        <div class="card-header">
+          <h3>¿Necesitás ayuda?</h3>
+          <p class="helper-text">Estamos disponibles de lunes a viernes de 9 a 18 h.</p>
+        </div>
+        <div class="support-actions support-actions--stacked">
+          <a id="supportBtn" class="button primary" target="_blank">Hablar por WhatsApp</a>
+          <a href="mailto:hola@nerinparts.com.ar" class="button secondary"
+            >Enviar correo</a
+          >
+        </div>
+        <ul class="link-list">
+          <li><a href="/seguimiento.html">¿Dónde está mi pedido?</a></li>
+          <li><a href="/politicas/devoluciones.html">Política de cambios</a></li>
+          <li><a href="/faq.html">Preguntas frecuentes</a></li>
+        </ul>
+      </section>
+    </main>
+    <script type="module" src="/js/account-minorista.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
+    <script type="module" src="/js/config.js"></script>
+  </body>
+</html>

--- a/nerin_final_updated/frontend/components/np-footer.js
+++ b/nerin_final_updated/frontend/components/np-footer.js
@@ -98,7 +98,7 @@
           {
             title: "Cuenta",
             links: [
-              { label: "Mi cuenta", href: "/account.html" },
+              { label: "Mi cuenta", href: "/account-minorista.html" },
               { label: "Mayoristas", href: "/mayoristas" },
               { label: "Soporte técnico", href: "/soporte" },
             ],

--- a/nerin_final_updated/frontend/js/account-minorista.js
+++ b/nerin_final_updated/frontend/js/account-minorista.js
@@ -1,0 +1,427 @@
+const TOAST_STYLES = {
+  success: "linear-gradient(135deg,#10b981,#22c55e)",
+  info: "linear-gradient(135deg,#3b82f6,#6366f1)",
+  warning: "linear-gradient(135deg,#f97316,#ea580c)",
+  danger: "linear-gradient(135deg,#ef4444,#dc2626)",
+};
+
+function showToast(message, type = "info") {
+  if (window.Toastify) {
+    window.Toastify({
+      text: message,
+      duration: 3200,
+      close: true,
+      gravity: "top",
+      position: "center",
+      style: { background: TOAST_STYLES[type] || TOAST_STYLES.info },
+    }).showToast();
+  } else {
+    console.log(message);
+  }
+}
+
+function formatCurrency(value) {
+  const number = Number(value || 0);
+  return number.toLocaleString("es-AR", {
+    style: "currency",
+    currency: "ARS",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  });
+}
+
+function formatDate(value, options = { day: "2-digit", month: "short", year: "numeric" }) {
+  if (!value) return "—";
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleDateString("es-AR", options);
+}
+
+function formatDateTime(value) {
+  if (!value) return "—";
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleString("es-AR", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function getFirstName(value, fallback) {
+  if (value && typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed) return trimmed.split(/\s+/)[0];
+  }
+  return fallback;
+}
+
+function computeOrderDate(order) {
+  return (
+    order?.created_at ||
+    order?.date ||
+    order?.fecha ||
+    order?.createdAt ||
+    order?.updated_at ||
+    order?.fecha_creacion ||
+    null
+  );
+}
+
+function getOrderNumber(order) {
+  return (
+    order?.order_number ||
+    order?.id ||
+    order?.external_reference ||
+    order?.numero ||
+    order?.orderId ||
+    ""
+  );
+}
+
+function getShippingStatus(order) {
+  return (
+    order?.shipping_status ||
+    order?.envio_estado ||
+    order?.status_envio ||
+    order?.estado_envio ||
+    order?.shippingStatus ||
+    "pendiente"
+  );
+}
+
+function toStatusCode(value) {
+  return value?.toString?.().toLowerCase().replace(/[^a-z0-9-]/g, "-") || "pendiente";
+}
+
+function formatStatusLabel(value) {
+  const code = toStatusCode(value);
+  return code.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function normalizeOrderItems(order) {
+  const rawItems = Array.isArray(order?.productos)
+    ? order.productos
+    : Array.isArray(order?.items)
+    ? order.items
+    : [];
+  return rawItems
+    .map((item) => {
+      const id =
+        item?.id ||
+        item?.product_id ||
+        item?.sku ||
+        item?.code ||
+        (item?.name ? item.name.toLowerCase().replace(/[^a-z0-9]+/gi, "-") : null);
+      return {
+        id,
+        name: item?.name || item?.product_name || item?.title || "Producto",
+        quantity: Number(item?.quantity || item?.qty || item?.cantidad || 0) || 0,
+        price: Number(item?.price || item?.unit_price || item?.precio || 0) || 0,
+        image: item?.image || item?.image_url || item?.img || null,
+      };
+    })
+    .filter((item) => item.quantity > 0);
+}
+
+function addItemsToCart(items) {
+  if (!Array.isArray(items) || !items.length) {
+    showToast("No encontramos productos para repetir el pedido.", "warning");
+    return;
+  }
+  let cart = [];
+  try {
+    cart = JSON.parse(localStorage.getItem("nerinCart")) || [];
+    if (!Array.isArray(cart)) cart = [];
+  } catch (err) {
+    cart = [];
+  }
+  const updatedCart = [...cart];
+  items.forEach((item) => {
+    if (!item?.id) return;
+    const existing = updatedCart.find((cartItem) => cartItem.id === item.id);
+    if (existing) {
+      existing.quantity += item.quantity || 1;
+    } else {
+      updatedCart.push({
+        id: item.id,
+        name: item.name || "Producto",
+        price: item.price || 0,
+        quantity: item.quantity || 1,
+        image: item.image || null,
+      });
+    }
+  });
+  localStorage.setItem("nerinCart", JSON.stringify(updatedCart));
+  if (window.updateNav) window.updateNav();
+  showToast("Añadimos los productos al carrito.", "success");
+}
+
+function determineMinorLoyalty(orderCount, totalSpent) {
+  let level = "Nuevo";
+  let progress = Math.min(100, (orderCount / 2) * 100);
+  let message = "Realizá tu primera compra para desbloquear envíos bonificados.";
+  let nextLabel = "Frecuente";
+
+  if (orderCount >= 8 || totalSpent >= 280000) {
+    level = "Mayorista invitado";
+    progress = 100;
+    message = "¡Felicitaciones! Podés solicitar beneficios mayoristas con tu ejecutivo.";
+    nextLabel = null;
+  } else if (orderCount >= 3 || totalSpent >= 120000) {
+    level = "Frecuente";
+    progress = Math.min(100, ((orderCount - 2) / 6) * 100);
+    message = "Mantené tu ritmo de compras para acceder a promos exclusivas.";
+    nextLabel = "Mayorista invitado";
+  }
+
+  progress = Math.max(0, Math.min(100, Math.round(progress)));
+
+  return { level, progress, message, nextLabel };
+}
+
+async function renderOrders(orders, email) {
+  const table = document.getElementById("ordersTable");
+  const tbody = table?.querySelector("tbody");
+  if (!tbody) return;
+
+  tbody.innerHTML = "";
+  if (!Array.isArray(orders) || !orders.length) {
+    const tr = document.createElement("tr");
+    tr.innerHTML =
+      '<td colspan="5">Todavía no registramos pedidos. ¡Empezá tu primera compra en la tienda!</td>';
+    tbody.appendChild(tr);
+    return;
+  }
+
+  orders
+    .map((order) => ({
+      raw: order,
+      dateValue: computeOrderDate(order),
+    }))
+    .sort((a, b) => (Date.parse(b.dateValue || 0) || 0) - (Date.parse(a.dateValue || 0) || 0))
+    .forEach(({ raw }) => {
+      const tr = document.createElement("tr");
+      const numero = getOrderNumber(raw);
+      const fechaValor = computeOrderDate(raw);
+      const fecha = fechaValor ? new Date(fechaValor) : null;
+      const statusRaw = getShippingStatus(raw) || "pendiente";
+      const statusCode = toStatusCode(statusRaw);
+      const statusLabel = formatStatusLabel(statusRaw);
+      const totalVal =
+        raw?.total_amount || raw?.total || raw?.total_amount_before_discount || raw?.amount || 0;
+
+      tr.innerHTML = `
+        <td>${numero || "—"}</td>
+        <td>${fecha ? formatDateTime(fecha) : "—"}</td>
+        <td><span class="status-badge status-${statusCode}">${statusLabel}</span></td>
+        <td>${formatCurrency(totalVal)}</td>
+        <td class="order-actions">
+          <button type="button" class="button secondary small" data-action="invoice">Factura</button>
+          <button type="button" class="button ghost small" data-action="repeat">Repetir</button>
+        </td>
+      `;
+
+      const actions = tr.querySelector(".order-actions");
+      const invoiceBtn = actions?.querySelector('[data-action="invoice"]');
+      const repeatBtn = actions?.querySelector('[data-action="repeat"]');
+
+      if (invoiceBtn) {
+        invoiceBtn.addEventListener("click", async () => {
+          try {
+            const oid = numero;
+            if (!oid) {
+              showToast("No pudimos encontrar el número de pedido.", "warning");
+              return;
+            }
+            const resp = await fetch(`/api/invoices/${encodeURIComponent(oid)}`, {
+              method: "POST",
+            });
+            if (resp.ok) {
+              window.open(`/invoice.html?orderId=${encodeURIComponent(oid)}`, "_blank");
+            } else {
+              const err = await resp.json().catch(() => ({}));
+              showToast(err.error || "No pudimos generar la factura.", "danger");
+            }
+          } catch (error) {
+            showToast("Ocurrió un error al solicitar la factura.", "danger");
+          }
+        });
+      }
+
+      if (repeatBtn) {
+        repeatBtn.addEventListener("click", () => {
+          const items = normalizeOrderItems(raw);
+          addItemsToCart(items);
+        });
+      }
+
+      tbody.appendChild(tr);
+    });
+}
+
+function updateQuickActions(handlers) {
+  const buttons = document.querySelectorAll(".action-tile");
+  buttons.forEach((button) => {
+    button.addEventListener("click", () => {
+      const action = button.getAttribute("data-action");
+      const handler = handlers[action];
+      if (typeof handler === "function") handler();
+    });
+  });
+}
+
+async function initMinorAccount() {
+  const role = localStorage.getItem("nerinUserRole");
+  if (role && role !== "minorista") {
+    window.location.replace("/account.html");
+    return;
+  }
+
+  const email = localStorage.getItem("nerinUserEmail");
+  if (!email) {
+    window.location.href = "/login.html";
+    return;
+  }
+
+  const name = localStorage.getItem("nerinUserName") || email;
+  const heroNameEl = document.getElementById("heroName");
+  const heroLevelEl = document.getElementById("heroLevel");
+  const heroOrdersEl = document.getElementById("heroOrders");
+  const heroTotalEl = document.getElementById("heroTotal");
+  const heroLastOrderEl = document.getElementById("heroLastOrder");
+  const heroLastStatusEl = document.getElementById("heroLastStatus");
+
+  const loyaltyBadge = document.getElementById("loyaltyBadge");
+  const totalSpentEl = document.getElementById("totalSpent");
+  const avgTicketEl = document.getElementById("avgTicket");
+  const ordersCountEl = document.getElementById("ordersCount");
+  const ordersFrequencyEl = document.getElementById("ordersFrequency");
+  const nextDeliveryEl = document.getElementById("nextDelivery");
+  const deliveryMetaEl = document.getElementById("deliveryMeta");
+  const progressLabelEl = document.getElementById("progressLabel");
+  const progressFillEl = document.getElementById("loyaltyProgress");
+  const progressMessageEl = document.getElementById("progressMessage");
+  const supportBtn = document.getElementById("supportBtn");
+
+  if (heroNameEl) heroNameEl.textContent = getFirstName(name, "Cliente NERIN");
+
+  let orders = [];
+  try {
+    const res = await fetch(`/api/orders?email=${encodeURIComponent(email)}`);
+    if (res.ok) {
+      const data = await res.json();
+      orders = Array.isArray(data?.orders) ? data.orders : [];
+    }
+  } catch (error) {
+    console.error(error);
+  }
+
+  const totalSpent = orders.reduce((total, order) => {
+    const value =
+      order?.total_amount || order?.total || order?.total_amount_before_discount || order?.amount || 0;
+    return total + Number(value);
+  }, 0);
+  const orderCount = orders.length;
+  const avgTicket = orderCount ? totalSpent / orderCount : 0;
+
+  const ordered = orders
+    .map((order) => ({
+      raw: order,
+      date: (() => {
+        const val = computeOrderDate(order);
+        return val ? new Date(val) : null;
+      })(),
+      status: getShippingStatus(order),
+    }))
+    .sort((a, b) => (b.date?.getTime?.() || 0) - (a.date?.getTime?.() || 0));
+
+  const lastOrder = ordered[0] || null;
+  const pendingOrder = ordered.find((entry) => {
+    const status = toStatusCode(entry.status);
+    return status && !["entregado", "cancelado", "devuelto"].includes(status);
+  });
+
+  const loyalty = determineMinorLoyalty(orderCount, totalSpent);
+
+  if (heroLevelEl) heroLevelEl.textContent = `Nivel ${loyalty.level}`;
+  if (heroOrdersEl) heroOrdersEl.textContent = orderCount.toString();
+  if (heroTotalEl) heroTotalEl.textContent = `${formatCurrency(totalSpent)} acumulado`;
+  if (heroLastOrderEl)
+    heroLastOrderEl.textContent = lastOrder?.date ? formatDate(lastOrder.date) : "—";
+  if (heroLastStatusEl)
+    heroLastStatusEl.textContent = lastOrder
+      ? `Estado: ${formatStatusLabel(getShippingStatus(lastOrder.raw))}`
+      : "Sin envíos";
+
+  if (loyaltyBadge) loyaltyBadge.textContent = loyalty.level;
+  if (totalSpentEl) totalSpentEl.textContent = formatCurrency(totalSpent);
+  if (avgTicketEl) avgTicketEl.textContent = `Ticket promedio ${formatCurrency(avgTicket)}`;
+  if (ordersCountEl) ordersCountEl.textContent = orderCount.toString();
+  if (ordersFrequencyEl) {
+    if (!orderCount) {
+      ordersFrequencyEl.textContent = "Tu próxima compra desbloquea beneficios.";
+    } else if (orderCount === 1) {
+      ordersFrequencyEl.textContent = "Tu primera compra ya está registrada.";
+    } else {
+      ordersFrequencyEl.textContent = `Realizaste ${orderCount} compras con nosotros.`;
+    }
+  }
+
+  if (pendingOrder) {
+    const estimated = pendingOrder.raw?.estimated_delivery || pendingOrder.raw?.deliveryDate;
+    if (nextDeliveryEl) nextDeliveryEl.textContent = formatDate(estimated || pendingOrder.date);
+    if (deliveryMetaEl)
+      deliveryMetaEl.textContent = `Estado actual: ${formatStatusLabel(pendingOrder.status)}.`;
+  } else if (lastOrder) {
+    if (nextDeliveryEl) nextDeliveryEl.textContent = formatDate(lastOrder.date);
+    if (deliveryMetaEl)
+      deliveryMetaEl.textContent = "Tu última compra ya fue entregada. ¡Gracias por confiar en NERIN!";
+  } else {
+    if (nextDeliveryEl) nextDeliveryEl.textContent = "—";
+    if (deliveryMetaEl) deliveryMetaEl.textContent = "Aún no hay envíos en curso.";
+  }
+
+  if (progressLabelEl) {
+    progressLabelEl.textContent = loyalty.nextLabel
+      ? `${loyalty.progress}% hacia nivel ${loyalty.nextLabel}`
+      : "Nivel máximo alcanzado";
+  }
+  if (progressFillEl) progressFillEl.style.width = `${loyalty.progress}%`;
+  if (progressMessageEl) progressMessageEl.textContent = loyalty.message;
+
+  await renderOrders(orders, email);
+
+  if (supportBtn) {
+    const phone = window.NERIN_CONFIG?.whatsappNumber;
+    if (phone) {
+      const sanitized = phone.replace(/[^0-9]/g, "");
+      supportBtn.href = `https://wa.me/${sanitized}`;
+    } else {
+      supportBtn.href = "https://wa.me/541112345678";
+    }
+  }
+
+  updateQuickActions({
+    orders: () => {
+      document.getElementById("ordersSection")?.scrollIntoView({ behavior: "smooth", block: "start" });
+    },
+    track: () => {
+      window.location.href = "/seguimiento.html";
+    },
+    profile: () => {
+      window.location.href = "/contact.html#form";
+    },
+    support: () => {
+      if (supportBtn?.href) {
+        window.open(supportBtn.href, "_blank");
+      } else {
+        window.location.href = "mailto:hola@nerinparts.com.ar";
+      }
+    },
+  });
+}
+
+document.addEventListener("DOMContentLoaded", initMinorAccount);

--- a/nerin_final_updated/frontend/js/account.js
+++ b/nerin_final_updated/frontend/js/account.js
@@ -1013,6 +1013,12 @@ async function loadUserReturns(email) {
 }
 
 async function initAccount() {
+  const role = localStorage.getItem("nerinUserRole");
+  if (role && !["mayorista", "admin", "vip", "vendedor"].includes(role)) {
+    window.location.replace("/account-minorista.html");
+    return;
+  }
+
   const email = localStorage.getItem("nerinUserEmail");
   const name = localStorage.getItem("nerinUserName");
   if (!email) {

--- a/nerin_final_updated/frontend/js/config.js
+++ b/nerin_final_updated/frontend/js/config.js
@@ -239,6 +239,9 @@ function updateNav() {
         if (role === "admin" || role === "vendedor") {
           a.textContent = "Admin";
           a.setAttribute("href", "/admin.html");
+        } else if (role === "minorista") {
+          a.textContent = "Mi cuenta";
+          a.setAttribute("href", "/account-minorista.html");
         } else {
           a.textContent = "Mi cuenta";
           a.setAttribute("href", "/account.html");

--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -2708,6 +2708,127 @@ footer .legal {
   box-shadow: 0 18px 45px rgba(15, 23, 42, 0.12);
 }
 
+.account-dashboard--minorista .account-hero {
+  background: linear-gradient(135deg, #7c3aed 0%, #2563eb 45%, #0ea5e9 100%);
+}
+
+.account-dashboard--minorista .hero-stat {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.account-dashboard--minorista .button.outline {
+  border-color: rgba(255, 255, 255, 0.85);
+}
+
+.insight-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.insight-card {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.08), rgba(14, 165, 233, 0.05));
+  border: 1px solid rgba(14, 165, 233, 0.2);
+  border-radius: 18px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.insight-label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #4b5563;
+  margin: 0;
+}
+
+.insight-value {
+  margin: 0;
+  font-size: clamp(1.4rem, 2vw, 1.75rem);
+  font-weight: 700;
+  color: #111827;
+}
+
+.insight-meta {
+  margin: 0;
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.progress-track {
+  margin-top: 1.75rem;
+  background: rgba(15, 118, 110, 0.06);
+  border: 1px solid rgba(16, 185, 129, 0.18);
+  border-radius: 16px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.progress-track__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.progress-track__header h4 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #0f172a;
+}
+
+.progress-track__bar {
+  position: relative;
+  width: 100%;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(14, 116, 144, 0.15);
+  overflow: hidden;
+}
+
+.progress-track__fill {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, #0ea5e9 0%, #10b981 100%);
+  border-radius: inherit;
+  width: 0;
+  transition: width 0.4s ease;
+}
+
+.account-card .benefits-list {
+  gap: 1rem;
+}
+
+.account-card .benefits-list li {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  background: rgba(14, 165, 233, 0.08);
+  border-color: rgba(14, 165, 233, 0.25);
+}
+
+.benefit-icon {
+  font-size: 1.5rem;
+  display: inline-flex;
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  align-items: center;
+  justify-content: center;
+  background: rgba(37, 99, 235, 0.12);
+}
+
+.support-actions--stacked {
+  display: grid;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
 .account-panels {
   display: grid;
   gap: 1.5rem;


### PR DESCRIPTION
## Summary
- add a dedicated Mi cuenta minorista page with tailored hero, actions, purchase summary, benefits and support blocks
- implement the client-side dashboard logic to hydrate the new view, reuse order utilities, and wire quick actions for retail users
- adjust navigation, footer, and styling so minorista roles land on the correct panel while mayoristas keep their experience

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da8a09e63c8331be411051156b80be