### PR TITLE
Fix duplicate count text in catalog results summary

### DIFF
--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -1281,7 +1281,7 @@ function renderShopListing(products, siteBase) {
     : [];
   const cards = valid.slice(0, 30).map((p) => buildShopCard(p, siteBase)).join("");
   const count = valid.length;
-  const summary = count === 1 ? "1 producto disponible." : `${count} productos listados.`;
+  const summary = count === 1 ? "producto disponible." : "productos listados.";
   return { cards, count, summary };
 }
 


### PR DESCRIPTION
### Motivation
- Prevent the count number from being duplicated in the shop catalog summary when the backend renders a sentence and the frontend also injects the dynamic `<span id="resultCount">` value, which produced outputs like "8 8 productos listados.".

### Description
- Update `renderShopListing` in `nerin_final_updated/backend/server.js` to remove the interpolated numeric count from the plural summary (changed from ```${count} productos listados.``` to `productos listados.`) while preserving the singular message `producto disponible.`.

### Testing
- Ran `node --check nerin_final_updated/backend/server.js` which completed successfully.
- Started the app with `npm start` in `nerin_final_updated` and confirmed the server booted at `http://localhost:3000`.
- Attempted a Playwright screenshot to validate the rendered page but Chromium crashed in this environment (SIGSEGV), so browser verification failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699af44ff6008331817e10fe7e0d017c)