### PR TITLE
Fix Render DATA_DIR detection, harden import-job persistence and reduce CSV import memory usage

### DIFF
--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -117,6 +117,7 @@ const IS_DATA_DIR_PERSISTENT =
 const DATA_DIR = resolvedDataDir;
 const EXPLICIT_DATA_DIR = (process.env.DATA_DIR || "").trim() || null;
 const RENDER_DISK_MOUNT_PATH = (process.env.RENDER_DISK_MOUNT_PATH || "").trim() || null;
+const RENDER_REPO_DISK_PREFIX = "/opt/render/project/src/nerin_final_updated";
 const PRODUCTS_FILE_PATH = (() => {
   const raw = (process.env.PRODUCTS_FILE_PATH || "").trim();
   if (!raw) return dataPath("products.json");
@@ -137,6 +138,15 @@ function isPathInside(targetPath, basePath) {
   if (target === base) return true;
   const rel = path.relative(base, target);
   return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+}
+function isInsideConfiguredDataDir(targetPath) {
+  const resolvedTarget = resolveSafePath(targetPath);
+  const resolvedDataDir = resolveSafePath(DATA_DIR);
+  if (isPathInside(resolvedTarget, resolvedDataDir)) return true;
+  return Boolean(
+    resolvedTarget &&
+      resolvedTarget.startsWith(`${RENDER_REPO_DISK_PREFIX}${path.sep}`),
+  );
 }
 const DATA_SOURCE_LABEL = (() => {
   switch (DATA_DIR_SOURCE.type) {
@@ -169,11 +179,17 @@ if (process.env.NODE_ENV !== "test") {
       count = Array.isArray(list) ? list.length : 0;
     }
     const isInsideRenderDisk = isPathInside(PRODUCTS_FILE_PATH, RENDER_DISK_MOUNT_PATH);
+    const isInsideConfiguredDataDirValue = isInsideConfiguredDataDir(PRODUCTS_FILE_PATH);
+    const storageValid = isInsideRenderDisk || isInsideConfiguredDataDirValue;
     console.log(`[NERIN] Using products file: ${PRODUCTS_FILE_PATH}`);
     console.log(`[NERIN] DATA_DIR: ${DATA_DIR}`);
     console.log(`[NERIN] RENDER_DISK_MOUNT_PATH: ${RENDER_DISK_MOUNT_PATH || "(unset)"}`);
     console.log(`[NERIN] productCount: ${count}`);
     console.log(`[NERIN] isInsideRenderDisk: ${isInsideRenderDisk}`);
+    console.log(`[NERIN] isInsideConfiguredDataDir: ${isInsideConfiguredDataDirValue}`);
+    console.log(`[NERIN] dataDir: ${DATA_DIR}`);
+    console.log(`[NERIN] productsFilePath: ${PRODUCTS_FILE_PATH}`);
+    console.log(`[NERIN] storageValid: ${storageValid}`);
   } catch (err) {
     console.error(
       `[NERIN] Using products file: ${PRODUCTS_FILE_PATH}`,
@@ -201,6 +217,7 @@ let _cache = { t: 0, data: null };
 let metaFeedCache = { t: 0, baseUrl: null, csv: null, count: 0, inStockCount: 0 };
 const importJobs = new Map();
 const importJobLogBuckets = new Map();
+const importJobLastPersistAt = new Map();
 const IMPORT_JOB_TTL_MS = 24 * 60 * 60 * 1000;
 const IMPORT_JOBS_DIR = dataPath("import-jobs");
 const IMPORT_JOB_LOG_STEP = 10;
@@ -273,9 +290,23 @@ function updateImportJob(jobId, patch = {}) {
     updatedAt: new Date().toISOString(),
   };
   importJobs.set(jobId, next);
-  persistImportJob(next).catch((error) => {
-    console.error("[import-job] persist update failed", jobId, error?.message || error);
-  });
+  const now = Date.now();
+  const lastPersistAt = Number(importJobLastPersistAt.get(jobId) || 0);
+  const progressChangedByPercent =
+    Math.floor(Number(next.progress || 0)) !== Math.floor(Number(current.progress || 0));
+  const shouldPersist =
+    !lastPersistAt ||
+    now - lastPersistAt >= 1000 ||
+    progressChangedByPercent ||
+    patch.status === "completed" ||
+    patch.status === "failed" ||
+    patch.status === "queued";
+  if (shouldPersist) {
+    importJobLastPersistAt.set(jobId, now);
+    persistImportJob(next).catch((error) => {
+      console.error("[import-job] persist update failed", jobId, error?.message || error);
+    });
+  }
   const progress = Number(next.progress || 0);
   const bucket = Number.isFinite(progress) ? Math.floor(progress / IMPORT_JOB_LOG_STEP) : -1;
   const previousBucket = importJobLogBuckets.get(jobId);
@@ -323,9 +354,12 @@ async function ensureImportJobsDir() {
 
 async function persistImportJob(job) {
   if (!job || !job.jobId) return;
+  fs.mkdirSync(IMPORT_JOBS_DIR, { recursive: true });
   await ensureImportJobsDir();
   const filePath = getImportJobFilePath(job.jobId);
-  const tmpPath = `${filePath}.tmp`;
+  const tmpPath = `${filePath}.${process.pid}.${Date.now()}.${Math.random()
+    .toString(16)
+    .slice(2)}.tmp`;
   await fsp.writeFile(tmpPath, JSON.stringify(job, null, 2), "utf8");
   await fsp.rename(tmpPath, filePath);
 }
@@ -3312,6 +3346,7 @@ function inspectProductsStorage() {
   const isInsideRepo = isPathInside(resolvedProductsPath, repoRoot);
   const isInsideRenderDisk = isPathInside(resolvedProductsPath, resolvedRenderDisk);
   const isInsideDataDir = isPathInside(resolvedProductsPath, resolvedDataDir);
+  const isInsideConfiguredDataDirValue = isInsideConfiguredDataDir(resolvedProductsPath);
 
   const report = {
     DATA_DIR,
@@ -3329,6 +3364,8 @@ function inspectProductsStorage() {
     firstKey: null,
     isInsideRepo,
     isInsideRenderDisk,
+    isInsideConfiguredDataDir: isInsideConfiguredDataDirValue,
+    storageValid: isInsideRenderDisk || isInsideConfiguredDataDirValue,
     renderDiskExpected:
       !!resolvedRenderDisk ||
       DATA_DIR.startsWith("/var/data") ||
@@ -3337,11 +3374,16 @@ function inspectProductsStorage() {
     errors: [],
   };
 
-  if (resolvedRenderDisk && !renderDiskExists) {
+  if (resolvedRenderDisk && !renderDiskExists && !isInsideConfiguredDataDirValue) {
     report.errors.push(`RENDER_DISK_MOUNT_PATH no existe: ${resolvedRenderDisk}`);
   }
 
-  if (resolvedProductsPath && resolvedProductsPath.startsWith("/opt/render/project/src") && !isInsideRenderDisk) {
+  if (
+    resolvedProductsPath &&
+    resolvedProductsPath.startsWith("/opt/render/project/src") &&
+    !isInsideRenderDisk &&
+    !isInsideConfiguredDataDirValue
+  ) {
     report.warnings.push(
       `productsFilePath está dentro del repo de deploy (/opt/render/project/src) pero fuera del Render Disk mount real (${resolvedRenderDisk || "unset"}).`,
     );
@@ -3350,12 +3392,13 @@ function inspectProductsStorage() {
   if (IS_PRODUCTION) {
     const hasExplicitDataDir = Boolean(EXPLICIT_DATA_DIR);
     const allowedByExplicitDataDir = hasExplicitDataDir && isInsideDataDir;
-    if (!isInsideRenderDisk && !allowedByExplicitDataDir) {
+    const allowedByConfiguredDataDir = allowedByExplicitDataDir || isInsideConfiguredDataDirValue;
+    if (!isInsideRenderDisk && !allowedByConfiguredDataDir) {
       report.errors.push(
         "En producción, productsFilePath debe estar dentro de RENDER_DISK_MOUNT_PATH o de DATA_DIR explícito.",
       );
     }
-    if (isInsideRepo && !isInsideRenderDisk && !allowedByExplicitDataDir) {
+    if (isInsideRepo && !isInsideRenderDisk && !allowedByConfiguredDataDir) {
       report.errors.push(
         "En producción no se permite usar carpeta local del repo para products.json sin mount path confirmado.",
       );

--- a/nerin_final_updated/backend/services/catalogCsvImport.js
+++ b/nerin_final_updated/backend/services/catalogCsvImport.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const path = require("path");
+const readline = require("readline");
 const Decimal = require("decimal.js");
 const { parse } = require("csv-parse");
 const { DATA_DIR } = require("../utils/dataDir");
@@ -19,32 +20,6 @@ const REQUIRED_COLUMNS = [
   "UnitPrice",
   "StockQuantity",
   "MaximumQuantityInOrder",
-];
-
-const ALL_COLUMNS = [
-  "PartId",
-  "ManufacturerName",
-  "ManufacturerId",
-  "ManufacturerArticleCode",
-  "MainCategory",
-  "SubCategory",
-  "PartNumber",
-  "Description",
-  "Status",
-  "CanBeOrdered",
-  "UnitPrice",
-  "StockQuantity",
-  "MaximumQuantityInOrder",
-  "Quality",
-  "Remarks",
-  "ImageUrl",
-  "ImageUrl2",
-  "ImageUrl3",
-  "ImageUrl4",
-  "ImageUrl5",
-  "EanNumber",
-  "CountryOfOrigin",
-  "ProductGroup",
 ];
 
 const IMAGE_COLUMNS = ["ImageUrl", "ImageUrl2", "ImageUrl3", "ImageUrl4", "ImageUrl5"];
@@ -171,10 +146,6 @@ function toImportedRecord(row, line) {
     pricing: null,
     pricingWarnings: [],
     pricingTrace: null,
-    rawRow: ALL_COLUMNS.reduce((acc, key) => {
-      acc[key] = row[key] == null ? null : String(row[key]);
-      return acc;
-    }, {}),
   };
 
   if (!record.manufacturerName) {
@@ -243,7 +214,8 @@ function createBaseSummary() {
     updated: 0,
     skipped: 0,
     failed: 0,
-    errors: [],
+    errorsCount: 0,
+    errorsSample: [],
     safety: {
       skippedUnavailable: 0,
       skippedNoStock: 0,
@@ -266,6 +238,18 @@ function createBaseSummary() {
       archiveMissing: false,
     },
   };
+}
+
+async function estimateCsvRows(filePath) {
+  let lineCount = 0;
+  const rl = readline.createInterface({
+    input: fs.createReadStream(filePath, { encoding: "utf8" }),
+    crlfDelay: Infinity,
+  });
+  for await (const line of rl) {
+    if (String(line || "").trim()) lineCount += 1;
+  }
+  return Math.max(0, lineCount - 1);
 }
 
 function isImportableByAvailability(record) {
@@ -308,16 +292,18 @@ function classifyAvailabilitySkip(record) {
 
 async function buildJsonPersistenceLayer() {
   const filePath = path.join(DATA_DIR, "products.json");
-  let current = [];
+  let products = [];
   try {
-    current = JSON.parse(fs.readFileSync(filePath, "utf8")).products || [];
+    products = JSON.parse(fs.readFileSync(filePath, "utf8")).products || [];
   } catch {
-    current = [];
+    products = [];
   }
 
-  const byId = new Map(current.map((product) => [String(product.id), { ...product }]));
+  const indexById = new Map();
   const partNumberToId = new Map();
-  for (const product of byId.values()) {
+  for (let idx = 0; idx < products.length; idx += 1) {
+    const product = products[idx];
+    indexById.set(String(product.id), idx);
     const supplierPartNumber =
       normalizeCell(product?.metadata?.supplierImport?.supplierPartNumber) ||
       normalizeCell(product?.metadata?.supplierPartNumber) ||
@@ -335,15 +321,17 @@ async function buildJsonPersistenceLayer() {
       for (const item of batch) {
         const id = String(item.record.externalId);
         const normalized = mapImportedRecordToStoreProduct(item.record);
-        if (byId.has(id)) {
-          const previous = byId.get(id);
-          byId.set(id, {
+        if (indexById.has(id)) {
+          const existingIdx = indexById.get(id);
+          const previous = products[existingIdx];
+          products[existingIdx] = {
             ...previous,
             ...normalized,
-          });
+          };
           updated += 1;
         } else {
-          byId.set(id, normalized);
+          indexById.set(id, products.length);
+          products.push(normalized);
           inserted += 1;
         }
         partNumberToId.set(item.supplierPartNumberKey, id);
@@ -352,11 +340,13 @@ async function buildJsonPersistenceLayer() {
     },
     async archiveMissing(importedExternalIds = new Set()) {
       let archived = 0;
-      for (const [id, product] of byId.entries()) {
+      for (let idx = 0; idx < products.length; idx += 1) {
+        const product = products[idx];
+        const id = String(product?.id);
         const importSource = normalizeCell(product?.metadata?.importSource);
         if (importSource !== "catalog_csv") continue;
         if (importedExternalIds.has(String(id))) continue;
-        byId.set(id, {
+        products[idx] = {
           ...product,
           stock: 0,
           remote_stock: 0,
@@ -366,17 +356,16 @@ async function buildJsonPersistenceLayer() {
             catalogCsvArchivedAt: new Date().toISOString(),
             catalogCsvArchivedBecauseMissing: true,
           },
-        });
+        };
         archived += 1;
       }
       return archived;
     },
     async finalize() {
-      const all = Array.from(byId.values());
-      safeWriteJsonWithBackup(filePath, { products: all });
+      safeWriteJsonWithBackup(filePath, { products });
       return {
-        totalProductsAfterImport: all.length,
-        withSupplierPartNumber: all.filter((product) => {
+        totalProductsAfterImport: products.length,
+        withSupplierPartNumber: products.filter((product) => {
           const supplierPartNumber =
             normalizeCell(product?.metadata?.supplierImport?.supplierPartNumber) ||
             normalizeCell(product?.metadata?.supplierPartNumber) ||
@@ -495,7 +484,7 @@ async function importCatalogCsvFile({
   filePath,
   pool = null,
   chunkSize = 400,
-  maxReportedErrors = 500,
+  maxReportedErrors = 100,
   includeOutOfStock = false,
   archiveMissing = false,
   onProgress = null,
@@ -527,8 +516,7 @@ async function importCatalogCsvFile({
   let processedRows = 0;
   let estimatedTotalRows = 0;
   try {
-    const rawCsv = fs.readFileSync(filePath, "utf8");
-    estimatedTotalRows = Math.max(0, rawCsv.split(/\r?\n/).filter(Boolean).length - 1);
+    estimatedTotalRows = await estimateCsvRows(filePath);
   } catch {
     estimatedTotalRows = 0;
   }
@@ -547,8 +535,40 @@ async function importCatalogCsvFile({
 
   const pushError = (error) => {
     summary.failed += 1;
-    if (summary.errors.length < maxReportedErrors) {
-      summary.errors.push(error);
+    summary.errorsCount += 1;
+    if (summary.errorsSample.length < maxReportedErrors) {
+      summary.errorsSample.push(error);
+    }
+  };
+
+  let lastProgressAt = 0;
+  let lastProgressPercent = -1;
+  let lastMemoryLogAt = 0;
+  const maybeLogMemory = () => {
+    const now = Date.now();
+    if (now - lastMemoryLogAt < 5000) return;
+    lastMemoryLogAt = now;
+    const usage = process.memoryUsage();
+    console.info("[csv-import-memory]", {
+      processedRows,
+      rssMB: Number((usage.rss / (1024 * 1024)).toFixed(1)),
+      heapUsedMB: Number((usage.heapUsed / (1024 * 1024)).toFixed(1)),
+      heapTotalMB: Number((usage.heapTotal / (1024 * 1024)).toFixed(1)),
+    });
+  };
+
+  const maybeNotifyProgress = () => {
+    const now = Date.now();
+    const totalRowsForProgress = estimatedTotalRows || summary.totalRows;
+    const percent = totalRowsForProgress > 0
+      ? Math.floor((processedRows / totalRowsForProgress) * 100)
+      : 0;
+    const percentChanged = percent > lastProgressPercent;
+    const enoughTimeElapsed = now - lastProgressAt >= 1000;
+    if (percentChanged || enoughTimeElapsed) {
+      lastProgressAt = now;
+      lastProgressPercent = percent;
+      notifyProgress();
     }
   };
 
@@ -652,7 +672,10 @@ async function importCatalogCsvFile({
     }
     processedRows += 1;
     if (processedRows % progressEveryRows === 0) {
-      notifyProgress();
+      maybeNotifyProgress();
+    }
+    if (processedRows % 500 === 0) {
+      maybeLogMemory();
     }
   }
 
@@ -673,6 +696,7 @@ async function importCatalogCsvFile({
   summary.catalog.hiddenNoStockOrNotOrderable = Number(
     summary.safety.importedHiddenNoStockOrNotOrderable || 0,
   );
+  summary.errors = summary.errorsSample;
   processedRows = summary.totalRows;
   notifyProgress();
 


### PR DESCRIPTION
### Motivation
- Evitar fallos en producción donde la importación CSV completa falla por `ENOENT` al persistir `import-jobs` y por `JavaScript heap out of memory` al procesar archivos grandes. 
- Aceptar la configuración real de Render donde `DATA_DIR` ya reside bajo `/opt/render/project/src/nerin_final_updated` aunque `RENDER_DISK_MOUNT_PATH` esté sin setear. 
- Reducir I/O y memoria durante importaciones masivas para que el proceso complete y el job persista en disco sin interrumpir la importación.

### Description
- Al detectar almacenamiento: añadí `RENDER_REPO_DISK_PREFIX` y la función `isInsideConfiguredDataDir()` y ahora se registra `isInsideConfiguredDataDir`, `dataDir`, `productsFilePath` y `storageValid` en los logs de arranque y en `inspectProductsStorage()` para considerar válido `DATA_DIR` ubicado en `/opt/render/project/src/nerin_final_updated` incluso con `RENDER_DISK_MOUNT_PATH` unset (`backend/server.js`).
- Persistencia de jobs: antes de cada escritura se asegura la carpeta con `fs.mkdirSync(..., { recursive: true })`, se usa un tmp file único por escritura con `.${process.pid}.${Date.now()}.${random}.tmp` y se mantiene la escritura atómica `write -> rename`; además se throttlean las escrituras con un mapa `importJobLastPersistAt` para no escribir en disco en cada update salvo cambios significativos o estados terminales (`backend/server.js`).
- Importador CSV optimizado: eliminé la retención de `rawRow` completo, reemplacé el almacenamiento de errores por `errorsCount` + `errorsSample` capado, usé un conteo de líneas por stream (`readline`) para estimar filas sin cargar todo el CSV, y reemplacé la clonación del catálogo por actualizaciones in-place usando un índice posicionable para evitar duplicar estructuras en memoria; la escritura de `products.json` se mantiene atómica y única al final (`backend/services/catalogCsvImport.js`).
- Progreso y telemetría: notificaciones de progreso ahora throttled (cada ~1s o cambio de %), logs periódicos de uso de memoria `console.info('[csv-import-memory]', {...})` y reducción de `maxReportedErrors` por defecto para limitar memoria usada por muestras de error.
- Conservé la semántica de `includeOutOfStock` (el backend ya interpreta `includeOutOfStock=1`), de modo que cuando está activado no se saltan productos por disponibilidad y se importan con `metadata.needsStockSync=true` y visibilidad adecuada.

### Testing
- Ejecuté la suite relacionada con el importador: `npm test -- --runInBand backend/__tests__/catalogCsvImport.test.js` y todos los tests pasaron (Test Suites: 1 passed, Tests: 6 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee260ecae883319a11a01b17d2bfc3)