### PR TITLE
Refine admin calculator styling and layout

### DIFF
--- a/nerin_final_updated/frontend/admin.html
+++ b/nerin_final_updated/frontend/admin.html
@@ -131,6 +131,51 @@
         font-weight: 600;
         text-transform: uppercase;
       }
+      .calculator-wrapper {
+        margin-top: 1.5rem;
+        padding: 1.5rem;
+        background: var(--color-surface, #fff);
+        border: 1px solid var(--color-border);
+        border-radius: calc(var(--radius, 8px) * 2);
+        box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+      }
+      .calculator-header h2 {
+        margin: 0 0 0.75rem;
+        font-size: 1.5rem;
+      }
+      .calculator-header p {
+        margin: 0 0 0.75rem;
+        color: var(--color-text-muted, #555);
+        line-height: 1.6;
+      }
+      .calculator-header a {
+        color: var(--color-primary, #2563eb);
+        font-weight: 600;
+        text-decoration: none;
+      }
+      .calculator-header a:hover {
+        text-decoration: underline;
+      }
+      .calculator-frame {
+        margin: 1.5rem 0;
+        border-radius: calc(var(--radius, 8px) * 1.75);
+        overflow: hidden;
+        border: 1px solid var(--color-border);
+        background: #fff;
+        min-height: 720px;
+      }
+      .calculator-frame iframe {
+        width: 100%;
+        min-height: 720px;
+        border: none;
+        background: #fff;
+        display: block;
+      }
+      .calculator-note {
+        margin-top: 0;
+        color: var(--color-text-muted, #555);
+        font-style: italic;
+      }
       @media (max-width: 768px) {
         .orders-filters {
           flex-direction: column;
@@ -138,6 +183,9 @@
         }
         .orders-pagination {
           justify-content: center;
+        }
+        .calculator-frame iframe {
+          min-height: 600px;
         }
       }
     </style>
@@ -197,6 +245,9 @@
         </button>
         <button data-target="metricsSection" data-i18n="nav.metrics">
           Métricas
+        </button>
+        <button data-target="calculatorSection" data-i18n="nav.calculator">
+          Calculadora
         </button>
         <button data-target="returnsSection" data-i18n="nav.returns">
           Devoluciones
@@ -723,6 +774,56 @@
         <h3>Métricas</h3>
         <div id="metricsContent"></div>
         <canvas id="salesChartCanvas" height="200"></canvas>
+      </section>
+
+      <section
+        id="calculatorSection"
+        class="admin-section"
+        style="display: none"
+      >
+        <div class="calculator-wrapper">
+          <header class="calculator-header">
+            <h2 data-i18n="calculator.title">
+              Calculadora profesional de costos
+            </h2>
+            <p data-i18n="calculator.description">
+              Esta vista integra la herramienta completa solicitada para calcular el costo
+              puesto, márgenes objetivo y precio final con IVA. Podés cargar costos en USD
+              o ARS, aplicar tributos parametrizables, simular comisiones o usar un fee real
+              notificado por el gateway de pago. El contenido se muestra dentro del admin
+              para evitar saltar entre pantallas.
+            </p>
+            <p>
+              <span data-i18n="calculator.linkPrompt">
+                Si preferís abrirla en otra pestaña, usá este acceso directo:
+              </span>
+              <a
+                href="../import_calc_frontend/index.html"
+                target="_blank"
+                rel="noopener noreferrer"
+                data-i18n="calculator.linkText"
+              >
+                Abrir calculadora completa
+              </a>
+            </p>
+          </header>
+          <div class="calculator-frame">
+            <iframe
+              src="../import_calc_frontend/index.html"
+              title="Calculadora de costos de importación"
+              loading="lazy"
+              referrerpolicy="no-referrer"
+            ></iframe>
+          </div>
+          <p
+            class="status-text calculator-note"
+            data-i18n="calculator.note"
+          >
+            Nota: si el iframe no carga (por políticas del servidor estático), utilizá el
+            enlace “Abrir calculadora completa” para acceder a la herramienta en una ventana
+            nueva.
+          </p>
+        </div>
       </section>
 
       <!-- Sección de devoluciones -->

--- a/nerin_final_updated/frontend/js/lang.js
+++ b/nerin_final_updated/frontend/js/lang.js
@@ -14,12 +14,21 @@ const translations = {
     "nav.orders": "Pedidos",
     "nav.clients": "Clientes",
     "nav.metrics": "Métricas",
+    "nav.calculator": "Calculadora",
     "nav.returns": "Devoluciones",
     "nav.config": "Configuración",
     "nav.shipping": "Envíos",
     "nav.suppliers": "Proveedores",
     "nav.purchase": "Órdenes de compra",
     "nav.analytics": "Analíticas",
+    "calculator.title": "Calculadora profesional de costos",
+    "calculator.description":
+      "Esta vista integra la herramienta completa solicitada para calcular el costo puesto, márgenes objetivo y precio final con IVA. Podés cargar costos en USD o ARS, aplicar tributos parametrizables, simular comisiones o usar un fee real notificado por el gateway de pago. El contenido se muestra dentro del admin para evitar saltar entre pantallas.",
+    "calculator.linkPrompt":
+      "Si preferís abrirla en otra pestaña, usá este acceso directo:",
+    "calculator.linkText": "Abrir calculadora completa",
+    "calculator.note":
+      "Nota: si el iframe no carga (por políticas del servidor estático), utilizá el enlace “Abrir calculadora completa” para acceder a la herramienta en una ventana nueva.",
     "products.title": "Gestión de productos",
     "orders.title": "Gestión de pedidos",
     "clients.title": "Clientes",
@@ -41,12 +50,21 @@ const translations = {
     "nav.orders": "Orders",
     "nav.clients": "Clients",
     "nav.metrics": "Metrics",
+    "nav.calculator": "Calculator",
     "nav.returns": "Returns",
     "nav.config": "Settings",
     "nav.shipping": "Shipping",
     "nav.suppliers": "Suppliers",
     "nav.purchase": "Purchase Orders",
     "nav.analytics": "Analytics",
+    "calculator.title": "Professional cost calculator",
+    "calculator.description":
+      "This view integrates the complete tool requested to calculate landed cost, target margins, and final price with VAT. You can enter costs in USD or ARS, apply configurable duties, simulate commissions, or use an actual fee reported by the payment gateway. The content is displayed inside the admin to avoid switching screens.",
+    "calculator.linkPrompt":
+      "If you prefer to open it in another tab, use this shortcut:",
+    "calculator.linkText": "Open full calculator",
+    "calculator.note":
+      "Note: if the iframe does not load (due to static server policies), use the “Open full calculator” link to access the tool in a new window.",
     "products.title": "Product Management",
     "orders.title": "Order Management",
     "clients.title": "Clients",


### PR DESCRIPTION
## Summary
- align the calculator wrapper styles with the existing admin look by matching heading levels, spacing, and iframe sizing
- update the embedded calculator section markup to mirror the original copy structure and reuse the status text styling for the note

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4feaeed988331ac9aff0767414ea0