### PR TITLE
Fix desktop product header layout

### DIFF
--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -2800,6 +2800,10 @@ footer .legal {
   box-shadow: 0 28px 48px rgba(15, 23, 42, 0.35);
   color: #f8fafc;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: clamp(0.85rem, 1vw, 1.2rem);
 }
 
 .product-page .product-summary::after {
@@ -2821,10 +2825,13 @@ footer .legal {
 }
 
 .product-page .product-summary h1 {
-  margin: 0 0 0.75rem;
-  font-size: clamp(1.65rem, 1.4vw + 1.4rem, 2.35rem);
+  margin: 0;
+  width: 100%;
+  font-size: clamp(1.7rem, 1.1vw + 1.4rem, 2.3rem);
+  line-height: 1.1;
   font-weight: 700;
   letter-spacing: -0.015em;
+  text-wrap: balance;
 }
 
 .product-page .product-meta {


### PR DESCRIPTION
## Summary
- ensure the product summary card uses a column layout so desktop headings can take the full width
- tweak heading sizing and wrapping to keep long product names readable on larger screens

## Testing
- Manual verification in Chromium at 1365px width

------
https://chatgpt.com/codex/tasks/task_e_68e19f95808c8331bdb91488f7cd8e0d