### PR TITLE
Simplify admin product description while keeping auto SEO

### DIFF
--- a/nerin_final_updated/frontend/admin.html
+++ b/nerin_final_updated/frontend/admin.html
@@ -220,6 +220,62 @@
       </div>
       <section id="productsSection" class="admin-section">
         <h3>Gestión de productos</h3>
+        <div class="product-toolbar">
+          <div class="product-summary" id="productsSummary">
+            <div class="product-summary__badge">0</div>
+            <div class="product-summary__details">
+              <p class="product-summary__title">Sin datos disponibles</p>
+              <p class="product-summary__meta">Sin filtros activos</p>
+              <div class="product-summary__indicators">
+                <span>Actualizá para ver estadísticas.</span>
+              </div>
+            </div>
+          </div>
+          <div class="product-filters" aria-label="Filtros de productos">
+            <label class="filter-field">
+              <span>Búsqueda</span>
+              <input
+                type="search"
+                id="productSearch"
+                placeholder="SKU, nombre, modelo o tag"
+                autocomplete="off"
+              />
+            </label>
+            <label class="filter-field">
+              <span>Categoría</span>
+              <select id="productFilterCategory">
+                <option value="">Todas</option>
+              </select>
+            </label>
+            <label class="filter-field">
+              <span>Visibilidad</span>
+              <select id="productFilterVisibility">
+                <option value="">Todas</option>
+                <option value="public">Público</option>
+                <option value="private">Privado</option>
+                <option value="draft">Borrador</option>
+              </select>
+            </label>
+            <label class="filter-field">
+              <span>Stock</span>
+              <select id="productFilterStock">
+                <option value="">Todos</option>
+                <option value="low">Stock bajo</option>
+                <option value="out">Sin stock</option>
+              </select>
+            </label>
+            <label class="filter-field">
+              <span>Ordenar por</span>
+              <select id="productSort">
+                <option value="recent">Actualizado recientemente</option>
+                <option value="name">Nombre (A→Z)</option>
+                <option value="stock">Stock (mayor a menor)</option>
+                <option value="price_desc">Precio (min. ↓)</option>
+                <option value="price_asc">Precio (min. ↑)</option>
+              </select>
+            </label>
+          </div>
+        </div>
         <div class="table-wrapper">
           <table class="admin-table" id="productsTable">
             <thead>
@@ -278,16 +334,44 @@
             <input type="text" id="productName" name="name" placeholder="Nombre" required />
             <input type="text" id="productBrand" name="brand" placeholder="Marca" />
             <input type="text" id="productModel" name="model" placeholder="Modelo" />
-            <select id="productCategory" name="category"></select>
-            <select id="productSubcategory" name="subcategory"></select>
-            <div class="tags-field">
-              <input
-                type="text"
-                id="productTags"
-                name="tags"
-                placeholder="Tags (coma separados)"
-              />
-              <div id="tagsPreview" class="tags-preview"></div>
+            <input
+              type="text"
+              id="productCategory"
+              name="category"
+              placeholder="Categoría"
+              list="productCategoryOptions"
+            />
+            <datalist id="productCategoryOptions"></datalist>
+            <input
+              type="text"
+              id="productSubcategory"
+              name="subcategory"
+              placeholder="Subcategoría"
+              list="productSubcategoryOptions"
+            />
+            <datalist id="productSubcategoryOptions"></datalist>
+            <div class="form-section form-grid-span form-section--tags" id="tagsAssistSection">
+              <div class="form-section__header">
+                <h5>Palabras clave y etiquetas</h5>
+                <label class="assist-toggle">
+                  <input type="checkbox" id="autoTagsToggle" checked />
+                  <span>Generar automáticamente</span>
+                </label>
+              </div>
+              <p class="form-hint" id="autoTagsStatus">
+                Usamos marca, modelo y categoría para crear tags relevantes sin
+                que tengas que escribirlos.
+              </p>
+              <div id="autoTagSuggestions" class="assist-preview assist-preview--chips"></div>
+              <div class="tags-field">
+                <input
+                  type="text"
+                  id="productTags"
+                  name="tags"
+                  placeholder="Tags (coma separados)"
+                />
+                <div id="tagsPreview" class="tags-preview"></div>
+              </div>
             </div>
             <input
               type="number"
@@ -328,30 +412,79 @@
               step="0.01"
             />
             <select id="productSupplier" name="supplier_id"></select>
-            <input
-              type="text"
-              id="productSlug"
-              name="slug"
-              placeholder="Slug"
-            />
-            <textarea
-              id="productDescription"
-              name="description"
-              placeholder="Descripción del producto"
-              rows="3"
-            ></textarea>
-            <input
-              type="text"
-              id="productMetaTitle"
-              name="meta_title"
-              placeholder="Meta título"
-            />
-            <textarea
-              id="productMetaDesc"
-              name="meta_description"
-              placeholder="Meta descripción"
-              rows="2"
-            ></textarea>
+            <div class="form-section form-grid-span form-section--description" id="descriptionAssistSection">
+              <div class="form-section__header">
+                <h5>Descripción para la tienda</h5>
+              </div>
+              <p class="form-hint" id="descriptionAssistStatus">
+                Escribí una descripción clara y simple con la información clave
+                para tus clientes. Nosotros usamos el resto de los datos para
+                potenciar el SEO automáticamente.
+              </p>
+              <textarea
+                id="productDescription"
+                name="description"
+                placeholder="Descripción del producto"
+                rows="4"
+              ></textarea>
+            </div>
+            <div class="form-section form-grid-span form-section--seo" id="seoAssistSection">
+              <div class="form-section__header">
+                <h5>SEO y visibilidad</h5>
+                <label class="assist-toggle">
+                  <input type="checkbox" id="autoSeoToggle" checked />
+                  <span>Optimizar automáticamente</span>
+                </label>
+              </div>
+              <p class="form-hint" id="seoAssistStatus">
+                Completá nombre, marca, modelo y categoría para generar título,
+                URL y meta descripción perfectos.
+              </p>
+              <div class="assist-grid">
+                <div class="assist-field">
+                  <label for="productSlug">URL pública</label>
+                  <input
+                    type="text"
+                    id="productSlug"
+                    name="slug"
+                    placeholder="mi-producto-estelar"
+                  />
+                  <p class="form-hint">
+                    La generamos con la información principal. Podés ajustarla
+                    si necesitás una URL personalizada.
+                  </p>
+                </div>
+                <div class="assist-preview" id="seoPreview" aria-live="polite">
+                  <p id="seoSlugPreview"></p>
+                  <h5 id="seoTitlePreview"></h5>
+                  <p id="seoDescPreview"></p>
+                </div>
+              </div>
+              <button
+                type="button"
+                class="button-link"
+                id="showSeoAdvancedBtn"
+                aria-expanded="false"
+              >
+                Editar meta título y descripción manualmente
+              </button>
+            </div>
+            <div id="seoAdvancedFields" class="seo-advanced form-grid-span is-collapsed">
+              <label for="productMetaTitle">Meta título (opcional)</label>
+              <input
+                type="text"
+                id="productMetaTitle"
+                name="meta_title"
+                placeholder="Meta título"
+              />
+              <label for="productMetaDesc">Meta descripción (opcional)</label>
+              <textarea
+                id="productMetaDesc"
+                name="meta_description"
+                placeholder="Meta descripción"
+                rows="3"
+              ></textarea>
+            </div>
             <input
               type="text"
               id="productDimensions"
@@ -379,10 +512,32 @@
               multiple
             />
             <div id="imagePreview" class="image-preview"></div>
-            <div class="seo-preview" id="seoPreview">
-              <p id="seoSlugPreview"></p>
-              <h5 id="seoTitlePreview"></h5>
-              <p id="seoDescPreview"></p>
+            <div class="product-preview" id="productPreview" aria-live="polite">
+              <div class="product-preview__media" id="productPreviewMedia">
+                <img
+                  id="productPreviewImage"
+                  alt="Vista previa del producto"
+                  loading="lazy"
+                />
+                <div class="product-preview__media-placeholder" id="productPreviewPlaceholder">
+                  Sin imagen
+                </div>
+              </div>
+              <div class="product-preview__content">
+                <p class="product-preview__sku" id="productPreviewSku">
+                  Completá el SKU para identificar el producto.
+                </p>
+                <h5 class="product-preview__name" id="productPreviewName">
+                  Nuevo producto sin título
+                </h5>
+                <p class="product-preview__price" id="productPreviewPrice">
+                  Definí los precios para ver cómo se mostrará.
+                </p>
+                <p class="product-preview__stock" id="productPreviewStock"></p>
+                <p class="product-preview__meta" id="productPreviewMeta">
+                  Indicá categoría, visibilidad y URL para completar la vista previa.
+                </p>
+              </div>
             </div>
             <div class="form-actions">
               <button type="submit" class="button primary" id="saveProductBtn">

--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -1499,6 +1499,9 @@ nav a:hover {
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
 }
+.admin-form input[list] {
+  padding-right: 2rem;
+}
 .admin-form input[type="file"] {
   padding: 0.2rem;
 }
@@ -1546,6 +1549,121 @@ nav a:hover {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+}
+
+.admin-form .product-preview {
+  display: grid;
+  grid-template-columns: minmax(96px, 140px) 1fr;
+  gap: 1rem;
+  margin-top: 1rem;
+  padding: 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  background: var(--color-surface, #fff);
+  box-shadow: 0 4px 16px rgba(15, 23, 42, 0.08);
+}
+
+.form-grid #productPreview {
+  grid-column: 1 / -1;
+}
+
+.product-preview__media {
+  position: relative;
+  border-radius: calc(var(--radius) * 0.75);
+  overflow: hidden;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.1), rgba(37, 99, 235, 0));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 120px;
+}
+
+.product-preview__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: none;
+}
+
+.product-preview__media--has-image img {
+  display: block;
+}
+
+.product-preview__media--has-image .product-preview__media-placeholder {
+  display: none;
+}
+
+.product-preview__media-placeholder {
+  font-size: 0.85rem;
+  color: var(--color-text-muted, #6b7280);
+  text-align: center;
+  padding: 0.5rem;
+}
+
+.product-preview__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.product-preview__sku {
+  font-size: 0.85rem;
+  color: var(--color-text-muted, #6b7280);
+  margin: 0;
+}
+
+.product-preview__name {
+  font-size: 1.05rem;
+  margin: 0;
+}
+
+.product-preview__price {
+  font-weight: 600;
+  margin: 0;
+}
+
+.product-preview__stock {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.product-preview__stock.is-warning {
+  color: #b45309;
+}
+
+.product-preview__stock.is-danger {
+  color: #b91c1c;
+}
+
+.product-preview__meta {
+  font-size: 0.85rem;
+  color: var(--color-text-muted, #6b7280);
+  margin: 0;
+}
+
+.admin-table tr.is-highlighted {
+  animation: rowHighlight 2.4s ease;
+}
+
+@keyframes rowHighlight {
+  0% {
+    box-shadow: inset 0 0 0 0 rgba(37, 99, 235, 0.45);
+    background: rgba(37, 99, 235, 0.18);
+  }
+  60% {
+    box-shadow: inset 0 0 0 2px rgba(37, 99, 235, 0.35);
+    background: rgba(37, 99, 235, 0.08);
+  }
+  100% {
+    box-shadow: inset 0 0 0 0 rgba(37, 99, 235, 0);
+    background: transparent;
+  }
+}
+
+@media (max-width: 768px) {
+  .admin-form .product-preview {
+    grid-template-columns: 1fr;
+  }
 }
 
 .admin-form .image-item {
@@ -1819,6 +1937,123 @@ nav a:hover {
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 0.75rem;
 }
+.form-grid-span {
+  grid-column: 1 / -1;
+}
+.form-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  padding: 1rem 1.1rem;
+  border: 1px solid var(--color-border);
+  border-radius: calc(var(--radius) * 1.1);
+  background: var(--color-surface, #fff);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+}
+.form-section__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+.form-hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-text-muted, #6b7280);
+}
+.assist-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.assist-toggle input {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+.assist-grid {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) minmax(240px, 1.3fr);
+  gap: 0.75rem;
+  align-items: stretch;
+}
+.assist-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+.assist-field label {
+  font-weight: 600;
+}
+.assist-preview {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: 0.75rem;
+  background: var(--color-surface, #f8fafc);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+}
+.assist-preview--chips {
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  min-height: 2.25rem;
+  border-style: dashed;
+}
+.assist-preview--chips:empty::after {
+  content: "Completá la información principal para ver las sugerencias.";
+  color: var(--color-text-muted, #6b7280);
+  font-size: 0.85rem;
+}
+.assist-preview--chips .form-hint {
+  margin: 0;
+  font-size: 0.85rem;
+}
+.chip--ghost,
+.assist-preview--chips .chip {
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--color-primary, #2563eb);
+}
+.button-link {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--color-primary, #2563eb);
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+  align-self: flex-start;
+}
+.button-link:hover {
+  color: #1d4ed8;
+}
+.seo-advanced {
+  display: grid;
+  gap: 0.5rem;
+  padding: 0.85rem 1rem;
+  border: 1px dashed var(--color-border);
+  border-radius: calc(var(--radius) * 1.1);
+  background: rgba(15, 23, 42, 0.02);
+}
+.seo-advanced.is-collapsed {
+  display: none;
+}
+.seo-advanced label {
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+.admin-form textarea,
+.admin-form select {
+  padding: 0.45rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  font-family: inherit;
+}
 .form-actions {
   display: flex;
   flex-wrap: wrap;
@@ -1837,6 +2072,118 @@ nav a:hover {
   gap: 1rem;
   margin: 1rem 0;
 }
+.product-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin: 1rem 0 1.5rem;
+}
+.product-summary {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--color-border);
+  border-radius: calc(var(--radius) * 1.25);
+  background: var(--color-surface, #fff);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
+}
+.product-summary__badge {
+  width: 3.25rem;
+  height: 3.25rem;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  background: var(--color-primary, #2563eb);
+  color: #fff;
+  font-weight: 700;
+  font-size: 1.15rem;
+}
+.product-summary__details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+.product-summary__title {
+  margin: 0;
+  font-weight: 600;
+}
+.product-summary__meta {
+  font-size: 0.9rem;
+  color: var(--color-text-muted, #6b7280);
+}
+.product-summary__indicators {
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  color: var(--color-text-muted, #6b7280);
+}
+.product-summary__indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.15rem 0.4rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--color-primary, #2563eb);
+  font-weight: 500;
+}
+.product-summary__indicator--low {
+  background: rgba(180, 83, 9, 0.12);
+  color: #b45309;
+}
+.product-summary__indicator--out {
+  background: rgba(185, 28, 28, 0.12);
+  color: #b91c1c;
+}
+.product-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: flex-end;
+}
+.product-filters .filter-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  min-width: 170px;
+}
+.product-filters input,
+.product-filters select {
+  min-height: 2.5rem;
+}
+.product-filters input[type="search"] {
+  min-width: 220px;
+}
+@media (min-width: 1024px) {
+  .product-toolbar {
+    flex-direction: row;
+    align-items: stretch;
+  }
+  .product-summary {
+    flex: 0 0 280px;
+  }
+  .product-filters {
+    flex: 1 1 auto;
+    justify-content: flex-end;
+  }
+}
+@media (max-width: 640px) {
+  .product-summary {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .product-summary__badge {
+    width: 2.75rem;
+    height: 2.75rem;
+    font-size: 1rem;
+  }
+  .product-filters .filter-field {
+    min-width: min(100%, 220px);
+  }
+}
 .badge {
   background: var(--color-danger);
   color: #fff;
@@ -1854,18 +2201,33 @@ nav a:hover {
   font-size: 0.8rem;
 }
 .tags-field {
-  grid-column: span 2;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
 }
 .tags-preview {
-  margin-top: 0.25rem;
+  margin-top: 0.35rem;
 }
 .seo-preview {
-  grid-column: span 2;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius);
-  padding: 0.5rem;
-  background: var(--color-muted);
-  font-size: 0.85rem;
+  font-size: 0.9rem;
+}
+.seo-preview p {
+  margin: 0;
+  color: var(--color-text-muted, #6b7280);
+}
+.seo-preview h5 {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--color-primary, #2563eb);
+}
+
+@media (max-width: 768px) {
+  .form-section {
+    padding: 0.9rem;
+  }
+  .assist-grid {
+    grid-template-columns: 1fr;
+  }
 }
 .invoice-status.pending {
   color: #f59e0b;


### PR DESCRIPTION
## Summary
- streamline the product modal by removing the guided assist banner and clarifying the manual description instructions
- keep automatic slug/meta/tag generation but stop overwriting the description so merchants can write simple copy themselves
- drop the unused auto-description helper and related styles after simplifying the flow

## Testing
- Not run (front-end change only)

------
https://chatgpt.com/codex/tasks/task_e_68dfb2a839c4833192a4fff3ebee825c