### PR TITLE
Avoid CORS preflight on product requests by removing custom cache headers

### DIFF
--- a/nerin_final_updated/frontend/js/api.js
+++ b/nerin_final_updated/frontend/js/api.js
@@ -36,12 +36,11 @@ export function apiFetch(path, options = {}) {
   if (token && !headers.has("Authorization")) {
     headers.set("Authorization", `Bearer ${token}`);
   }
-  if (path === "/api/products" || String(path).startsWith("/api/products?")) {
-    headers.set("Cache-Control", "no-store, no-cache, max-age=0");
-    headers.set("Pragma", "no-cache");
-  }
+  const isProductsEndpoint =
+    path === "/api/products" || String(path).startsWith("/api/products?");
   return fetch(buildApiUrl(path), {
     ...options,
+    cache: options.cache || (isProductsEndpoint ? "no-store" : options.cache),
     headers,
   });
 }


### PR DESCRIPTION
### Motivation
- Product list requests could fail when `apiBase` pointed to a different origin because manually-set `Cache-Control`/`Pragma` request headers triggered a CORS preflight that the backend did not allow, leaving the shop/admin views unable to load products.

### Description
- Modified `frontend/js/api.js` to stop adding `Cache-Control`/`Pragma` request headers for `/api/products` and instead set the Fetch option `cache: "no-store"` for product endpoint requests to preserve the no-cache intent without causing preflight.

### Testing
- Ran `npm test -- --runInBand backend/__tests__/catalogPricing.test.js` and the test suite passed (1 suite, 3 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eebfc4fa148331a71b3d5d63d63f25)