### PR TITLE
Importador CSV: propagar opción ‘Incluir sin stock/no ordenables’ y mostrar modo efectivo en admin

### DIFF
--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -5834,7 +5834,15 @@ async function requestHandler(req, res) {
       ? Math.min(Math.floor(chunkSizeParam), 2000)
       : 400;
     const includeOutOfStock = ["1", "true", "yes", "si"].includes(
-      String(parsedUrl.query.includeOutOfStock || parsedUrl.query.include_out_of_stock || "")
+      String(
+        parsedUrl.query.includeOutOfStock ||
+          parsedUrl.query.include_out_of_stock ||
+          parsedUrl.query.includeWithoutStock ||
+          parsedUrl.query.include_without_stock ||
+          parsedUrl.query.includeNoStock ||
+          parsedUrl.query.include_no_stock ||
+          "",
+      )
         .trim()
         .toLowerCase(),
     );

--- a/nerin_final_updated/backend/services/catalogCsvImport.js
+++ b/nerin_final_updated/backend/services/catalogCsvImport.js
@@ -261,6 +261,10 @@ function createBaseSummary() {
       visibleOrPublishable: 0,
       hiddenNoStockOrNotOrderable: 0,
     },
+    options: {
+      includeOutOfStock: false,
+      archiveMissing: false,
+    },
   };
 }
 
@@ -498,6 +502,8 @@ async function importCatalogCsvFile({
   progressEveryRows = 250,
 }) {
   const summary = createBaseSummary();
+  summary.options.includeOutOfStock = Boolean(includeOutOfStock);
+  summary.options.archiveMissing = Boolean(archiveMissing);
   const pricingSummary = createPricingSummaryAccumulator();
   const seenPartIds = new Set();
   const seenPartNumbers = new Set();

--- a/nerin_final_updated/frontend/admin.html
+++ b/nerin_final_updated/frontend/admin.html
@@ -412,7 +412,7 @@
             />
             <label style="display:flex;align-items:center;gap:8px;">
               <input type="checkbox" id="catalogCsvIncludeOutOfStock" />
-              Incluir sin stock/no ordenables
+              Incluir sin stock/no ordenables (catálogo completo)
             </label>
             <label style="display:flex;align-items:center;gap:8px;">
               <input type="checkbox" id="catalogCsvArchiveMissing" checked />
@@ -1753,7 +1753,7 @@
     <script>
       window.__NERIN_ADMIN_BUILD__ = "20241002-nerin-01";
     </script>
-    <script type="module" src="/js/admin.js?v=20241002-nerin-01"></script>
+    <script type="module" src="/js/admin.js?v=20260426-catalog-import-01"></script>
     <!-- Configuración y analíticas globales -->
     <script type="module" src="/admin-footer.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>

--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -3615,8 +3615,8 @@ async function importCatalogCsvFromAdmin() {
     const includeOutOfStock = Boolean(catalogCsvIncludeOutOfStock?.checked);
     const archiveMissing = catalogCsvArchiveMissing?.checked !== false;
     const query = new URLSearchParams();
-    if (includeOutOfStock) query.set("includeOutOfStock", "1");
-    if (archiveMissing) query.set("archiveMissing", "1");
+    query.set("includeOutOfStock", includeOutOfStock ? "1" : "0");
+    query.set("archiveMissing", archiveMissing ? "1" : "0");
     const importUrl = `/api/admin/import/catalog-csv${query.toString() ? `?${query.toString()}` : ""}`;
 
     const resp = await apiFetch(importUrl, {
@@ -3662,9 +3662,18 @@ async function importCatalogCsvFromAdmin() {
     const pricing = summary.pricing || {};
     const safety = summary.safety || {};
     const catalog = summary.catalog || {};
+    const options = summary.options || {};
+    const includeCatalogAll =
+      typeof options.includeOutOfStock === "boolean"
+        ? options.includeOutOfStock
+        : includeOutOfStock;
+    const archiveMissingApplied =
+      typeof options.archiveMissing === "boolean" ? options.archiveMissing : archiveMissing;
     const statusMessage =
       `Importación OK · Filas: ${summary.totalRows || 0} · ` +
       `Insertados: ${summary.inserted || 0} · Actualizados: ${summary.updated || 0} · ` +
+      `Modo catálogo completo: ${includeCatalogAll ? "Sí" : "No"} · ` +
+      `Desactivar faltantes CSV: ${archiveMissingApplied ? "Sí" : "No"} · ` +
       `Desactivados por no venir en CSV: ${safety.archivedMissing || 0} · ` +
       `Salteados por stock/estado: ${safety.skippedUnavailable || 0} · ` +
       `Errores: ${summary.failed || 0} · Pricing OK: ${pricing.okRows || 0} · ` +


### PR DESCRIPTION
### Motivation
- El CSV estaba filtrando productos por disponibilidad y solo importaba ~125 ítems en vez del catálogo maestro completo, impidiendo que el XLSX luego actualice stock real.
- Se necesitaba garantizar que la opción “Incluir sin stock/no ordenables” se envíe y respete por el backend y que el admin muestre claramente qué modo se ejecutó.

### Description
- El frontend ahora envía siempre `includeOutOfStock` y `archiveMissing` como `1`/`0` en la URL al iniciar la importación CSV y actualiza la etiqueta UI a “Incluir sin stock/no ordenables (catálogo completo)”.
- El backend acepta aliases adicionales del parámetro de inclusión sin stock (`includeWithoutStock`, `include_no_stock`, etc.) para evitar pérdidas del flag por diferencias de naming.
- El servicio de importación CSV incluye un nuevo bloque `options` en el `summary` (`includeOutOfStock` / `archiveMissing`) y marca esos valores internamente al ejecutar la importación.
- El admin muestra en el resumen final si se ejecutó en “Modo catálogo completo” y si se aplicó “Desactivar faltantes CSV”, tomando la fuente efectiva desde `summary.options` para evitar ambigüedades por caché o fallos de transmisión.

### Testing
- Ejecuté los tests de importación dirigidos con `npm test -- backend/__tests__/catalogCsvImport.test.js backend/__tests__/stockXlsxImport.test.js` y ambos suites pasaron (2 suites, 9 tests passed).
- Las pruebas incluyen el caso `includeOutOfStock importa todo el catálogo y guarda stock CSV como metadato` que valida que el CSV con `includeOutOfStock` importe todos los registros y persista `csvStockQuantity` en `products.json`, y pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee14599ab08331ac55e325410031e7)