### PR TITLE
Hotfix: desactivar analytics pesado para catálogos grandes

### DIFF
--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -210,6 +210,8 @@ const MAX_ACTIVITY_SESSIONS = 300;
 const ACTIVITY_SESSION_RETENTION_MS = 7 * 24 * 60 * 60 * 1000; // 7 días
 const MAX_ANALYTICS_HISTORY_DAYS = 35;
 const MAX_HISTORY_SESSION_IDS = 2000;
+const DISABLE_HEAVY_ANALYTICS = true;
+const HEAVY_ANALYTICS_PRODUCTS_SIZE_LIMIT_BYTES = 5 * 1024 * 1024;
 const REVIEW_TOKEN_TTL_DAYS =
   parseInt(process.env.REVIEW_TOKEN_TTL_DAYS, 10) || 14;
 
@@ -3621,6 +3623,15 @@ async function calculateDetailedAnalytics(options = {}) {
     funnel,
     sessionStories,
     recentEvents,
+  };
+}
+
+function buildDisabledAnalyticsPayload({ reason = "disabled_for_large_catalog" } = {}) {
+  return {
+    analyticsAvailable: false,
+    reason,
+    productManifest: productsStreamRepo.safeReadManifest() || null,
+    message: "Analytics desactivado temporalmente para catálogo grande",
   };
 }
 
@@ -10387,6 +10398,39 @@ async function requestHandler(req, res) {
   if (pathname === "/api/analytics/detailed" && req.method === "GET") {
     try {
       const range = parseAnalyticsRange(parsedUrl.query);
+      let productsSizeBytes = 0;
+      try {
+        productsSizeBytes = Number(fs.statSync(PRODUCTS_FILE_PATH)?.size || 0);
+      } catch (statErr) {
+        if (process.env.NODE_ENV !== "test") {
+          console.warn("[analytics-disabled] products size lookup failed", statErr?.message || statErr);
+        }
+      }
+      if (
+        DISABLE_HEAVY_ANALYTICS ||
+        productsSizeBytes > HEAVY_ANALYTICS_PRODUCTS_SIZE_LIMIT_BYTES
+      ) {
+        if (process.env.NODE_ENV !== "test") {
+          console.log("[analytics-disabled] large catalog, skipping stream", {
+            productsSizeBytes,
+            limitBytes: HEAVY_ANALYTICS_PRODUCTS_SIZE_LIMIT_BYTES,
+            forcedDisabled: DISABLE_HEAVY_ANALYTICS,
+          });
+        }
+        const disabledPayload = buildDisabledAnalyticsPayload();
+        return sendJson(res, 200, {
+          ...disabledPayload,
+          analytics: {
+            ...disabledPayload,
+            trackingHealth: getTrackingHealth(),
+            range: {
+              from: range.from ? range.from.toISOString() : null,
+              to: range.to ? range.to.toISOString() : null,
+              label: range.range || "7d",
+            },
+          },
+        });
+      }
       const storeSessions = getStoredSessions();
       const storeEvents = getEventsByRange({ from: range.from, to: range.to });
       const analytics = await calculateDetailedAnalytics({
@@ -10409,12 +10453,13 @@ async function requestHandler(req, res) {
       return sendJson(res, 200, { analytics });
     } catch (err) {
       console.error("[analytics] detailed failed", err);
-      const manifest = productsStreamRepo.safeReadManifest() || null;
+      const disabledPayload = buildDisabledAnalyticsPayload({
+        reason: "disabled_after_error",
+      });
       return sendJson(res, 200, {
         analytics: {
-          analyticsAvailable: false,
+          ...disabledPayload,
           error: "Analytics temporarily unavailable",
-          productManifest: manifest,
         },
       });
     }

--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -4271,9 +4271,7 @@ if (typeof window !== "undefined") {
   });
 }
 
-if (isAnalyticsSectionVisible()) {
-  startAnalyticsAutoRefresh();
-}
+// Hotfix: evitar cualquier carga automática de analytics al entrar al admin.
 
 // ------------ Pedidos ------------
 const OrdersUI = (() => {

--- a/nerin_final_updated/frontend/js/analytics.js
+++ b/nerin_final_updated/frontend/js/analytics.js
@@ -331,8 +331,19 @@ export async function renderAnalyticsDashboard(
   const rangeParams = buildRangeParams(analyticsRangeState);
   try {
     const res = await apiFetch(`/api/analytics/detailed?${rangeParams.toString()}`);
-    const { analytics } = await res.json();
+    const payload = await res.json();
+    const analytics = payload?.analytics || payload || {};
     container.innerHTML = "";
+    if (!analytics?.analyticsAvailable) {
+      const disabled = document.createElement("div");
+      disabled.className = "analytics-empty analytics-empty--inline";
+      disabled.innerHTML = `
+        <strong>Métricas no disponibles temporalmente</strong>
+        <p>${analytics?.message || "Métricas desactivadas temporalmente para catálogo grande"}</p>
+      `;
+      container.appendChild(disabled);
+      return;
+    }
     const fetchedAt = new Date();
     const rangeLabelMap = {
       today: "Hoy",


### PR DESCRIPTION
### Motivation
- El procesamiento de `products.json` (catalogos grandes) provocaba OOM en el endpoint de analytics y bloqueaba el admin/productos, por lo que hay que desactivar urgentemente el recorrido pesado de productos.

### Description
- Añade `DISABLE_HEAVY_ANALYTICS = true` y `HEAVY_ANALYTICS_PRODUCTS_SIZE_LIMIT_BYTES = 5 * 1024 * 1024` para controlar el hotfix.    
- Implementa `buildDisabledAnalyticsPayload()` que devuelve un payload estable con `analyticsAvailable: false`, `reason`, `productManifest` y `message` de contingencia.    
- Modifica `GET /api/analytics/detailed` para medir el tamaño de `products.json` y devolver inmediatamente el payload de analytics deshabilitado (y loguear `[analytics-disabled] large catalog, skipping stream`) sin invocar `calculateDetailedAnalytics()`, `buildAnalyticsCatalogSnapshot()` ni `streamProducts()`.    
- Frontend: evita la auto-ejecución de analytics al cargar el admin y hace que `renderAnalyticsDashboard` muestre “Métricas no disponibles temporalmente” cuando el endpoint indica analytics deshabilitado, sin bloquear la carga de productos.

### Testing
- Ejecutado `node nerin_final_updated/scripts/check-no-products-full-parse.js` y pasó correctamente.    
- Intenté levantar el servidor (`node nerin_final_updated/backend/server.js`) y probar `/api/analytics/detailed` y endpoints de productos, pero el arranque falló en este entorno por una dependencia faltante (`Cannot find module 'stream-chain'`), por lo que la verificación end-to-end no pudo completarse aquí.    
- Resultado esperado tras deploy: no debería verse `[analytics-stream] start` al cargar admin/productos/home/shop, y `/api/admin/products` y `/api/products` deberían responder normalmente con analytics desactivado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeb84e23b48331952d20130f5587fb)