### PR TITLE
Add supplier pricing engine with tests and add fulfillment UX/normalization on frontend

### DIFF
--- a/nerin_final_updated/__tests__/backend/supplier-pricing.test.js
+++ b/nerin_final_updated/__tests__/backend/supplier-pricing.test.js
@@ -1,0 +1,75 @@
+const {
+  normalizeProductRow,
+  calculateProductPricing,
+  buildPricingAudit,
+} = require('../../backend/services/supplierPricing');
+
+describe('supplierPricing conservative configurable module', () => {
+  test('producto EUR normal calcula precio final y breakdown', () => {
+    const product = normalizeProductRow({
+      Nombre: 'Pantalla iPhone',
+      UnitPrice: '10',
+      Stock: 5,
+      Image: 'https://cdn/img.jpg',
+      Categoria: 'Pantallas',
+    });
+
+    const result = calculateProductPricing(product);
+    expect(result.ok).toBe(true);
+    expect(result.price_final_sugerido).toBeGreaterThan(1000);
+    expect(result.breakdown.supplier_currency).toBe('EUR');
+    expect(result.breakdown.final_price_ars_rounded % 100).toBe(0);
+  });
+
+  test('producto con costo bajo respeta precio mínimo y redondeo', () => {
+    const product = normalizeProductRow({ UnitPrice: 0.01, Stock: 1, Image: 'x' });
+    const result = calculateProductPricing(product);
+    expect(result.ok).toBe(true);
+    expect(result.price_final_sugerido).toBeGreaterThanOrEqual(1000);
+    expect(result.price_final_sugerido % 100).toBe(0);
+  });
+
+  test('producto con costo alto calcula mayor precio final', () => {
+    const low = calculateProductPricing(normalizeProductRow({ UnitPrice: 5, Stock: 1, Image: 'x' }));
+    const high = calculateProductPricing(normalizeProductRow({ UnitPrice: 100, Stock: 1, Image: 'x' }));
+    expect(high.price_final_sugerido).toBeGreaterThan(low.price_final_sugerido);
+  });
+
+  test('producto sin UnitPrice devuelve error', () => {
+    const product = normalizeProductRow({ Nombre: 'Sin precio', Stock: 4, Image: 'x' });
+    const result = calculateProductPricing(product);
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain('unit_price_missing');
+  });
+
+  test('cambio de margen impacta precio final', () => {
+    const product = normalizeProductRow({ UnitPrice: 10, Stock: 3, Image: 'x' });
+    const base = calculateProductPricing(product);
+    const lowerMargin = calculateProductPricing(product, { net_margin: 0.12 });
+    expect(lowerMargin.price_final_sugerido).toBeLessThan(base.price_final_sugerido);
+  });
+
+  test('cambio de envío ML impacta precio final', () => {
+    const product = normalizeProductRow({ UnitPrice: 10, Stock: 3, Image: 'x' });
+    const base = calculateProductPricing(product);
+    const moreShipping = calculateProductPricing(product, { ml_shipping_cost_ars: 15000 });
+    expect(moreShipping.price_final_sugerido).toBeGreaterThan(base.price_final_sugerido);
+  });
+
+  test('cambio de tipo de cambio impacta precio final', () => {
+    const product = normalizeProductRow({ UnitPrice: 10, Stock: 3, Image: 'x' });
+    const base = calculateProductPricing(product);
+    const higherFx = calculateProductPricing(product, { usd_ars: 1700 });
+    expect(higherFx.price_final_sugerido).toBeGreaterThan(base.price_final_sugerido);
+  });
+
+  test('buildPricingAudit devuelve estructura auditable', () => {
+    const product = normalizeProductRow({ Nombre: 'Modulo', UnitPrice: 10, Stock: 0, Image: '' });
+    const pricing = calculateProductPricing(product);
+    const audit = buildPricingAudit(product, pricing);
+    expect(audit.product.title).toBe('Modulo');
+    expect(audit.pricing).toBeDefined();
+    expect(audit.parameters_used).toBeDefined();
+    expect(typeof audit.calculated_at).toBe('string');
+  });
+});

--- a/nerin_final_updated/backend/config/supplierPricingDefaults.js
+++ b/nerin_final_updated/backend/config/supplierPricingDefaults.js
@@ -1,0 +1,24 @@
+const DEFAULT_SUPPLIER_PRICING_CONFIG = {
+  supplier_currency: 'EUR',
+  usd_ars: 1500,
+  eur_usd: 1.1489,
+  international_shipping_total_eur: 106.75,
+  minimum_order_usd: 1000,
+  die: 0,
+  tasa_estadistica: 0.03,
+  iva_importacion: 0.21,
+  percepcion_iva: 0.2,
+  percepcion_ganancias: 0.06,
+  ml_commission: 0.16,
+  iibb: 0.03,
+  net_margin: 0.15,
+  ml_shipping_cost_ars: 7720,
+  packaging_cost_ars: 0,
+  ads_cost_ars: 0,
+  minimum_final_price_ars: 1000,
+  rounding_mode: 'ceil_100',
+};
+
+module.exports = {
+  DEFAULT_SUPPLIER_PRICING_CONFIG,
+};

--- a/nerin_final_updated/backend/services/supplierPricing.js
+++ b/nerin_final_updated/backend/services/supplierPricing.js
@@ -1,0 +1,228 @@
+const Decimal = require('decimal.js');
+const { DEFAULT_SUPPLIER_PRICING_CONFIG } = require('../config/supplierPricingDefaults');
+
+const PRICE_KEYS = ['unitprice', 'price', 'precio', 'supplierprice', 'unit_price', 'costo', 'cost'];
+const TITLE_KEYS = ['name', 'nombre', 'title', 'titulo', 'description', 'descripcion', 'producto'];
+const CATEGORY_KEYS = ['category', 'categoria', 'rubro', 'type'];
+const BRAND_KEYS = ['brand', 'marca', 'compatibility', 'compatibilidad'];
+const STOCK_KEYS = ['stock', 'quantity', 'qty', 'cantidad', 'available_quantity'];
+const IMAGE_KEYS = ['image', 'image_url', 'imagen', 'images', 'picture', 'thumbnail', 'foto'];
+const SKU_KEYS = ['sku', 'codigo', 'code', 'id', 'itemid'];
+const EAN_KEYS = ['ean', 'gtin', 'barcode', 'upc'];
+
+function normalizeHeader(value) {
+  return String(value || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '');
+}
+
+function toNumber(value) {
+  if (value === null || value === undefined || value === '') return null;
+  const cleaned = String(value).replace(/\s+/g, '').replace(/\$/g, '').replace(/,/g, '.');
+  const num = Number(cleaned);
+  return Number.isFinite(num) ? num : null;
+}
+
+function getFirstByKeys(row, keys) {
+  if (!row || typeof row !== 'object') return undefined;
+  const entries = Object.entries(row);
+  for (const [key, value] of entries) {
+    const normalized = normalizeHeader(key);
+    if (keys.some((candidate) => normalized.includes(candidate))) {
+      if (value !== null && value !== undefined && String(value).trim() !== '') return value;
+    }
+  }
+  return undefined;
+}
+
+function normalizeSupplierPricingConfig(overrides = {}) {
+  return {
+    ...DEFAULT_SUPPLIER_PRICING_CONFIG,
+    ...(overrides || {}),
+  };
+}
+
+function normalizeProductRow(row, config = {}) {
+  const cfg = normalizeSupplierPricingConfig(config);
+  const warnings = [];
+  const supplierUnitPriceRaw = getFirstByKeys(row, PRICE_KEYS);
+  const stockRaw = getFirstByKeys(row, STOCK_KEYS);
+  const imageRaw = getFirstByKeys(row, IMAGE_KEYS);
+  const image = Array.isArray(imageRaw) ? imageRaw[0] : imageRaw;
+  const normalized = {
+    title: getFirstByKeys(row, TITLE_KEYS) || 'Producto sin título',
+    category: getFirstByKeys(row, CATEGORY_KEYS) || '',
+    brand_or_compatibility: getFirstByKeys(row, BRAND_KEYS) || '',
+    stock: toNumber(stockRaw),
+    image_url: image ? String(image).trim() : '',
+    supplier_currency: String(row?.supplier_currency || cfg.supplier_currency || 'EUR').toUpperCase(),
+    supplier_unit_price_original: toNumber(supplierUnitPriceRaw),
+    ean_gtin: getFirstByKeys(row, EAN_KEYS) || '',
+    sku: getFirstByKeys(row, SKU_KEYS) || '',
+    raw: row,
+  };
+
+  if (normalized.stock === null) warnings.push('stock_missing');
+  if (!normalized.image_url) warnings.push('image_missing');
+  if (normalized.supplier_unit_price_original === null) warnings.push('unit_price_missing');
+
+  return {
+    ...normalized,
+    warnings,
+  };
+}
+
+function roundFinalPrice(value, roundingMode) {
+  const decimal = new Decimal(value);
+  if (roundingMode === 'ceil_100') {
+    return decimal.div(100).ceil().mul(100);
+  }
+  return decimal.ceil();
+}
+
+function isPublishable(product) {
+  const stock = Number(product?.stock);
+  const hasImage = Boolean(String(product?.image_url || '').trim());
+  return Number.isFinite(stock) && stock > 0 && hasImage;
+}
+
+function calculateProductPricing(product, config = {}) {
+  const cfg = normalizeSupplierPricingConfig(config);
+  const errors = [];
+  const warnings = [...(Array.isArray(product?.warnings) ? product.warnings : [])];
+  const unitPrice = toNumber(product?.supplier_unit_price_original);
+
+  if (unitPrice === null) errors.push('unit_price_missing');
+  if (unitPrice !== null && unitPrice <= 0) errors.push('unit_price_non_positive');
+
+  if (errors.length) {
+    return {
+      ok: false,
+      errors,
+      warnings,
+      price_final_sugerido: null,
+      breakdown: null,
+      parameters_used: cfg,
+      publishable: false,
+    };
+  }
+
+  const currency = String(product?.supplier_currency || cfg.supplier_currency || 'EUR').toUpperCase();
+  let supplierCostUsd;
+  if (currency === 'EUR') {
+    supplierCostUsd = new Decimal(unitPrice).mul(cfg.eur_usd);
+  } else if (currency === 'USD') {
+    supplierCostUsd = new Decimal(unitPrice);
+  } else {
+    return {
+      ok: false,
+      errors: ['unsupported_supplier_currency'],
+      warnings,
+      price_final_sugerido: null,
+      breakdown: null,
+      parameters_used: cfg,
+      publishable: false,
+    };
+  }
+
+  const supplierCostArs = supplierCostUsd.mul(cfg.usd_ars);
+  const shippingTotalUsd = new Decimal(cfg.international_shipping_total_eur).mul(cfg.eur_usd);
+  const shippingTotalArs = shippingTotalUsd.mul(cfg.usd_ars);
+  const shareOfOrder = supplierCostUsd.div(cfg.minimum_order_usd);
+  const internationalShippingAllocatedArs = shippingTotalArs.mul(shareOfOrder);
+
+  const cifArs = supplierCostArs.add(internationalShippingAllocatedArs);
+  const baseImportArs = cifArs.mul(new Decimal(1).add(cfg.die).add(cfg.tasa_estadistica));
+  const ivaImportArs = baseImportArs.mul(cfg.iva_importacion);
+  const percepcionIvaArs = baseImportArs.mul(cfg.percepcion_iva);
+  const percepcionGananciasArs = baseImportArs.mul(cfg.percepcion_ganancias);
+
+  const totalLandedCostArs = baseImportArs
+    .add(ivaImportArs)
+    .add(percepcionIvaArs)
+    .add(percepcionGananciasArs)
+    .add(cfg.ml_shipping_cost_ars)
+    .add(cfg.packaging_cost_ars)
+    .add(cfg.ads_cost_ars);
+
+  const denominator = new Decimal(1).sub(cfg.ml_commission).sub(cfg.iibb).sub(cfg.net_margin);
+  if (denominator.lte(0)) {
+    return {
+      ok: false,
+      errors: ['invalid_commission_iibb_margin_denominator'],
+      warnings,
+      price_final_sugerido: null,
+      breakdown: null,
+      parameters_used: cfg,
+      publishable: false,
+    };
+  }
+
+  const finalPriceRaw = totalLandedCostArs.div(denominator);
+  const withMinimum = Decimal.max(finalPriceRaw, new Decimal(cfg.minimum_final_price_ars));
+  const finalPriceRounded = roundFinalPrice(withMinimum, cfg.rounding_mode);
+
+  if (!Number.isFinite(Number(product?.stock)) || Number(product?.stock) <= 0) {
+    warnings.push('not_publishable_stock');
+  }
+  if (!String(product?.image_url || '').trim()) {
+    warnings.push('not_publishable_image');
+  }
+
+  const breakdown = {
+    supplier_currency: currency,
+    supplier_unit_price_original: unitPrice,
+    supplier_cost_usd: Number(supplierCostUsd.toDecimalPlaces(6)),
+    supplier_cost_ars: Number(supplierCostArs.toDecimalPlaces(2)),
+    international_shipping_allocated_ars: Number(internationalShippingAllocatedArs.toDecimalPlaces(2)),
+    cif_ars: Number(cifArs.toDecimalPlaces(2)),
+    base_import_ars: Number(baseImportArs.toDecimalPlaces(2)),
+    iva_import_ars: Number(ivaImportArs.toDecimalPlaces(2)),
+    percepcion_iva_ars: Number(percepcionIvaArs.toDecimalPlaces(2)),
+    percepcion_ganancias_ars: Number(percepcionGananciasArs.toDecimalPlaces(2)),
+    ml_shipping_cost_ars: Number(new Decimal(cfg.ml_shipping_cost_ars).toDecimalPlaces(2)),
+    packaging_cost_ars: Number(new Decimal(cfg.packaging_cost_ars).toDecimalPlaces(2)),
+    ads_cost_ars: Number(new Decimal(cfg.ads_cost_ars).toDecimalPlaces(2)),
+    total_landed_cost_ars: Number(totalLandedCostArs.toDecimalPlaces(2)),
+    ml_commission: cfg.ml_commission,
+    iibb: cfg.iibb,
+    net_margin: cfg.net_margin,
+    final_price_ars_raw: Number(finalPriceRaw.toDecimalPlaces(2)),
+    final_price_ars_rounded: Number(finalPriceRounded.toDecimalPlaces(2)),
+  };
+
+  return {
+    ok: true,
+    errors: [],
+    warnings: Array.from(new Set(warnings)),
+    price_final_sugerido: breakdown.final_price_ars_rounded,
+    breakdown,
+    parameters_used: cfg,
+    publishable: isPublishable(product),
+  };
+}
+
+function buildPricingAudit(product, pricing, config = {}) {
+  return {
+    product: {
+      title: product?.title || '',
+      category: product?.category || '',
+      sku: product?.sku || '',
+      stock: product?.stock,
+      image_url: product?.image_url || '',
+    },
+    pricing,
+    parameters_used: normalizeSupplierPricingConfig(config),
+    calculated_at: new Date().toISOString(),
+  };
+}
+
+module.exports = {
+  normalizeSupplierPricingConfig,
+  normalizeProductRow,
+  calculateProductPricing,
+  isPublishable,
+  buildPricingAudit,
+};

--- a/nerin_final_updated/docs/supplier-pricing.md
+++ b/nerin_final_updated/docs/supplier-pricing.md
@@ -1,0 +1,79 @@
+# Supplier Pricing Conservador (Excel/CSV)
+
+Este módulo evita publicar el `UnitPrice` del proveedor como precio final.
+
+## Ubicación
+- Config defaults: `backend/config/supplierPricingDefaults.js`
+- Motor de pricing: `backend/services/supplierPricing.js`
+- Tests: `__tests__/backend/supplier-pricing.test.js`
+
+## Fórmula implementada
+
+1) Conversión proveedor -> USD -> ARS
+- Si proveedor EUR: `supplier_cost_usd = unit_price_eur * eur_usd`
+- Si proveedor USD: `supplier_cost_usd = unit_price_usd`
+- `supplier_cost_ars = supplier_cost_usd * usd_ars`
+
+2) Prorrateo envío internacional
+- `shipping_total_usd = international_shipping_total_eur * eur_usd`
+- `shipping_total_ars = shipping_total_usd * usd_ars`
+- `share_of_order = supplier_cost_usd / minimum_order_usd`
+- `international_shipping_allocated_ars = shipping_total_ars * share_of_order`
+
+3) CIF y base importación
+- `cif_ars = supplier_cost_ars + international_shipping_allocated_ars`
+- `base_import_ars = cif_ars * (1 + die + tasa_estadistica)`
+
+4) Impuestos importación
+- `iva_import_ars = base_import_ars * iva_importacion`
+- `percepcion_iva_ars = base_import_ars * percepcion_iva`
+- `percepcion_ganancias_ars = base_import_ars * percepcion_ganancias`
+
+5) Costo landed total
+- `total_landed_cost_ars = base_import_ars + iva_import_ars + percepcion_iva_ars + percepcion_ganancias_ars + ml_shipping_cost_ars + packaging_cost_ars + ads_cost_ars`
+
+6) Precio final
+- `final_price_ars_raw = total_landed_cost_ars / (1 - ml_commission - iibb - net_margin)`
+- Se aplica mínimo `minimum_final_price_ars`
+- Con `rounding_mode = ceil_100`: redondea al próximo 100 ARS hacia arriba.
+
+## Parámetros configurables (defaults)
+Se centralizan en `DEFAULT_SUPPLIER_PRICING_CONFIG`.
+
+- `supplier_currency`, `usd_ars`, `eur_usd`
+- `international_shipping_total_eur`, `minimum_order_usd`
+- `die`, `tasa_estadistica`, `iva_importacion`, `percepcion_iva`, `percepcion_ganancias`
+- `ml_commission`, `iibb`, `net_margin`
+- `ml_shipping_cost_ars`, `packaging_cost_ars`, `ads_cost_ars`
+- `minimum_final_price_ars`, `rounding_mode`
+
+## Uso recomendado
+
+```js
+const {
+  normalizeProductRow,
+  calculateProductPricing,
+  isPublishable,
+  buildPricingAudit,
+} = require('./backend/services/supplierPricing');
+
+const normalized = normalizeProductRow(row, configOverrides);
+const pricing = calculateProductPricing(normalized, configOverrides);
+const publishable = isPublishable(normalized);
+const audit = buildPricingAudit(normalized, pricing, configOverrides);
+```
+
+## Detección de columnas Excel/CSV
+`normalizeProductRow` intenta detectar variaciones de columnas:
+- precio proveedor: `UnitPrice`, `Price`, `Precio`, `SupplierPrice`, etc.
+- título: `Name`, `Nombre`, `Title`, `Descripción`, etc.
+- stock: `Stock`, `Quantity`, `Cantidad`, etc.
+- imagen: `Image`, `ImageURL`, `Imagen`, `Pictures`, etc.
+- SKU/EAN: variantes comunes.
+
+## Supuestos conservadores
+- Si falta `UnitPrice` o es <= 0: no calcula precio (`ok=false`).
+- Si falta stock o stock <= 0: calcula pero marca warning de no publicable.
+- Si falta imagen: calcula pero marca warning de no publicable.
+- Si moneda no soportada: error explícito.
+

--- a/nerin_final_updated/frontend/admin.html
+++ b/nerin_final_updated/frontend/admin.html
@@ -546,6 +546,40 @@
               step="0.01"
             />
             <select id="productSupplier" name="supplier_id"></select>
+            <div class="form-section form-grid-span" id="fulfillmentAssistSection">
+              <div class="form-section__header">
+                <h5>Disponibilidad y entrega (opcional)</h5>
+              </div>
+              <p class="form-hint">
+                Si no completás estos campos, la tienda mantiene el comportamiento actual.
+                Usá <strong>stock remoto</strong> solo para productos a pedido.
+              </p>
+              <div class="catalog-grid">
+                <div class="catalog-field">
+                  <label for="productStockMode">Modo de stock</label>
+                  <select id="productStockMode" name="stock_mode">
+                    <option value="">Automático (actual)</option>
+                    <option value="physical">Stock físico</option>
+                    <option value="remote">Stock remoto</option>
+                  </select>
+                </div>
+                <div class="catalog-field">
+                  <label for="productRemoteLeadMinDays">Entrega remota mínima (días)</label>
+                  <input type="number" id="productRemoteLeadMinDays" name="remote_lead_min_days" min="1" />
+                </div>
+                <div class="catalog-field">
+                  <label for="productRemoteLeadMaxDays">Entrega remota máxima (días)</label>
+                  <input type="number" id="productRemoteLeadMaxDays" name="remote_lead_max_days" min="1" />
+                </div>
+              </div>
+              <label class="assist-toggle" style="margin-top:0.5rem;">
+                <input type="checkbox" id="productShowMarketplaceTrust" name="show_marketplace_trust" value="1" />
+                <span>Mostrar bloque “Entrega asegurada + Mercado Libre” en la ficha</span>
+              </label>
+              <button type="button" class="button secondary" id="suggestFulfillmentBtn" style="margin-top:0.75rem;">
+                Sugerir con IA
+              </button>
+            </div>
             <div class="form-section form-grid-span form-section--description" id="descriptionAssistSection">
               <div class="form-section__header">
                 <h5>Descripción para la tienda</h5>

--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -1732,6 +1732,7 @@ const productPreviewSku = document.getElementById("productPreviewSku");
 const productPreviewPrice = document.getElementById("productPreviewPrice");
 const productPreviewStock = document.getElementById("productPreviewStock");
 const productPreviewMeta = document.getElementById("productPreviewMeta");
+const suggestFulfillmentBtn = document.getElementById("suggestFulfillmentBtn");
 
 const currencyFormatter = typeof Intl !== "undefined"
   ? new Intl.NumberFormat("es-AR", {
@@ -2509,8 +2510,83 @@ function gatherProductBasics() {
     cost: getNumber("cost"),
     stock: getNumber("stock"),
     min_stock: getNumber("min_stock"),
+    stock_mode: get("stock_mode"),
+    remote_lead_min_days: getNumber("remote_lead_min_days"),
+    remote_lead_max_days: getNumber("remote_lead_max_days"),
+    show_marketplace_trust: Boolean(productForm.elements["show_marketplace_trust"]?.checked),
     description: descriptionInput ? descriptionInput.value.trim() : "",
   };
+}
+
+
+function suggestFulfillmentByHeuristics(data = {}) {
+  const text = [
+    data.name,
+    data.description,
+    data.category,
+    data.subcategory,
+    Array.isArray(data.tags) ? data.tags.join(" ") : "",
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+
+  const stock = Number(data.stock);
+  const hasRemoteSignals =
+    /a pedido|preventa|importad|internacional|encargo|bajo pedido/.test(text) ||
+    (Number.isFinite(stock) && stock <= 0);
+
+  const isDisplayAssembly = /pantalla|modulo|módulo|display|service pack/.test(text);
+  const isAccessory = /funda|cable|cargador|templado|accesorio/.test(text);
+
+  const mode = hasRemoteSignals ? "remote" : "physical";
+  let minDays = null;
+  let maxDays = null;
+  if (mode === "remote") {
+    if (isAccessory) {
+      minDays = 3;
+      maxDays = 7;
+    } else if (isDisplayAssembly) {
+      minDays = 4;
+      maxDays = 10;
+    } else {
+      minDays = 5;
+      maxDays = 12;
+    }
+  }
+
+  return {
+    mode,
+    minDays,
+    maxDays,
+    showTrust: mode === "remote",
+  };
+}
+
+function applySuggestedFulfillment() {
+  if (!productForm) return;
+  const data = serializeProductForm(productForm);
+  const suggestion = suggestFulfillmentByHeuristics(data);
+  if (productForm.elements["stock_mode"]) {
+    productForm.elements["stock_mode"].value = suggestion.mode;
+  }
+  if (productForm.elements["remote_lead_min_days"]) {
+    productForm.elements["remote_lead_min_days"].value = suggestion.minDays ?? "";
+  }
+  if (productForm.elements["remote_lead_max_days"]) {
+    productForm.elements["remote_lead_max_days"].value = suggestion.maxDays ?? "";
+  }
+  if (productForm.elements["show_marketplace_trust"]) {
+    productForm.elements["show_marketplace_trust"].checked = suggestion.showTrust;
+  }
+  renderProductFormPreview();
+  if (window.showToast) {
+    showToast(
+      suggestion.mode === "remote"
+        ? "Sugerencia IA aplicada: stock remoto con ventana de entrega estimada."
+        : "Sugerencia IA aplicada: stock físico inmediato.",
+    );
+  }
 }
 
 function formatCurrencyValue(value) {
@@ -2867,6 +2943,15 @@ function fillProductForm(p) {
   set("price_mayorista", p.price_mayorista);
   set("cost", p.cost);
   set("supplier_id", p.supplier_id);
+  set("stock_mode", p.stock_mode || p.fulfillment_mode);
+  set("remote_lead_min_days", p.remote_lead_min_days || p.remote_lead_days);
+  set("remote_lead_max_days", p.remote_lead_max_days);
+  if (productForm.elements["show_marketplace_trust"]) {
+    productForm.elements["show_marketplace_trust"].checked =
+      p.show_marketplace_trust === true ||
+      p.show_marketplace_trust === 1 ||
+      p.show_marketplace_trust === "1";
+  }
   set("slug", p.slug);
   set("description", p.description);
   set("seoTitle", p.seoTitle || p.meta_title);
@@ -2916,11 +3001,19 @@ function serializeProductForm(form) {
       .map((s) => s.trim())
       .filter(Boolean);
   }
-  ["stock", "min_stock", "price_minorista", "price_mayorista", "cost", "weight"].forEach(
+  ["stock", "min_stock", "price_minorista", "price_mayorista", "cost", "weight", "remote_lead_min_days", "remote_lead_max_days"].forEach(
     (k) => {
       if (k in obj && obj[k] !== "") obj[k] = Number(obj[k]);
     },
   );
+  if ("show_marketplace_trust" in obj) {
+    obj.show_marketplace_trust = obj.show_marketplace_trust === "1";
+  }
+  if (!obj.stock_mode) delete obj.stock_mode;
+  if (!(obj.stock_mode === "remote" || obj.stock_mode === "physical")) {
+    delete obj.remote_lead_min_days;
+    delete obj.remote_lead_max_days;
+  }
   ["catalog_brand", "catalog_model", "catalog_piece"].forEach((field) => {
     if (!(field in obj)) return;
     const value = cleanLabel(obj[field]);
@@ -3000,6 +3093,18 @@ function renderProductFormPreview() {
       }
     } else if (Number.isFinite(minStock) && minStock > 0) {
       stockMessage = `Stock mínimo deseado: ${minStock}`;
+    }
+    const stockMode = (data.stock_mode || "").toLowerCase();
+    if (stockMode === "remote") {
+      const minLead = Number(data.remote_lead_min_days);
+      const maxLead = Number(data.remote_lead_max_days);
+      if (Number.isFinite(minLead) && minLead > 0) {
+        stockMessage += Number.isFinite(maxLead) && maxLead >= minLead
+          ? ` · Remoto: ${minLead}-${maxLead} días`
+          : ` · Remoto: ${minLead} días`;
+      } else {
+        stockMessage += " · Remoto: plazo a confirmar";
+      }
     }
     productPreviewStock.textContent = stockMessage;
   }
@@ -3208,6 +3313,9 @@ async function saveProduct(e) {
 }
 
 productForm.addEventListener("submit", saveProduct);
+if (suggestFulfillmentBtn) {
+  suggestFulfillmentBtn.addEventListener("click", applySuggestedFulfillment);
+}
 
 async function loadProducts(options = {}) {
   if (!productsTableBody) return;

--- a/nerin_final_updated/frontend/js/product.js
+++ b/nerin_final_updated/frontend/js/product.js
@@ -24,6 +24,63 @@ const FALLBACK_IMAGE =
   "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
 
 
+
+function toNumberOrNull(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function normalizeProductPayload(product) {
+  if (!product || typeof product !== "object") return product;
+  const normalized = { ...product };
+  if (!normalized.name && typeof normalized.title === "string") {
+    normalized.name = normalized.title.trim();
+  }
+  if (!normalized.category && typeof normalized.categoria === "string") {
+    normalized.category = normalized.categoria.trim();
+  }
+  if (!Number.isFinite(Number(normalized.stock))) {
+    const parsedStock =
+      toNumberOrNull(normalized.quantity) ??
+      toNumberOrNull(normalized.available_quantity) ??
+      toNumberOrNull(normalized.qty_available);
+    if (parsedStock !== null) normalized.stock = parsedStock;
+  }
+
+  const imageCandidates = [];
+  const pushImage = (value) => {
+    if (typeof value !== "string") return;
+    const cleaned = value.trim();
+    if (!cleaned) return;
+    imageCandidates.push(cleaned);
+  };
+
+  if (Array.isArray(normalized.images)) {
+    normalized.images.forEach((img) => {
+      if (typeof img === "string") pushImage(img);
+      else pushImage(img?.url || img?.secure_url || "");
+    });
+  }
+  if (Array.isArray(normalized.pictures)) {
+    normalized.pictures.forEach((img) => {
+      if (typeof img === "string") pushImage(img);
+      else pushImage(img?.url || img?.secure_url || "");
+    });
+  }
+  pushImage(normalized.image);
+  pushImage(normalized.image_url);
+  pushImage(normalized.thumbnail);
+  pushImage(normalized.picture);
+
+  const uniqueImages = Array.from(new Set(imageCandidates));
+  if (uniqueImages.length) {
+    normalized.images = uniqueImages;
+    normalized.image = uniqueImages[0];
+  }
+
+  return normalized;
+}
+
 function resolveProductPriceContext(product) {
   const retailRaw = Number(product?.price_minorista ?? product?.price);
   const wholesaleRaw = Number(product?.price_mayorista ?? product?.price_wholesale);
@@ -52,6 +109,35 @@ function resolveProductDisplayPrice(product) {
   return resolveProductPriceContext(product).active;
 }
 
+
+function resolveFulfillmentProfile(product) {
+  const explicitMode = String(product?.stock_mode || product?.fulfillment_mode || "")
+    .trim()
+    .toLowerCase();
+  const stock = toNumberOrNull(product?.stock);
+  const textSignals = [product?.name, product?.description, product?.category, product?.subcategory]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  const hasRemoteText = /a pedido|preventa|importad|internacional|encargo|bajo pedido/.test(textSignals);
+  const isRemote =
+    explicitMode === "remote" ||
+    explicitMode === "remoto" ||
+    Number(product?.remote_stock) > 0 ||
+    Number(product?.remote_lead_days) > 0 ||
+    hasRemoteText ||
+    (Number.isFinite(stock) && stock <= 0 && /a pedido|encargo/.test(textSignals));
+
+  const minDays = Number(product?.remote_lead_min_days || product?.remote_lead_days || 4);
+  const maxDays = Number(product?.remote_lead_max_days || (isRemote ? Math.max(minDays, 10) : minDays));
+
+  return {
+    mode: isRemote ? "remote" : "physical",
+    isConfigured: Boolean(explicitMode) || Number(product?.remote_lead_days) > 0,
+    minDays,
+    maxDays: maxDays >= minDays ? maxDays : minDays,
+  };
+}
 
 function sanitizeStorefrontCopy(text) {
   if (typeof text !== "string") return "";
@@ -1165,16 +1251,43 @@ function renderProduct(product) {
 
   const shippingBanner = document.createElement("div");
   shippingBanner.className = "product-shipping-banner";
+  const fulfillment = resolveFulfillmentProfile(product);
+  const leadCopy =
+    fulfillment.minDays === fulfillment.maxDays
+      ? `${fulfillment.minDays} día${fulfillment.minDays === 1 ? "" : "s"}`
+      : `${fulfillment.minDays} a ${fulfillment.maxDays} días`;
   shippingBanner.innerHTML = `
     <div class="shipping-banner__badge" aria-hidden="true">🚚</div>
     <div class="shipping-banner__copy">
       <span class="shipping-banner__title">Envío gratis a todo el país</span>
       <span class="shipping-banner__meta">
-        Despachamos a diario con empaque blindado y seguimiento en vivo.
+        ${
+          fulfillment.mode === "remote"
+            ? `Stock remoto: entrega estimada en ${leadCopy} (incluye preparación del proveedor).`
+            : fulfillment.isConfigured
+              ? "Stock físico: despacho prioritario en 24 h hábiles con seguimiento en vivo."
+              : "Despachamos a diario con empaque blindado y seguimiento en vivo."
+        }
       </span>
     </div>
   `;
   purchaseCard.appendChild(shippingBanner);
+
+  const shouldShowTrust =
+    fulfillment.mode === "remote" ||
+    product.show_marketplace_trust === true ||
+    product.show_marketplace_trust === 1 ||
+    product.show_marketplace_trust === "1";
+  if (shouldShowTrust) {
+    const fulfillmentTrust = document.createElement("div");
+    fulfillmentTrust.className = "product-fulfillment-trust";
+    fulfillmentTrust.innerHTML = `
+      <p><strong>${fulfillment.mode === "remote" ? "Stock remoto" : "Stock físico"}</strong> · Entrega asegurada.</p>
+      <p>También vendemos en Mercado Libre para que puedas validar reputación y comprar con la misma seguridad.</p>
+      <p>Acá el precio publicado ya es final: IVA incluido, factura A y envío gratis.</p>
+    `;
+    purchaseCard.appendChild(fulfillmentTrust);
+  }
 
   const priceGrid = document.createElement("div");
   priceGrid.className = "product-buy-price-grid";
@@ -1482,12 +1595,12 @@ async function initProduct() {
     if (previewMode) {
       const previewProduct = await fetchPreviewProduct();
       if (previewProduct) {
-        renderProduct(previewProduct);
+        renderProduct(normalizeProductPayload(previewProduct));
         return;
       }
     }
 
-    const products = await fetchProducts();
+    const products = (await fetchProducts()).map(normalizeProductPayload);
     let product = null;
     if (targetSlug) {
       product = products.find((p) => getProductSlug(p) === targetSlug);
@@ -1498,7 +1611,7 @@ async function initProduct() {
     if (!product && !products.length) {
       const previewProduct = await fetchPreviewProduct();
       if (previewProduct) {
-        renderProduct(previewProduct);
+        renderProduct(normalizeProductPayload(previewProduct));
         return;
       }
     }
@@ -1508,7 +1621,7 @@ async function initProduct() {
       if (galleryContainer) galleryContainer.innerHTML = "";
       return;
     }
-    renderProduct(product);
+    renderProduct(normalizeProductPayload(product));
   } catch (err) {
     if (infoContainer)
       infoContainer.innerHTML = `<p>Error al cargar producto: ${err.message}</p>`;

--- a/nerin_final_updated/frontend/js/shop.js
+++ b/nerin_final_updated/frontend/js/shop.js
@@ -8,6 +8,61 @@ const currencyFormatter = new Intl.NumberFormat("es-AR", {
   maximumFractionDigits: 0,
 });
 
+
+function toNumberOrNull(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function resolveProductTitle(product) {
+  return cleanLabel(product.name || product.title || product.product_title || "");
+}
+
+function resolveCategoryLabel(product) {
+  return cleanLabel(product.category || product.categoria || product.product_category || "");
+}
+
+function resolveStockQuantity(product) {
+  const candidates = [product.stock, product.quantity, product.available_quantity, product.qty_available];
+  for (const candidate of candidates) {
+    const parsed = toNumberOrNull(candidate);
+    if (parsed !== null) return parsed;
+  }
+  return null;
+}
+
+function normalizeStorefrontProduct(product) {
+  if (!product || typeof product !== "object") return product;
+  const normalized = { ...product };
+  const title = resolveProductTitle(product);
+  if (title && !cleanLabel(normalized.name)) normalized.name = title;
+  const category = resolveCategoryLabel(product);
+  if (category && !cleanLabel(normalized.category)) normalized.category = category;
+  const stockQty = resolveStockQuantity(product);
+  if (stockQty !== null && !Number.isFinite(Number(normalized.stock))) normalized.stock = stockQty;
+  if (!normalized.image) {
+    normalized.image =
+      product.image_url ||
+      product.thumbnail ||
+      product.picture ||
+      (Array.isArray(product.pictures) && product.pictures[0]) ||
+      "";
+  }
+  if (!Array.isArray(normalized.images) || !normalized.images.length) {
+    const candidates = [normalized.image, product.image_url, product.thumbnail, product.picture]
+      .map((value) => cleanLabel(value))
+      .filter(Boolean);
+    if (Array.isArray(product.pictures)) {
+      product.pictures.forEach((pic) => {
+        const value = cleanLabel(typeof pic === "string" ? pic : pic?.url || pic?.secure_url || "");
+        if (value) candidates.push(value);
+      });
+    }
+    normalized.images = Array.from(new Set(candidates));
+  }
+  return normalized;
+}
+
 const PLACEHOLDER_IMAGE =
   "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
 
@@ -78,8 +133,40 @@ function getPrimaryImage(product) {
   return product.image;
 }
 
+
+function getFulfillmentMode(product) {
+  const explicitMode = cleanLabel(product.stock_mode || product.fulfillment_mode || "").toLowerCase();
+  if (explicitMode === "remote" || explicitMode === "remoto") return "remote";
+  if (explicitMode === "physical" || explicitMode === "fisico" || explicitMode === "físico") return "physical";
+
+  if (Number(product.remote_stock) > 0 || Number(product.remote_lead_days) > 0) return "remote";
+
+  const stock = resolveStockQuantity(product);
+  const textSignals = [product.name, product.description, product.category, product.subcategory]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  if (/a pedido|preventa|importad|internacional|encargo|bajo pedido/.test(textSignals)) {
+    return "remote";
+  }
+  if (Number.isFinite(stock) && stock <= 0 && /a pedido|encargo/.test(textSignals)) {
+    return "remote";
+  }
+  return "physical";
+}
+
+function getRemoteLeadTimeCopy(product) {
+  const minDays = Number(product.remote_lead_min_days || product.remote_lead_days || 0);
+  const maxDays = Number(product.remote_lead_max_days || minDays || 0);
+  if (minDays > 0 && maxDays >= minDays) {
+    if (maxDays === minDays) return `Entrega estimada: ${minDays} día${minDays === 1 ? "" : "s"}.`;
+    return `Entrega estimada: ${minDays} a ${maxDays} días.`;
+  }
+  return "Entrega estimada: 4 a 10 días (incluye preparación del proveedor).";
+}
+
 function getStockStatus(product) {
-  const stock = Number(product.stock);
+  const stock = resolveStockQuantity(product);
   if (!Number.isFinite(stock)) return "unknown";
   if (stock <= 0) return "out";
   if (Number.isFinite(Number(product.min_stock)) && stock <= Number(product.min_stock)) {
@@ -179,7 +266,7 @@ function populateFilters(products) {
   const categories = new Map();
   products.forEach((product) => {
     const brand = getCatalogBrand(product);
-    const category = cleanLabel(product.category);
+    const category = resolveCategoryLabel(product);
     if (brand) brands.set(normalizeKey(brand), brand);
     if (category) categories.set(normalizeKey(category), category);
   });
@@ -328,10 +415,18 @@ function createProductCard(product) {
   const availability = document.createElement("p");
   availability.className = "description";
   const status = getStockStatus(product);
+  const fulfillmentMode = getFulfillmentMode(product);
   if (status === "out") availability.textContent = "Sin stock";
   else if (status === "low") availability.textContent = `Pocas unidades (${product.stock})`;
-  else availability.textContent = `Stock: ${Number(product.stock) || 0} unidades`;
+  else availability.textContent = `Stock: ${resolveStockQuantity(product) || 0} unidades`;
   card.appendChild(availability);
+
+  if (fulfillmentMode === "remote") {
+    const fulfillmentNote = document.createElement("p");
+    fulfillmentNote.className = "product-fulfillment-note";
+    fulfillmentNote.textContent = `Stock remoto • ${getRemoteLeadTimeCopy(product)}`;
+    card.appendChild(fulfillmentNote);
+  }
 
   const priceBlock = document.createElement("div");
   priceBlock.className = "price-block";
@@ -463,7 +558,14 @@ function updateActiveFilters(filters) {
     ["Marca", filters.brand],
     ["Modelo", filters.model],
     ["Tipo", filters.category],
-    ["Stock", filters.stock === "in-stock" ? "Solo con stock" : ""],
+    ["Stock",
+      filters.stock === "in-stock"
+        ? "Solo con stock"
+        : filters.stock === "physical"
+          ? "Stock físico"
+          : filters.stock === "remote"
+            ? "Stock remoto"
+            : ""],
     ["Precio ≤", filters.priceActive ? formatCurrency(filters.price) : ""],
   ];
   descriptors.filter(([, value]) => value).forEach(([label, value]) => {
@@ -503,7 +605,10 @@ function renderProducts() {
     if (model && normalizeKey(getCatalogModel(product)) !== normalizeKey(model)) return false;
     if (category && normalizeKey(product.category) !== normalizeKey(category)) return false;
     const status = getStockStatus(product);
+    const fulfillmentMode = getFulfillmentMode(product);
     if (stock === "in-stock" && status !== "in" && status !== "low") return false;
+    if (stock === "physical" && fulfillmentMode !== "physical") return false;
+    if (stock === "remote" && fulfillmentMode !== "remote") return false;
     if (priceActive && resolveDisplayPrice(product).active > price) return false;
     return true;
   });
@@ -529,7 +634,12 @@ function applyInitialFilters() {
   updateModelOptions(brandFilter?.value || "");
   if (modelFilter && params.get("model")) modelFilter.value = params.get("model");
   if (categoryFilter && params.get("category")) categoryFilter.value = params.get("category");
-  if (stockFilter && params.get("stock") === "in-stock") stockFilter.value = "in-stock";
+  if (stockFilter) {
+    const stockParam = params.get("stock");
+    if (["in-stock", "physical", "remote"].includes(stockParam)) {
+      stockFilter.value = stockParam;
+    }
+  }
   if (sortSelect && params.get("sort")) sortSelect.value = params.get("sort");
   if (priceRange && params.get("price_max")) {
     const value = Number(params.get("price_max"));
@@ -578,7 +688,10 @@ function setupFiltersUi() {
 async function initShop() {
   try {
     const rawProducts = await fetchProducts();
-    allProducts = rawProducts.map(sanitizePublicProduct).filter(Boolean);
+    allProducts = rawProducts
+      .map(normalizeStorefrontProduct)
+      .map(sanitizePublicProduct)
+      .filter(Boolean);
     populateFilters(allProducts);
     updateModelOptions("");
     configurePriceSlider(allProducts);

--- a/nerin_final_updated/frontend/shop.html
+++ b/nerin_final_updated/frontend/shop.html
@@ -228,6 +228,8 @@
             <select id="stockFilter">
               <option value="">Todo el catálogo</option>
               <option value="in-stock">Solo con stock</option>
+              <option value="physical">Stock físico inmediato</option>
+              <option value="remote">Stock remoto (a pedido)</option>
             </select>
           </div>
           <div class="filter-block">
@@ -260,7 +262,10 @@
           </div>
           <div id="activeFilters" class="active-filters" aria-live="polite"></div>
           <p class="shop-results-legal" aria-label="Información legal de precios">
-            Precios finales con IVA incluido. Factura A/B disponible.
+            Precios finales con IVA incluido. Factura A/B disponible. En stock remoto, los plazos de entrega incluyen la preparación o fabricación del proveedor.
+          </p>
+          <p class="shop-results-legal shop-results-legal--highlight" aria-label="Diferencial frente a compras internacionales">
+            A diferencia de una compra internacional, acá ves precio final en ARS: IVA, envío gratis y costos finales incluidos desde el inicio.
           </p>
           <div id="productGrid" class="product-grid premium-grid" role="list"></div>
         </section>

--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -859,12 +859,19 @@ body.cart-indicator-visible .toastify {
   font-size: 0.9rem;
   color: #4b5563;
   flex-grow: 1;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.35rem;
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.product-card .product-fulfillment-note {
+  margin: 0 0 0.6rem;
+  font-size: 0.8rem;
+  color: #2563eb;
+  font-weight: 600;
 }
 
 .price {
@@ -9042,9 +9049,16 @@ html, body{ max-width:100%; overflow-x:hidden; }
 
 /* Ajustes visuales pro: botones y legales en catálogo */
 .shop-results-legal {
-  margin: 0.25rem 0 0.85rem;
+  margin: 0.25rem 0 0.45rem;
   color: #6b7280;
   font-size: 0.86rem;
+}
+
+.shop-results-legal--highlight {
+  margin-top: 0;
+  margin-bottom: 0.9rem;
+  color: #111827;
+  font-weight: 600;
 }
 
 .shop-page .button,
@@ -9354,4 +9368,23 @@ html, body{ max-width:100%; overflow-x:hidden; }
   .price-tier__value {
     font-size: 1.1rem;
   }
+}
+
+
+.product-page .product-fulfillment-trust {
+  margin: 0.75rem 0 1rem;
+  padding: 0.8rem 0.9rem;
+  border-radius: 12px;
+  border: 1px solid #dbeafe;
+  background: #f8fbff;
+  color: #1f2937;
+  font-size: 0.88rem;
+}
+
+.product-page .product-fulfillment-trust p {
+  margin: 0;
+}
+
+.product-page .product-fulfillment-trust p + p {
+  margin-top: 0.35rem;
 }


### PR DESCRIPTION
### Motivation
- Provide a conservative supplier pricing engine to avoid exposing supplier unit prices directly and compute a rounded final ARS price with configurable parameters. 
- Surface fulfillment controls and heuristics in the admin so sellers can indicate or auto-suggest remote vs physical fulfillment and lead times. 
- Normalize incoming product payloads on storefront and product pages to reliably display images, stock and fulfillment metadata.

### Description
- Introduces a new backend pricing module at `backend/services/supplierPricing.js` with helpers `normalizeProductRow`, `calculateProductPricing`, `buildPricingAudit`, `isPublishable` and `normalizeSupplierPricingConfig`, and central defaults in `backend/config/supplierPricingDefaults.js`.
- Adds documentation `docs/supplier-pricing.md` describing the formula, defaults and usage, and includes a Jest test file `__tests__/backend/supplier-pricing.test.js` covering price calculation, errors, rounding and audit structure.
- Admin UI changes add a fulfillment section to `frontend/admin.html` and wiring in `frontend/js/admin.js` including `suggestFulfillmentByHeuristics`, `applySuggestedFulfillment`, form serialization of new fields and a button to apply suggestions. 
- Storefront/product tweaks add normalization and fulfillment display logic in `frontend/js/product.js`, `frontend/js/shop.js` and `frontend/shop.html`, including new filters for `physical`/`remote` stock, product card fulfillment notes, trust block, and related CSS in `frontend/style.css`.

### Testing
- Added unit tests in `__tests__/backend/supplier-pricing.test.js` exercising `normalizeProductRow`, `calculateProductPricing` and `buildPricingAudit` behavior.
- Ran the JavaScript unit test suite with `npm test` (Jest) and all added tests passed.
- Basic frontend behavior covered by the changes is exercised via automated build checks (bundle) and no unit tests were added for UI code in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd45e4c17083318690654a4bf2ed53)