### PR TITLE
Add CSV catalog import and pricing engine with API endpoint, enrichment script and tests

### DIFF
--- a/nerin_final_updated/backend/__tests__/catalogCsvImport.test.js
+++ b/nerin_final_updated/backend/__tests__/catalogCsvImport.test.js
@@ -1,0 +1,92 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  parseEuropeanDecimal,
+  toImportedRecord,
+  importCatalogCsvFile,
+} = require("../services/catalogCsvImport");
+
+describe("catalogCsvImport", () => {
+  test("parseEuropeanDecimal soporta coma decimal", () => {
+    expect(parseEuropeanDecimal("10,17")).toBe(10.17);
+    expect(parseEuropeanDecimal("1.234,56")).toBe(1234.56);
+  });
+
+  test("toImportedRecord transforma imágenes y flags", () => {
+    const row = {
+      PartId: "1001",
+      ManufacturerName: "ACME",
+      ManufacturerId: "44",
+      ManufacturerArticleCode: "",
+      MainCategory: "Display",
+      SubCategory: "OLED",
+      PartNumber: "ABC-123",
+      Description: "Pantalla iPhone, calidad premium",
+      Status: "Available (longer delivery time)",
+      CanBeOrdered: "Yes",
+      UnitPrice: "10,17",
+      StockQuantity: "12",
+      MaximumQuantityInOrder: "5",
+      Quality: "Original",
+      Remarks: "",
+      ImageUrl: "https://cdn.example.com/1.jpg",
+      ImageUrl2: "",
+      ImageUrl3: "https://cdn.example.com/2.jpg",
+      ImageUrl4: "",
+      ImageUrl5: "",
+      EanNumber: "",
+      CountryOfOrigin: "CN",
+      ProductGroup: "Mobile",
+    };
+
+    const transformed = toImportedRecord(row, 2).record;
+    expect(transformed.externalId).toBe(1001);
+    expect(transformed.images).toEqual([
+      "https://cdn.example.com/1.jpg",
+      "https://cdn.example.com/2.jpg",
+    ]);
+    expect(transformed.isAvailable).toBe(true);
+    expect(transformed.hasLongerDeliveryTime).toBe(true);
+    expect(transformed.isExpiring).toBe(false);
+    expect(transformed.manufacturerArticleCode).toBeNull();
+    expect(transformed.remarks).toBeNull();
+  });
+
+  test("importCatalogCsvFile devuelve errores por duplicados y parsea descripción con comas", async () => {
+    const csv = [
+      "PartId,ManufacturerName,ManufacturerId,ManufacturerArticleCode,MainCategory,SubCategory,PartNumber,Description,Status,CanBeOrdered,UnitPrice,StockQuantity,MaximumQuantityInOrder,Quality,Remarks,ImageUrl,ImageUrl2,ImageUrl3,ImageUrl4,ImageUrl5,EanNumber,CountryOfOrigin,ProductGroup",
+      '1001,ACME,1,,Main,Sub,SKU-1,"Desc, con coma",Available,Yes,"10,17",5,2,Original,,https://img/1.jpg,,,,,,CN,Mobile',
+      '1001,ACME,1,,Main,Sub,SKU-2,"Otro",Available,Yes,"11,00",5,2,Original,,https://img/2.jpg,,,,,,CN,Mobile',
+      '1003,ACME,1,,Main,Sub,SKU-1,"Dup partnumber",Available,Yes,"11,00",5,2,Original,,https://img/3.jpg,,,,,,CN,Mobile',
+    ].join("\n");
+
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "csv-import-test-"));
+    const filePath = path.join(tempDir, "catalog.csv");
+    fs.writeFileSync(filePath, csv, "utf8");
+
+    const query = jest.fn(async (sql) => {
+      if (/SELECT id, metadata/.test(sql)) return { rows: [] };
+      if (/INSERT INTO products/.test(sql)) return { rows: [{ inserted: true }], rowCount: 1 };
+      return { rows: [], rowCount: 0 };
+    });
+
+    const result = await importCatalogCsvFile({
+      filePath,
+      pool: { query },
+      chunkSize: 2,
+    });
+
+    expect(result.totalRows).toBe(3);
+    expect(result.inserted).toBe(1);
+    expect(result.failed).toBe(2);
+    expect(result.errors.some((err) => /PartId duplicado/.test(err.message))).toBe(true);
+    expect(result.errors.some((err) => /PartNumber duplicado/.test(err.message))).toBe(true);
+    expect(result.pricing).toBeDefined();
+    expect(result.pricing.processedRows).toBe(3);
+    expect(result.pricing.okRows).toBe(3);
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+});

--- a/nerin_final_updated/backend/__tests__/catalogPricing.test.js
+++ b/nerin_final_updated/backend/__tests__/catalogPricing.test.js
@@ -1,0 +1,66 @@
+const {
+  computePricingForRow,
+  createPricingSummaryAccumulator,
+} = require("../services/catalogPricing");
+
+describe("catalogPricing", () => {
+  test("calcula precio final con redondeo a 100 ARS", () => {
+    const row = {
+      PartId: "1",
+      PartNumber: "SKU-1",
+      Description: "Repuesto",
+      UnitPrice: "10,17",
+    };
+
+    const result = computePricingForRow(row, undefined, {
+      costColumn: "UnitPrice",
+      currencyHeuristics: { assumeEuropeanSupplier: true },
+    });
+
+    expect(result.pricing.estado_calculo).toBe("ok");
+    expect(result.pricing.moneda_origen).toBe("EUR");
+    expect(result.pricing.precio_final_ars % 100).toBe(0);
+    expect(result.pricing.precio_final_ars).toBeGreaterThanOrEqual(1000);
+    expect(result.pricing.ganancia_estimada_ars).toBeGreaterThan(0);
+  });
+
+  test("marca revisión si no hay costo válido", () => {
+    const row = {
+      PartId: "1",
+      PartNumber: "SKU-1",
+      Description: "Repuesto",
+      UnitPrice: "",
+    };
+    const result = computePricingForRow(row, undefined, {
+      costColumn: "UnitPrice",
+      currencyHeuristics: { assumeEuropeanSupplier: true },
+    });
+
+    expect(result.pricing.estado_calculo).toBe("revisión");
+  });
+
+  test("acumulador genera resumen con top y promedio", () => {
+    const acc = createPricingSummaryAccumulator();
+
+    acc.add({ PartNumber: "A", Description: "Prod A" }, {
+      estado_calculo: "ok",
+      margen_neto_sobre_venta: 0.2,
+      margen_sobre_costo_caja: 0.25,
+      ganancia_estimada_ars: 1000,
+    });
+
+    acc.add({ PartNumber: "B", Description: "Prod B" }, {
+      estado_calculo: "revisión",
+      margen_neto_sobre_venta: null,
+      margen_sobre_costo_caja: null,
+      ganancia_estimada_ars: -50,
+    });
+
+    const report = acc.finalize();
+    expect(report.processedRows).toBe(2);
+    expect(report.okRows).toBe(1);
+    expect(report.revisionRows).toBe(1);
+    expect(report.averageNetMargin).toBe(0.2);
+    expect(report.top10ByEstimatedProfit[0].sku).toBe("A");
+  });
+});

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -60,6 +60,7 @@ const {
   validatePurchaseReview,
   validateServiceReview,
 } = require("./utils/reviewValidation");
+const { importCatalogCsvFile } = require("./services/catalogCsvImport");
 const {
   appendEvent,
   upsertSession,
@@ -4792,6 +4793,39 @@ const accountDocsUpload = multer({
   },
 });
 
+const catalogCsvUpload = multer({
+  storage: multer.diskStorage({
+    destination: (_req, _file, cb) => {
+      const dir = path.join(UPLOADS_DIR, "catalog-imports");
+      fs.mkdirSync(dir, { recursive: true });
+      cb(null, dir);
+    },
+    filename: (_req, file, cb) => {
+      const ext = path.extname(file.originalname || "").toLowerCase() || ".csv";
+      const stamp = `${Date.now().toString(36)}-${Math.random().toString(16).slice(2, 8)}`;
+      cb(null, `catalog-${stamp}${ext}`);
+    },
+  }),
+  limits: {
+    fileSize: 120 * 1024 * 1024,
+    files: 1,
+  },
+  fileFilter: (_req, file, cb) => {
+    const ext = path.extname(file.originalname || "").toLowerCase();
+    const mime = String(file.mimetype || "").toLowerCase();
+    if (
+      ext === ".csv" ||
+      mime.includes("csv") ||
+      mime === "application/vnd.ms-excel" ||
+      mime === "text/plain"
+    ) {
+      cb(null, true);
+    } else {
+      cb(new Error("Formato inválido. Subí un archivo CSV."));
+    }
+  },
+});
+
 // Servir archivos estáticos (HTML, CSS, JS, imágenes)
 function hydrateHtmlSeo(buffer) {
   try {
@@ -5215,6 +5249,52 @@ async function requestHandler(req, res) {
         return sendJson(res, 400, { error: "No se recibió archivo" });
       }
       return sendJson(res, 201, { filename: req.file.filename });
+    });
+    return;
+  }
+
+  if (pathname === "/api/import/catalog-csv" && req.method === "POST") {
+    const adminKey = req.headers["x-admin-key"];
+    if (process.env.ADMIN_KEY && adminKey !== process.env.ADMIN_KEY) {
+      return sendJson(res, 401, { error: "Unauthorized" });
+    }
+    const chunkSizeParam = Number(parsedUrl.query.chunkSize || parsedUrl.query.chunk_size || 400);
+    const chunkSize = Number.isFinite(chunkSizeParam) && chunkSizeParam > 0
+      ? Math.min(Math.floor(chunkSizeParam), 2000)
+      : 400;
+
+    catalogCsvUpload.single("file")(req, res, async (err) => {
+      if (err) {
+        console.error("catalog-csv-upload", err);
+        return sendJson(res, 400, { error: err.message || "No se pudo subir el CSV" });
+      }
+      if (!req.file || !req.file.path) {
+        return sendJson(res, 400, { error: "No se recibió archivo CSV" });
+      }
+
+      const pool = db.getPool();
+      try {
+        const summary = await importCatalogCsvFile({
+          filePath: req.file.path,
+          pool,
+          chunkSize,
+        });
+        return sendJson(res, 200, {
+          success: true,
+          summary,
+        });
+      } catch (importError) {
+        console.error("catalog-csv-import", importError);
+        const statusCode = importError?.code === "MISSING_REQUIRED_COLUMNS" ? 400 : 500;
+        return sendJson(res, statusCode, {
+          success: false,
+          error: importError.message || "Error al importar catálogo CSV",
+        });
+      } finally {
+        try {
+          await fsp.unlink(req.file.path);
+        } catch {}
+      }
     });
     return;
   }

--- a/nerin_final_updated/backend/services/catalogCsvImport.js
+++ b/nerin_final_updated/backend/services/catalogCsvImport.js
@@ -1,0 +1,483 @@
+const fs = require("fs");
+const path = require("path");
+const Decimal = require("decimal.js");
+const { parse } = require("csv-parse");
+const { DATA_DIR } = require("../utils/dataDir");
+const {
+  computePricingForRow,
+  createPricingSummaryAccumulator,
+} = require("./catalogPricing");
+
+const REQUIRED_COLUMNS = [
+  "PartId",
+  "ManufacturerName",
+  "ManufacturerId",
+  "PartNumber",
+  "Description",
+  "Status",
+  "CanBeOrdered",
+  "UnitPrice",
+  "StockQuantity",
+  "MaximumQuantityInOrder",
+];
+
+const ALL_COLUMNS = [
+  "PartId",
+  "ManufacturerName",
+  "ManufacturerId",
+  "ManufacturerArticleCode",
+  "MainCategory",
+  "SubCategory",
+  "PartNumber",
+  "Description",
+  "Status",
+  "CanBeOrdered",
+  "UnitPrice",
+  "StockQuantity",
+  "MaximumQuantityInOrder",
+  "Quality",
+  "Remarks",
+  "ImageUrl",
+  "ImageUrl2",
+  "ImageUrl3",
+  "ImageUrl4",
+  "ImageUrl5",
+  "EanNumber",
+  "CountryOfOrigin",
+  "ProductGroup",
+];
+
+const IMAGE_COLUMNS = ["ImageUrl", "ImageUrl2", "ImageUrl3", "ImageUrl4", "ImageUrl5"];
+
+function normalizeCell(value) {
+  if (value == null) return null;
+  const text = String(value).replace(/\u0000/g, "").trim();
+  return text === "" ? null : text;
+}
+
+function isRowFullyEmpty(row) {
+  return Object.values(row || {}).every((value) => normalizeCell(value) == null);
+}
+
+function parseStrictInteger(value, fieldName) {
+  const text = normalizeCell(value);
+  if (text == null) throw new Error(`${fieldName} es obligatorio`);
+  if (!/^-?\d+$/.test(text)) {
+    throw new Error(`${fieldName} debe ser entero`);
+  }
+  return Number.parseInt(text, 10);
+}
+
+function parseEuropeanDecimal(value, fieldName = "UnitPrice") {
+  const raw = normalizeCell(value);
+  if (raw == null) throw new Error(`${fieldName} es obligatorio`);
+  let text = raw.replace(/\s+/g, "");
+
+  if (/^-?\d{1,3}(\.\d{3})*(,\d+)?$/.test(text)) {
+    text = text.replace(/\./g, "");
+  }
+
+  if (text.includes(",")) {
+    text = text.replace(",", ".");
+  }
+
+  if (!/^-?\d+(\.\d+)?$/.test(text)) {
+    throw new Error(`${fieldName} inválido (${raw})`);
+  }
+
+  return Number(new Decimal(text).toString());
+}
+
+function parseCanBeOrdered(value) {
+  const normalized = normalizeCell(value);
+  if (normalized === "Yes") return true;
+  if (normalized === "No") return false;
+  throw new Error(`CanBeOrdered inválido (${normalized ?? "vacío"})`);
+}
+
+function deriveStatusFlags(status) {
+  const source = String(status || "");
+  const lowered = source.toLowerCase();
+  return {
+    isAvailable: lowered.includes("available"),
+    hasLongerDeliveryTime: lowered.includes("longer delivery time"),
+    isExpiring: source.trim() === "Expiring",
+  };
+}
+
+function extractImages(row) {
+  return IMAGE_COLUMNS.map((key) => normalizeCell(row?.[key])).filter(Boolean);
+}
+
+function validateRequiredColumns(columns = []) {
+  const missing = REQUIRED_COLUMNS.filter((column) => !columns.includes(column));
+  return {
+    ok: missing.length === 0,
+    missing,
+  };
+}
+
+function toImportedRecord(row, line) {
+  const partId = parseStrictInteger(row.PartId, "PartId");
+  const manufacturerId = parseStrictInteger(row.ManufacturerId, "ManufacturerId");
+  const supplierPartNumber = normalizeCell(row.PartNumber);
+  if (!supplierPartNumber) {
+    throw new Error("PartNumber es obligatorio");
+  }
+  const description = normalizeCell(row.Description);
+  if (!description) {
+    throw new Error("Description es obligatoria");
+  }
+  const supplierStatus = normalizeCell(row.Status);
+  if (!supplierStatus) {
+    throw new Error("Status es obligatorio");
+  }
+
+  const unitPrice = parseEuropeanDecimal(row.UnitPrice, "UnitPrice");
+  const stockQuantity = parseStrictInteger(row.StockQuantity, "StockQuantity");
+  const maximumQuantityInOrder = parseStrictInteger(
+    row.MaximumQuantityInOrder,
+    "MaximumQuantityInOrder",
+  );
+  const canBeOrdered = parseCanBeOrdered(row.CanBeOrdered);
+  const images = extractImages(row);
+
+  const record = {
+    externalId: partId,
+    supplierPartNumber,
+    manufacturerName: normalizeCell(row.ManufacturerName),
+    externalManufacturerId: manufacturerId,
+    manufacturerArticleCode: normalizeCell(row.ManufacturerArticleCode),
+    mainCategory: normalizeCell(row.MainCategory),
+    subCategory: normalizeCell(row.SubCategory),
+    description,
+    supplierStatus,
+    ...deriveStatusFlags(supplierStatus),
+    canBeOrdered,
+    unitPrice,
+    stockQuantity,
+    maximumQuantityInOrder,
+    quality: normalizeCell(row.Quality),
+    remarks: normalizeCell(row.Remarks),
+    eanNumber: normalizeCell(row.EanNumber),
+    countryOfOrigin: normalizeCell(row.CountryOfOrigin),
+    productGroup: normalizeCell(row.ProductGroup),
+    images,
+    pricing: null,
+    pricingWarnings: [],
+    pricingTrace: null,
+    rawRow: ALL_COLUMNS.reduce((acc, key) => {
+      acc[key] = row[key] == null ? null : String(row[key]);
+      return acc;
+    }, {}),
+  };
+
+  if (!record.manufacturerName) {
+    throw new Error("ManufacturerName es obligatorio");
+  }
+
+  return {
+    line,
+    record,
+    rowKey: String(partId),
+    supplierPartNumberKey: supplierPartNumber.toLowerCase(),
+  };
+}
+
+function mapImportedRecordToStoreProduct(imported) {
+  const finalPrice = Number(imported?.pricing?.precio_final_ars);
+  const safePrice =
+    Number.isFinite(finalPrice) && finalPrice > 0 ? finalPrice : imported.unitPrice;
+  const metadata = {
+    supplierImport: imported,
+    supplierPartNumber: imported.supplierPartNumber,
+    externalManufacturerId: imported.externalManufacturerId,
+    manufacturerArticleCode: imported.manufacturerArticleCode,
+    supplierStatus: imported.supplierStatus,
+    importSource: "catalog_csv",
+    importVersion: 1,
+    importedAt: new Date().toISOString(),
+  };
+
+  return {
+    id: String(imported.externalId),
+    sku: imported.supplierPartNumber,
+    name: imported.description,
+    description: imported.description,
+    brand: imported.manufacturerName,
+    price: safePrice,
+    price_minorista: safePrice,
+    price_mayorista: safePrice,
+    stock: imported.stockQuantity,
+    min_stock: 0,
+    image: imported.images[0] || null,
+    images: imported.images,
+    metadata,
+  };
+}
+
+function createBaseSummary() {
+  return {
+    totalRows: 0,
+    inserted: 0,
+    updated: 0,
+    skipped: 0,
+    failed: 0,
+    errors: [],
+  };
+}
+
+async function buildJsonPersistenceLayer() {
+  const filePath = path.join(DATA_DIR, "products.json");
+  let current = [];
+  try {
+    current = JSON.parse(fs.readFileSync(filePath, "utf8")).products || [];
+  } catch {
+    current = [];
+  }
+
+  const byId = new Map(current.map((product) => [String(product.id), { ...product }]));
+  const partNumberToId = new Map();
+  for (const product of byId.values()) {
+    const supplierPartNumber =
+      normalizeCell(product?.metadata?.supplierImport?.supplierPartNumber) ||
+      normalizeCell(product?.metadata?.supplierPartNumber) ||
+      normalizeCell(product?.sku);
+    if (supplierPartNumber) {
+      partNumberToId.set(supplierPartNumber.toLowerCase(), String(product.id));
+    }
+  }
+
+  return {
+    partNumberToId,
+    async upsertBatch(batch) {
+      let inserted = 0;
+      let updated = 0;
+      for (const item of batch) {
+        const id = String(item.record.externalId);
+        const normalized = mapImportedRecordToStoreProduct(item.record);
+        if (byId.has(id)) {
+          const previous = byId.get(id);
+          byId.set(id, {
+            ...previous,
+            ...normalized,
+          });
+          updated += 1;
+        } else {
+          byId.set(id, normalized);
+          inserted += 1;
+        }
+        partNumberToId.set(item.supplierPartNumberKey, id);
+      }
+      return { inserted, updated };
+    },
+    async finalize() {
+      const all = Array.from(byId.values());
+      fs.writeFileSync(filePath, JSON.stringify({ products: all }, null, 2), "utf8");
+    },
+  };
+}
+
+async function buildPgPersistenceLayer(pool) {
+  const { rows } = await pool.query(
+    `SELECT id, metadata->>'supplierPartNumber' AS supplier_part_number,
+            metadata->'supplierImport'->>'supplierPartNumber' AS nested_supplier_part_number
+     FROM products`,
+  );
+  const partNumberToId = new Map();
+  for (const row of rows) {
+    const candidate =
+      normalizeCell(row.nested_supplier_part_number) || normalizeCell(row.supplier_part_number);
+    if (candidate) {
+      partNumberToId.set(candidate.toLowerCase(), String(row.id));
+    }
+  }
+
+  return {
+    partNumberToId,
+    async upsertBatch(batch) {
+      if (!batch.length) return { inserted: 0, updated: 0 };
+      const values = [];
+      const placeholders = [];
+      let i = 1;
+      for (const item of batch) {
+        const mapped = mapImportedRecordToStoreProduct(item.record);
+        placeholders.push(`($${i},$${i + 1},$${i + 2},$${i + 3},$${i + 4},$${i + 5})`);
+        values.push(
+          mapped.id,
+          mapped.name,
+          mapped.price,
+          mapped.stock,
+          mapped.image,
+          mapped.metadata,
+        );
+        i += 6;
+      }
+
+      const sql = `
+        INSERT INTO products (id, name, price, stock, image_url, metadata)
+        VALUES ${placeholders.join(",")}
+        ON CONFLICT (id) DO UPDATE SET
+          name = EXCLUDED.name,
+          price = EXCLUDED.price,
+          stock = EXCLUDED.stock,
+          image_url = EXCLUDED.image_url,
+          metadata = EXCLUDED.metadata,
+          updated_at = now()
+        RETURNING (xmax = 0) AS inserted
+      `;
+
+      const result = await pool.query(sql, values);
+      const inserted = result.rows.filter((row) => row.inserted).length;
+      const updated = result.rowCount - inserted;
+
+      for (const item of batch) {
+        partNumberToId.set(item.supplierPartNumberKey, String(item.record.externalId));
+      }
+
+      return { inserted, updated };
+    },
+    async finalize() {},
+  };
+}
+
+function createImportError(line, message, context = null) {
+  return {
+    line,
+    message,
+    ...(context ? { context } : {}),
+  };
+}
+
+async function importCatalogCsvFile({
+  filePath,
+  pool = null,
+  chunkSize = 400,
+  maxReportedErrors = 500,
+}) {
+  const summary = createBaseSummary();
+  const pricingSummary = createPricingSummaryAccumulator();
+  const seenPartIds = new Set();
+  const seenPartNumbers = new Set();
+
+  const persistence = pool
+    ? await buildPgPersistenceLayer(pool)
+    : await buildJsonPersistenceLayer();
+
+  const parseStream = fs.createReadStream(filePath, { encoding: "utf8" }).pipe(
+    parse({
+      columns: true,
+      bom: true,
+      skip_empty_lines: true,
+      relax_column_count: true,
+      info: true,
+    }),
+  );
+
+  let headersValidated = false;
+  let pendingBatch = [];
+
+  const pushError = (error) => {
+    summary.failed += 1;
+    if (summary.errors.length < maxReportedErrors) {
+      summary.errors.push(error);
+    }
+  };
+
+  const flushBatch = async () => {
+    if (!pendingBatch.length) return;
+    try {
+      const { inserted, updated } = await persistence.upsertBatch(pendingBatch);
+      summary.inserted += inserted;
+      summary.updated += updated;
+    } catch (error) {
+      for (const item of pendingBatch) {
+        pushError(
+          createImportError(
+            item.line,
+            `Error al persistir producto externalId=${item.record.externalId}: ${error.message}`,
+          ),
+        );
+      }
+    } finally {
+      pendingBatch = [];
+    }
+  };
+
+  for await (const data of parseStream) {
+    const row = data.record || {};
+    const line = data.info?.lines || null;
+
+    if (!headersValidated) {
+      const headers = Object.keys(row);
+      const requiredCheck = validateRequiredColumns(headers);
+      if (!requiredCheck.ok) {
+        const error = new Error(
+          `Faltan columnas obligatorias: ${requiredCheck.missing.join(", ")}`,
+        );
+        error.code = "MISSING_REQUIRED_COLUMNS";
+        throw error;
+      }
+      headersValidated = true;
+    }
+
+    if (isRowFullyEmpty(row)) {
+      summary.skipped += 1;
+      continue;
+    }
+
+    summary.totalRows += 1;
+
+    try {
+      const transformed = toImportedRecord(row, line);
+      const pricingResult = computePricingForRow(row, undefined, {
+        costColumn: "UnitPrice",
+        currencyHeuristics: { assumeEuropeanSupplier: true },
+      });
+      transformed.record.pricing = pricingResult.pricing;
+      transformed.record.pricingWarnings = pricingResult.warnings;
+      transformed.record.pricingTrace = pricingResult.mapping;
+      pricingSummary.add(row, pricingResult.pricing);
+
+      if (seenPartIds.has(transformed.rowKey)) {
+        throw new Error(`PartId duplicado dentro del CSV (${transformed.rowKey})`);
+      }
+      seenPartIds.add(transformed.rowKey);
+
+      if (seenPartNumbers.has(transformed.supplierPartNumberKey)) {
+        throw new Error(
+          `PartNumber duplicado dentro del CSV (${transformed.record.supplierPartNumber})`,
+        );
+      }
+      seenPartNumbers.add(transformed.supplierPartNumberKey);
+
+      const existingOwner = persistence.partNumberToId.get(transformed.supplierPartNumberKey);
+      if (existingOwner && existingOwner !== transformed.rowKey) {
+        throw new Error(
+          `PartNumber ya existe en otro producto (PartId actual: ${existingOwner})`,
+        );
+      }
+
+      pendingBatch.push(transformed);
+      if (pendingBatch.length >= chunkSize) {
+        await flushBatch();
+      }
+    } catch (error) {
+      pushError(createImportError(line, error.message));
+    }
+  }
+
+  await flushBatch();
+  await persistence.finalize();
+  summary.pricing = pricingSummary.finalize();
+
+  return summary;
+}
+
+module.exports = {
+  REQUIRED_COLUMNS,
+  validateRequiredColumns,
+  parseEuropeanDecimal,
+  toImportedRecord,
+  importCatalogCsvFile,
+};

--- a/nerin_final_updated/backend/services/catalogPricing.js
+++ b/nerin_final_updated/backend/services/catalogPricing.js
@@ -1,0 +1,387 @@
+const Decimal = require("decimal.js");
+
+const PRICING_OUTPUT_COLUMNS = [
+  "costo_proveedor_original",
+  "moneda_origen",
+  "costo_proveedor_usd",
+  "costo_proveedor_ars",
+  "envio_internacional_prorrateado_usd",
+  "envio_internacional_prorrateado_ars",
+  "base_importacion_ars",
+  "die_ars",
+  "tasa_estadistica_ars",
+  "iva_importacion_ars",
+  "percepcion_iva_ars",
+  "percepcion_ganancias_ars",
+  "costo_caja_ars",
+  "envio_ml_unitario_ars",
+  "empaque_ars",
+  "publicidad_ars",
+  "costo_total_completo_ars",
+  "precio_teorico_ars",
+  "precio_final_ars",
+  "comision_ml_ars",
+  "iibb_ars",
+  "ganancia_estimada_ars",
+  "margen_sobre_costo_caja",
+  "margen_neto_sobre_venta",
+  "estado_calculo",
+];
+
+const DEFAULT_PRICING_CONFIG = {
+  defaultSupplierCurrency: "EUR",
+  USD_ARS: 1500,
+  EUR_USD: 1.1489,
+  envio_internacional_total_eur: 106.75,
+  pedido_base_usd: 1000,
+  die: 0,
+  tasa_estadistica: 0.03,
+  iva_importacion: 0.21,
+  percepcion_iva: 0.2,
+  percepcion_ganancias: 0.06,
+  comision_ml: 0.16,
+  iibb: 0.03,
+  margen_neto_objetivo: 0.15,
+  envio_ml_unitario_ars: 7720,
+  empaque_ars: 0,
+  publicidad_ars: 0,
+  precio_minimo_ars: 1000,
+  redondeo_ars: 100,
+};
+
+const COST_COLUMN_CANDIDATES = [
+  "unitprice",
+  "unit_price",
+  "unit cost",
+  "unitcost",
+  "supplier_price",
+  "supplierprice",
+  "costo proveedor",
+  "costoproveedor",
+  "precio proveedor",
+  "precioproveedor",
+  "costo",
+  "cost",
+  "price",
+  "precio",
+];
+
+const CURRENCY_COLUMN_CANDIDATES = [
+  "currency",
+  "moneda",
+  "currency_code",
+  "currencycode",
+  "supplier_currency",
+  "suppliercurrency",
+  "moneda_origen",
+];
+
+const SKU_CANDIDATES = ["PartNumber", "SKU", "sku", "id", "PartId"];
+const TITLE_CANDIDATES = ["Description", "Title", "name", "product_name"];
+
+function toDecimal(value) {
+  return new Decimal(value);
+}
+
+function normalizeText(value) {
+  if (value == null) return null;
+  const text = String(value).trim();
+  return text ? text : null;
+}
+
+function normalizeKey(value) {
+  return String(value || "")
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function buildColumnLookup(row = {}) {
+  const lookup = new Map();
+  for (const key of Object.keys(row)) {
+    lookup.set(normalizeKey(key), key);
+  }
+  return lookup;
+}
+
+function findColumnByCandidates(lookup, candidates = []) {
+  for (const candidate of candidates) {
+    const normalizedCandidate = normalizeKey(candidate);
+    if (lookup.has(normalizedCandidate)) {
+      return lookup.get(normalizedCandidate);
+    }
+  }
+  return null;
+}
+
+function parseMoneyLike(value) {
+  const text = normalizeText(value);
+  if (!text) return null;
+  let sanitized = text.replace(/\s+/g, "");
+  if (/^-?\d{1,3}(\.\d{3})*(,\d+)?$/.test(sanitized)) {
+    sanitized = sanitized.replace(/\./g, "");
+  }
+  if (sanitized.includes(",")) {
+    sanitized = sanitized.replace(",", ".");
+  }
+  if (!/^-?\d+(\.\d+)?$/.test(sanitized)) return null;
+  return Number(new Decimal(sanitized).toString());
+}
+
+function resolveCurrency(rawValue, heuristics = {}) {
+  const value = normalizeText(rawValue);
+  if (value) {
+    const upper = value.toUpperCase();
+    if (["EUR", "€"].includes(upper)) return { currency: "EUR", inferred: false };
+    if (["USD", "US$", "$USD"].includes(upper)) return { currency: "USD", inferred: false };
+    if (["ARS", "$", "$ARS"].includes(upper)) return { currency: "ARS", inferred: false };
+    return { currency: null, inferred: false };
+  }
+
+  if (heuristics.assumeEuropeanSupplier === true) {
+    return { currency: "EUR", inferred: true };
+  }
+
+  return { currency: null, inferred: false };
+}
+
+function roundUpToStep(value, step) {
+  if (!Number.isFinite(value)) return null;
+  const divider = new Decimal(step);
+  return Number(new Decimal(value).div(divider).ceil().mul(divider).toString());
+}
+
+function nullPricingResult() {
+  return PRICING_OUTPUT_COLUMNS.reduce((acc, key) => {
+    acc[key] = key === "estado_calculo" ? "revisión" : null;
+    return acc;
+  }, {});
+}
+
+function pickFirstValue(row, keys = []) {
+  for (const key of keys) {
+    if (row[key] != null && String(row[key]).trim() !== "") return row[key];
+  }
+  return null;
+}
+
+function selectCostColumn(row) {
+  const lookup = buildColumnLookup(row);
+  const found = findColumnByCandidates(lookup, COST_COLUMN_CANDIDATES);
+  return found;
+}
+
+function selectCurrencyColumn(row) {
+  const lookup = buildColumnLookup(row);
+  return findColumnByCandidates(lookup, CURRENCY_COLUMN_CANDIDATES);
+}
+
+function computePricingForRow(row, config = DEFAULT_PRICING_CONFIG, options = {}) {
+  const result = nullPricingResult();
+  const warnings = [];
+  const merged = { ...DEFAULT_PRICING_CONFIG, ...(config || {}) };
+
+  const costColumn = options.costColumn || selectCostColumn(row);
+  const currencyColumn = options.currencyColumn || selectCurrencyColumn(row);
+
+  if (!costColumn) {
+    warnings.push("No se encontró columna de costo proveedor");
+    return { pricing: result, warnings, mapping: { costColumn: null, currencyColumn } };
+  }
+
+  const supplierCost = parseMoneyLike(row[costColumn]);
+  if (!Number.isFinite(supplierCost) || supplierCost <= 0) {
+    warnings.push(`Costo proveedor inválido en columna ${costColumn}`);
+    return { pricing: result, warnings, mapping: { costColumn, currencyColumn } };
+  }
+
+  const currencyResolved = resolveCurrency(
+    currencyColumn ? row[currencyColumn] : null,
+    options.currencyHeuristics,
+  );
+
+  if (!currencyResolved.currency) {
+    warnings.push("No se pudo deducir la moneda de origen con seguridad");
+    return { pricing: result, warnings, mapping: { costColumn, currencyColumn } };
+  }
+
+  if (currencyResolved.inferred) {
+    warnings.push(`Moneda inferida como ${currencyResolved.currency}`);
+  }
+
+  const usdArs = toDecimal(merged.USD_ARS);
+  const eurUsd = toDecimal(merged.EUR_USD);
+
+  let supplierUsd;
+  if (currencyResolved.currency === "EUR") {
+    supplierUsd = toDecimal(supplierCost).mul(eurUsd);
+  } else if (currencyResolved.currency === "USD") {
+    supplierUsd = toDecimal(supplierCost);
+  } else {
+    supplierUsd = toDecimal(supplierCost).div(usdArs);
+  }
+
+  const supplierArs = supplierUsd.mul(usdArs);
+  const envioTotalUsd = toDecimal(merged.envio_internacional_total_eur).mul(eurUsd);
+  const proporcion = supplierUsd.div(toDecimal(merged.pedido_base_usd));
+  const envioProrrateadoUsd = envioTotalUsd.mul(proporcion);
+  const envioProrrateadoArs = envioProrrateadoUsd.mul(usdArs);
+
+  const baseImportacion = supplierArs.add(envioProrrateadoArs);
+  const die = baseImportacion.mul(toDecimal(merged.die));
+  const tasaEstadistica = baseImportacion.mul(toDecimal(merged.tasa_estadistica));
+  const ivaImportacion = baseImportacion.mul(toDecimal(merged.iva_importacion));
+  const percepcionIva = baseImportacion.mul(toDecimal(merged.percepcion_iva));
+  const percepcionGanancias = baseImportacion.mul(toDecimal(merged.percepcion_ganancias));
+
+  const costoCaja = supplierArs
+    .add(envioProrrateadoArs)
+    .add(die)
+    .add(tasaEstadistica)
+    .add(ivaImportacion)
+    .add(percepcionIva)
+    .add(percepcionGanancias);
+
+  const costoTotalCompleto = costoCaja
+    .add(toDecimal(merged.envio_ml_unitario_ars))
+    .add(toDecimal(merged.empaque_ars))
+    .add(toDecimal(merged.publicidad_ars));
+
+  const divisor = toDecimal(1)
+    .sub(toDecimal(merged.comision_ml))
+    .sub(toDecimal(merged.iibb))
+    .sub(toDecimal(merged.margen_neto_objetivo));
+
+  if (divisor.lte(0)) {
+    warnings.push("Configuración inválida: divisor <= 0");
+    return { pricing: result, warnings, mapping: { costColumn, currencyColumn } };
+  }
+
+  const precioTeorico = costoTotalCompleto.div(divisor);
+  const precioConMinimo = Decimal.max(precioTeorico, toDecimal(merged.precio_minimo_ars));
+  const precioFinal = toDecimal(roundUpToStep(Number(precioConMinimo.toString()), merged.redondeo_ars));
+
+  const comisionMl = precioFinal.mul(toDecimal(merged.comision_ml));
+  const iibb = precioFinal.mul(toDecimal(merged.iibb));
+  const gananciaEstimada = precioFinal.sub(comisionMl).sub(iibb).sub(costoTotalCompleto);
+
+  const margenSobreCostoCaja = costoCaja.gt(0) ? gananciaEstimada.div(costoCaja) : null;
+  const margenNetoSobreVenta = precioFinal.gt(0) ? gananciaEstimada.div(precioFinal) : null;
+
+  const isInvalidCost = !costoTotalCompleto.gt(0);
+  const underCost = precioFinal.lt(costoTotalCompleto);
+
+  const estadoCalculo = isInvalidCost || underCost || !margenSobreCostoCaja ? "revisión" : "ok";
+
+  result.costo_proveedor_original = supplierCost;
+  result.moneda_origen = currencyResolved.currency;
+  result.costo_proveedor_usd = Number(supplierUsd.toString());
+  result.costo_proveedor_ars = Number(supplierArs.toString());
+  result.envio_internacional_prorrateado_usd = Number(envioProrrateadoUsd.toString());
+  result.envio_internacional_prorrateado_ars = Number(envioProrrateadoArs.toString());
+  result.base_importacion_ars = Number(baseImportacion.toString());
+  result.die_ars = Number(die.toString());
+  result.tasa_estadistica_ars = Number(tasaEstadistica.toString());
+  result.iva_importacion_ars = Number(ivaImportacion.toString());
+  result.percepcion_iva_ars = Number(percepcionIva.toString());
+  result.percepcion_ganancias_ars = Number(percepcionGanancias.toString());
+  result.costo_caja_ars = Number(costoCaja.toString());
+  result.envio_ml_unitario_ars = merged.envio_ml_unitario_ars;
+  result.empaque_ars = merged.empaque_ars;
+  result.publicidad_ars = merged.publicidad_ars;
+  result.costo_total_completo_ars = Number(costoTotalCompleto.toString());
+  result.precio_teorico_ars = Number(precioTeorico.toString());
+  result.precio_final_ars = Number(precioFinal.toString());
+  result.comision_ml_ars = Number(comisionMl.toString());
+  result.iibb_ars = Number(iibb.toString());
+  result.ganancia_estimada_ars = Number(gananciaEstimada.toString());
+  result.margen_sobre_costo_caja = margenSobreCostoCaja
+    ? Number(margenSobreCostoCaja.toString())
+    : null;
+  result.margen_neto_sobre_venta = margenNetoSobreVenta
+    ? Number(margenNetoSobreVenta.toString())
+    : null;
+  result.estado_calculo = estadoCalculo;
+
+  if (underCost) warnings.push("El precio final quedó por debajo del costo total completo");
+
+  return {
+    pricing: result,
+    warnings,
+    mapping: {
+      costColumn,
+      currencyColumn,
+      inferredCurrency: currencyResolved.inferred,
+    },
+  };
+}
+
+function createPricingSummaryAccumulator() {
+  const state = {
+    processed: 0,
+    ok: 0,
+    revision: 0,
+    marginValues: [],
+    gainRows: [],
+    lowMarginRows: [],
+  };
+
+  return {
+    add(row, pricing) {
+      state.processed += 1;
+      if (pricing.estado_calculo === "ok") state.ok += 1;
+      else state.revision += 1;
+
+      if (typeof pricing.margen_neto_sobre_venta === "number") {
+        state.marginValues.push(pricing.margen_neto_sobre_venta);
+      }
+
+      const sku = String(pickFirstValue(row, SKU_CANDIDATES) || "sin_sku");
+      const title = String(pickFirstValue(row, TITLE_CANDIDATES) || sku);
+      const gain = Number(pricing.ganancia_estimada_ars || 0);
+      const margin =
+        typeof pricing.margen_sobre_costo_caja === "number"
+          ? pricing.margen_sobre_costo_caja
+          : Number.POSITIVE_INFINITY;
+
+      state.gainRows.push({ sku, title, ganancia_estimada_ars: gain, estado_calculo: pricing.estado_calculo });
+      state.lowMarginRows.push({ sku, title, margen_sobre_costo_caja: margin, estado_calculo: pricing.estado_calculo });
+    },
+    finalize() {
+      const avgMargin =
+        state.marginValues.length > 0
+          ? state.marginValues.reduce((acc, value) => acc + value, 0) / state.marginValues.length
+          : null;
+
+      const topGanancia = [...state.gainRows]
+        .sort((a, b) => b.ganancia_estimada_ars - a.ganancia_estimada_ars)
+        .slice(0, 10);
+
+      const menoresMargenes = [...state.lowMarginRows]
+        .filter((item) => Number.isFinite(item.margen_sobre_costo_caja))
+        .sort((a, b) => a.margen_sobre_costo_caja - b.margen_sobre_costo_caja)
+        .slice(0, 10);
+
+      return {
+        processedRows: state.processed,
+        okRows: state.ok,
+        revisionRows: state.revision,
+        averageNetMargin: avgMargin,
+        top10ByEstimatedProfit: topGanancia,
+        bottom10ByMargin: menoresMargenes,
+      };
+    },
+  };
+}
+
+module.exports = {
+  PRICING_OUTPUT_COLUMNS,
+  DEFAULT_PRICING_CONFIG,
+  computePricingForRow,
+  createPricingSummaryAccumulator,
+  selectCostColumn,
+  selectCurrencyColumn,
+};

--- a/nerin_final_updated/package.json
+++ b/nerin_final_updated/package.json
@@ -6,13 +6,15 @@
   "scripts": {
     "start": "node backend/server.js",
     "test": "jest",
-    "validate:meta-feed": "node scripts/validate-meta-feed.js"
+    "validate:meta-feed": "node scripts/validate-meta-feed.js",
+    "catalog:enrich-csv": "node scripts/enrichCatalogCsv.js"
   },
   "dependencies": {
     "@react-email/components": "^0.5.4",
     "afip.ts": "^3.2.2",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
+    "csv-parse": "^5.5.6",
     "decimal.js": "^10.4.3",
     "express": "^4.19.2",
     "http-proxy-middleware": "^3.0.0",

--- a/nerin_final_updated/scripts/enrichCatalogCsv.js
+++ b/nerin_final_updated/scripts/enrichCatalogCsv.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+const { parse } = require("csv-parse");
+const {
+  computePricingForRow,
+  createPricingSummaryAccumulator,
+  PRICING_OUTPUT_COLUMNS,
+} = require("../backend/services/catalogPricing");
+
+function csvEscape(value) {
+  if (value == null) return "";
+  const text = String(value);
+  if (/[,"\n\r]/.test(text)) {
+    return `"${text.replace(/"/g, '""')}"`;
+  }
+  return text;
+}
+
+function toCsvLine(values) {
+  return values.map(csvEscape).join(",") + "\n";
+}
+
+function usage() {
+  console.error("Uso: node scripts/enrichCatalogCsv.js <input.csv> [output.csv]");
+}
+
+async function run() {
+  const input = process.argv[2];
+  const output = process.argv[3] || path.join(process.cwd(), "catalog_enriched.csv");
+  if (!input) {
+    usage();
+    process.exit(1);
+  }
+
+  const inputPath = path.resolve(process.cwd(), input);
+  const outputPath = path.resolve(process.cwd(), output);
+
+  if (!fs.existsSync(inputPath)) {
+    console.error(`No existe el archivo: ${inputPath}`);
+    process.exit(1);
+  }
+
+  const summary = createPricingSummaryAccumulator();
+  let headersWritten = false;
+  let outputHeaders = [];
+
+  const writer = fs.createWriteStream(outputPath, { encoding: "utf8" });
+  const parser = fs.createReadStream(inputPath, { encoding: "utf8" }).pipe(
+    parse({
+      columns: true,
+      bom: true,
+      skip_empty_lines: true,
+      relax_column_count: true,
+    }),
+  );
+
+  for await (const row of parser) {
+    if (!headersWritten) {
+      outputHeaders = [...Object.keys(row), ...PRICING_OUTPUT_COLUMNS];
+      writer.write(toCsvLine(outputHeaders));
+      headersWritten = true;
+    }
+
+    const pricingResult = computePricingForRow(row, undefined, {
+      costColumn: row.UnitPrice != null ? "UnitPrice" : undefined,
+      currencyHeuristics: { assumeEuropeanSupplier: true },
+    });
+
+    const enriched = {
+      ...row,
+      ...pricingResult.pricing,
+    };
+
+    summary.add(row, pricingResult.pricing);
+
+    const ordered = outputHeaders.map((key) => enriched[key]);
+    writer.write(toCsvLine(ordered));
+  }
+
+  writer.end();
+  await new Promise((resolve) => writer.on("finish", resolve));
+
+  const report = summary.finalize();
+
+  console.log(JSON.stringify({
+    output: outputPath,
+    summary: report,
+  }, null, 2));
+}
+
+run().catch((error) => {
+  console.error("Error enriqueciendo CSV:", error);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation

- Provide a robust pipeline to ingest supplier catalog CSVs, compute local pricing and persist products to the store. 
- Support European-formatted numbers, multi-image rows, basic validation and duplicate detection to avoid bad imports. 
- Expose a secured API endpoint for uploading/importing CSVs and add a utility script to enrich CSVs with pricing columns.

### Description

- Added a pricing module at `backend/services/catalogPricing.js` that computes full cost/pricing (`computePricingForRow`), includes currency heuristics, rounding to configurable steps, and a summary accumulator (`createPricingSummaryAccumulator`).
- Implemented the CSV import service at `backend/services/catalogCsvImport.js` with CSV parsing (`csv-parse`), European decimal parsing (`parseEuropeanDecimal`), image extraction, required-column validation, duplicate checks, chunked upserts and dual persistence backends (Postgres via `pool.query` or JSON file fallback). 
- Integrated a multipart upload handler and new route `POST /api/import/catalog-csv` in `backend/server.js` using a dedicated `multer` configuration `catalogCsvUpload`, and wired the import flow to call `importCatalogCsvFile`. 
- Added a CLI helper `scripts/enrichCatalogCsv.js` and `package.json` script `catalog:enrich-csv` to annotate an input CSV with pricing columns using the pricing module. 
- Added unit tests `__tests__/catalogPricing.test.js` and `__tests__/catalogCsvImport.test.js` covering pricing calculations, accumulator behavior, European decimal parsing, CSV description parsing with commas, duplicate detection and a mocked persistence layer. 

### Testing

- Ran the test suite with `npm test` (Jest) which exercised the new tests in `__tests__/catalogPricing.test.js` and `__tests__/catalogCsvImport.test.js`, and they passed. 
- The import flow was covered by unit tests that mock DB `pool.query` responses to validate inserted/failed counts, error messages and pricing summary aggregation. 
- The `catalog:enrich-csv` script was added and exercised in CI/local runs by creating enriched CSVs from sample inputs as part of development verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4d82cd8ec8331a252d09889614380)