### PR TITLE
Async import jobs & progress; admin pagination; import persistence improvements

### DIFF
--- a/nerin_final_updated/backend/__tests__/catalogCsvImport.test.js
+++ b/nerin_final_updated/backend/__tests__/catalogCsvImport.test.js
@@ -9,6 +9,13 @@ const {
 } = require("../services/catalogCsvImport");
 
 describe("catalogCsvImport", () => {
+  const originalDataDir = process.env.DATA_DIR;
+
+  afterEach(() => {
+    if (originalDataDir === undefined) delete process.env.DATA_DIR;
+    else process.env.DATA_DIR = originalDataDir;
+  });
+
   test("parseEuropeanDecimal soporta coma decimal", () => {
     expect(parseEuropeanDecimal("10,17")).toBe(10.17);
     expect(parseEuropeanDecimal("1.234,56")).toBe(1234.56);
@@ -159,6 +166,50 @@ describe("catalogCsvImport", () => {
     expect(result.safety.skippedNotOrderable).toBe(1);
     expect(result.safety.skippedStatusNotAvailable).toBe(1);
     expect(result.safety.skippedMaxOrderZero).toBe(1);
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test("includeOutOfStock importa todo el catálogo y guarda stock CSV como metadato", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "csv-import-test-"));
+    const filePath = path.join(tempDir, "catalog.csv");
+    const productsPath = path.join(tempDir, "products.json");
+    const csv = [
+      "PartId,ManufacturerName,ManufacturerId,ManufacturerArticleCode,MainCategory,SubCategory,PartNumber,Description,Status,CanBeOrdered,UnitPrice,StockQuantity,MaximumQuantityInOrder,Quality,Remarks,ImageUrl,ImageUrl2,ImageUrl3,ImageUrl4,ImageUrl5,EanNumber,CountryOfOrigin,ProductGroup",
+      '3001,ACME,1,,Main,Sub,SKU-ALL-A,"Con stock",Available,Yes,"10,00",8,2,Original,,https://img/1.jpg,,,,,,CN,Mobile',
+      '3002,ACME,1,,Main,Sub,SKU-ALL-B,"Sin stock",Available,Yes,"10,00",0,2,Original,,https://img/2.jpg,,,,,,CN,Mobile',
+      '3003,ACME,1,,Main,Sub,SKU-ALL-C,"No ordenable",Available,No,"10,00",5,2,Original,,https://img/3.jpg,,,,,,CN,Mobile',
+      '3004,ACME,1,,Main,Sub,SKU-ALL-D,"No disponible",Unavailable,Yes,"10,00",5,0,Original,,https://img/4.jpg,,,,,,CN,Mobile',
+    ].join("\n");
+    fs.writeFileSync(filePath, csv, "utf8");
+    fs.writeFileSync(productsPath, JSON.stringify({ products: [] }, null, 2), "utf8");
+
+    jest.resetModules();
+    process.env.DATA_DIR = tempDir;
+    const { importCatalogCsvFile: importer } = require("../services/catalogCsvImport");
+
+    const result = await importer({
+      filePath,
+      includeOutOfStock: true,
+      archiveMissing: false,
+    });
+
+    expect(result.inserted).toBe(4);
+    expect(result.safety.skippedUnavailable).toBe(0);
+    expect(result.catalog.totalProductsAfterImport).toBe(4);
+    expect(result.catalog.withSupplierPartNumber).toBe(4);
+    expect(result.catalog.potentialXlsxMatches).toBe(4);
+    expect(result.catalog.visibleOrPublishable).toBe(1);
+    expect(result.catalog.hiddenNoStockOrNotOrderable).toBe(3);
+
+    const saved = JSON.parse(fs.readFileSync(productsPath, "utf8"));
+    expect(saved.products).toHaveLength(4);
+    for (const product of saved.products) {
+      expect(product.stock).toBe(0);
+      expect(product.remote_stock).toBe(0);
+      expect(product.metadata.needsStockSync).toBe(true);
+      expect(typeof product.metadata.csvStockQuantity).toBe("number");
+    }
 
     fs.rmSync(tempDir, { recursive: true, force: true });
   });

--- a/nerin_final_updated/backend/__tests__/stockXlsxImport.test.js
+++ b/nerin_final_updated/backend/__tests__/stockXlsxImport.test.js
@@ -48,7 +48,14 @@ describe("stockXlsxImport", () => {
               id: "1",
               sku: "GH82-33638A",
               stock: 1,
-              metadata: { supplierPartNumber: "GH82-33638A" },
+              metadata: {
+                supplierPartNumber: "GH82-33638A",
+                supplierImport: {
+                  canBeOrdered: true,
+                  isAvailable: true,
+                  maximumQuantityInOrder: 5,
+                },
+              },
             },
           ],
         },
@@ -84,7 +91,11 @@ describe("stockXlsxImport", () => {
     expect(saved.products[0].stock).toBe(25);
     expect(saved.products[0].stockRaw).toBe("25+");
     expect(saved.products[0].stockIsAtLeast).toBe(true);
+    expect(saved.products[0].visibility).toBe("public");
+    expect(saved.products[0].enabled).toBe(true);
+    expect(saved.products[0].needsStockSync).toBe(false);
     expect(saved.products[0].metadata.stockSource).toBe("mps_xlsx_nl");
+    expect(saved.products[0].metadata.needsStockSync).toBe(false);
     expect(fs.existsSync(`${productsPath}.bak`)).toBe(true);
 
     fs.rmSync(tempDir, { recursive: true, force: true });

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -156,6 +156,8 @@ const REVIEW_STATUSES = ["PENDING", "PUBLISHED", "FLAGGED", "REMOVED"];
 
 let _cache = { t: 0, data: null };
 let metaFeedCache = { t: 0, baseUrl: null, csv: null, count: 0, inStockCount: 0 };
+const importJobs = new Map();
+const IMPORT_JOB_TTL_MS = 60 * 60 * 1000;
 
 function normalizeBaseUrl(value) {
   if (!value || typeof value !== "string") return null;
@@ -178,6 +180,59 @@ function getPublicBaseUrl(cfg) {
   const fromEnv = normalizeBaseUrl(process.env.PUBLIC_URL);
   if (fromEnv) return fromEnv;
   return FALLBACK_BASE_URL;
+}
+
+function createImportJob(type = "catalog_csv") {
+  const jobId = `import_${type}_${Date.now()}_${crypto.randomBytes(3).toString("hex")}`;
+  const job = {
+    jobId,
+    type,
+    status: "queued",
+    progress: 0,
+    processedRows: 0,
+    totalRows: 0,
+    inserted: 0,
+    updated: 0,
+    skipped: 0,
+    errors: 0,
+    message: "En cola…",
+    summary: null,
+    error: null,
+    startedAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+  importJobs.set(jobId, job);
+  return job;
+}
+
+function updateImportJob(jobId, patch = {}) {
+  const current = importJobs.get(jobId);
+  if (!current) return null;
+  const next = {
+    ...current,
+    ...patch,
+    updatedAt: new Date().toISOString(),
+  };
+  importJobs.set(jobId, next);
+  return next;
+}
+
+function cleanupImportJobs() {
+  const now = Date.now();
+  for (const [jobId, job] of importJobs.entries()) {
+    const updatedAt = new Date(job.updatedAt || job.startedAt || Date.now()).getTime();
+    if (!Number.isFinite(updatedAt)) continue;
+    if (now - updatedAt > IMPORT_JOB_TTL_MS) {
+      importJobs.delete(jobId);
+    }
+  }
+}
+
+function hasRunningImportJob() {
+  for (const job of importJobs.values()) {
+    if (job.status === "queued" || job.status === "running") return true;
+  }
+  return false;
 }
 
 function buildReviewLink({ tokenId, tokenPlain, cfg } = {}) {
@@ -1907,6 +1962,183 @@ function sanitizePublicProducts(products) {
     delete sanitized.price_wholesale;
     return sanitized;
   });
+}
+
+function normalizeQueryText(value) {
+  const text = String(value || "")
+    .trim()
+    .toLowerCase();
+  if (!text) return "";
+  try {
+    return text.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+  } catch {
+    return text;
+  }
+}
+
+function parsePaginationParams(query = {}, defaults = {}) {
+  const defaultPage = Number(defaults.page || 1);
+  const defaultPageSize = Number(defaults.pageSize || 24);
+  const maxPageSize = Number(defaults.maxPageSize || 250);
+  const pageRaw = Number(query.page);
+  const sizeRaw = Number(query.pageSize || query.limit);
+  const page = Number.isFinite(pageRaw) && pageRaw > 0 ? Math.floor(pageRaw) : defaultPage;
+  const pageSize =
+    Number.isFinite(sizeRaw) && sizeRaw > 0
+      ? Math.min(Math.floor(sizeRaw), maxPageSize)
+      : defaultPageSize;
+  return { page, pageSize };
+}
+
+function paginateItems(items = [], page = 1, pageSize = 24) {
+  const totalItems = Array.isArray(items) ? items.length : 0;
+  const totalPages = Math.max(1, Math.ceil(totalItems / pageSize));
+  const safePage = Math.min(Math.max(1, page), totalPages);
+  const start = (safePage - 1) * pageSize;
+  const end = start + pageSize;
+  return {
+    items: items.slice(start, end),
+    page: safePage,
+    pageSize,
+    totalItems,
+    totalPages,
+    hasNextPage: safePage < totalPages,
+    hasPrevPage: safePage > 1,
+  };
+}
+
+function getSupplierPartNumber(product = {}) {
+  return String(
+    product?.metadata?.supplierImport?.supplierPartNumber ||
+      product?.metadata?.supplierPartNumber ||
+      product?.sku ||
+      "",
+  ).trim();
+}
+
+function applyCatalogFilters(products = [], query = {}) {
+  const search = normalizeQueryText(query.search || query.q || "");
+  const category = normalizeQueryText(query.category || "");
+  const brand = normalizeQueryText(query.brand || "");
+  const sort = String(query.sort || "relevance").trim().toLowerCase();
+  const filtered = products.filter((product) => {
+    if (!product || typeof product !== "object") return false;
+    if (search) {
+      const haystack = normalizeQueryText(
+        [
+          product.name,
+          product.sku,
+          product.brand,
+          product.model,
+          product.category,
+          product.subcategory,
+          product?.metadata?.supplierImport?.supplierPartNumber,
+        ]
+          .filter(Boolean)
+          .join(" "),
+      );
+      if (!haystack.includes(search)) return false;
+    }
+    if (category && normalizeQueryText(product.category) !== category) return false;
+    if (brand && normalizeQueryText(product.brand) !== brand) return false;
+    return true;
+  });
+
+  const byPrice = (product) =>
+    Number(product?.price_minorista ?? product?.price ?? 0) || 0;
+  const byStock = (product) => Number(product?.stock ?? 0) || 0;
+
+  switch (sort) {
+    case "price-asc":
+      filtered.sort((a, b) => byPrice(a) - byPrice(b));
+      break;
+    case "price-desc":
+      filtered.sort((a, b) => byPrice(b) - byPrice(a));
+      break;
+    case "stock-desc":
+      filtered.sort((a, b) => byStock(b) - byStock(a));
+      break;
+    case "name":
+      filtered.sort((a, b) =>
+        String(a?.name || "").localeCompare(String(b?.name || ""), "es", { sensitivity: "base" }),
+      );
+      break;
+    default:
+      filtered.sort((a, b) => String(a?.id || "").localeCompare(String(b?.id || ""), "es"));
+      break;
+  }
+  return filtered;
+}
+
+function applyAdminProductFilters(products = [], query = {}) {
+  const search = normalizeQueryText(query.search || query.q || "");
+  const category = normalizeQueryText(query.category || "");
+  const brand = normalizeQueryText(query.brand || "");
+  const visibility = normalizeQueryText(query.visibility || "");
+  const stockStatus = normalizeQueryText(query.stockStatus || query.stock || "");
+  const sort = String(query.sort || "recent").trim().toLowerCase();
+  const filtered = products.filter((product) => {
+    if (!product || typeof product !== "object") return false;
+    if (search) {
+      const haystack = normalizeQueryText(
+        [
+          product.name,
+          product.sku,
+          product.brand,
+          product.model,
+          product.category,
+          product.subcategory,
+          getSupplierPartNumber(product),
+        ]
+          .filter(Boolean)
+          .join(" "),
+      );
+      if (!haystack.includes(search)) return false;
+    }
+    if (category && normalizeQueryText(product.category) !== category) return false;
+    if (brand && normalizeQueryText(product.brand) !== brand) return false;
+    if (visibility && normalizeQueryText(product.visibility || "public") !== visibility) return false;
+
+    const stock = Number(product.stock);
+    const minStock = Number(product.min_stock);
+    if (stockStatus === "out" && !(Number.isFinite(stock) && stock <= 0)) return false;
+    if (
+      stockStatus === "low" &&
+      !(Number.isFinite(stock) && Number.isFinite(minStock) && minStock > 0 && stock > 0 && stock < minStock)
+    ) {
+      return false;
+    }
+    if (stockStatus === "in" && !(Number.isFinite(stock) && stock > 0)) return false;
+    return true;
+  });
+
+  const byTs = (product) => {
+    const raw = product?.updated_at || product?.updatedAt || product?.created_at || product?.createdAt;
+    const ts = new Date(raw || 0).getTime();
+    return Number.isFinite(ts) ? ts : 0;
+  };
+  const byName = (product) => String(product?.name || "");
+  const byStock = (product) => Number(product?.stock ?? 0) || 0;
+  const byPrice = (product) => Number(product?.price_minorista ?? product?.price ?? 0) || 0;
+
+  switch (sort) {
+    case "name":
+      filtered.sort((a, b) => byName(a).localeCompare(byName(b), "es", { sensitivity: "base" }));
+      break;
+    case "stock":
+      filtered.sort((a, b) => byStock(b) - byStock(a));
+      break;
+    case "price_desc":
+      filtered.sort((a, b) => byPrice(b) - byPrice(a));
+      break;
+    case "price_asc":
+      filtered.sort((a, b) => byPrice(a) - byPrice(b));
+      break;
+    default:
+      filtered.sort((a, b) => byTs(b) - byTs(a));
+      break;
+  }
+  return filtered;
 }
 function findUserByEmail(email) {
   const normalized = normalizeEmailInput(email);
@@ -5009,16 +5241,39 @@ async function requestHandler(req, res) {
   // API: obtener productos
   if (pathname === "/api/products" && req.method === "GET") {
     try {
-      const products = getProducts();
-      const withWholesale = canSeeWholesalePrices(req);
-      return sendJson(res, 200, {
-        products: withWholesale ? products : sanitizePublicProducts(products),
+      const { page, pageSize } = parsePaginationParams(parsedUrl.query, {
+        page: 1,
+        pageSize: 24,
+        maxPageSize: 96,
       });
+      const products = getProducts().filter((product) => isProductPublic(product));
+      const filtered = applyCatalogFilters(products, parsedUrl.query || {});
+      const withWholesale = canSeeWholesalePrices(req);
+      const safe = withWholesale ? filtered : sanitizePublicProducts(filtered);
+      const pageData = paginateItems(safe, page, pageSize);
+      return sendJson(res, 200, pageData);
     } catch (err) {
       console.error(err);
       return sendJson(res, 500, {
         error: "No se pudieron cargar los productos",
       });
+    }
+  }
+
+  if (pathname === "/api/admin/products" && req.method === "GET") {
+    try {
+      const { page, pageSize } = parsePaginationParams(parsedUrl.query, {
+        page: 1,
+        pageSize: 100,
+        maxPageSize: 250,
+      });
+      const products = getProducts();
+      const filtered = applyAdminProductFilters(products, parsedUrl.query || {});
+      const pageData = paginateItems(filtered, page, pageSize);
+      return sendJson(res, 200, pageData);
+    } catch (err) {
+      console.error("admin-products-list", err);
+      return sendJson(res, 500, { error: "No se pudieron cargar los productos del admin" });
     }
   }
 
@@ -5286,7 +5541,26 @@ async function requestHandler(req, res) {
     return;
   }
 
-  if (pathname === "/api/import/catalog-csv" && req.method === "POST") {
+  if (pathname === "/api/admin/import/jobs" && req.method === "GET") {
+    cleanupImportJobs();
+    const jobs = Array.from(importJobs.values())
+      .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+      .slice(0, 20);
+    return sendJson(res, 200, { jobs });
+  }
+
+  if (pathname.startsWith("/api/admin/import/jobs/") && req.method === "GET") {
+    cleanupImportJobs();
+    const jobId = pathname.split("/").pop();
+    const job = importJobs.get(jobId);
+    if (!job) return sendJson(res, 404, { error: "Job no encontrado" });
+    return sendJson(res, 200, job);
+  }
+
+  if (
+    (pathname === "/api/admin/import/catalog-csv" || pathname === "/api/import/catalog-csv") &&
+    req.method === "POST"
+  ) {
     const adminKey = req.headers["x-admin-key"];
     if (!process.env.ADMIN_KEY) {
       return sendJson(res, 503, {
@@ -5296,6 +5570,11 @@ async function requestHandler(req, res) {
     }
     if (adminKey !== process.env.ADMIN_KEY) {
       return sendJson(res, 401, { error: "Unauthorized" });
+    }
+    if (hasRunningImportJob()) {
+      return sendJson(res, 409, {
+        error: "Ya hay una importación en curso. Esperá a que finalice.",
+      });
     }
     const chunkSizeParam = Number(parsedUrl.query.chunkSize || parsedUrl.query.chunk_size || 400);
     const chunkSize = Number.isFinite(chunkSizeParam) && chunkSizeParam > 0
@@ -5321,35 +5600,73 @@ async function requestHandler(req, res) {
         return sendJson(res, 400, { error: "No se recibió archivo CSV" });
       }
 
-      try {
-        const summary = await importCatalogCsvFile({
-          filePath: req.file.path,
-          pool: null,
-          chunkSize,
-          includeOutOfStock,
-          archiveMissing,
-        });
-        return sendJson(res, 200, {
-          success: true,
-          summary,
-        });
-      } catch (importError) {
-        console.error("catalog-csv-import", importError);
-        const statusCode = importError?.code === "MISSING_REQUIRED_COLUMNS" ? 400 : 500;
-        return sendJson(res, statusCode, {
-          success: false,
-          error: importError.message || "Error al importar catálogo CSV",
-        });
-      } finally {
+      const job = createImportJob("catalog_csv");
+      updateImportJob(job.jobId, {
+        status: "running",
+        message: "Importando catálogo…",
+      });
+      sendJson(res, 202, {
+        success: true,
+        jobId: job.jobId,
+      });
+      (async () => {
         try {
-          await fsp.unlink(req.file.path);
-        } catch {}
-      }
+          const summary = await importCatalogCsvFile({
+            filePath: req.file.path,
+            pool: null,
+            chunkSize,
+            includeOutOfStock,
+            archiveMissing,
+            onProgress: (progressPayload = {}) => {
+              const totalRows = Number(progressPayload.totalRows || 0);
+              const processedRows = Number(progressPayload.processedRows || 0);
+              const progress = totalRows > 0 ? Math.min(99, Math.floor((processedRows / totalRows) * 100)) : 0;
+              updateImportJob(job.jobId, {
+                status: "running",
+                progress,
+                processedRows,
+                totalRows,
+                inserted: Number(progressPayload.inserted || 0),
+                updated: Number(progressPayload.updated || 0),
+                skipped: Number(progressPayload.skipped || 0),
+                errors: Number(progressPayload.failed || 0),
+                message: "Importando catálogo…",
+              });
+            },
+          });
+          updateImportJob(job.jobId, {
+            status: "completed",
+            progress: 100,
+            processedRows: Number(summary.totalRows || 0),
+            totalRows: Number(summary.totalRows || 0),
+            inserted: Number(summary.inserted || 0),
+            updated: Number(summary.updated || 0),
+            skipped: Number(summary.skipped || 0),
+            errors: Number(summary.failed || 0),
+            message: "Importación completada.",
+            summary,
+          });
+        } catch (importError) {
+          console.error("catalog-csv-import", importError);
+          updateImportJob(job.jobId, {
+            status: "failed",
+            message: importError.message || "Error al importar catálogo CSV",
+            error: importError.message || "Error al importar catálogo CSV",
+          });
+        } finally {
+          try {
+            await fsp.unlink(req.file.path);
+          } catch {}
+        }
+      })();
     });
     return;
   }
 
-  if (pathname === "/api/import/stock-xlsx" && req.method === "POST") {
+  if (
+    (pathname === "/api/admin/import/stock-xlsx" || pathname === "/api/import/stock-xlsx") &&
+    req.method === "POST"
+  ) {
     const adminKey = req.headers["x-admin-key"];
     if (!process.env.ADMIN_KEY) {
       return sendJson(res, 503, {
@@ -5359,6 +5676,11 @@ async function requestHandler(req, res) {
     }
     if (adminKey !== process.env.ADMIN_KEY) {
       return sendJson(res, 401, { error: "Unauthorized" });
+    }
+    if (hasRunningImportJob()) {
+      return sendJson(res, 409, {
+        error: "Ya hay una importación en curso. Esperá a que finalice.",
+      });
     }
     const zeroMissingProducts = ["1", "true", "yes", "si"].includes(
       String(parsedUrl.query.zeroMissingProducts || parsedUrl.query.zero_missing_products || "")
@@ -5375,30 +5697,62 @@ async function requestHandler(req, res) {
         return sendJson(res, 400, { error: "No se recibió archivo XLSX" });
       }
 
-      try {
-        const summary = await importStockXlsxFile({
-          filePath: req.file.path,
-          zeroMissingProducts,
-        });
-        return sendJson(res, 200, {
-          success: true,
-          summary,
-        });
-      } catch (importError) {
-        console.error("stock-xlsx-import", importError);
-        const statusCode =
-          importError?.code === "MISSING_REQUIRED_COLUMNS" || importError?.code === "MISSING_SHEET"
-            ? 400
-            : 500;
-        return sendJson(res, statusCode, {
-          success: false,
-          error: importError.message || "Error al importar stock XLSX",
-        });
-      } finally {
+      const job = createImportJob("stock_xlsx");
+      updateImportJob(job.jobId, {
+        status: "running",
+        message: "Importando stock real…",
+      });
+      sendJson(res, 202, {
+        success: true,
+        jobId: job.jobId,
+      });
+      (async () => {
         try {
-          await fsp.unlink(req.file.path);
-        } catch {}
-      }
+          const summary = await importStockXlsxFile({
+            filePath: req.file.path,
+            zeroMissingProducts,
+            onProgress: (progressPayload = {}) => {
+              const totalRows = Number(progressPayload.totalRows || 0);
+              const processedRows = Number(progressPayload.processedRows || 0);
+              const progress = totalRows > 0 ? Math.min(99, Math.floor((processedRows / totalRows) * 100)) : 0;
+              updateImportJob(job.jobId, {
+                status: "running",
+                progress,
+                processedRows,
+                totalRows,
+                inserted: 0,
+                updated: Number(progressPayload.updatedProducts || 0),
+                skipped: Number(progressPayload.unmatchedRows || 0),
+                errors: Number(progressPayload.failedRows || 0),
+                message: "Importando stock real…",
+              });
+            },
+          });
+          updateImportJob(job.jobId, {
+            status: "completed",
+            progress: 100,
+            processedRows: Number(summary.totalRows || 0),
+            totalRows: Number(summary.totalRows || 0),
+            inserted: 0,
+            updated: Number(summary.updatedProducts || 0),
+            skipped: Number(summary.unmatchedRows || 0),
+            errors: Number(summary.failedRows || 0),
+            message: "Importación completada.",
+            summary,
+          });
+        } catch (importError) {
+          console.error("stock-xlsx-import", importError);
+          updateImportJob(job.jobId, {
+            status: "failed",
+            message: importError.message || "Error al importar stock XLSX",
+            error: importError.message || "Error al importar stock XLSX",
+          });
+        } finally {
+          try {
+            await fsp.unlink(req.file.path);
+          } catch {}
+        }
+      })();
     });
     return;
   }

--- a/nerin_final_updated/backend/services/catalogCsvImport.js
+++ b/nerin_final_updated/backend/services/catalogCsvImport.js
@@ -198,13 +198,16 @@ function mapImportedRecordToStoreProduct(imported) {
   const metadata = {
     supplierImport: imported,
     supplierPartNumber: imported.supplierPartNumber,
+    csvStockQuantity: imported.stockQuantity,
     externalManufacturerId: imported.externalManufacturerId,
     manufacturerArticleCode: imported.manufacturerArticleCode,
     supplierStatus: imported.supplierStatus,
     importSource: "catalog_csv",
     importVersion: 1,
     importedAt: new Date().toISOString(),
+    needsStockSync: true,
   };
+  const isPublishableByCatalogSignals = isImportableByAvailability(imported);
 
   return {
     id: String(imported.externalId),
@@ -215,14 +218,18 @@ function mapImportedRecordToStoreProduct(imported) {
     price: safePrice,
     price_minorista: safePrice,
     price_mayorista: safePrice,
-    stock: imported.stockQuantity,
+    stock: 0,
     min_stock: 0,
     stock_mode: "remote",
     fulfillment_mode: "remote",
-    remote_stock: imported.stockQuantity,
+    remote_stock: 0,
     remote_lead_days: safeLeadDays,
     remote_lead_min_days: safeLeadDays,
     remote_lead_max_days: safeLeadDays,
+    visibility: isPublishableByCatalogSignals ? "public" : "private",
+    enabled: isPublishableByCatalogSignals,
+    available: false,
+    needsStockSync: true,
     image: imported.images[0] || null,
     images: imported.images,
     metadata,
@@ -243,7 +250,16 @@ function createBaseSummary() {
       skippedNotOrderable: 0,
       skippedStatusNotAvailable: 0,
       skippedMaxOrderZero: 0,
+      importedVisibleOrPublishable: 0,
+      importedHiddenNoStockOrNotOrderable: 0,
       archivedMissing: 0,
+    },
+    catalog: {
+      totalProductsAfterImport: 0,
+      withSupplierPartNumber: 0,
+      potentialXlsxMatches: 0,
+      visibleOrPublishable: 0,
+      hiddenNoStockOrNotOrderable: 0,
     },
   };
 }
@@ -354,6 +370,16 @@ async function buildJsonPersistenceLayer() {
     async finalize() {
       const all = Array.from(byId.values());
       safeWriteJsonWithBackup(filePath, { products: all });
+      return {
+        totalProductsAfterImport: all.length,
+        withSupplierPartNumber: all.filter((product) => {
+          const supplierPartNumber =
+            normalizeCell(product?.metadata?.supplierImport?.supplierPartNumber) ||
+            normalizeCell(product?.metadata?.supplierPartNumber) ||
+            normalizeCell(product?.sku);
+          return Boolean(supplierPartNumber);
+        }).length,
+      };
     },
   };
 }
@@ -433,7 +459,23 @@ async function buildPgPersistenceLayer(pool) {
       );
       return result.rowCount || 0;
     },
-    async finalize() {},
+    async finalize() {
+      const [{ rows: totalsRows }, { rows: supplierRows }] = await Promise.all([
+        pool.query(`SELECT COUNT(*)::int AS total FROM products`),
+        pool.query(
+          `SELECT COUNT(*)::int AS total
+             FROM products
+            WHERE COALESCE(
+              NULLIF(metadata->'supplierImport'->>'supplierPartNumber', ''),
+              NULLIF(metadata->>'supplierPartNumber', '')
+            ) IS NOT NULL`,
+        ),
+      ]);
+      return {
+        totalProductsAfterImport: Number(totalsRows?.[0]?.total || 0),
+        withSupplierPartNumber: Number(supplierRows?.[0]?.total || 0),
+      };
+    },
   };
 }
 
@@ -452,6 +494,8 @@ async function importCatalogCsvFile({
   maxReportedErrors = 500,
   includeOutOfStock = false,
   archiveMissing = false,
+  onProgress = null,
+  progressEveryRows = 250,
 }) {
   const summary = createBaseSummary();
   const pricingSummary = createPricingSummaryAccumulator();
@@ -474,6 +518,26 @@ async function importCatalogCsvFile({
 
   let headersValidated = false;
   let pendingBatch = [];
+  let processedRows = 0;
+  let estimatedTotalRows = 0;
+  try {
+    const rawCsv = fs.readFileSync(filePath, "utf8");
+    estimatedTotalRows = Math.max(0, rawCsv.split(/\r?\n/).filter(Boolean).length - 1);
+  } catch {
+    estimatedTotalRows = 0;
+  }
+
+  const notifyProgress = () => {
+    if (typeof onProgress !== "function") return;
+    onProgress({
+      totalRows: estimatedTotalRows || summary.totalRows,
+      processedRows,
+      inserted: summary.inserted,
+      updated: summary.updated,
+      skipped: summary.skipped,
+      failed: summary.failed,
+    });
+  };
 
   const pushError = (error) => {
     summary.failed += 1;
@@ -567,6 +631,12 @@ async function importCatalogCsvFile({
         continue;
       }
 
+      if (isImportableByAvailability(transformed.record)) {
+        summary.safety.importedVisibleOrPublishable += 1;
+      } else {
+        summary.safety.importedHiddenNoStockOrNotOrderable += 1;
+      }
+
       pendingBatch.push(transformed);
       if (pendingBatch.length >= chunkSize) {
         await flushBatch();
@@ -574,14 +644,31 @@ async function importCatalogCsvFile({
     } catch (error) {
       pushError(createImportError(line, error.message));
     }
+    processedRows += 1;
+    if (processedRows % progressEveryRows === 0) {
+      notifyProgress();
+    }
   }
 
   await flushBatch();
   if (archiveMissing && typeof persistence.archiveMissing === "function") {
     summary.safety.archivedMissing = await persistence.archiveMissing(seenPartIds);
   }
-  await persistence.finalize();
+  const persistenceStats = await persistence.finalize();
   summary.pricing = pricingSummary.finalize();
+  summary.catalog.totalProductsAfterImport = Number(
+    persistenceStats?.totalProductsAfterImport || 0,
+  );
+  summary.catalog.withSupplierPartNumber = Number(
+    persistenceStats?.withSupplierPartNumber || 0,
+  );
+  summary.catalog.potentialXlsxMatches = summary.catalog.withSupplierPartNumber;
+  summary.catalog.visibleOrPublishable = Number(summary.safety.importedVisibleOrPublishable || 0);
+  summary.catalog.hiddenNoStockOrNotOrderable = Number(
+    summary.safety.importedHiddenNoStockOrNotOrderable || 0,
+  );
+  processedRows = summary.totalRows;
+  notifyProgress();
 
   return summary;
 }

--- a/nerin_final_updated/backend/services/stockXlsxImport.js
+++ b/nerin_final_updated/backend/services/stockXlsxImport.js
@@ -88,6 +88,11 @@ function readWorksheet(filePath, sheetName = "Price list") {
 function buildStockMetadata(product, stock, stockSource, articleNumber) {
   const previous = product?.metadata || {};
   const stockUpdatedAt = new Date().toISOString();
+  const supplierImport = previous?.supplierImport || {};
+  const catalogImportable =
+    Boolean(supplierImport?.canBeOrdered) &&
+    Boolean(supplierImport?.isAvailable) &&
+    Number(supplierImport?.maximumQuantityInOrder || 0) > 0;
   return {
     ...previous,
     stockQuantity: stock.stockQuantity,
@@ -96,6 +101,8 @@ function buildStockMetadata(product, stock, stockSource, articleNumber) {
     stockUpdatedAt,
     stockSource,
     stockArticleNumber: articleNumber,
+    needsStockSync: false,
+    catalogImportableByRules: catalogImportable,
   };
 }
 
@@ -130,6 +137,12 @@ async function buildJsonPersistenceLayer() {
         const existing = byId.get(id);
         if (!existing) continue;
         const metadata = buildStockMetadata(existing, item.stock, stockSource, item.articleNumber);
+        const supplierImport = metadata?.supplierImport || {};
+        const catalogImportable =
+          Boolean(supplierImport?.canBeOrdered) &&
+          Boolean(supplierImport?.isAvailable) &&
+          Number(supplierImport?.maximumQuantityInOrder || 0) > 0;
+        const isPublicByRealStock = catalogImportable && item.stock.stockQuantity > 0;
         byId.set(id, {
           ...existing,
           stock: item.stock.stockQuantity,
@@ -139,6 +152,10 @@ async function buildJsonPersistenceLayer() {
           stockIsAtLeast: item.stock.stockIsAtLeast,
           stockUpdatedAt: metadata.stockUpdatedAt,
           stockSource,
+          visibility: isPublicByRealStock ? "public" : "private",
+          enabled: isPublicByRealStock,
+          available: item.stock.stockQuantity > 0,
+          needsStockSync: false,
           metadata,
         });
         touched.add(id);
@@ -195,6 +212,8 @@ async function importStockXlsxFile({
   filePath,
   maxReportedErrors = 500,
   zeroMissingProducts = false,
+  onProgress = null,
+  progressEveryRows = 250,
 }) {
   const summary = createBaseSummary();
   const { rows, articleIndex, stockIndex } = readWorksheet(filePath, "Price list");
@@ -202,6 +221,18 @@ async function importStockXlsxFile({
 
   const updates = [];
   const seenPartNumbers = new Set();
+  let processedRows = 0;
+  const notifyProgress = () => {
+    if (typeof onProgress !== "function") return;
+    onProgress({
+      totalRows: Math.max(0, rows.length - 1),
+      processedRows,
+      matchedProducts: summary.matchedProducts,
+      updatedProducts: summary.updatedProducts,
+      unmatchedRows: summary.unmatchedRows,
+      failedRows: summary.failedRows,
+    });
+  };
 
   for (let i = 1; i < rows.length; i += 1) {
     const row = rows[i] || [];
@@ -218,6 +249,8 @@ async function importStockXlsxFile({
           reason: "Article number vacío",
         });
       }
+      processedRows += 1;
+      if (processedRows % progressEveryRows === 0) notifyProgress();
       continue;
     }
     const key = articleNumber.toLowerCase();
@@ -235,6 +268,8 @@ async function importStockXlsxFile({
           reason: error.message || "Invalid stock value",
         });
       }
+      processedRows += 1;
+      if (processedRows % progressEveryRows === 0) notifyProgress();
       continue;
     }
 
@@ -244,11 +279,15 @@ async function importStockXlsxFile({
     const productId = persistence.partNumberToId.get(key);
     if (!productId) {
       summary.unmatchedRows += 1;
+      processedRows += 1;
+      if (processedRows % progressEveryRows === 0) notifyProgress();
       continue;
     }
 
     summary.matchedProducts += 1;
     updates.push({ id: productId, articleNumber, stock });
+    processedRows += 1;
+    if (processedRows % progressEveryRows === 0) notifyProgress();
   }
 
   summary.updatedProducts = await persistence.updateStockBatch(updates, "mps_xlsx_nl");
@@ -258,6 +297,8 @@ async function importStockXlsxFile({
   }
 
   await persistence.finalize();
+  processedRows = summary.totalRows;
+  notifyProgress();
   return summary;
 }
 

--- a/nerin_final_updated/frontend/admin.html
+++ b/nerin_final_updated/frontend/admin.html
@@ -385,6 +385,20 @@
             <tbody></tbody>
           </table>
         </div>
+        <div class="bulk-actions" id="adminProductsPagination" style="justify-content:space-between;">
+          <div id="adminProductsRange" aria-live="polite">Mostrando 0-0 de 0 productos</div>
+          <div style="display:flex;align-items:center;gap:8px;">
+            <label for="adminProductsPageSize">Por página</label>
+            <select id="adminProductsPageSize">
+              <option value="50">50</option>
+              <option value="100" selected>100</option>
+              <option value="250">250</option>
+            </select>
+            <button id="adminProductsPrevPage" class="button secondary" type="button">Anterior</button>
+            <span id="adminProductsPageInfo">Página 1 / 1</span>
+            <button id="adminProductsNextPage" class="button secondary" type="button">Siguiente</button>
+          </div>
+        </div>
         <div class="product-actions">
           <button id="openProductModal" class="button primary">
             Agregar producto
@@ -409,6 +423,7 @@
             </button>
           </div>
           <div id="catalogCsvImportStatus" role="status" aria-live="polite"></div>
+          <progress id="catalogCsvImportProgress" value="0" max="100" style="width:100%;display:none;"></progress>
           <div class="bulk-actions">
             <input
               type="file"
@@ -425,6 +440,7 @@
             </button>
           </div>
           <div id="stockXlsxImportStatus" role="status" aria-live="polite"></div>
+          <progress id="stockXlsxImportProgress" value="0" max="100" style="width:100%;display:none;"></progress>
           <div class="bulk-actions">
             <select id="bulkActionSelect">
               <option value="">Acción masiva…</option>

--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -1738,7 +1738,14 @@ const importStockXlsxBtn = document.getElementById("importStockXlsxBtn");
 const stockXlsxFileInput = document.getElementById("stockXlsxFile");
 const stockXlsxZeroMissingProducts = document.getElementById("stockXlsxZeroMissingProducts");
 const stockXlsxImportStatus = document.getElementById("stockXlsxImportStatus");
+const catalogCsvImportProgress = document.getElementById("catalogCsvImportProgress");
+const stockXlsxImportProgress = document.getElementById("stockXlsxImportProgress");
 const stockXlsxZeroMissingProductsWrap = stockXlsxZeroMissingProducts?.closest("label");
+const adminProductsRange = document.getElementById("adminProductsRange");
+const adminProductsPageInfo = document.getElementById("adminProductsPageInfo");
+const adminProductsPageSize = document.getElementById("adminProductsPageSize");
+const adminProductsPrevPage = document.getElementById("adminProductsPrevPage");
+const adminProductsNextPage = document.getElementById("adminProductsNextPage");
 const selectAllCheckbox = document.getElementById("selectAllProducts");
 const productPreviewCard = document.getElementById("productPreview");
 const productPreviewMedia = document.getElementById("productPreviewMedia");
@@ -1769,10 +1776,15 @@ let dragImageIndex = null;
 let productFilters = {
   query: "",
   category: "",
+  brand: "",
   visibility: "",
   stock: "",
   sort: "recent",
 };
+let productsPage = 1;
+let productsPageSize = Number(adminProductsPageSize?.value || 100);
+let productsTotalItems = 0;
+let productsTotalPages = 1;
 
 let isApplyingAutoSeo = false;
 let isApplyingAutoTags = false;
@@ -1973,7 +1985,7 @@ function updateProductSummary(filtered) {
       </div>`;
     return;
   }
-  const total = productsCache.length;
+  const total = Number(productsTotalItems || productsCache.length);
   const visible = filtered.length;
   const filteredLow = filtered.filter((p) => isLowStock(p)).length;
   const filteredOut = filtered.filter((p) => isOutOfStock(p)).length;
@@ -1987,7 +1999,7 @@ function updateProductSummary(filtered) {
   ).length;
   const title =
     visible === total
-      ? `${visible} ${visible === 1 ? "producto" : "productos"} visibles`
+      ? `${visible} ${visible === 1 ? "producto" : "productos"} en esta página`
       : `${visible} ${visible === 1 ? "producto" : "productos"} de ${total}`;
   const meta = describeActiveFilters();
   const formatIndicator = (current, totalCount) => {
@@ -2091,55 +2103,9 @@ function buildProductRow(product) {
 }
 
 
-function getFilteredProducts() {
-  if (!Array.isArray(productsCache) || productsCache.length === 0) {
-    return [];
-  }
-  let result = Array.from(productsCache);
-  if (productFilters.query) {
-    const query = normalizeSearchText(productFilters.query);
-    result = result.filter((product) => {
-      const searchable = [
-        product.sku,
-        product.name,
-        product.brand,
-        product.model,
-        product.catalog_brand,
-        product.catalog_model,
-        product.catalog_piece,
-        resolveCatalogBrand(product),
-        resolveCatalogModel(product),
-        resolveCatalogPiece(product),
-        product.category,
-        product.subcategory,
-        Array.isArray(product.tags) ? product.tags.join(" ") : product.tags,
-      ]
-        .filter(Boolean)
-        .map((value) => normalizeSearchText(value))
-        .join(" ");
-      return searchable.includes(query);
-    });
-  }
-  if (productFilters.category) {
-    result = result.filter((product) => product.category === productFilters.category);
-  }
-  if (productFilters.visibility) {
-    result = result.filter(
-      (product) => (product.visibility || "public") === productFilters.visibility,
-    );
-  }
-  if (productFilters.stock === "low") {
-    result = result.filter((product) => isLowStock(product));
-  } else if (productFilters.stock === "out") {
-    result = result.filter((product) => isOutOfStock(product));
-  }
-  const sorter = PRODUCT_SORTERS[productFilters.sort] || PRODUCT_SORTERS.recent;
-  return result.sort((a, b) => sorter(a, b));
-}
-
 function renderProductsTable() {
   if (!productsTableBody) return;
-  const rows = getFilteredProducts();
+  const rows = Array.isArray(productsCache) ? productsCache : [];
   if (!rows.length) {
     const message = productsCache.length
       ? "No hay productos que coincidan con los filtros actuales."
@@ -2202,7 +2168,8 @@ function updateProductFilters(patch) {
     ...productFilters,
     ...patch,
   };
-  renderProductsTable();
+  productsPage = 1;
+  loadProducts();
 }
 
 if (productSearchInput) {
@@ -2229,6 +2196,27 @@ if (productFilterStock) {
 if (productSortSelect) {
   productSortSelect.addEventListener("change", () => {
     updateProductFilters({ sort: productSortSelect.value || "recent" });
+  });
+}
+if (adminProductsPageSize) {
+  adminProductsPageSize.addEventListener("change", () => {
+    productsPageSize = Number(adminProductsPageSize.value || 100);
+    productsPage = 1;
+    loadProducts();
+  });
+}
+if (adminProductsPrevPage) {
+  adminProductsPrevPage.addEventListener("click", () => {
+    if (productsPage <= 1) return;
+    productsPage -= 1;
+    loadProducts();
+  });
+}
+if (adminProductsNextPage) {
+  adminProductsNextPage.addEventListener("click", () => {
+    if (productsPage >= productsTotalPages) return;
+    productsPage += 1;
+    loadProducts();
   });
 }
 
@@ -3351,20 +3339,44 @@ async function loadProducts(options = {}) {
   try {
     productsTableBody.innerHTML =
       '<tr><td colspan="15">Cargando productos…</td></tr>';
-    const res = await apiFetch("/api/products");
+    const query = new URLSearchParams({
+      page: String(productsPage),
+      pageSize: String(productsPageSize),
+      search: productFilters.query || "",
+      category: productFilters.category || "",
+      visibility: productFilters.visibility || "",
+      stockStatus: productFilters.stock || "",
+      sort: productFilters.sort || "recent",
+    });
+    const res = await apiFetch(`/api/admin/products?${query.toString()}`);
     if (!res.ok) {
-      throw new Error(`GET /api/products failed: ${res.status}`);
+      throw new Error(`GET /api/admin/products failed: ${res.status}`);
     }
     const data = await res.json();
-    productsCache = Array.isArray(data.products) ? data.products : [];
+    productsCache = Array.isArray(data.items) ? data.items : [];
+    productsTotalItems = Number(data.totalItems || productsCache.length);
+    productsTotalPages = Number(data.totalPages || 1);
+    productsPage = Number(data.page || productsPage);
     syncProductTaxonomies(productsCache);
     renderProductsTable();
+    const start = productsTotalItems ? (productsPage - 1) * productsPageSize + 1 : 0;
+    const end = Math.min(productsPage * productsPageSize, productsTotalItems);
+    if (adminProductsRange) {
+      adminProductsRange.textContent = `Mostrando ${start}-${end} de ${productsTotalItems} productos`;
+    }
+    if (adminProductsPageInfo) {
+      adminProductsPageInfo.textContent = `Página ${productsPage} / ${productsTotalPages}`;
+    }
+    if (adminProductsPrevPage) adminProductsPrevPage.disabled = productsPage <= 1;
+    if (adminProductsNextPage) adminProductsNextPage.disabled = productsPage >= productsTotalPages;
     if (highlightId) {
       highlightProductRow(highlightId);
     }
   } catch (err) {
     console.error(err);
     productsCache = [];
+    productsTotalItems = 0;
+    productsTotalPages = 1;
     productsTableBody.innerHTML =
       '<tr><td colspan="15">No se pudieron cargar los productos.</td></tr>';
     updateProductSummary([]);
@@ -3417,7 +3429,7 @@ if (productsTableBody) {
     const product = productsCache.find((item) => String(item.id) === String(id));
     if (product) {
       product[field] = value;
-      updateProductSummary(getFilteredProducts());
+      updateProductSummary(productsCache);
     }
   });
 }
@@ -3582,7 +3594,12 @@ async function importCatalogCsvFromAdmin() {
     catalogCsvImportStatus.textContent = "Importando catálogo… esto puede tardar unos minutos.";
     catalogCsvImportStatus.style.color = "";
   }
+  if (catalogCsvImportProgress) {
+    catalogCsvImportProgress.value = 0;
+    catalogCsvImportProgress.style.display = "block";
+  }
   if (importCatalogCsvBtn) importCatalogCsvBtn.disabled = true;
+  if (importStockXlsxBtn) importStockXlsxBtn.disabled = true;
 
   try {
     const includeOutOfStock = Boolean(catalogCsvIncludeOutOfStock?.checked);
@@ -3590,7 +3607,7 @@ async function importCatalogCsvFromAdmin() {
     const query = new URLSearchParams();
     if (includeOutOfStock) query.set("includeOutOfStock", "1");
     if (archiveMissing) query.set("archiveMissing", "1");
-    const importUrl = `/api/import/catalog-csv${query.toString() ? `?${query.toString()}` : ""}`;
+    const importUrl = `/api/admin/import/catalog-csv${query.toString() ? `?${query.toString()}` : ""}`;
 
     const resp = await apiFetch(importUrl, {
       method: "POST",
@@ -3604,16 +3621,52 @@ async function importCatalogCsvFromAdmin() {
       }
       throw new Error(data.error || "No se pudo importar el CSV");
     }
-    const summary = data.summary || {};
+    const jobId = data.jobId;
+    if (!jobId) {
+      throw new Error("No se recibió jobId para monitorear la importación");
+    }
+    let summary = null;
+    while (!summary) {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      const progressResp = await apiFetch(`/api/admin/import/jobs/${encodeURIComponent(jobId)}`, {
+        headers: getAdminHeaders(),
+      });
+      const job = await progressResp.json().catch(() => ({}));
+      if (!progressResp.ok) {
+        throw new Error(job.error || "No se pudo consultar progreso de importación");
+      }
+      if (catalogCsvImportProgress) {
+        catalogCsvImportProgress.value = Number(job.progress || 0);
+      }
+      if (catalogCsvImportStatus) {
+        catalogCsvImportStatus.textContent =
+          `${job.message || "Importando catálogo…"} ${job.progress || 0}% · ` +
+          `${job.processedRows || 0} / ${job.totalRows || 0} filas · ` +
+          `Insertados: ${job.inserted || 0} · Actualizados: ${job.updated || 0} · ` +
+          `Salteados: ${job.skipped || 0} · Errores: ${job.errors || 0}`;
+      }
+      if (job.status === "failed") {
+        throw new Error(job.error || job.message || "Falló la importación CSV");
+      }
+      if (job.status === "completed") {
+        summary = job.summary || {};
+      }
+    }
     const pricing = summary.pricing || {};
     const safety = summary.safety || {};
+    const catalog = summary.catalog || {};
     const statusMessage =
       `Importación OK · Filas: ${summary.totalRows || 0} · ` +
       `Insertados: ${summary.inserted || 0} · Actualizados: ${summary.updated || 0} · ` +
       `Desactivados por no venir en CSV: ${safety.archivedMissing || 0} · ` +
       `Salteados por stock/estado: ${safety.skippedUnavailable || 0} · ` +
       `Errores: ${summary.failed || 0} · Pricing OK: ${pricing.okRows || 0} · ` +
-      `Revisión: ${pricing.revisionRows || 0}`;
+      `Revisión: ${pricing.revisionRows || 0} · ` +
+      `Catálogo final: ${catalog.totalProductsAfterImport || 0} · ` +
+      `Con supplierPartNumber: ${catalog.withSupplierPartNumber || 0} · ` +
+      `Match potencial XLSX: ${catalog.potentialXlsxMatches || 0} · ` +
+      `Publicables: ${catalog.visibleOrPublishable || 0} · ` +
+      `Ocultos por stock/ordenable: ${catalog.hiddenNoStockOrNotOrderable || 0}`;
     const skippedUnavailable = Number(safety.skippedUnavailable || 0);
     const showAvailabilityHint = !includeOutOfStock && skippedUnavailable > 0;
     const availabilityBreakdown = showAvailabilityHint
@@ -3649,6 +3702,10 @@ async function importCatalogCsvFromAdmin() {
     }
   } finally {
     if (importCatalogCsvBtn) importCatalogCsvBtn.disabled = false;
+    if (importStockXlsxBtn) importStockXlsxBtn.disabled = false;
+    if (catalogCsvImportProgress && catalogCsvImportProgress.value >= 100) {
+      catalogCsvImportProgress.style.display = "none";
+    }
   }
 }
 
@@ -3677,13 +3734,18 @@ async function importStockXlsxFromAdmin() {
     stockXlsxImportStatus.textContent = "Importando stock real desde XLSX…";
     stockXlsxImportStatus.style.color = "";
   }
+  if (stockXlsxImportProgress) {
+    stockXlsxImportProgress.value = 0;
+    stockXlsxImportProgress.style.display = "block";
+  }
   if (importStockXlsxBtn) importStockXlsxBtn.disabled = true;
+  if (importCatalogCsvBtn) importCatalogCsvBtn.disabled = true;
 
   try {
     const zeroMissing = Boolean(stockXlsxZeroMissingProducts?.checked);
     const query = new URLSearchParams();
     if (zeroMissing) query.set("zeroMissingProducts", "1");
-    const importUrl = `/api/import/stock-xlsx${query.toString() ? `?${query.toString()}` : ""}`;
+    const importUrl = `/api/admin/import/stock-xlsx${query.toString() ? `?${query.toString()}` : ""}`;
 
     const resp = await apiFetch(importUrl, {
       method: "POST",
@@ -3698,7 +3760,37 @@ async function importStockXlsxFromAdmin() {
       throw new Error(data.error || "No se pudo importar stock XLSX");
     }
 
-    const summary = data.summary || {};
+    const jobId = data.jobId;
+    if (!jobId) {
+      throw new Error("No se recibió jobId para monitorear la importación");
+    }
+    let summary = null;
+    while (!summary) {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      const progressResp = await apiFetch(`/api/admin/import/jobs/${encodeURIComponent(jobId)}`, {
+        headers: getAdminHeaders(),
+      });
+      const job = await progressResp.json().catch(() => ({}));
+      if (!progressResp.ok) {
+        throw new Error(job.error || "No se pudo consultar progreso de importación");
+      }
+      if (stockXlsxImportProgress) {
+        stockXlsxImportProgress.value = Number(job.progress || 0);
+      }
+      if (stockXlsxImportStatus) {
+        stockXlsxImportStatus.textContent =
+          `${job.message || "Importando stock real…"} ${job.progress || 0}% · ` +
+          `${job.processedRows || 0} / ${job.totalRows || 0} filas · ` +
+          `Actualizados: ${job.updated || 0} · Sin match: ${job.skipped || 0} · ` +
+          `Errores: ${job.errors || 0}`;
+      }
+      if (job.status === "failed") {
+        throw new Error(job.error || job.message || "Falló la importación XLSX");
+      }
+      if (job.status === "completed") {
+        summary = job.summary || {};
+      }
+    }
     const statusMessage =
       `Stock XLSX OK · Filas: ${summary.totalRows || 0} · ` +
       `Matcheados: ${summary.matchedProducts || 0} · ` +
@@ -3734,6 +3826,10 @@ async function importStockXlsxFromAdmin() {
     }
   } finally {
     if (importStockXlsxBtn) importStockXlsxBtn.disabled = false;
+    if (importCatalogCsvBtn) importCatalogCsvBtn.disabled = false;
+    if (stockXlsxImportProgress && stockXlsxImportProgress.value >= 100) {
+      stockXlsxImportProgress.style.display = "none";
+    }
   }
 }
 

--- a/nerin_final_updated/frontend/js/api.js
+++ b/nerin_final_updated/frontend/js/api.js
@@ -43,17 +43,34 @@ export function apiFetch(path, options = {}) {
 }
 
 // Obtener la lista de productos desde el backend
-export async function fetchProducts() {
+export async function fetchProductsPage(params = {}) {
   try {
-    const res = await apiFetch("/api/products");
+    const query = new URLSearchParams();
+    Object.entries(params || {}).forEach(([key, value]) => {
+      if (value == null || value === "") return;
+      query.set(key, String(value));
+    });
+    const endpoint = `/api/products${query.toString() ? `?${query.toString()}` : ""}`;
+    const res = await apiFetch(endpoint);
     if (!res.ok) {
       throw new Error("No se pudieron obtener los productos");
     }
     const data = await res.json();
+    if (data && Array.isArray(data.items)) {
+      return data;
+    }
     if (!data || !Array.isArray(data.products)) {
       throw new Error("Respuesta de productos inválida");
     }
-    return data.products;
+    return {
+      items: data.products,
+      page: 1,
+      pageSize: data.products.length,
+      totalItems: data.products.length,
+      totalPages: 1,
+      hasNextPage: false,
+      hasPrevPage: false,
+    };
   } catch (error) {
     console.warn("Fallo el endpoint de productos, usando datos locales", error);
     try {
@@ -65,7 +82,15 @@ export async function fetchProducts() {
       }
       const fallbackData = await fallbackResponse.json();
       if (fallbackData && Array.isArray(fallbackData.products)) {
-        return fallbackData.products;
+        return {
+          items: fallbackData.products,
+          page: 1,
+          pageSize: fallbackData.products.length,
+          totalItems: fallbackData.products.length,
+          totalPages: 1,
+          hasNextPage: false,
+          hasPrevPage: false,
+        };
       }
       throw new Error("Fallback de productos inválido");
     } catch (fallbackError) {
@@ -73,6 +98,14 @@ export async function fetchProducts() {
       throw fallbackError;
     }
   }
+}
+
+export async function fetchProducts(params = {}) {
+  const pageData = await fetchProductsPage(params);
+  if (!params || Object.keys(params).length === 0) {
+    return pageData.items || [];
+  }
+  return pageData;
 }
 
 // Iniciar sesión. Devuelve objeto con success, token y role

--- a/nerin_final_updated/frontend/js/shop.js
+++ b/nerin_final_updated/frontend/js/shop.js
@@ -1,4 +1,4 @@
-import { fetchProducts, getUserRole, isWholesale } from "./api.js";
+import { fetchProductsPage, getUserRole, isWholesale } from "./api.js";
 import { createPriceLegalBlock } from "./components/PriceLegalBlock.js";
 import { calculateNetNoNationalTaxes } from "./utils/pricing.js";
 
@@ -87,6 +87,25 @@ const mobileLayoutQuery = window.matchMedia("(max-width: 900px)");
 
 let allProducts = [];
 let priceFilterTouched = false;
+let currentPage = 1;
+let currentPageSize = 24;
+let totalFilteredItems = 0;
+let hasNextPage = false;
+
+const PAGE_SIZE_OPTIONS = [24, 48, 96];
+const loadMoreBtn = document.createElement("button");
+loadMoreBtn.type = "button";
+loadMoreBtn.className = "button secondary";
+loadMoreBtn.id = "shopLoadMoreBtn";
+loadMoreBtn.textContent = "Cargar más";
+const pageSizeSelect = document.createElement("select");
+pageSizeSelect.id = "shopPageSize";
+PAGE_SIZE_OPTIONS.forEach((size) => {
+  const option = document.createElement("option");
+  option.value = String(size);
+  option.textContent = `${size} por página`;
+  pageSizeSelect.appendChild(option);
+});
 
 function formatCurrency(value) {
   const amount = Number(value);
@@ -576,8 +595,7 @@ function updateActiveFilters(filters) {
   });
 }
 
-function renderProducts() {
-  if (!productGrid) return;
+function getCurrentFilters() {
   const search = searchInput?.value?.trim() || "";
   const brand = brandFilter?.value || "";
   const model = modelFilter?.value || "";
@@ -587,42 +605,57 @@ function renderProducts() {
   const price = Number(priceRange?.value) || 0;
   const priceMax = Number(priceRange?.max) || 0;
   const priceActive = priceFilterTouched && priceMax > 0 && price < priceMax;
+  return { search, brand, model, category, stock, sort, price, priceActive };
+}
+
+async function renderProducts({ append = false } = {}) {
+  if (!productGrid) return;
+  const filters = getCurrentFilters();
+  if (!append) {
+    currentPage = 1;
+    allProducts = [];
+    productGrid.innerHTML = "<p>Cargando productos…</p>";
+  }
+  const requestedPage = append ? currentPage + 1 : 1;
+  const response = await fetchProductsPage({
+    page: requestedPage,
+    pageSize: currentPageSize,
+    search: filters.search,
+    category: filters.category,
+    brand: filters.brand,
+    sort: filters.sort,
+  });
+  const normalizedItems = (response.items || [])
+    .map(normalizeStorefrontProduct)
+    .map(sanitizePublicProduct)
+    .filter(Boolean);
+  allProducts = append ? allProducts.concat(normalizedItems) : normalizedItems;
+  currentPage = Number(response.page || requestedPage || 1);
+  hasNextPage = Boolean(response.hasNextPage);
+  totalFilteredItems = Number(response.totalItems || allProducts.length);
 
   const filtered = allProducts.filter((product) => {
-    const haystack = [
-      product.name,
-      product.sku,
-      getCatalogBrand(product),
-      getCatalogModel(product),
-      cleanLabel(product.category),
-      getPartLabel(product),
-    ]
-      .filter(Boolean)
-      .join(" ")
-      .toLowerCase();
-    if (search && !haystack.includes(search.toLowerCase())) return false;
-    if (brand && normalizeKey(getCatalogBrand(product)) !== normalizeKey(brand)) return false;
-    if (model && normalizeKey(getCatalogModel(product)) !== normalizeKey(model)) return false;
-    if (category && normalizeKey(product.category) !== normalizeKey(category)) return false;
+    if (filters.model && normalizeKey(getCatalogModel(product)) !== normalizeKey(filters.model)) return false;
     const status = getStockStatus(product);
     const fulfillmentMode = getFulfillmentMode(product);
-    if (stock === "in-stock" && status !== "in" && status !== "low") return false;
-    if (stock === "physical" && fulfillmentMode !== "physical") return false;
-    if (stock === "remote" && fulfillmentMode !== "remote") return false;
-    if (priceActive && resolveDisplayPrice(product).active > price) return false;
+    if (filters.stock === "in-stock" && status !== "in" && status !== "low") return false;
+    if (filters.stock === "physical" && fulfillmentMode !== "physical") return false;
+    if (filters.stock === "remote" && fulfillmentMode !== "remote") return false;
+    if (filters.priceActive && resolveDisplayPrice(product).active > filters.price) return false;
     return true;
   });
-
-  const sorted = sortProducts(filtered, sort, search);
+  const sorted = sortProducts(filtered, filters.sort, filters.search);
   productGrid.innerHTML = "";
   if (!sorted.length) {
     productGrid.innerHTML = "<p>No encontramos productos para esos filtros.</p>";
   } else {
     sorted.forEach((product) => productGrid.appendChild(createProductCard(product)));
   }
-
-  const filters = { search, brand, model, category, stock, sort, price, priceActive };
-  updateResultSummary(sorted.length);
+  loadMoreBtn.style.display = hasNextPage ? "inline-flex" : "none";
+  if (!loadMoreBtn.parentElement && productGrid.parentElement) {
+    productGrid.parentElement.appendChild(loadMoreBtn);
+  }
+  updateResultSummary(totalFilteredItems);
   updateActiveFilters(filters);
   syncQueryParams(filters);
 }
@@ -687,8 +720,8 @@ function setupFiltersUi() {
 
 async function initShop() {
   try {
-    const rawProducts = await fetchProducts();
-    allProducts = rawProducts
+    const firstPage = await fetchProductsPage({ page: 1, pageSize: currentPageSize });
+    allProducts = (firstPage.items || [])
       .map(normalizeStorefrontProduct)
       .map(sanitizePublicProduct)
       .filter(Boolean);
@@ -697,8 +730,11 @@ async function initShop() {
     configurePriceSlider(allProducts);
     applyInitialFilters();
     setupFiltersUi();
+    if (sortSelect?.parentElement && !document.getElementById("shopPageSize")) {
+      sortSelect.parentElement.appendChild(pageSizeSelect);
+    }
 
-    searchInput?.addEventListener("input", renderProducts);
+    searchInput?.addEventListener("input", () => renderProducts());
     searchClear?.addEventListener("click", () => {
       searchInput.value = "";
       renderProducts();
@@ -707,10 +743,15 @@ async function initShop() {
       updateModelOptions(brandFilter.value);
       renderProducts();
     });
-    modelFilter?.addEventListener("change", renderProducts);
-    categoryFilter?.addEventListener("change", renderProducts);
-    stockFilter?.addEventListener("change", renderProducts);
-    sortSelect?.addEventListener("change", renderProducts);
+    modelFilter?.addEventListener("change", () => renderProducts());
+    categoryFilter?.addEventListener("change", () => renderProducts());
+    stockFilter?.addEventListener("change", () => renderProducts());
+    sortSelect?.addEventListener("change", () => renderProducts());
+    pageSizeSelect?.addEventListener("change", () => {
+      currentPageSize = Number(pageSizeSelect.value) || 24;
+      renderProducts();
+    });
+    loadMoreBtn.addEventListener("click", () => renderProducts({ append: true }));
     priceRange?.addEventListener("input", () => {
       priceFilterTouched = true;
       updatePriceRangeDisplay();


### PR DESCRIPTION
### Motivation
- Add robust import job tracking and progress reporting for long-running catalog and stock imports.
- Improve admin product listing with server-side pagination and richer filtering for large catalogs.
- Ensure CSV/XLSX import persistence records metadata needed for later stock sync and correct visibility/enable behaviour.

### Description
- Backend: introduce an in-memory import job manager (`createImportJob`, `updateImportJob`, `/api/admin/import/jobs` endpoints) and prevent concurrent imports by returning `409` when one is running. 
- Imports: make `importCatalogCsvFile` and `importStockXlsxFile` support `onProgress` callbacks and periodic progress notifications, update persistence layers to record `csvStockQuantity`, `needsStockSync`, visibility/enable flags, and return catalog statistics from `finalize`.
- Server/API: add admin endpoints for job listing and job status, change import endpoints to enqueue jobs and return `202` with `jobId`, and add helper utilities for pagination and catalog filtering (`parsePaginationParams`, `applyCatalogFilters`, `applyAdminProductFilters`, `paginateItems`).
- Frontend: admin UI now polls job status for CSV/XLSX imports, shows progress bars and detailed status, disables actions while importing, and adds server-side pagination controls for `/api/admin/products`; `api.js` adds `fetchProductsPage` and adapts `fetchProducts` to support paged results; storefront uses paged product loading with "load more" and page size control.

### Testing
- Ran backend unit tests with `jest` covering `catalogCsvImport.test.js` and `stockXlsxImport.test.js`, and the updated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed4ecfc40083319c37ae0d6ec42eac)