### PR TITLE
Harden admin import progress polling and persist import jobs on disk

### DIFF
--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -200,7 +200,14 @@ const REVIEW_STATUSES = ["PENDING", "PUBLISHED", "FLAGGED", "REMOVED"];
 let _cache = { t: 0, data: null };
 let metaFeedCache = { t: 0, baseUrl: null, csv: null, count: 0, inStockCount: 0 };
 const importJobs = new Map();
+const importJobLogBuckets = new Map();
 const IMPORT_JOB_TTL_MS = 60 * 60 * 1000;
+const IMPORT_JOBS_DIR = dataPath("import-jobs");
+const IMPORT_JOB_LOG_STEP = 10;
+
+fsp.mkdir(IMPORT_JOBS_DIR, { recursive: true }).catch((error) => {
+  console.warn("[import-job] no se pudo inicializar carpeta persistente", error?.message || error);
+});
 
 function normalizeBaseUrl(value) {
   if (!value || typeof value !== "string") return null;
@@ -245,6 +252,15 @@ function createImportJob(type = "catalog_csv") {
     updatedAt: new Date().toISOString(),
   };
   importJobs.set(jobId, job);
+  importJobLogBuckets.set(jobId, -1);
+  persistImportJob(job).catch((error) => {
+    console.error("[import-job] persist create failed", jobId, error?.message || error);
+  });
+  console.log("[import-job] created", {
+    jobId,
+    type,
+    status: job.status,
+  });
   return job;
 }
 
@@ -257,7 +273,90 @@ function updateImportJob(jobId, patch = {}) {
     updatedAt: new Date().toISOString(),
   };
   importJobs.set(jobId, next);
+  persistImportJob(next).catch((error) => {
+    console.error("[import-job] persist update failed", jobId, error?.message || error);
+  });
+  const progress = Number(next.progress || 0);
+  const bucket = Number.isFinite(progress) ? Math.floor(progress / IMPORT_JOB_LOG_STEP) : -1;
+  const previousBucket = importJobLogBuckets.get(jobId);
+  const statusChanged = patch.status && patch.status !== current.status;
+  if (statusChanged || (bucket >= 0 && bucket > previousBucket)) {
+    importJobLogBuckets.set(jobId, bucket);
+    console.log("[import-job] updated", {
+      jobId,
+      status: next.status,
+      progress: Number(next.progress || 0),
+      processedRows: Number(next.processedRows || 0),
+      totalRows: Number(next.totalRows || 0),
+      inserted: Number(next.inserted || 0),
+      updated: Number(next.updated || 0),
+      skipped: Number(next.skipped || 0),
+      errors: Number(next.errors || 0),
+      message: next.message || null,
+    });
+  }
+  if (next.status === "completed") {
+    console.log("[import-job] completed", { jobId, type: next.type, progress: next.progress });
+  } else if (next.status === "failed") {
+    console.error("[import-job] failed", {
+      jobId,
+      type: next.type,
+      message: next.error || next.message || "unknown",
+    });
+  }
   return next;
+}
+
+function toImportJobFileName(jobId) {
+  return `${String(jobId || "")
+    .trim()
+    .replace(/[^a-zA-Z0-9._-]/g, "_")}.json`;
+}
+
+function getImportJobFilePath(jobId) {
+  return path.join(IMPORT_JOBS_DIR, toImportJobFileName(jobId));
+}
+
+async function ensureImportJobsDir() {
+  await fsp.mkdir(IMPORT_JOBS_DIR, { recursive: true });
+}
+
+async function persistImportJob(job) {
+  if (!job || !job.jobId) return;
+  await ensureImportJobsDir();
+  const filePath = getImportJobFilePath(job.jobId);
+  const tmpPath = `${filePath}.tmp`;
+  await fsp.writeFile(tmpPath, JSON.stringify(job, null, 2), "utf8");
+  await fsp.rename(tmpPath, filePath);
+}
+
+async function listKnownImportJobIds() {
+  const known = new Set(Array.from(importJobs.keys()));
+  try {
+    const entries = await fsp.readdir(IMPORT_JOBS_DIR, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry?.isFile?.() || !entry.name.endsWith(".json")) continue;
+      known.add(entry.name.replace(/\.json$/i, ""));
+    }
+  } catch {}
+  return Array.from(known).sort();
+}
+
+async function getImportJobById(jobId) {
+  const normalizedJobId = String(jobId || "").trim();
+  if (!normalizedJobId) return { job: null, source: "none" };
+  const inMemory = importJobs.get(normalizedJobId);
+  if (inMemory) return { job: inMemory, source: "memory" };
+  try {
+    const filePath = getImportJobFilePath(normalizedJobId);
+    const raw = await fsp.readFile(filePath, "utf8");
+    const parsed = JSON.parse(raw);
+    if (parsed && parsed.jobId === normalizedJobId) {
+      importJobs.set(normalizedJobId, parsed);
+      return { job: parsed, source: "disk" };
+    }
+  } catch {}
+  return { job: null, source: "none" };
 }
 
 function cleanupImportJobs() {
@@ -267,6 +366,8 @@ function cleanupImportJobs() {
     if (!Number.isFinite(updatedAt)) continue;
     if (now - updatedAt > IMPORT_JOB_TTL_MS) {
       importJobs.delete(jobId);
+      importJobLogBuckets.delete(jobId);
+      fsp.unlink(getImportJobFilePath(jobId)).catch(() => {});
     }
   }
 }
@@ -5807,6 +5908,10 @@ async function requestHandler(req, res) {
     const jobs = Array.from(importJobs.values())
       .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
       .slice(0, 20);
+    console.log("[import-job] list queried", {
+      requestedBy: resolveAuthUser(req)?.email || resolveAuthUser(req)?.id || "unknown",
+      count: jobs.length,
+    });
     return sendJson(res, 200, { jobs });
   }
 
@@ -5814,8 +5919,16 @@ async function requestHandler(req, res) {
     if (!requireAdmin(req, res, { allowSeller: false })) return;
     cleanupImportJobs();
     const jobId = pathname.split("/").pop();
-    const job = importJobs.get(jobId);
-    if (!job) return sendJson(res, 404, { error: "Job no encontrado" });
+    const { job, source } = await getImportJobById(jobId);
+    console.log("[import-job] get queried", {
+      jobId,
+      source,
+      requestedBy: resolveAuthUser(req)?.email || resolveAuthUser(req)?.id || "unknown",
+    });
+    if (!job) {
+      const knownJobs = await listKnownImportJobIds();
+      return sendJson(res, 404, { error: "Job no encontrado", jobId, knownJobs });
+    }
     return sendJson(res, 200, job);
   }
 
@@ -5865,6 +5978,12 @@ async function requestHandler(req, res) {
       updateImportJob(job.jobId, {
         status: "running",
         message: "Importando catálogo…",
+      });
+      console.log("[catalog-csv-import] started", {
+        jobId: job.jobId,
+        includeOutOfStock,
+        archiveMissing,
+        chunkSize,
       });
       sendJson(res, 202, {
         success: true,
@@ -5953,6 +6072,10 @@ async function requestHandler(req, res) {
       updateImportJob(job.jobId, {
         status: "running",
         message: "Importando stock real…",
+      });
+      console.log("[stock-xlsx-import] started", {
+        jobId: job.jobId,
+        zeroMissingProducts,
       });
       sendJson(res, 202, {
         success: true,

--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -3587,6 +3587,100 @@ duplicateProductBtn.addEventListener("click", async () => {
   }
 });
 
+function formatImportProgressError({ endpoint, jobId, status, statusText, errorBody }) {
+  const statusLabel = Number.isFinite(Number(status))
+    ? `status ${status}${statusText ? ` ${statusText}` : ""}`
+    : "sin status HTTP";
+  const bodyLabel = errorBody ? ` · body: ${errorBody}` : "";
+  return `No se pudo consultar progreso: ${statusLabel}${bodyLabel} · jobId=${jobId} · endpoint=${endpoint}`;
+}
+
+async function pollImportJob({
+  jobId,
+  statusElement,
+  progressElement,
+  runningMessage,
+  renderCounters,
+}) {
+  const endpoint = `/api/admin/import/jobs/${encodeURIComponent(jobId)}`;
+  let consecutiveFailures = 0;
+  let warningShown = false;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    try {
+      const progressResp = await apiFetch(endpoint, {
+        headers: getAdminHeaders(),
+      });
+      const rawBody = await progressResp.text();
+      let job = {};
+      try {
+        job = rawBody ? JSON.parse(rawBody) : {};
+      } catch {
+        job = { error: rawBody || "Respuesta no JSON" };
+      }
+      if (!progressResp.ok) {
+        const details = job?.error || job?.message || rawBody || "sin detalle";
+        throw new Error(
+          formatImportProgressError({
+            endpoint,
+            jobId,
+            status: progressResp.status,
+            statusText: progressResp.statusText,
+            errorBody: String(details),
+          }),
+        );
+      }
+      if (consecutiveFailures > 0 && statusElement) {
+        statusElement.textContent = "Reconexión de progreso OK. Continuando importación…";
+        statusElement.style.color = "";
+      }
+      consecutiveFailures = 0;
+      warningShown = false;
+
+      if (progressElement) {
+        progressElement.value = Number(job.progress || 0);
+        progressElement.style.display = "block";
+      }
+      if (statusElement) {
+        statusElement.textContent =
+          `${job.message || runningMessage} ${job.progress || 0}% · ` +
+          `${job.processedRows || 0} / ${job.totalRows || 0} filas · ${renderCounters(job)}`;
+      }
+      if (job.status === "failed") {
+        throw new Error(job.error || job.message || "Falló la importación");
+      }
+      if (job.status === "completed") {
+        return job.summary || {};
+      }
+    } catch (error) {
+      consecutiveFailures += 1;
+      if (statusElement) {
+        if (consecutiveFailures <= 2) {
+          statusElement.textContent = `Reconectando con progreso… intento ${consecutiveFailures}/5`;
+          statusElement.style.color = "";
+        } else if (consecutiveFailures < 5) {
+          warningShown = true;
+          statusElement.textContent =
+            `Reconectando con progreso… (${consecutiveFailures}/5). Último error: ${error?.message || "sin detalle"}`;
+          statusElement.style.color = "darkorange";
+        }
+      }
+      if (consecutiveFailures >= 5) {
+        throw error;
+      }
+      if (warningShown) {
+        console.warn("import-progress-poll-warning", {
+          jobId,
+          endpoint,
+          consecutiveFailures,
+          message: error?.message || error,
+        });
+      }
+    }
+  }
+}
+
 async function importCatalogCsvFromAdmin() {
   if (currentRole !== "admin") {
     alert("Solo administradores pueden importar CSV.");
@@ -3632,33 +3726,15 @@ async function importCatalogCsvFromAdmin() {
     if (!jobId) {
       throw new Error("No se recibió jobId para monitorear la importación");
     }
-    let summary = null;
-    while (!summary) {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      const progressResp = await apiFetch(`/api/admin/import/jobs/${encodeURIComponent(jobId)}`, {
-        headers: getAdminHeaders(),
-      });
-      const job = await progressResp.json().catch(() => ({}));
-      if (!progressResp.ok) {
-        throw new Error(job.error || "No se pudo consultar progreso de importación");
-      }
-      if (catalogCsvImportProgress) {
-        catalogCsvImportProgress.value = Number(job.progress || 0);
-      }
-      if (catalogCsvImportStatus) {
-        catalogCsvImportStatus.textContent =
-          `${job.message || "Importando catálogo…"} ${job.progress || 0}% · ` +
-          `${job.processedRows || 0} / ${job.totalRows || 0} filas · ` +
-          `Insertados: ${job.inserted || 0} · Actualizados: ${job.updated || 0} · ` +
-          `Salteados: ${job.skipped || 0} · Errores: ${job.errors || 0}`;
-      }
-      if (job.status === "failed") {
-        throw new Error(job.error || job.message || "Falló la importación CSV");
-      }
-      if (job.status === "completed") {
-        summary = job.summary || {};
-      }
-    }
+    const summary = await pollImportJob({
+      jobId,
+      statusElement: catalogCsvImportStatus,
+      progressElement: catalogCsvImportProgress,
+      runningMessage: "Importando catálogo…",
+      renderCounters: (job) =>
+        `Insertados: ${job.inserted || 0} · Actualizados: ${job.updated || 0} · ` +
+        `Salteados: ${job.skipped || 0} · Errores: ${job.errors || 0}`,
+    });
     const pricing = summary.pricing || {};
     const safety = summary.safety || {};
     const catalog = summary.catalog || {};
@@ -3774,33 +3850,15 @@ async function importStockXlsxFromAdmin() {
     if (!jobId) {
       throw new Error("No se recibió jobId para monitorear la importación");
     }
-    let summary = null;
-    while (!summary) {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      const progressResp = await apiFetch(`/api/admin/import/jobs/${encodeURIComponent(jobId)}`, {
-        headers: getAdminHeaders(),
-      });
-      const job = await progressResp.json().catch(() => ({}));
-      if (!progressResp.ok) {
-        throw new Error(job.error || "No se pudo consultar progreso de importación");
-      }
-      if (stockXlsxImportProgress) {
-        stockXlsxImportProgress.value = Number(job.progress || 0);
-      }
-      if (stockXlsxImportStatus) {
-        stockXlsxImportStatus.textContent =
-          `${job.message || "Importando stock real…"} ${job.progress || 0}% · ` +
-          `${job.processedRows || 0} / ${job.totalRows || 0} filas · ` +
-          `Actualizados: ${job.updated || 0} · Sin match: ${job.skipped || 0} · ` +
-          `Errores: ${job.errors || 0}`;
-      }
-      if (job.status === "failed") {
-        throw new Error(job.error || job.message || "Falló la importación XLSX");
-      }
-      if (job.status === "completed") {
-        summary = job.summary || {};
-      }
-    }
+    const summary = await pollImportJob({
+      jobId,
+      statusElement: stockXlsxImportStatus,
+      progressElement: stockXlsxImportProgress,
+      runningMessage: "Importando stock real…",
+      renderCounters: (job) =>
+        `Actualizados: ${job.updated || 0} · Sin match: ${job.skipped || 0} · ` +
+        `Errores: ${job.errors || 0}`,
+    });
     const statusMessage =
       `Stock XLSX OK · Filas: ${summary.totalRows || 0} · ` +
       `Matcheados: ${summary.matchedProducts || 0} · ` +


### PR DESCRIPTION
### Motivation
- Prevent false `404` and lost progress when the server restarts by persisting import job state to disk. 
- Make admin progress polling robust so a transient failure does not abort monitoring and the UI shows meaningful errors. 
- Keep admin authentication unchanged and avoid introducing a second manual `x-admin-key` while ensuring the frontend polling works after a regular admin login. 

### Description
- Persist import jobs on every create/update to `DATA_DIR/import-jobs/<jobId>.json` and load jobs from disk when missing from memory via new helpers `persistImportJob`, `getImportJobById` and `listKnownImportJobIds` in `backend/server.js`. 
- Enhance `GET /api/admin/import/jobs/:jobId` to fall back to disk, log the request and return a richer 404 payload `{ error, jobId, knownJobs }` when not found. 
- Add lifecycle and progress logging for import jobs (created, periodic updates every `IMPORT_JOB_LOG_STEP` percent, completed, failed, list/get queries and whether read from memory or disk) and remove stale job files on TTL expiry. 
- Replace fragile frontend polling with `pollImportJob` in `frontend/js/admin.js` that shows detailed fetch errors (HTTP status, body, `jobId`, endpoint), retries on transient failures, shows reconnection warnings after repeated failures, and only fails after 5 consecutive errors while keeping the progress bar visible. 
- Preserve existing behavior for the CSV option `includeOutOfStock=1` and ensure the backend continues to forward the parsed `includeOutOfStock` flag to the CSV importer. 

### Testing
- Ran unit tests with `npm test -- --runInBand backend/__tests__/catalogCsvImport.test.js backend/__tests__/stockXlsxImport.test.js` and the suites passed. 
- Test results: `Test Suites: 2 passed, 2 total` and `Tests: 9 passed, 9 total`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee1a1eb7bc8331a71e0fb48dcb008d)