### PR TITLE
Prevent cart preview on mobile and clarify auth CTA labels

### DIFF
--- a/nerin_final_updated/frontend/js/config.js
+++ b/nerin_final_updated/frontend/js/config.js
@@ -541,6 +541,9 @@ function attachCartPreview(a) {
   a.appendChild(preview);
 
   const openPreview = () => {
+    if (window.matchMedia("(max-width: 900px), (hover: none)").matches) {
+      return;
+    }
     if (cartPreviewHideTimer) {
       clearTimeout(cartPreviewHideTimer);
       cartPreviewHideTimer = null;
@@ -578,12 +581,13 @@ function attachCartPreview(a) {
   a.addEventListener("mouseleave", closePreview);
   a.addEventListener("blur", closePreview);
   a.addEventListener("click", (event) => {
-    if (window.matchMedia("(hover: none)").matches) {
-      const willOpen = !preview.classList.contains("is-visible");
-      if (willOpen) {
-        event.preventDefault();
-        openPreview();
-      }
+    if (window.matchMedia("(max-width: 900px), (hover: none)").matches) {
+      return;
+    }
+    const willOpen = !preview.classList.contains("is-visible");
+    if (willOpen) {
+      event.preventDefault();
+      openPreview();
     }
   });
 
@@ -690,7 +694,7 @@ function updateNav() {
           a.setAttribute("href", "/account.html");
         }
       } else {
-        a.textContent = "Acceder";
+        a.textContent = "Ingresar";
         a.setAttribute("href", "/login.html");
       }
     }
@@ -735,7 +739,7 @@ function updateNav() {
       signupLi.className = "signup-item";
       const signupLink = document.createElement("a");
       signupLink.href = "/register.html";
-      signupLink.textContent = "Registrarse";
+      signupLink.textContent = "Crear cuenta";
       signupLi.appendChild(signupLink);
       navUl.appendChild(signupLi);
     }


### PR DESCRIPTION
### Motivation
- The cart preview popup was blocking access on mobile/touch devices because it opened as an overlay and was poorly positioned, preventing users from entering the cart page. 
- Unauthenticated navigation labels were ambiguous and needed clearer CTAs for first-time or returning users.

### Description
- Updated `nerin_final_updated/frontend/js/config.js` to skip opening the cart preview when `window.matchMedia("(max-width: 900px), (hover: none)").matches` so the preview does not appear on mobile/touch contexts. 
- Modified the cart link click handler to return early on mobile/touch so taps navigate directly to `/cart.html` instead of triggering the preview. 
- Changed unauthenticated nav labels from "Acceder" to "Ingresar" and from "Registrarse" to "Crear cuenta" to improve clarity.

### Testing
- Ran a JavaScript syntax check with `node --check nerin_final_updated/frontend/js/config.js` which passed. 
- Served the frontend with `python3 -m http.server 4173` and executed a Playwright script in a mobile viewport (390x844) that opened the menu and clicked `a[href="/cart.html]`, confirming navigation reached `cart.html` and saving a screenshot. 
- All automated checks and the Playwright validation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b86e1bb3c8331b57e5be0a6249aa8)