### PR TITLE
Actualizar costos de envío y datos de checkout

### DIFF
--- a/nerin_final_updated/data/shipping.json
+++ b/nerin_final_updated/data/shipping.json
@@ -1,9 +1,29 @@
 {
+  "methods": [
+    { "id": "retiro", "label": "Retiro en local" },
+    { "id": "estandar", "label": "Envío estándar" },
+    { "id": "express", "label": "Envío express" }
+  ],
   "costos": [
-    {"provincia": "CABA", "costo": 1500},
-    {"provincia": "Buenos Aires", "costo": 2000},
-    {"provincia": "Córdoba", "costo": 2500},
-    {"provincia": "Santa Fe", "costo": 2200},
-    {"provincia": "Otras", "costo": 3000}
+    {
+      "provincia": "CABA",
+      "metodos": { "retiro": 0, "estandar": 1500, "express": 2500 }
+    },
+    {
+      "provincia": "Buenos Aires",
+      "metodos": { "retiro": 0, "estandar": 2000, "express": 3200 }
+    },
+    {
+      "provincia": "Córdoba",
+      "metodos": { "retiro": 0, "estandar": 2500, "express": 3800 }
+    },
+    {
+      "provincia": "Santa Fe",
+      "metodos": { "retiro": 0, "estandar": 2200, "express": 3400 }
+    },
+    {
+      "provincia": "Otras",
+      "metodos": { "retiro": 0, "estandar": 3000, "express": 4500 }
+    }
   ]
 }

--- a/nerin_final_updated/frontend/admin.html
+++ b/nerin_final_updated/frontend/admin.html
@@ -700,7 +700,9 @@
             <thead>
               <tr>
                 <th>Provincia</th>
-                <th>Costo ($)</th>
+                <th data-method="retiro">Retiro en local ($)</th>
+                <th data-method="estandar">Envío estándar ($)</th>
+                <th data-method="express">Envío express ($)</th>
               </tr>
             </thead>
             <tbody></tbody>


### PR DESCRIPTION
## Resumen
- normalizar la tabla de envíos para soportar varios métodos y exponerlos vía API
- ajustar el checkout y la creación de preferencias de Mercado Pago para cobrar el envío y mostrar el método elegido
- mejorar el panel de administración mostrando el piso en direcciones y permitiendo editar costos por método

## Pruebas
- npm test -- --runTestsByPath backend/__tests__/orders-admin.test.js

------
https://chatgpt.com/codex/tasks/task_e_68de9421b8488331acb7fa25125ede35