### PR TITLE
Fix streaming early-stop, pagination metadata and frontend request storms

### DIFF
--- a/nerin_final_updated/backend/data/productsStreamRepo.js
+++ b/nerin_final_updated/backend/data/productsStreamRepo.js
@@ -21,18 +21,20 @@ function safeReadManifest() {
   }
 }
 
-function buildProductsPipeline(filePath = productsFilePath) {
+function buildProductsPipeline(filePath = productsFilePath, sourceStream = null) {
+  const source = sourceStream || fs.createReadStream(filePath, { encoding: "utf8" });
   return chain([
-    fs.createReadStream(filePath, { encoding: "utf8" }),
+    source,
     parser(),
     pick({ filter: "products" }),
     StreamArray.streamArray(),
   ]);
 }
 
-function buildRootArrayPipeline(filePath = productsFilePath) {
+function buildRootArrayPipeline(filePath = productsFilePath, sourceStream = null) {
+  const source = sourceStream || fs.createReadStream(filePath, { encoding: "utf8" });
   return chain([
-    fs.createReadStream(filePath, { encoding: "utf8" }),
+    source,
     parser(),
     StreamArray.streamArray(),
   ]);
@@ -61,24 +63,44 @@ async function streamProducts({ onProduct, filePath = productsFilePath } = {}) {
 
   let index = 0;
 
-  const consume = async (pipeline) => {
-    for await (const token of pipeline) {
-      const product = token?.value;
-      if (typeof onProduct === "function") {
-        await onProduct(product, index);
-      }
-      index += 1;
+  const shape = detectJsonShape(filePath);
+  const sourceStream = fs.createReadStream(filePath, { encoding: "utf8" });
+  const pipeline =
+    shape === "array"
+      ? buildRootArrayPipeline(filePath, sourceStream)
+      : buildProductsPipeline(filePath, sourceStream);
+
+  let stoppedEarly = false;
+  const destroyStream = () => {
+    if (typeof pipeline?.destroy === "function" && !pipeline.destroyed) {
+      pipeline.destroy();
+    }
+    if (typeof sourceStream?.destroy === "function" && !sourceStream.destroyed) {
+      sourceStream.destroy();
     }
   };
 
-  const shape = detectJsonShape(filePath);
-  if (shape === "array") {
-    await consume(buildRootArrayPipeline(filePath));
-  } else {
-    await consume(buildProductsPipeline(filePath));
+  try {
+    for await (const token of pipeline) {
+      const product = token?.value;
+      let shouldContinue = true;
+      if (typeof onProduct === "function") {
+        shouldContinue = await onProduct(product, index);
+      }
+      index += 1;
+      if (shouldContinue === false) {
+        stoppedEarly = true;
+        destroyStream();
+        break;
+      }
+    }
+  } finally {
+    if (stoppedEarly) {
+      destroyStream();
+    }
   }
 
-  return { count: index };
+  return { count: index, stoppedEarly };
 }
 
 async function countProductsStreaming({ filePath = productsFilePath } = {}) {
@@ -96,21 +118,16 @@ async function getProductById(id, { filePath = productsFilePath } = {}) {
   let found = null;
   const target = String(id || "").trim();
   if (!target) return null;
-  const STOP_EARLY = "__PRODUCT_BY_ID_STOP__";
-
-  try {
-    await streamProducts({
-      filePath,
-      onProduct: (product) => {
-        if (String(product?.id || "") === target) {
-          found = product;
-          throw new Error(STOP_EARLY);
-        }
-      },
-    });
-  } catch (err) {
-    if (err?.message !== STOP_EARLY) throw err;
-  }
+  await streamProducts({
+    filePath,
+    onProduct: (product) => {
+      if (String(product?.id || "") === target) {
+        found = product;
+        return false;
+      }
+      return true;
+    },
+  });
 
   return found;
 }
@@ -119,30 +136,25 @@ async function getProductByCode(code, { filePath = productsFilePath } = {}) {
   let found = null;
   const target = String(code || "").trim().toLowerCase();
   if (!target) return null;
-  const STOP_EARLY = "__PRODUCT_BY_CODE_STOP__";
-
-  try {
-    await streamProducts({
-      filePath,
-      onProduct: (product) => {
-        const candidates = [
-          product?.code,
-          product?.sku,
-          product?.supplierPartNumber,
-          product?.metadata?.supplierPartNumber,
-          product?.metadata?.supplierImport?.supplierPartNumber,
-        ]
-          .map((item) => String(item || "").trim().toLowerCase())
-          .filter(Boolean);
-        if (candidates.includes(target)) {
-          found = product;
-          throw new Error(STOP_EARLY);
-        }
-      },
-    });
-  } catch (err) {
-    if (err?.message !== STOP_EARLY) throw err;
-  }
+  await streamProducts({
+    filePath,
+    onProduct: (product) => {
+      const candidates = [
+        product?.code,
+        product?.sku,
+        product?.supplierPartNumber,
+        product?.metadata?.supplierPartNumber,
+        product?.metadata?.supplierImport?.supplierPartNumber,
+      ]
+        .map((item) => String(item || "").trim().toLowerCase())
+        .filter(Boolean);
+      if (candidates.includes(target)) {
+        found = product;
+        return false;
+      }
+      return true;
+    },
+  });
 
   return found;
 }
@@ -151,22 +163,17 @@ async function getProductBySlug(slug, { filePath = productsFilePath } = {}) {
   let found = null;
   const target = String(slug || "").trim().toLowerCase();
   if (!target) return null;
-  const STOP_EARLY = "__PRODUCT_BY_SLUG_STOP__";
-
-  try {
-    await streamProducts({
-      filePath,
-      onProduct: (product) => {
-        const currentSlug = String(product?.slug || "").trim().toLowerCase();
-        if (currentSlug && currentSlug === target) {
-          found = product;
-          throw new Error(STOP_EARLY);
-        }
-      },
-    });
-  } catch (err) {
-    if (err?.message !== STOP_EARLY) throw err;
-  }
+  await streamProducts({
+    filePath,
+    onProduct: (product) => {
+      const currentSlug = String(product?.slug || "").trim().toLowerCase();
+      if (currentSlug && currentSlug === target) {
+        found = product;
+        return false;
+      }
+      return true;
+    },
+  });
 
   return found;
 }
@@ -278,30 +285,23 @@ async function getProductsEmergencyPage({
 
   const items = [];
   let matchedCount = 0;
-  const STOP_EARLY = "__PRODUCTS_STREAM_STOP_EARLY__";
-
-  try {
-    await streamProducts({
-      filePath,
-      onProduct: (product) => {
-        const accepted = typeof matchItem === "function" ? !!matchItem(product) : true;
-        if (!accepted) return;
-        const currentMatchIndex = matchedCount;
-        matchedCount += 1;
-        if (currentMatchIndex >= start && currentMatchIndex < endExclusive) {
-          const mapped = typeof mapItem === "function" ? mapItem(product) : product;
-          items.push(mapped);
-        }
-        if (matchedCount >= stopAfter) {
-          throw new Error(STOP_EARLY);
-        }
-      },
-    });
-  } catch (err) {
-    if (err?.message !== STOP_EARLY) {
-      throw err;
-    }
-  }
+  await streamProducts({
+    filePath,
+    onProduct: (product) => {
+      const accepted = typeof matchItem === "function" ? !!matchItem(product) : true;
+      if (!accepted) return true;
+      const currentMatchIndex = matchedCount;
+      matchedCount += 1;
+      if (currentMatchIndex >= start && currentMatchIndex < endExclusive) {
+        const mapped = typeof mapItem === "function" ? mapItem(product) : product;
+        items.push(mapped);
+      }
+      if (matchedCount >= stopAfter) {
+        return false;
+      }
+      return true;
+    },
+  });
 
   return {
     items,

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -3787,6 +3787,28 @@ function buildAdminStreamFilter(query = {}) {
   return buildAdminMatcher(query);
 }
 
+function resolveStreamingSortPolicy({ endpoint = "", query = {}, storage = {} } = {}) {
+  const requestedSort = String(query?.sort || "").trim().toLowerCase();
+  const isLargeCatalog = Number(storage?.sizeBytes || 0) > LARGE_CATALOG_THRESHOLD_BYTES;
+  const hasManifestCount = Number.isFinite(Number(storage?.manifest?.productCount));
+  const canGloballySort = !isLargeCatalog || hasManifestCount;
+  const unsupportedPublicSorts = new Set(["price-asc", "price-desc", "stock-desc", "name"]);
+  const unsupportedAdminSorts = new Set(["name", "stock", "price_desc", "price_asc"]);
+  const unsupportedSet =
+    endpoint === "/api/admin/products" ? unsupportedAdminSorts : unsupportedPublicSorts;
+  if (!requestedSort || canGloballySort || !unsupportedSet.has(requestedSort)) {
+    return { warning: null, effectiveQuery: query };
+  }
+  return {
+    warning:
+      "sort_ignored_streaming_large_catalog: orden global no disponible sin índice/manifest completo",
+    effectiveQuery: {
+      ...query,
+      sort: endpoint === "/api/admin/products" ? "recent" : "relevance",
+    },
+  };
+}
+
 async function loadProductsStrict() {
   const storage = await inspectProductsStorage();
   if (!storage.exists) {
@@ -3826,6 +3848,7 @@ async function getProductsEmergencyResponse({
   pageSize,
   matchItem,
   mapItem,
+  warning = null,
 } = {}) {
   const startedAt = Date.now();
   console.log(`[products-endpoint:start] ${endpoint} page=${page} pageSize=${pageSize}`);
@@ -3863,9 +3886,10 @@ async function getProductsEmergencyResponse({
     totalItemsUnknown: estimatedTotalItems == null,
     mode: EMERGENCY_PRODUCTS_MODE ? "emergency_streaming" : "standard",
   };
+  if (warning) responsePayload.warning = warning;
   const durationMs = Date.now() - startedAt;
   console.log(
-    `[products-endpoint:respond] items=${responsePayload.items.length} count=${responsePayload.totalItems ?? "unknown"} durationMs=${durationMs}`,
+    `[products-endpoint:respond] items=${responsePayload.items.length} hasNextPage=${responsePayload.hasNextPage} durationMs=${durationMs}`,
   );
   return responsePayload;
 }
@@ -6019,16 +6043,22 @@ async function requestHandler(req, res) {
         maxPageSize: 96,
       });
       const { storage } = await loadProductsStrict();
+      const { warning, effectiveQuery } = resolveStreamingSortPolicy({
+        endpoint: "/api/products",
+        query: parsedUrl.query || {},
+        storage,
+      });
       const withWholesale = canSeeWholesalePrices(req);
       const pageData = await getProductsEmergencyResponse({
         endpoint: "/api/products",
         page,
         pageSize,
-        matchItem: buildCatalogStreamFilter(parsedUrl.query || {}),
+        matchItem: buildCatalogStreamFilter(effectiveQuery || {}),
         mapItem: (product) => {
           if (withWholesale) return normalizeProductImages(product);
           return normalizeProductImages(sanitizePublicProducts([product])[0]);
         },
+        warning,
       });
       const responsePayload = {
         ...pageData,
@@ -6077,12 +6107,18 @@ async function requestHandler(req, res) {
         maxPageSize: 250,
       });
       const { storage } = await loadProductsStrict();
+      const { warning, effectiveQuery } = resolveStreamingSortPolicy({
+        endpoint: "/api/admin/products",
+        query: parsedUrl.query || {},
+        storage,
+      });
       const pageData = await getProductsEmergencyResponse({
         endpoint: "/api/admin/products",
         page,
         pageSize,
-        matchItem: buildAdminStreamFilter(parsedUrl.query || {}),
+        matchItem: buildAdminStreamFilter(effectiveQuery || {}),
         mapItem: (product) => normalizeProductImages(product),
+        warning,
       });
       const responsePayload = {
         ...pageData,

--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -3375,11 +3375,13 @@ async function loadProducts(options = {}) {
     const data = await res.json();
     productsLoadErrorMessage = "";
     productsCache = Array.isArray(data.items) ? data.items : [];
+    const rawTotal = data.totalItems;
     const hasKnownTotal =
-      data.totalItems !== null &&
-      data.totalItems !== undefined &&
-      Number.isFinite(Number(data.totalItems));
-    productsTotalItems = hasKnownTotal ? Number(data.totalItems) : null;
+      rawTotal !== null &&
+      rawTotal !== undefined &&
+      rawTotal !== "" &&
+      Number.isFinite(Number(rawTotal));
+    productsTotalItems = hasKnownTotal ? Number(rawTotal) : null;
     productsTotalPages =
       data.totalPages !== null &&
       data.totalPages !== undefined &&
@@ -3393,7 +3395,11 @@ async function loadProducts(options = {}) {
     const end = productsCache.length ? start + productsCache.length - 1 : 0;
     if (adminProductsRange) {
       if (productsTotalItems == null) {
-        adminProductsRange.textContent = `Mostrando ${start}-${end} (total estimado no disponible)`;
+        if (productsCache.length > 0) {
+          adminProductsRange.textContent = `Mostrando ${productsCache.length} productos · total no calculado`;
+        } else {
+          adminProductsRange.textContent = `Mostrando página ${productsPage} · total no calculado`;
+        }
       } else {
         adminProductsRange.textContent = `Mostrando ${start}-${end} de ${productsTotalItems} productos`;
       }
@@ -3406,7 +3412,10 @@ async function loadProducts(options = {}) {
     }
     if (adminProductsPrevPage) adminProductsPrevPage.disabled = productsPage <= 1;
     if (adminProductsNextPage) {
-      const hasNextPage = Boolean(data.hasNextPage) || productsCache.length >= productsPageSize;
+      const hasExplicitHasNextPage = typeof data.hasNextPage === "boolean";
+      const hasNextPage = hasExplicitHasNextPage
+        ? data.hasNextPage
+        : productsCache.length >= productsPageSize;
       adminProductsNextPage.disabled = !hasNextPage;
     }
     if (highlightId) {

--- a/nerin_final_updated/frontend/js/api.js
+++ b/nerin_final_updated/frontend/js/api.js
@@ -32,6 +32,7 @@ export function buildApiUrl(path = "") {
 
 export function apiFetch(path, options = {}) {
   const headers = new Headers(options.headers || {});
+  const { signal } = options || {};
   const token = localStorage.getItem("nerinToken");
   if (token && !headers.has("Authorization")) {
     headers.set("Authorization", `Bearer ${token}`);
@@ -40,6 +41,7 @@ export function apiFetch(path, options = {}) {
     path === "/api/products" || String(path).startsWith("/api/products?");
   return fetch(buildApiUrl(path), {
     ...options,
+    signal,
     cache: options.cache || (isProductsEndpoint ? "no-store" : options.cache),
     headers,
   });

--- a/nerin_final_updated/frontend/js/shop.js
+++ b/nerin_final_updated/frontend/js/shop.js
@@ -94,6 +94,10 @@ let hasNextPage = false;
 let hasRealCatalogResponse = false;
 let latestRequestId = 0;
 let filtersInitialized = false;
+let productsAbortController = null;
+let searchDebounceTimer = null;
+let priceDebounceTimer = null;
+const INPUT_DEBOUNCE_MS = 300;
 
 const SHOP_DEBUG =
   new URLSearchParams(window.location.search).get("shopDebug") === "1" ||
@@ -595,8 +599,25 @@ function sortProducts(products, sortMode, searchTerm) {
   }
 }
 
-function updateResultSummary(count) {
-  if (resultCountEl) resultCountEl.textContent = String(count);
+function updateResultSummary({ displayedCount = 0, totalCount = 0, hasKnownTotal = false } = {}) {
+  if (!resultCountEl) return;
+  const parent = resultCountEl.parentElement;
+  if (!parent) {
+    resultCountEl.textContent = String(hasKnownTotal ? totalCount : displayedCount);
+    return;
+  }
+  if (hasKnownTotal) {
+    resultCountEl.textContent = String(totalCount);
+    parent.textContent = "";
+    parent.appendChild(resultCountEl);
+    parent.append(" coincidencias encontradas.");
+    return;
+  }
+  resultCountEl.textContent = String(displayedCount);
+  parent.textContent = "";
+  parent.append("Mostrando ");
+  parent.appendChild(resultCountEl);
+  parent.append(" productos.");
 }
 
 function syncQueryParams(filters) {
@@ -673,7 +694,13 @@ async function renderProducts({ append = false } = {}) {
     sort: filters.sort,
   };
   shopLog("loadProducts:start", { append, requestId, requestParams });
-  const response = await fetchProductsPage(requestParams);
+  if (productsAbortController) {
+    productsAbortController.abort();
+  }
+  productsAbortController = new AbortController();
+  const response = await fetchProductsPage(requestParams, {
+    signal: productsAbortController.signal,
+  });
   shopLog("response", {
     requestId,
     status: "ok",
@@ -689,7 +716,7 @@ async function renderProducts({ append = false } = {}) {
   if (response?.usingFallback && isProductionStorefront()) {
     hasNextPage = false;
     loadMoreBtn.style.display = "none";
-    updateResultSummary(0);
+    updateResultSummary({ displayedCount: 0, totalCount: 0, hasKnownTotal: false });
     productGrid.innerHTML =
       "<p>Error: catálogo no disponible temporalmente. Intentá nuevamente en unos minutos.</p>";
     throw new Error("Respuesta con usingFallback=true bloqueada en producción");
@@ -716,7 +743,12 @@ async function renderProducts({ append = false } = {}) {
   allProducts = append ? allProducts.concat(normalizedItems) : normalizedItems;
   currentPage = Number(response.page || requestedPage || 1);
   hasNextPage = Boolean(response.hasNextPage);
-  totalFilteredItems = Number(response.totalItems || allProducts.length);
+  const hasKnownTotal =
+    response.totalItems !== null &&
+    response.totalItems !== undefined &&
+    response.totalItems !== "" &&
+    Number.isFinite(Number(response.totalItems));
+  totalFilteredItems = hasKnownTotal ? Number(response.totalItems) : allProducts.length;
   productGrid.innerHTML = "";
   if (!allProducts.length) {
     productGrid.innerHTML = "<p>No encontramos productos para esos filtros.</p>";
@@ -733,7 +765,11 @@ async function renderProducts({ append = false } = {}) {
   if (!loadMoreBtn.parentElement && productGrid.parentElement) {
     productGrid.parentElement.appendChild(loadMoreBtn);
   }
-  updateResultSummary(totalFilteredItems);
+  updateResultSummary({
+    displayedCount: allProducts.length,
+    totalCount: totalFilteredItems,
+    hasKnownTotal,
+  });
   updateActiveFilters(filters);
   syncQueryParams(filters);
 }
@@ -806,7 +842,12 @@ async function initShop() {
       sortSelect.parentElement.appendChild(pageSizeSelect);
     }
 
-    searchInput?.addEventListener("input", () => renderProducts());
+    searchInput?.addEventListener("input", () => {
+      clearTimeout(searchDebounceTimer);
+      searchDebounceTimer = window.setTimeout(() => {
+        renderProducts();
+      }, INPUT_DEBOUNCE_MS);
+    });
     searchClear?.addEventListener("click", () => {
       searchInput.value = "";
       renderProducts();
@@ -827,11 +868,19 @@ async function initShop() {
     priceRange?.addEventListener("input", () => {
       priceFilterTouched = true;
       updatePriceRangeDisplay();
-      if (!mobileLayoutQuery.matches) renderProducts();
+      if (!mobileLayoutQuery.matches) {
+        clearTimeout(priceDebounceTimer);
+        priceDebounceTimer = window.setTimeout(() => {
+          renderProducts();
+        }, INPUT_DEBOUNCE_MS);
+      }
     });
 
     await renderProducts();
   } catch (error) {
+    if (error?.name === "AbortError") {
+      return;
+    }
     console.error(error);
     if (productGrid) {
       productGrid.innerHTML = `<p>Error al cargar productos: ${error.message}</p>`;

--- a/nerin_final_updated/scripts/test-products-stream-early-stop.js
+++ b/nerin_final_updated/scripts/test-products-stream-early-stop.js
@@ -1,0 +1,86 @@
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const {
+  getProductsEmergencyPage,
+  getProductBySlug,
+} = require("../backend/data/productsStreamRepo");
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function buildProduct(index) {
+  return {
+    id: String(index + 1),
+    name: `Producto ${index + 1}`,
+    slug: `producto-${index + 1}`,
+    sku: `SKU-${index + 1}`,
+    price_minorista: 1000 + index,
+    stock: index % 20,
+    visibility: "public",
+  };
+}
+
+async function main() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nerin-products-stream-"));
+  const filePath = path.join(tmpDir, "products.json");
+  const productCount = 10000;
+  const products = Array.from({ length: productCount }, (_, index) => buildProduct(index));
+  fs.writeFileSync(filePath, JSON.stringify({ products }), "utf8");
+
+  const page1Start = Date.now();
+  const page1 = await getProductsEmergencyPage({ page: 1, pageSize: 24, filePath });
+  const page1Duration = Date.now() - page1Start;
+  assert(Array.isArray(page1.items) && page1.items.length === 24, "page=1 debe devolver 24 items");
+  assert(page1.hasNextPage === true, "page=1 debe informar hasNextPage=true");
+  assert(page1.matchedCountScanned < productCount, "page=1 no debe escanear los 10.000 productos");
+
+  const page2Start = Date.now();
+  const page2 = await getProductsEmergencyPage({ page: 2, pageSize: 24, filePath });
+  const page2Duration = Date.now() - page2Start;
+  assert(Array.isArray(page2.items) && page2.items.length === 24, "page=2 debe devolver 24 items");
+  assert(page2.hasNextPage === true, "page=2 debe informar hasNextPage=true");
+  assert(page2.matchedCountScanned < productCount, "page=2 no debe escanear los 10.000 productos");
+
+  const slugNearStart = "producto-5";
+  const slugNearStartStart = Date.now();
+  const foundEarly = await getProductBySlug(slugNearStart, { filePath });
+  const slugNearStartDuration = Date.now() - slugNearStartStart;
+  assert(foundEarly && foundEarly.slug === slugNearStart, "getProductBySlug debe encontrar un slug cercano al inicio");
+
+  const missingSlugStart = Date.now();
+  const notFound = await getProductBySlug("slug-inexistente-total", { filePath });
+  const missingSlugDuration = Date.now() - missingSlugStart;
+  assert(notFound === null, "getProductBySlug inexistente debe devolver null");
+
+  console.log("[test-products-stream-early-stop] ok", {
+    filePath,
+    productCount,
+    page1: {
+      durationMs: page1Duration,
+      matchedCountScanned: page1.matchedCountScanned,
+      hasNextPage: page1.hasNextPage,
+    },
+    page2: {
+      durationMs: page2Duration,
+      matchedCountScanned: page2.matchedCountScanned,
+      hasNextPage: page2.hasNextPage,
+    },
+    slugNearStart: {
+      durationMs: slugNearStartDuration,
+      slug: foundEarly.slug,
+    },
+    missingSlug: {
+      durationMs: missingSlugDuration,
+      found: notFound,
+    },
+  });
+}
+
+main().catch((error) => {
+  console.error("[test-products-stream-early-stop] failed", error);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation
- Prevent uncontrolled `throw`-based early-stop behavior during product streaming that left streams open and caused memory/IO problems.
- Make `/api/products` and `/api/admin/products` streaming responses consistent with pagination metadata even when the catalog is large and `totalItems` is unknown.
- Stop the storefront from issuing overlapping repeated requests when users type or move the price slider, causing UI stalls and redundant server load.
- Avoid attempting global sorts that require loading the whole catalog when streaming only is available for large files.

### Description
- Refactored streaming pipeline in `backend/data/productsStreamRepo.js` so `streamProducts` accepts `onProduct` that can `return false` to stop early, and explicitly destroys both pipeline and source stream; it now returns `{ count, stoppedEarly }` instead of relying on thrown errors.
- Updated `getProductById`, `getProductByCode`, `getProductBySlug`, and `getProductsEmergencyPage` to use the `return false` early-stop protocol instead of throwing `STOP_EARLY` errors.
- Added `resolveStreamingSortPolicy` in `backend/server.js` to ignore unsupported global sorts for large catalogs (and attach a `warning` to responses), and improved the products endpoint logging to always emit `[products-endpoint:respond]` including `hasNextPage` for correct observability.
- Adjusted admin UI in `frontend/js/admin.js` to treat `data.hasNextPage` only when boolean and to treat `totalItems === null` as “total no calculado” rather than `0` when rendering ranges and page info.
- Made frontend API calls abortable by forwarding `signal` in `frontend/js/api.js`, and in `frontend/js/shop.js` added `AbortController` to cancel prior catalog requests, a 300ms debounce for search and price inputs, suppression of `AbortError` user messages, and clearer handling of unknown totals in the result summary.
- Added a test script `scripts/test-products-stream-early-stop.js` that constructs a 10k products JSON and verifies pages, `hasNextPage`, early-stop scanning counts, and product lookup behavior without parsing the whole file.

### Testing
- Syntax/static checks: `node --check nerin_final_updated/backend/server.js`, `node --check nerin_final_updated/backend/data/productsStreamRepo.js`, `node --check nerin_final_updated/frontend/js/admin.js`, and `node --check nerin_final_updated/frontend/js/shop.js` all completed successfully.
- Safety check: `node nerin_final_updated/scripts/check-no-products-full-parse.js` executed and returned `ok` (no forbidden full-parse patterns detected).
- Functional streaming test: `node nerin_final_updated/scripts/test-products-stream-early-stop.js` executed and reported success verifying page sizes, `hasNextPage`, and that the stream stops early without scanning all 10,000 items.
- End-to-end smoke: ran the combined `node --check ... && node nerin_final_updated/scripts/test-products-stream-early-stop.js` sequence and it completed successfully with the expected assertions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef52e3fd688331919a99d945f2bb8b)