### PR TITLE
Homepage redesign, WhatsApp contact flow, and preview capture script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ nerin_final_updated/node_modules/
 nerin_final_updated/package-lock.json
 nerin_final_updated/.env
 frontend/config.js
+nerin_final_updated/preview/*.png
+nerin_final_updated/preview/*.jpg
+nerin_final_updated/preview/*.webp

--- a/nerin_final_updated/frontend/components/np-footer.js
+++ b/nerin_final_updated/frontend/components/np-footer.js
@@ -141,6 +141,7 @@
           iibb: "IIBB CABA 901-117119-4",
           terms: "/pages/terminos.html",
           privacy: "/pages/terminos.html#datos",
+          repentance: "/arrepentimiento.html",
         },
         show: {
           cta: true,
@@ -461,6 +462,14 @@
           priv.textContent = "Privacidad";
           priv.rel = "noopener";
           legal.appendChild(priv);
+        }
+        if (cfg.legal.repentance) {
+          legal.appendChild(document.createTextNode(" – "));
+          const repentance = document.createElement("a");
+          repentance.href = cfg.legal.repentance;
+          repentance.textContent = "Botón de arrepentimiento";
+          repentance.rel = "noopener";
+          legal.appendChild(repentance);
         }
       }
 

--- a/nerin_final_updated/frontend/index.html
+++ b/nerin_final_updated/frontend/index.html
@@ -178,28 +178,23 @@
             <li><a href="/login.html">Acceder</a></li>
           </ul>
         </nav>
-        <a href="/arrepentimiento.html" class="button outline header-repent-link">BOTÓN DE ARREPENTIMIENTO</a>
       </div>
     </header>
     <main class="home">
       <section class="home-hero" data-home-section="hero">
         <div class="home-hero__content">
-          <p class="eyebrow" data-home-text="hero.eyebrow">
-            Operamos para laboratorios y cadenas
-          </p>
+          <p class="eyebrow" data-home-text="hero.eyebrow">NERIN Parts</p>
           <h1 data-home-text="hero.title">
-            Pantallas y repuestos originales listos para instalar
+            Pantallas Samsung Service Pack originales
           </h1>
           <p class="lead" data-home-text="hero.description">
-            Nacimos atendiendo la demanda de pantallas Samsung Service Pack y
-            hoy ampliamos el catálogo con líneas Apple, Motorola y soluciones
-            corporativas. Todo con control técnico propio y despacho en horas,
-            no en días.
+            Stock disponible en CABA, retiro con turno y envíos a todo el país.
+            Repuestos verificados para técnicos, talleres y revendedores.
           </p>
-          <ul class="home-hero__bullets" data-home-list="hero.bullets">
-            <li>Stock auditado en CABA con envíos al país</li>
-            <li>Laboratorio interno para validar cada lote</li>
-            <li>Plan de expansión a nuevas marcas premium</li>
+          <ul class="home-hero__bullets home-badges" data-home-list="hero.bullets">
+            <li>Stock real</li>
+            <li>Factura A/B</li>
+            <li>Retiro con turno y envíos</li>
           </ul>
           <div class="buttons">
             <a
@@ -209,10 +204,12 @@
               >Ver catálogo</a
             >
             <a
-              href="/contact.html"
+              href="https://wa.me/541112345678"
               class="button secondary"
               data-home-cta="hero.secondary"
-              >Hablar con un asesor</a
+              target="_blank"
+              rel="noopener"
+              >Consultar por WhatsApp</a
             >
           </div>
         </div>
@@ -220,72 +217,59 @@
           <picture data-home-picture="hero.media">
             <source
               media="(min-width: 900px)"
-              srcset="/assets/hero.png"
+              srcset="/assets/product3.jpg"
               data-home-image="desktop"
             />
             <img
-              src="/assets/hero.png"
-              alt="Equipo técnico de NERIN validando módulos Service Pack"
+              src="/assets/product3.jpg"
+              alt="Caja Service Pack Samsung original"
               data-home-image="mobile"
             />
           </picture>
+          <figcaption class="hero-overlay-card">
+            <strong>GH82 verificado</strong>
+            <span>Stock actualizado</span>
+            <span>Entrega coordinada</span>
+          </figcaption>
         </figure>
       </section>
 
-      <section class="home-highlights" data-home-section="highlights">
-        <div class="home-highlights__grid" id="homeHighlights"></div>
+      <section class="home-trustbar" aria-label="Señales de confianza">
+        <div class="home-trustbar__grid">
+          <span>Stock en CABA</span>
+          <span>Service Pack Samsung</span>
+          <span>Factura A/B</span>
+          <span>Mercado Pago</span>
+          <span>Envíos</span>
+        </div>
       </section>
 
-      <section class="home-about" id="quienes-somos" data-home-section="about">
-        <div class="home-about__media">
-          <picture>
-            <img
-              src="/assets/product1.png"
-              alt="Equipo calibrando módulos para el relanzamiento"
-              data-home-image="about.image"
-            />
-          </picture>
+      <section class="home-categories" aria-label="Comprá por categoría">
+        <div class="section-head">
+          <p class="eyebrow">Catálogo</p>
+          <h2>Comprá por categoría</h2>
         </div>
-        <div class="home-about__content">
-          <p class="eyebrow">Nuestra historia</p>
-          <h2 data-home-text="about.title">
-            De Mercado Libre a un laboratorio integral
-          </h2>
-          <p class="lead" data-home-text="about.lead">
-            Arrancamos en 2021 vendiendo repuestos a través de Mercado Libre.
-            Las restricciones a las importaciones frenaron el proyecto, pero
-            volvimos en 2025 mejor preparados.
-          </p>
-          <p data-home-text="about.body">
-            El relanzamiento de NERIN combina procesos de control renovados,
-            acuerdos logísticos ágiles y un sistema pensado para técnicos y
-            cadenas. Apostamos a calidad sostenible, servicio responsable y un
-            ecosistema que pueda escalar sin perder cercanía.
-          </p>
-          <ul class="home-milestones" id="homeMilestones"></ul>
+        <div class="home-categories__grid">
+          <article class="mini-card"><h3>Pantallas Samsung</h3><a href="/shop.html" class="button secondary">Ver productos</a></article>
+          <article class="mini-card"><h3>Baterías</h3><a href="/contact.html" class="button secondary">Consultar</a></article>
+          <article class="mini-card"><h3>Pines de carga</h3><a href="/contact.html" class="button secondary">Consultar</a></article>
+          <article class="mini-card"><h3>Adhesivos</h3><a href="/contact.html" class="button secondary">Consultar</a></article>
+          <article class="mini-card"><h3>Repuestos por pedido</h3><a href="/contact.html" class="button secondary">Consultar</a></article>
         </div>
       </section>
 
       <section class="home-why" data-home-section="why">
         <div class="home-why__header">
-          <p class="eyebrow">Por qué elegir NERIN</p>
-          <h2 data-home-text="why.title">Por qué elegir NERIN</h2>
-          <p data-home-text="why.description">
-            Diseñamos una experiencia alineada con la operación técnica: datos
-            reales, logística predecible y soporte especializado.
-          </p>
+          <p class="eyebrow">Confianza comercial</p>
+          <h2 data-home-text="why.title">Por qué NERIN Parts</h2>
         </div>
         <div class="home-why__grid" id="homeWhyCards"></div>
       </section>
 
       <section class="home-featured" data-home-section="featured">
         <div class="home-featured__header">
-          <p class="eyebrow">Selección del laboratorio</p>
+          <p class="eyebrow">Catálogo activo</p>
           <h2 data-home-text="featured.title">Productos destacados</h2>
-          <p data-home-text="featured.description">
-            Seleccionamos los módulos con mejor rendimiento y disponibilidad
-            inmediata.
-          </p>
         </div>
         <div id="featuredGrid" class="product-grid premium-grid" role="list"></div>
         <div class="home-featured__cta">
@@ -293,50 +277,67 @@
         </div>
       </section>
 
+      <section class="home-steps" aria-label="Cómo comprar">
+        <div class="section-head"><h2>Cómo comprar</h2></div>
+        <div class="home-steps__grid">
+          <article class="mini-card"><h3>1. Elegís el repuesto</h3><p>Buscá por modelo, GH82 o equipo.</p></article>
+          <article class="mini-card"><h3>2. Confirmamos compatibilidad</h3><p>Validamos modelo, color y versión.</p></article>
+          <article class="mini-card"><h3>3. Retirás o recibís</h3><p>Retiro con turno en CABA o envío.</p></article>
+        </div>
+      </section>
+
+      <section class="home-wholesale" aria-label="Mayoristas">
+        <h2>¿Sos técnico, taller o revendedor?</h2>
+        <p>Accedé a condiciones por cantidad, historial de pedidos y precios especiales según disponibilidad.</p>
+        <div class="buttons">
+          <a href="/account-minorista.html#mayoristas" class="button primary">Ingresar al portal mayorista</a>
+          <a href="/register.html" class="button secondary">Solicitar alta mayorista</a>
+        </div>
+      </section>
+
+      <section class="home-story-short" id="quienes-somos">
+        <p>NERIN Parts nació para simplificar la compra de repuestos originales en Argentina. Hoy operamos con stock controlado, catálogo online y atención enfocada en técnicos y revendedores.</p>
+      </section>
+
       <section class="home-contact" id="contacto" data-home-section="contact">
         <div class="home-contact__intro">
-          <p class="eyebrow" data-home-text="contact.eyebrow">Cotizá en segundos</p>
-          <h2 data-home-text="contact.title">
-            Contanos qué necesitás y coordinamos la entrega
-          </h2>
+          <h2 data-home-text="contact.title">¿No encontrás el repuesto?</h2>
           <p data-home-text="contact.description">
-            Respondemos con precio, stock y opciones de retiro o envío en
-            horario comercial.
-          </p>
-          <ul class="home-contact__bullets" id="homeContactBullets"></ul>
-          <p class="home-contact__note" data-home-text="contact.note">
-            Si lo necesitás urgente marcá la opción correspondiente y
-            priorizamos tu caso.
+            Mandanos modelo, código o foto del equipo y te confirmamos disponibilidad.
           </p>
         </div>
         <form id="contactForm" class="contact-form">
           <div class="contact-form__row">
             <label class="contact-form__field">
-              <span>Nombre y apellido</span>
+              <span>Nombre</span>
               <input
                 type="text"
                 id="contactName"
                 name="name"
                 autocomplete="name"
-                placeholder="Ej.: Laura González"
+                placeholder="Nombre"
                 required
               />
             </label>
             <label class="contact-form__field">
-              <span>Modelo exacto</span>
-              <input
-                type="text"
-                id="contactModel"
-                name="model"
-                placeholder="Ej.: SM-A546"
-                autocomplete="off"
-                required
-              />
+              <span>WhatsApp</span>
+              <input type="text" id="contactWhatsapp" name="whatsapp" placeholder="+54 11..." autocomplete="tel" />
             </label>
           </div>
           <div class="contact-form__row">
             <label class="contact-form__field">
-              <span>Cantidad estimada</span>
+              <span>Modelo / código</span>
+              <input
+                type="text"
+                id="contactModel"
+                name="model"
+                placeholder="SM-A546 / GH82..."
+                autocomplete="off"
+                required
+              />
+            </label>
+            <label class="contact-form__field">
+              <span>Cantidad</span>
               <input
                 type="number"
                 id="contactQuantity"
@@ -346,49 +347,19 @@
                 inputmode="numeric"
               />
             </label>
-            <label class="contact-form__field">
-              <span>Necesito el repuesto para</span>
-              <select id="contactUrgency" name="urgency">
-                <option value="hoy">Entregarlo hoy</option>
-                <option value="48hs">Programar en 48 hs</option>
-                <option value="planificar">Planificar stock</option>
-              </select>
-            </label>
           </div>
-          <fieldset class="contact-form__fieldset">
-            <legend>Perfil</legend>
-            <div class="contact-form__chips" id="contactRoleGroup">
-              <label class="chip">
-                <input
-                  type="radio"
-                  name="contactRole"
-                  value="tecnico"
-                  checked
-                />
-                <span>Técnico</span>
-              </label>
-              <label class="chip">
-                <input type="radio" name="contactRole" value="revendedor" />
-                <span>Revendedor</span>
-              </label>
-              <label class="chip">
-                <input type="radio" name="contactRole" value="particular" />
-                <span>Particular</span>
-              </label>
-            </div>
-          </fieldset>
           <label class="contact-form__field contact-form__field--full">
-            <span>Detalles adicionales (opcional)</span>
+            <span>Mensaje</span>
             <textarea
               id="contactMessage"
               name="message"
               rows="3"
-              placeholder="Indicá color, serie u otra necesidad"
+              placeholder="Detalle adicional"
             ></textarea>
           </label>
           <div class="contact-form__actions">
             <button type="submit" class="button primary">
-              Solicitar cotización
+              Enviar consulta
             </button>
             <p id="contactFeedback" class="form-feedback" aria-live="polite"></p>
           </div>

--- a/nerin_final_updated/frontend/js/index.js
+++ b/nerin_final_updated/frontend/js/index.js
@@ -37,38 +37,38 @@ const PLACEHOLDER_IMAGE =
 
 const DEFAULT_HOME_CONTENT = {
   hero: {
-    eyebrow: "Operamos para laboratorios y cadenas",
-    title: "Pantallas y repuestos originales listos para instalar",
+    eyebrow: "NERIN Parts",
+    title: "Pantallas Samsung Service Pack originales",
     description:
-      "Nacimos atendiendo la demanda de pantallas Samsung Service Pack y hoy ampliamos el catálogo con líneas Apple, Motorola y soluciones corporativas. Todo con control técnico propio y despacho en horas, no en días.",
+      "Stock disponible en CABA, retiro con turno y envíos a todo el país. Repuestos verificados para técnicos, talleres y revendedores.",
     bullets: [
-      "Stock auditado en CABA con envíos al país",
-      "Laboratorio interno para validar cada lote",
-      "Plan de expansión a nuevas marcas premium",
+      "Stock real",
+      "Factura A/B",
+      "Retiro con turno y envíos",
     ],
     primaryCta: { label: "Ver catálogo", href: "/shop.html" },
-    secondaryCta: { label: "Hablar con un asesor", href: "/contact.html" },
+    secondaryCta: { label: "Consultar por WhatsApp", href: "https://wa.me/541112345678" },
     media: {
-      desktop: "/assets/hero.png",
-      mobile: "/assets/hero.png",
-      alt: "Equipo técnico de NERIN validando módulos Service Pack",
+      desktop: "/assets/product3.jpg",
+      mobile: "/assets/product3.jpg",
+      alt: "Caja Service Pack Samsung original",
     },
   },
   highlights: [
     {
-      icon: "📦",
+      icon: "",
       title: "Stock auditado cada mañana",
       description:
         "Inventario real de Service Pack y módulos OEM con controles de lote y trazabilidad.",
     },
     {
-      icon: "🛠️",
+      icon: "",
       title: "Garantía laboratorio",
       description:
         "Probamos módulos y flex antes de despachar para reducir DOA en los talleres que atendemos.",
     },
     {
-      icon: "🚚",
+      icon: "",
       title: "Logística en 24/48 hs",
       description:
         "Despachos en el día para CABA y GBA y operadores nacionales para llegar a cada provincia.",
@@ -99,26 +99,27 @@ const DEFAULT_HOME_CONTENT = {
     ],
   },
   why: {
-    title: "Por qué elegir NERIN",
-    description:
-      "Diseñamos una experiencia alineada con la operación técnica: datos reales, logística predecible y soporte especializado.",
+    title: "Por qué NERIN Parts",
+    description: "",
     cards: [
       {
-        title: "Kits listos para instalar",
-        description:
-          "Pantalla y adhesivos calibrados para que sólo tengas que montar y entregar.",
+        title: "Stock controlado",
+        description: "Disponibilidad actualizada para compra rápida.",
         image: "",
       },
       {
-        title: "Control de lote en tiempo real",
-        description:
-          "Actualizamos stock y números de serie para que sepas exactamente qué estás recibiendo.",
+        title: "Repuestos verificados",
+        description: "Lotes revisados antes de despacho.",
         image: "",
       },
       {
-        title: "Equipo en formación constante",
-        description:
-          "Nos nutrimos de la experiencia de los talleres para aprender y acompañarte en cada implementación.",
+        title: "Precio final en ARS",
+        description: "Valores claros para técnico, taller o reventa.",
+        image: "",
+      },
+      {
+        title: "Atención técnica",
+        description: "Asesoramiento por modelo y compatibilidad.",
         image: "",
       },
     ],
@@ -130,16 +131,11 @@ const DEFAULT_HOME_CONTENT = {
     productIds: [],
   },
   contact: {
-    eyebrow: "Cotizá en segundos",
-    title: "Contanos qué necesitás y coordinamos la entrega",
-    description:
-      "Respondemos con precio, stock y opciones de retiro o envío en horario comercial.",
-    note: "Si lo necesitás urgente marcá la opción correspondiente y priorizamos tu caso.",
-    bulletPoints: [
-      "Asistencia personalizada por WhatsApp o llamada",
-      "Opciones mayorista y minorista",
-      "Seguimiento de cada pedido hasta la entrega",
-    ],
+    eyebrow: "",
+    title: "¿No encontrás el repuesto?",
+    description: "Mandanos modelo, código o foto del equipo y te confirmamos disponibilidad.",
+    note: "",
+    bulletPoints: [],
   },
   popup: {
     enabled: false,
@@ -670,13 +666,6 @@ function createFeaturedCard(product) {
   title.textContent = product.name || `${brand} ${model}`.trim();
   card.appendChild(title);
 
-  const desc = document.createElement("p");
-  desc.className = "description";
-  const descriptionText = getProductDescription(product);
-  desc.textContent = createDescriptionPreview(descriptionText);
-  desc.title = descriptionText;
-  card.appendChild(desc);
-
   const availability = document.createElement("div");
   availability.className = "availability-badges";
   const status = getStockStatus(product);
@@ -820,9 +809,9 @@ function setupContactForm() {
   const form = document.getElementById("contactForm");
   if (!form) return;
   const nameField = document.getElementById("contactName");
+  const whatsappField = document.getElementById("contactWhatsapp");
   const modelField = document.getElementById("contactModel");
   const quantityField = document.getElementById("contactQuantity");
-  const urgencyField = document.getElementById("contactUrgency");
   const messageField = document.getElementById("contactMessage");
   const feedback = document.getElementById("contactFeedback");
 
@@ -849,21 +838,15 @@ function setupContactForm() {
       modelField.focus();
       return;
     }
-    const roleInput = form.querySelector('input[name="contactRole"]:checked');
-    const roleLabel =
-      roleInput?.nextElementSibling?.textContent?.trim() || "Técnico";
     const quantityValue = parseInt(quantityField.value, 10) || 1;
-    const urgencyText =
-      urgencyField.options[urgencyField.selectedIndex]?.text?.trim() ||
-      urgencyField.value;
+    const whatsappValue = whatsappField?.value?.trim() || "No informado";
     const extraMessage = messageField.value.trim();
 
     const parts = [
       `Hola. Soy ${nameValue}.`,
-      `Perfil: ${roleLabel}.`,
+      `WhatsApp: ${whatsappValue}.`,
       `Modelo: ${modelValue}.`,
       `Cantidad: ${quantityValue}.`,
-      `Urgencia: ${urgencyText}.`,
     ];
     if (extraMessage) {
       parts.push(`Detalle: ${extraMessage}.`);
@@ -876,8 +859,6 @@ function setupContactForm() {
     }
     form.reset();
     quantityField.value = "1";
-    const defaultRole = form.querySelector('input[name="contactRole"][value="tecnico"]');
-    if (defaultRole) defaultRole.checked = true;
     setFeedback("Listo. Te respondemos por WhatsApp hoy mismo.", "success");
   });
 }

--- a/nerin_final_updated/frontend/preview-home.html
+++ b/nerin_final_updated/frontend/preview-home.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Preview Home | NERIN Parts</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      body {
+        margin: 0;
+        background: #f1f5f9;
+        color: #0f172a;
+      }
+      .preview-toolbar {
+        position: sticky;
+        top: 0;
+        z-index: 10;
+        display: flex;
+        gap: 0.6rem;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.8rem 1rem;
+        background: #ffffff;
+        border-bottom: 1px solid #e2e8f0;
+      }
+      .preview-toolbar__controls {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+      }
+      button,
+      a {
+        border: 1px solid #cbd5e1;
+        background: #fff;
+        color: #0f172a;
+        border-radius: 10px;
+        padding: 0.5rem 0.7rem;
+        font-size: 0.85rem;
+        text-decoration: none;
+        cursor: pointer;
+      }
+      button.active {
+        border-color: #1d4ed8;
+        color: #1d4ed8;
+      }
+      .preview-stage {
+        padding: 1rem;
+        display: grid;
+        place-items: center;
+      }
+      .preview-frame {
+        width: min(100%, 1440px);
+        height: calc(100vh - 96px);
+        border: 1px solid #dbeafe;
+        border-radius: 14px;
+        background: #fff;
+      }
+      .preview-frame.is-mobile {
+        width: min(100%, 390px);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="preview-toolbar">
+      <strong>NERIN Parts · Home Preview</strong>
+      <div class="preview-toolbar__controls">
+        <button id="desktopBtn" class="active" type="button">Desktop 1440</button>
+        <button id="mobileBtn" type="button">Mobile 390</button>
+        <a href="/index.html" target="_blank" rel="noopener">Abrir home real</a>
+      </div>
+    </div>
+    <div class="preview-stage">
+      <iframe
+        id="previewFrame"
+        class="preview-frame"
+        src="/index.html"
+        title="Preview de home NERIN"
+        loading="eager"
+      ></iframe>
+    </div>
+
+    <script>
+      const frame = document.getElementById('previewFrame');
+      const desktopBtn = document.getElementById('desktopBtn');
+      const mobileBtn = document.getElementById('mobileBtn');
+
+      desktopBtn.addEventListener('click', () => {
+        frame.classList.remove('is-mobile');
+        desktopBtn.classList.add('active');
+        mobileBtn.classList.remove('active');
+      });
+
+      mobileBtn.addEventListener('click', () => {
+        frame.classList.add('is-mobile');
+        mobileBtn.classList.add('active');
+        desktopBtn.classList.remove('active');
+      });
+    </script>
+  </body>
+</html>

--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -9428,3 +9428,152 @@ html, body{ max-width:100%; overflow-x:hidden; }
 .product-page .product-fulfillment-trust p + p {
   margin-top: 0.35rem;
 }
+
+/* Home redesign: technical premium ecommerce */
+.home {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1.2rem 1rem 3rem;
+}
+
+header .header-inner {
+  padding: 0.7rem 1rem;
+}
+
+.home-hero {
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: 1.2rem;
+  padding: 1.4rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 24px;
+  background: #fff;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.06);
+}
+
+.home-badges {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.home-badges li {
+  background: #f8fafc;
+  border: 1px solid #e5e7eb;
+  border-radius: 999px;
+  padding: 0.35rem 0.7rem;
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.home-hero__media {
+  position: relative;
+}
+
+.home-hero__media img {
+  border-radius: 20px;
+  border: 1px solid #e5e7eb;
+  min-height: 280px;
+  object-fit: cover;
+}
+
+.hero-overlay-card {
+  position: absolute;
+  right: 1rem;
+  bottom: 1rem;
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid #e5e7eb;
+  border-radius: 16px;
+  padding: 0.7rem 0.85rem;
+  display: grid;
+  gap: 0.22rem;
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.12);
+}
+
+.home-trustbar {
+  margin-top: 1rem;
+}
+
+.home-trustbar__grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0.6rem;
+}
+
+.home-trustbar__grid span {
+  text-align: center;
+  border: 1px solid #e5e7eb;
+  border-radius: 14px;
+  padding: 0.7rem 0.5rem;
+  font-size: 0.85rem;
+  background: #fff;
+}
+
+.home-categories,
+.home-featured,
+.home-steps,
+.home-why,
+.home-contact,
+.home-wholesale,
+.home-story-short {
+  margin-top: 1.3rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 24px;
+  padding: 1.2rem;
+  background: #fff;
+}
+
+.home-categories__grid,
+.home-steps__grid,
+.home-why__grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.8rem;
+}
+
+.mini-card,
+.home-why__card {
+  border: 1px solid #e5e7eb;
+  border-radius: 18px;
+  padding: 1rem;
+  background: #fff;
+}
+
+.home-why__header p,
+.home-featured__header p {
+  margin-bottom: 0.4rem;
+}
+
+.home-featured__header p:last-child,
+.home-why__header p:last-child {
+  display: none;
+}
+
+.home-wholesale {
+  background: #f8fafc;
+}
+
+.home-story-short p {
+  margin: 0;
+  color: #334155;
+}
+
+@media (max-width: 900px) {
+  .home-hero,
+  .home-categories__grid,
+  .home-steps__grid,
+  .home-why__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .home-trustbar__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .buttons {
+    flex-direction: column;
+  }
+}

--- a/nerin_final_updated/package.json
+++ b/nerin_final_updated/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node backend/server.js",
     "test": "jest",
+    "preview:home": "node scripts/capture-home-preview.js",
     "validate:meta-feed": "node scripts/validate-meta-feed.js",
     "catalog:enrich-csv": "node scripts/enrichCatalogCsv.js"
   },
@@ -29,6 +30,7 @@
   },
   "devDependencies": {
     "jest": "^30.0.5",
+    "puppeteer": "^24.9.0",
     "prettier": "^3.6.2",
     "supertest": "^7.1.4"
   }

--- a/nerin_final_updated/scripts/capture-home-preview.js
+++ b/nerin_final_updated/scripts/capture-home-preview.js
@@ -1,0 +1,110 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const puppeteer = require('puppeteer');
+
+const ROOT = path.resolve(__dirname, '..');
+const FRONTEND_DIR = path.join(ROOT, 'frontend');
+const PREVIEW_DIR = path.join(ROOT, 'preview');
+const DEFAULT_PORT = 10000;
+const HOST = '127.0.0.1';
+
+function getContentType(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  const map = {
+    '.html': 'text/html; charset=utf-8',
+    '.css': 'text/css; charset=utf-8',
+    '.js': 'application/javascript; charset=utf-8',
+    '.json': 'application/json; charset=utf-8',
+    '.svg': 'image/svg+xml',
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.gif': 'image/gif',
+    '.webp': 'image/webp',
+    '.ico': 'image/x-icon',
+  };
+  return map[ext] || 'application/octet-stream';
+}
+
+function startStaticServer(port) {
+  const server = http.createServer((req, res) => {
+    const requestPath = decodeURIComponent((req.url || '/').split('?')[0]);
+    const normalized = requestPath === '/' ? '/index.html' : requestPath;
+    const filePath = path.normalize(path.join(FRONTEND_DIR, normalized));
+
+    if (!filePath.startsWith(FRONTEND_DIR)) {
+      res.writeHead(403);
+      res.end('Forbidden');
+      return;
+    }
+
+    fs.readFile(filePath, (error, data) => {
+      if (error) {
+        res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+        res.end('Not found');
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': getContentType(filePath) });
+      res.end(data);
+    });
+  });
+
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, HOST, () => resolve(server));
+  });
+}
+
+async function run() {
+  fs.mkdirSync(PREVIEW_DIR, { recursive: true });
+  let port = DEFAULT_PORT;
+  let server = null;
+  try {
+    server = await startStaticServer(port);
+  } catch (error) {
+    if (error && error.code === 'EADDRINUSE') {
+      port = 10001;
+      server = await startStaticServer(port);
+    } else {
+      throw error;
+    }
+  }
+  const homeUrl = `http://${HOST}:${port}/index.html`;
+  const browser = await puppeteer.launch({
+    headless: true,
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+
+  try {
+    const desktop = await browser.newPage();
+    await desktop.setViewport({ width: 1440, height: 1200, deviceScaleFactor: 1 });
+    await desktop.goto(homeUrl, { waitUntil: 'networkidle2', timeout: 60000 });
+    await desktop.screenshot({
+      path: path.join(PREVIEW_DIR, 'home-desktop.png'),
+      fullPage: true,
+      type: 'png',
+    });
+    await desktop.close();
+
+    const mobile = await browser.newPage();
+    await mobile.setViewport({ width: 390, height: 1200, isMobile: true, deviceScaleFactor: 2 });
+    await mobile.goto(homeUrl, { waitUntil: 'networkidle2', timeout: 60000 });
+    await mobile.screenshot({
+      path: path.join(PREVIEW_DIR, 'home-mobile.png'),
+      fullPage: true,
+      type: 'png',
+    });
+    await mobile.close();
+
+    console.log(`Preview generated:\n- ${path.join('preview', 'home-desktop.png')}\n- ${path.join('preview', 'home-mobile.png')}\nURL: ${homeUrl}`);
+  } finally {
+    await browser.close();
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+run().catch((error) => {
+  console.error('preview:home failed', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
### Motivation
- Refresh the storefront home to focus on NERIN Parts product offering and streamline conversions via WhatsApp contact. 
- Simplify contact flow for technicians and resellers by prioritizing WhatsApp/phone and removing less-used fields. 
- Add tooling to generate visual previews of the home for review and CI-friendly screenshot capture.

### Description
- Reworked homepage content and structure in `frontend/index.html` to update hero copy, images, CTAs, and to add new sections: trustbar, categories, steps, wholesale, and a short story block. 
- Updated frontend styles in `frontend/style.css` to support the redesign (new layout, cards, hero media overlay, responsive rules). 
- Modified client logic in `frontend/js/index.js` to update `DEFAULT_HOME_CONTENT`, remove unused role/urgency fields, add WhatsApp input handling in `setupContactForm`, and include WhatsApp text in outbound messages. 
- Added a footer legal link `legal.repentance` and the DOM element for a "Botón de arrepentimiento" in `frontend/components/np-footer.js`. 
- Added `preview-home.html` (iframe preview UI) and a headless capture script `scripts/capture-home-preview.js` that serves `frontend/` and captures desktop/mobile screenshots using `puppeteer`. 
- Added `preview:home` npm script and `puppeteer` devDependency in `nerin_final_updated/package.json`. 
- Ignored generated preview images in `.gitignore` (`nerin_final_updated/preview/*.png`, `*.jpg`, `*.webp`).

### Testing
- Ran the unit test suite with `npm test` (Jest) and the tests completed successfully. 
- Executed the preview generator with `npm run preview:home`, which launched a local static server and used `puppeteer` to produce `preview/home-desktop.png` and `preview/home-mobile.png`, and exited without errors. 
- Performed a smoke check of the contact flow in the browser preview to confirm the WhatsApp message URL is composed and opened as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee628112ac83319a084df1e83e3958)