### PR TITLE
Integrate customer profiles across account flows

### DIFF
--- a/nerin_final_updated/frontend/account.html
+++ b/nerin_final_updated/frontend/account.html
@@ -422,8 +422,30 @@
             <input type="text" id="pPhone" />
           </div>
           <div class="form-row">
-            <label for="pAddress">Dirección de facturación</label>
-            <input type="text" id="pAddress" />
+            <label for="pStreet">Calle</label>
+            <input type="text" id="pStreet" />
+          </div>
+          <div class="form-row form-row--split">
+            <div class="field">
+              <label for="pNumber">Número</label>
+              <input type="text" id="pNumber" />
+            </div>
+            <div class="field">
+              <label for="pFloor">Piso / Depto</label>
+              <input type="text" id="pFloor" />
+            </div>
+          </div>
+          <div class="form-row">
+            <label for="pCity">Localidad</label>
+            <input type="text" id="pCity" />
+          </div>
+          <div class="form-row">
+            <label for="pProvince">Provincia</label>
+            <input type="text" id="pProvince" />
+          </div>
+          <div class="form-row">
+            <label for="pZip">Código postal</label>
+            <input type="text" id="pZip" />
           </div>
           <div class="form-row">
             <label for="pPassword">Contraseña</label>

--- a/nerin_final_updated/frontend/register.html
+++ b/nerin_final_updated/frontend/register.html
@@ -123,6 +123,75 @@
                   <option value="mayorista">Mayorista</option>
                 </select>
               </div>
+              <div class="form-field">
+                <label for="regPhone">Teléfono de contacto</label>
+                <input
+                  type="tel"
+                  id="regPhone"
+                  name="phone"
+                  autocomplete="tel"
+                  placeholder="Ej: +54 11 5555-0000"
+                />
+              </div>
+              <div class="form-field">
+                <label for="regProvince">Provincia</label>
+                <input
+                  type="text"
+                  id="regProvince"
+                  name="province"
+                  autocomplete="address-level1"
+                  placeholder="Buenos Aires"
+                />
+              </div>
+              <div class="form-field">
+                <label for="regCity">Localidad</label>
+                <input
+                  type="text"
+                  id="regCity"
+                  name="city"
+                  autocomplete="address-level2"
+                  placeholder="Ej: Mar del Plata"
+                />
+              </div>
+              <div class="form-field">
+                <label for="regStreet">Calle</label>
+                <input
+                  type="text"
+                  id="regStreet"
+                  name="street"
+                  autocomplete="address-line1"
+                  placeholder="Av. Siempreviva"
+                />
+              </div>
+              <div class="form-field">
+                <label for="regNumber">Número</label>
+                <input
+                  type="text"
+                  id="regNumber"
+                  name="number"
+                  autocomplete="address-line2"
+                  placeholder="742"
+                />
+              </div>
+              <div class="form-field">
+                <label for="regFloor">Piso / Depto</label>
+                <input
+                  type="text"
+                  id="regFloor"
+                  name="floor"
+                  placeholder="Opcional"
+                />
+              </div>
+              <div class="form-field">
+                <label for="regZip">Código postal</label>
+                <input
+                  type="text"
+                  id="regZip"
+                  name="zip"
+                  autocomplete="postal-code"
+                  placeholder="Ej: 1414"
+                />
+              </div>
             </div>
             <div
               id="regError"

--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -3427,6 +3427,18 @@ footer .legal {
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
+.profile-form .form-row--split {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+}
+
+.profile-form .form-row--split .field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
 .profile-form .form-row label {
   font-weight: 600;
   color: #374151;


### PR DESCRIPTION
## Summary
- normalize stored client records and expose profile data through the authentication, orders, and client APIs
- update the wholesale and retail dashboards to hydrate, edit, and persist structured profile information in local storage
- expand registration and account forms with address/contact fields and styling to collect profile data up front

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd06d5a9f08331b5d3e174aff3ba8c