### PR TITLE
Unify admin endpoints auth with existing login token

### DIFF
--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -1771,10 +1771,28 @@ function enforceRateLimit(req, res, group) {
   return null;
 }
 
-function requireAdmin(req, res) {
-  const adminKey = req.headers["x-admin-key"];
-  if (process.env.ADMIN_KEY && adminKey !== process.env.ADMIN_KEY) {
-    sendJson(res, 401, { error: "Unauthorized" });
+function hasAdminRole(user) {
+  if (!user || typeof user !== "object") return false;
+  if (user.isAdmin === true || user?.profile?.isAdmin === true) return true;
+  if (String(user.accountType || "").toLowerCase() === "admin") return true;
+  return String(user.role || "").toLowerCase() === "admin";
+}
+
+function hasAdminPanelAccess(user) {
+  if (hasAdminRole(user)) return true;
+  return String(user?.role || "").toLowerCase() === "vendedor";
+}
+
+function requireAdmin(req, res, options = {}) {
+  const { allowSeller = true } = options;
+  const user = resolveAuthUser(req);
+  if (!user) {
+    sendJson(res, 401, { error: "Debés iniciar sesión para acceder al panel admin." });
+    return false;
+  }
+  const allowed = allowSeller ? hasAdminPanelAccess(user) : hasAdminRole(user);
+  if (!allowed) {
+    sendJson(res, 403, { error: "No tenés permisos para acceder a este recurso admin." });
     return false;
   }
   return true;
@@ -5784,6 +5802,7 @@ async function requestHandler(req, res) {
   }
 
   if (pathname === "/api/admin/import/jobs" && req.method === "GET") {
+    if (!requireAdmin(req, res, { allowSeller: false })) return;
     cleanupImportJobs();
     const jobs = Array.from(importJobs.values())
       .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
@@ -5792,6 +5811,7 @@ async function requestHandler(req, res) {
   }
 
   if (pathname.startsWith("/api/admin/import/jobs/") && req.method === "GET") {
+    if (!requireAdmin(req, res, { allowSeller: false })) return;
     cleanupImportJobs();
     const jobId = pathname.split("/").pop();
     const job = importJobs.get(jobId);
@@ -5803,16 +5823,7 @@ async function requestHandler(req, res) {
     (pathname === "/api/admin/import/catalog-csv" || pathname === "/api/import/catalog-csv") &&
     req.method === "POST"
   ) {
-    const adminKey = req.headers["x-admin-key"];
-    if (!process.env.ADMIN_KEY) {
-      return sendJson(res, 503, {
-        error:
-          "Catalog CSV import deshabilitado: falta configurar ADMIN_KEY en el servidor.",
-      });
-    }
-    if (adminKey !== process.env.ADMIN_KEY) {
-      return sendJson(res, 401, { error: "Unauthorized" });
-    }
+    if (!requireAdmin(req, res, { allowSeller: false })) return;
     if (hasRunningImportJob()) {
       return sendJson(res, 409, {
         error: "Ya hay una importación en curso. Esperá a que finalice.",
@@ -5909,16 +5920,7 @@ async function requestHandler(req, res) {
     (pathname === "/api/admin/import/stock-xlsx" || pathname === "/api/import/stock-xlsx") &&
     req.method === "POST"
   ) {
-    const adminKey = req.headers["x-admin-key"];
-    if (!process.env.ADMIN_KEY) {
-      return sendJson(res, 503, {
-        error:
-          "Importación de stock XLSX deshabilitada: falta configurar ADMIN_KEY en el servidor.",
-      });
-    }
-    if (adminKey !== process.env.ADMIN_KEY) {
-      return sendJson(res, 401, { error: "Unauthorized" });
-    }
+    if (!requireAdmin(req, res, { allowSeller: false })) return;
     if (hasRunningImportJob()) {
       return sendJson(res, 409, {
         error: "Ya hay una importación en curso. Esperá a que finalice.",
@@ -7282,10 +7284,7 @@ async function requestHandler(req, res) {
   }
 
   if (pathname === "/api/footer" && req.method === "POST") {
-    const adminKey = req.headers["x-admin-key"];
-    if (process.env.ADMIN_KEY && adminKey !== process.env.ADMIN_KEY) {
-      return sendJson(res, 401, { error: "Unauthorized" });
-    }
+    if (!requireAdmin(req, res, { allowSeller: false })) return;
     let body = "";
     req.on("data", (c) => (body += c));
     req.on("end", () => {

--- a/nerin_final_updated/frontend/admin-footer.js
+++ b/nerin_final_updated/frontend/admin-footer.js
@@ -220,8 +220,6 @@ async function persistFooterConfig({ showSuccessAlert = true } = {}) {
   const headers = { 'Content-Type': 'application/json' };
   const token = localStorage.getItem('nerinToken');
   if (token) headers['Authorization'] = `Bearer ${token}`;
-  const adminKey = localStorage.getItem('nerinAdminKey');
-  if (adminKey) headers['x-admin-key'] = adminKey;
   const res = await fetch('/api/footer', {
     method: 'POST',
     headers,
@@ -246,8 +244,8 @@ form.addEventListener('submit', async (e) => {
 
 resetBtn.addEventListener('click', async () => {
   const headers = { 'Content-Type': 'application/json' };
-  const adminKey = localStorage.getItem('nerinAdminKey');
-  if (adminKey) headers['x-admin-key'] = adminKey;
+  const token = localStorage.getItem('nerinToken');
+  if (token) headers.Authorization = `Bearer ${token}`;
   await fetch('/api/footer', { method: 'POST', headers, body: JSON.stringify(defaultConfig) });
   fillForm(defaultConfig);
   alert('Restaurado');
@@ -265,8 +263,6 @@ async function uploadBadgeImage(file) {
   const headers = {};
   const token = localStorage.getItem("nerinToken");
   if (token) headers.Authorization = `Bearer ${token}`;
-  const adminKey = localStorage.getItem("nerinAdminKey");
-  if (adminKey) headers["x-admin-key"] = adminKey;
   const res = await fetch("/api/upload", {
     method: "POST",
     headers,
@@ -283,8 +279,6 @@ async function persistBadgeImageOnly(key, url) {
   const headers = { 'Content-Type': 'application/json' };
   const token = localStorage.getItem('nerinToken');
   if (token) headers.Authorization = `Bearer ${token}`;
-  const adminKey = localStorage.getItem('nerinAdminKey');
-  if (adminKey) headers['x-admin-key'] = adminKey;
 
   const currentRes = await fetch('/api/footer', { headers });
   const current = await currentRes.json().catch(() => ({}));

--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -167,10 +167,7 @@ function compactText(value, maxLength = 72) {
 }
 
 function getAdminHeaders(extra = {}) {
-  const headers = { ...extra };
-  const adminKey = localStorage.getItem("nerinAdminKey");
-  if (adminKey) headers["x-admin-key"] = adminKey;
-  return headers;
+  return { ...extra };
 }
 
 function cleanLabel(value) {
@@ -3365,7 +3362,7 @@ async function loadProducts(options = {}) {
     });
     if (!res.ok) {
       if (res.status === 401 || res.status === 403) {
-        throw new Error("No autorizado. Revisá la Admin Key (x-admin-key).");
+        throw new Error("No autorizado. Iniciá sesión con una cuenta con permisos de admin.");
       }
       throw new Error(`GET /api/admin/products failed: ${res.status}`);
     }
@@ -3590,35 +3587,9 @@ duplicateProductBtn.addEventListener("click", async () => {
   }
 });
 
-function ensureAdminKeyForCsvImport() {
-  const savedKey = localStorage.getItem("nerinAdminKey");
-  if (savedKey) return savedKey;
-
-  const providedKey = window.prompt(
-    "Ingresá la clave admin (ADMIN_KEY) para importar CSV. Se guardará en este navegador como nerinAdminKey.",
-  );
-
-  if (!providedKey) {
-    alert("Falta la clave admin (nerinAdminKey) para importar CSV.");
-    return null;
-  }
-
-  const normalizedKey = providedKey.trim();
-  if (!normalizedKey) {
-    alert("La clave admin no puede estar vacía.");
-    return null;
-  }
-
-  localStorage.setItem("nerinAdminKey", normalizedKey);
-  return normalizedKey;
-}
-
 async function importCatalogCsvFromAdmin() {
   if (currentRole !== "admin") {
     alert("Solo administradores pueden importar CSV.");
-    return;
-  }
-  if (!ensureAdminKeyForCsvImport()) {
     return;
   }
   if (!catalogCsvFileInput || !catalogCsvFileInput.files?.length) {
@@ -3655,9 +3626,6 @@ async function importCatalogCsvFromAdmin() {
     });
     const data = await resp.json().catch(() => ({}));
     if (!resp.ok) {
-      if (resp.status === 401) {
-        localStorage.removeItem("nerinAdminKey");
-      }
       throw new Error(data.error || "No se pudo importar el CSV");
     }
     const jobId = data.jobId;
@@ -3757,9 +3725,6 @@ async function importStockXlsxFromAdmin() {
     alert("Solo administradores pueden importar stock XLSX.");
     return;
   }
-  if (!ensureAdminKeyForCsvImport()) {
-    return;
-  }
   if (!stockXlsxFileInput || !stockXlsxFileInput.files?.length) {
     alert("Seleccioná un archivo XLSX antes de importar.");
     return;
@@ -3793,9 +3758,6 @@ async function importStockXlsxFromAdmin() {
     });
     const data = await resp.json().catch(() => ({}));
     if (!resp.ok) {
-      if (resp.status === 401) {
-        localStorage.removeItem("nerinAdminKey");
-      }
       throw new Error(data.error || "No se pudo importar stock XLSX");
     }
 


### PR DESCRIPTION
### Motivation
- Remove the secondary manual `x-admin-key` flow so admin panel uses the same login session/token already produced by `POST /api/login` and stored as `nerinToken` in `localStorage`.
- Keep admin endpoints non-public and preserve strict authorization so only authenticated users with admin permissions (or seller where appropriate) can access admin UI and actions.
- Avoid asking administrators for a second key in the frontend and prevent 401s after a successful admin login.

### Description
- Added role-based helpers in `backend/server.js`: `hasAdminRole(user)`, `hasAdminPanelAccess(user)` and replaced the previous `requireAdmin` check to validate the logged-in user via `resolveAuthUser(req)` and return `401` (not authenticated) or `403` (insufficient permissions).
- Switched admin routes to use the unified session/token auth instead of `ADMIN_KEY` header checks for the import and admin job endpoints, specifically applying `requireAdmin(..., { allowSeller: false })` to: `GET /api/admin/import/jobs`, `GET /api/admin/import/jobs/:id`, `POST /api/admin/import/catalog-csv`, `POST /api/admin/import/stock-xlsx`, and `POST /api/footer` (write path).
- Kept product panel access aligned with existing behavior (admins + `vendedor` where appropriate) while imports and critical admin writes require strict admin role.
- Removed frontend reliance on a second stored key (`nerinAdminKey`) and eliminated `x-admin-key` headers in admin scripts, by changing `getAdminHeaders()` and removing the `ensureAdminKeyForCsvImport` prompt from `frontend/js/admin.js` and `frontend/admin-footer.js` so requests rely on the existing `Authorization: Bearer <nerinToken>` provided by `apiFetch`.
- Updated admin UI error text to no longer reference the Admin Key and to instruct to sign in with an account that has admin permissions.

### Testing
- Ran the test suite with `npm test -- --runInBand` in the project root and all automated tests passed successfully: `16 suites passed, 57 tests passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee04f524808331afd9654f7cb56f5e)