### PR TITLE
Fix products catalog persistence path, remove frontend demo fallback, and enforce admin auth

### DIFF
--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -115,6 +115,11 @@ const IS_DATA_DIR_PERSISTENT =
     : DATA_DIR_SOURCE.type !== "local";
 
 const DATA_DIR = resolvedDataDir;
+const PRODUCTS_FILE_PATH = (() => {
+  const raw = (process.env.PRODUCTS_FILE_PATH || "").trim();
+  if (!raw) return dataPath("products.json");
+  return path.isAbsolute(raw) ? raw : path.join(DATA_DIR, raw);
+})();
 const DATA_SOURCE_LABEL = (() => {
   switch (DATA_DIR_SOURCE.type) {
     case "env":
@@ -135,6 +140,24 @@ if (process.env.NODE_ENV !== "test") {
   if (!IS_DATA_DIR_PERSISTENT) {
     console.warn(
       "[NERIN] ⚠️ No se detectó un Render Disk persistente. Configurá un disco y seteá DATA_DIR o montá /var/data para conservar la información tras cada deploy.",
+    );
+  }
+  try {
+    const exists = fs.existsSync(PRODUCTS_FILE_PATH);
+    let count = 0;
+    if (exists) {
+      const raw = JSON.parse(fs.readFileSync(PRODUCTS_FILE_PATH, "utf8"));
+      const list = Array.isArray(raw?.products) ? raw.products : raw;
+      count = Array.isArray(list) ? list.length : 0;
+    }
+    const size = exists ? fs.statSync(PRODUCTS_FILE_PATH).size : 0;
+    console.log(
+      `[NERIN] PRODUCTS_FILE_PATH=${PRODUCTS_FILE_PATH} exists=${exists} size=${size} products=${count} fallbackDemo=false`,
+    );
+  } catch (err) {
+    console.error(
+      `[NERIN] PRODUCTS_FILE_PATH=${PRODUCTS_FILE_PATH} exists=unknown products=unknown fallbackDemo=false`,
+      err,
     );
   }
 }
@@ -815,11 +838,8 @@ function getShopTemplateParts() {
 async function loadProducts() {
   const now = Date.now();
   if (_cache.data && now - _cache.t < PRODUCTS_TTL) return _cache.data;
-  const p = typeof dataPath === 'function'
-    ? dataPath('products.json')
-    : path.join(DATA_DIR, 'products.json');
   try {
-    const json = JSON.parse(fs.readFileSync(p, 'utf8'));
+    const json = JSON.parse(fs.readFileSync(PRODUCTS_FILE_PATH, 'utf8'));
     const arr = Array.isArray(json?.products) ? json.products : json;
     const normalized = normalizeProductsList(arr);
     _cache = { t: now, data: normalized };
@@ -3086,9 +3106,8 @@ function calculateDetailedAnalytics(options = {}) {
 
 // Leer productos desde el archivo JSON
 function getProducts() {
-  const filePath = dataPath("products.json");
   try {
-    const file = fs.readFileSync(filePath, "utf8");
+    const file = fs.readFileSync(PRODUCTS_FILE_PATH, "utf8");
     const data = JSON.parse(file);
     const list = Array.isArray(data?.products) ? data.products : data;
     return normalizeProductsList(list);
@@ -3099,10 +3118,9 @@ function getProducts() {
 
 // Guardar productos en el archivo JSON
 function saveProducts(products) {
-  const filePath = dataPath("products.json");
   const normalized = normalizeProductsList(products);
   fs.writeFileSync(
-    filePath,
+    PRODUCTS_FILE_PATH,
     JSON.stringify({ products: normalized }, null, 2),
     "utf8",
   );
@@ -5261,6 +5279,7 @@ async function requestHandler(req, res) {
   }
 
   if (pathname === "/api/admin/products" && req.method === "GET") {
+    if (!requireAdmin(req, res)) return;
     try {
       const { page, pageSize } = parsePaginationParams(parsedUrl.query, {
         page: 1,

--- a/nerin_final_updated/backend/utils/dataDir.js
+++ b/nerin_final_updated/backend/utils/dataDir.js
@@ -9,11 +9,13 @@ const RENDER_MOUNT_DIR = process.env.RENDER_DISK_MOUNT_PATH;
 // 2) Si tenés el disco montado en /var/nerin-data (lo que muestra tu log), usamos ahí.
 //    Si en tu servicio lo montaste en /var/data, también lo detectamos y preferimos /var/data/nerin.
 const CANDIDATES = [
+  // Si Render monta en /var/data, priorizamos una carpeta de app explícita
+  RENDER_MOUNT_DIR ? path.join(RENDER_MOUNT_DIR, 'nerin_final_updated') : null,
   RENDER_MOUNT_DIR,
-  '/var/nerin-data',        // como muestra tu error/log
   '/var/data/nerin_final_updated',
-  '/var/data/nerin',        // patrón recomendado
-  '/var/data'               // disco genérico
+  '/var/data/nerin',
+  '/var/nerin-data',
+  '/var/data',
 ].filter(Boolean);
 
 let RENDER_DIR = null;
@@ -35,26 +37,8 @@ const SOURCE = ENV_DIR
 // Asegurar que exista
 try { fs.mkdirSync(BASE, { recursive: true }); } catch {}
 
-// Si estamos usando un directorio distinto al local y faltan datos,
-// copiar el contenido de la carpeta de ejemplo para evitar errores.
-if (BASE !== LOCAL_DIR) {
-  try {
-    const sample = path.join(BASE, 'products.json');
-    if (!fs.existsSync(sample)) {
-      for (const f of fs.readdirSync(LOCAL_DIR)) {
-        const src = path.join(LOCAL_DIR, f);
-        const dest = path.join(BASE, f);
-        if (fs.existsSync(dest)) continue;
-        const stat = fs.statSync(src);
-        if (stat.isFile()) {
-          fs.copyFileSync(src, dest);
-        }
-      }
-    }
-  } catch (e) {
-    console.error('cannot seed data dir', e);
-  }
-}
+// No sembrar products.json automáticamente:
+// si falta, preferimos fallar de forma explícita antes que introducir catálogo demo.
 
 // API
 module.exports = {

--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -3348,8 +3348,13 @@ async function loadProducts(options = {}) {
       stockStatus: productFilters.stock || "",
       sort: productFilters.sort || "recent",
     });
-    const res = await apiFetch(`/api/admin/products?${query.toString()}`);
+    const res = await apiFetch(`/api/admin/products?${query.toString()}`, {
+      headers: getAdminHeaders(),
+    });
     if (!res.ok) {
+      if (res.status === 401 || res.status === 403) {
+        throw new Error("No autorizado. Revisá la Admin Key (x-admin-key).");
+      }
       throw new Error(`GET /api/admin/products failed: ${res.status}`);
     }
     const data = await res.json();
@@ -3378,7 +3383,7 @@ async function loadProducts(options = {}) {
     productsTotalItems = 0;
     productsTotalPages = 1;
     productsTableBody.innerHTML =
-      '<tr><td colspan="15">No se pudieron cargar los productos.</td></tr>';
+      `<tr><td colspan="15">${escapeHtml(err.message || "No se pudieron cargar los productos.")}</td></tr>`;
     updateProductSummary([]);
   }
 }

--- a/nerin_final_updated/frontend/js/api.js
+++ b/nerin_final_updated/frontend/js/api.js
@@ -44,60 +44,24 @@ export function apiFetch(path, options = {}) {
 
 // Obtener la lista de productos desde el backend
 export async function fetchProductsPage(params = {}) {
-  try {
-    const query = new URLSearchParams();
-    Object.entries(params || {}).forEach(([key, value]) => {
-      if (value == null || value === "") return;
-      query.set(key, String(value));
-    });
-    const endpoint = `/api/products${query.toString() ? `?${query.toString()}` : ""}`;
-    const res = await apiFetch(endpoint);
-    if (!res.ok) {
-      throw new Error("No se pudieron obtener los productos");
-    }
-    const data = await res.json();
-    if (data && Array.isArray(data.items)) {
-      return data;
-    }
-    if (!data || !Array.isArray(data.products)) {
-      throw new Error("Respuesta de productos inválida");
-    }
-    return {
-      items: data.products,
-      page: 1,
-      pageSize: data.products.length,
-      totalItems: data.products.length,
-      totalPages: 1,
-      hasNextPage: false,
-      hasPrevPage: false,
-    };
-  } catch (error) {
-    console.warn("Fallo el endpoint de productos, usando datos locales", error);
-    try {
-      const fallbackResponse = await fetch("/mock-data/products.json", {
-        cache: "no-store",
-      });
-      if (!fallbackResponse.ok) {
-        throw new Error("No se pudo cargar el fallback de productos");
-      }
-      const fallbackData = await fallbackResponse.json();
-      if (fallbackData && Array.isArray(fallbackData.products)) {
-        return {
-          items: fallbackData.products,
-          page: 1,
-          pageSize: fallbackData.products.length,
-          totalItems: fallbackData.products.length,
-          totalPages: 1,
-          hasNextPage: false,
-          hasPrevPage: false,
-        };
-      }
-      throw new Error("Fallback de productos inválido");
-    } catch (fallbackError) {
-      console.error("Error al obtener productos", fallbackError);
-      throw fallbackError;
-    }
+  const query = new URLSearchParams();
+  Object.entries(params || {}).forEach(([key, value]) => {
+    if (value == null || value === "") return;
+    query.set(key, String(value));
+  });
+  const endpoint = `/api/products${query.toString() ? `?${query.toString()}` : ""}`;
+  const res = await apiFetch(endpoint);
+  if (!res.ok) {
+    const errPayload = await res.json().catch(() => ({}));
+    throw new Error(
+      errPayload.error || errPayload.message || "No se pudo cargar el catálogo",
+    );
   }
+  const data = await res.json();
+  if (data && Array.isArray(data.items)) {
+    return data;
+  }
+  throw new Error("Respuesta de productos inválida");
 }
 
 export async function fetchProducts(params = {}) {


### PR DESCRIPTION
### Motivation
- Recent pagination/import changes caused the storefront to show demo/fallback products and the admin to show zero items by reading from inconsistent or repo-local paths instead of the persistent Render Disk. 
- The goal is to ensure both public and admin endpoints read and write the same real catalog on persistent storage, avoid auto-seeding demo data, and surface clear errors for auth or missing files.

### Description
- Resolve data-dir candidates to prefer the Render Disk app folder (e.g. `/var/data/nerin_final_updated`) and stop auto-copying/seeding `data/products.json` from the repo local `data/` directory. 
- Add a single `PRODUCTS_FILE_PATH` resolution (env override -> persistent data path) and wire `loadProducts`, `getProducts`, and `saveProducts` to consistently use that path for read/write. 
- Emit a startup diagnostic log that reports `PRODUCTS_FILE_PATH`, existence, size and loaded product count, and an explicit `fallbackDemo=false` flag. 
- Enforce admin auth for `GET /api/admin/products` (returns 401/403 when the `x-admin-key` is missing/invalid) and update the admin UI to include the `x-admin-key` header and display clear auth/error messages. 
- Remove the frontend fallback that silently used `/mock-data/products.json` when the public products endpoint failed so the storefront now surfaces real API errors instead of demo products.

### Testing
- Verified file discovery and counts for candidate product files using scripted checks that found `/backend/data/products.json` (406 bytes, 3 products), `/nerin_final_updated/data/products.json` (8869 bytes, 6 products), and `/nerin_final_updated/frontend/mock-data/products.json` (6926 bytes, 5 products). 
- Ran `node --check` on the modified JS files (`backend/server.js`, `backend/utils/dataDir.js`, `frontend/js/api.js`, `frontend/js/admin.js`) to ensure no syntax errors. 
- Ran repository searches and backup lookups for `products.backup-*`, `products.tmp.json`, and common backup patterns and confirmed no backups were restored or modified. 
- Confirmed the new behavior locally in the codebase: admin requests include `x-admin-key`, public fetch now throws on non-2xx and no longer falls back to the mock dataset, and startup logging prints `PRODUCTS_FILE_PATH` diagnostics (all automated checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed59a83cbc8331a87284e90313d534)