### PR TITLE
Serve calculator static assets in admin

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -199,6 +199,18 @@ for (const dir of assetRoots) {
   }
 }
 
+const calculatorStaticDir = path.join(
+  __dirname,
+  '../nerin_final_updated/import_calc_frontend'
+);
+
+if (fs.existsSync(calculatorStaticDir)) {
+  app.use(
+    '/nerin_final_updated/import_calc_frontend',
+    express.static(calculatorStaticDir)
+  );
+}
+
 app.use(express.static(path.join(__dirname, '../frontend')));
 
 app.get('*', (_req, res) => {


### PR DESCRIPTION
## Summary
- serve the calculator frontend directory through Express so the admin iframe can load it

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5705aa15c8331b2b69153578ade44