### PR TITLE
Fix streaming catalog request lifecycle and restore paginated admin/shop behavior

### DIFF
--- a/nerin_final_updated/backend/data/productsStreamRepo.js
+++ b/nerin_final_updated/backend/data/productsStreamRepo.js
@@ -275,19 +275,41 @@ async function getProductsEmergencyPage({
   pageSize = 24,
   matchItem = null,
   mapItem = null,
+  maxScanItems = null,
+  shouldStop = null,
   filePath = productsFilePath,
 } = {}) {
   const safePage = Math.max(1, Number(page) || 1);
   const safePageSize = Math.max(1, Number(pageSize) || 24);
   const start = (safePage - 1) * safePageSize;
   const endExclusive = start + safePageSize;
-  const stopAfter = endExclusive + 1;
 
   const items = [];
+  let scannedCount = 0;
   let matchedCount = 0;
-  await streamProducts({
+  let cancelled = false;
+  let stoppedEarly = false;
+
+  const { stoppedEarly: streamStoppedEarly } = await streamProducts({
     filePath,
     onProduct: (product) => {
+      if (typeof shouldStop === "function" && shouldStop()) {
+        cancelled = true;
+        return false;
+      }
+
+      scannedCount += 1;
+      const hasScanLimit =
+        maxScanItems !== null &&
+        maxScanItems !== undefined &&
+        maxScanItems !== "" &&
+        Number.isFinite(Number(maxScanItems)) &&
+        Number(maxScanItems) > 0;
+      if (hasScanLimit && scannedCount >= Number(maxScanItems)) {
+        stoppedEarly = true;
+        return false;
+      }
+
       const accepted = typeof matchItem === "function" ? !!matchItem(product) : true;
       if (!accepted) return true;
       const currentMatchIndex = matchedCount;
@@ -296,19 +318,26 @@ async function getProductsEmergencyPage({
         const mapped = typeof mapItem === "function" ? mapItem(product) : product;
         items.push(mapped);
       }
-      if (matchedCount >= stopAfter) {
+      if (matchedCount > endExclusive) {
+        stoppedEarly = true;
         return false;
       }
       return true;
     },
   });
 
+  const hasNextPage = cancelled ? false : matchedCount > endExclusive || stoppedEarly || streamStoppedEarly;
+
   return {
     items,
     page: safePage,
     pageSize: safePageSize,
-    matchedCountScanned: matchedCount,
-    hasNextPage: matchedCount > endExclusive,
+    scannedCount,
+    matchedCount,
+    stoppedEarly: Boolean(stoppedEarly || streamStoppedEarly),
+    cancelled,
+    hasNextPage,
+    hasPrevPage: safePage > 1,
   };
 }
 

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -1684,16 +1684,23 @@ function isProductPublic(product) {
     typeof product.visibility === "string"
       ? product.visibility.trim().toLowerCase()
       : "";
-  if (visibility && visibility !== "public") return false;
-  if (product.vip_only) return false;
+  const blockedVisibility = new Set(["private", "hidden", "draft", "archived", "disabled"]);
+  if (blockedVisibility.has(visibility)) return false;
+  if (product.vip_only === true) return false;
+  if (product.wholesaleOnly === true) return false;
   if (product.enabled === false) return false;
   const status =
     typeof product.status === "string"
       ? product.status.trim().toLowerCase()
       : "";
-  if (status === "draft" || status === "archived") return false;
+  const blockedStatus = new Set(["private", "hidden", "draft", "archived", "disabled"]);
+  if (blockedStatus.has(status)) return false;
   return Boolean(
     (typeof product.slug === "string" && product.slug.trim()) ||
+      (typeof product.sku === "string" && product.sku.trim()) ||
+      (typeof product.code === "string" && product.code.trim()) ||
+      (typeof product.title === "string" && product.title.trim()) ||
+      (typeof product.name === "string" && product.name.trim()) ||
       (typeof product.id === "string" && product.id.trim()) ||
       typeof product.id === "number",
   );
@@ -3790,18 +3797,44 @@ function buildAdminStreamFilter(query = {}) {
 function resolveStreamingSortPolicy({ endpoint = "", query = {}, storage = {} } = {}) {
   const requestedSort = String(query?.sort || "").trim().toLowerCase();
   const isLargeCatalog = Number(storage?.sizeBytes || 0) > LARGE_CATALOG_THRESHOLD_BYTES;
-  const hasManifestCount = Number.isFinite(Number(storage?.manifest?.productCount));
-  const canGloballySort = !isLargeCatalog || hasManifestCount;
-  const unsupportedPublicSorts = new Set(["price-asc", "price-desc", "stock-desc", "name"]);
-  const unsupportedAdminSorts = new Set(["name", "stock", "price_desc", "price_asc"]);
+  const canGloballySort = !isLargeCatalog;
+  const unsupportedPublicSorts = new Set([
+    "price-asc",
+    "price-desc",
+    "price_asc",
+    "price_desc",
+    "stock-desc",
+    "stock",
+    "name",
+    "name_asc",
+    "name_desc",
+    "newest",
+    "featured",
+  ]);
+  const unsupportedAdminSorts = new Set([
+    "name",
+    "name_asc",
+    "name_desc",
+    "stock",
+    "newest",
+    "featured",
+    "price_desc",
+    "price_asc",
+    "price-asc",
+    "price-desc",
+  ]);
   const unsupportedSet =
     endpoint === "/api/admin/products" ? unsupportedAdminSorts : unsupportedPublicSorts;
   if (!requestedSort || canGloballySort || !unsupportedSet.has(requestedSort)) {
     return { warning: null, effectiveQuery: query };
   }
+  console.warn("[products-endpoint] sort ignored in streaming mode", {
+    endpoint,
+    requestedSort,
+  });
   return {
-    warning:
-      "sort_ignored_streaming_large_catalog: orden global no disponible sin índice/manifest completo",
+    warning: "sort_not_supported_in_streaming_mode",
+    ignoredSort: requestedSort,
     effectiveQuery: {
       ...query,
       sort: endpoint === "/api/admin/products" ? "recent" : "relevance",
@@ -3849,49 +3882,75 @@ async function getProductsEmergencyResponse({
   matchItem,
   mapItem,
   warning = null,
+  ignoredSort = null,
+  shouldStop = null,
+  maxScanItems = null,
 } = {}) {
   const startedAt = Date.now();
   console.log(`[products-endpoint:start] ${endpoint} page=${page} pageSize=${pageSize}`);
   let firstItemLogged = false;
-  const emergencyPage = await productsStreamRepo.getProductsEmergencyPage({
-    page,
-    pageSize,
-    matchItem,
-    mapItem: (product) => {
-      const mapped = typeof mapItem === "function" ? mapItem(product) : product;
-      if (!firstItemLogged) {
-        firstItemLogged = true;
-        console.log("[products-endpoint:first-item]");
-      }
-      return mapped;
-    },
-  });
-  const manifest = productsStreamRepo.safeReadManifest() || null;
-  const manifestCount = Number(manifest?.productCount);
-  const estimatedTotalItems = Number.isFinite(manifestCount) ? manifestCount : null;
-  const totalPages =
-    Number.isFinite(estimatedTotalItems) && estimatedTotalItems > 0
-      ? Math.ceil(estimatedTotalItems / pageSize)
-      : null;
-  const responsePayload = {
-    items: emergencyPage.items,
-    page,
-    pageSize,
-    totalItems: estimatedTotalItems,
-    totalPages,
-    hasNextPage:
-      emergencyPage.hasNextPage ||
-      (Number.isFinite(totalPages) ? page < totalPages : emergencyPage.items.length === pageSize),
-    hasPrevPage: page > 1,
-    totalItemsUnknown: estimatedTotalItems == null,
-    mode: EMERGENCY_PRODUCTS_MODE ? "emergency_streaming" : "standard",
-  };
-  if (warning) responsePayload.warning = warning;
-  const durationMs = Date.now() - startedAt;
-  console.log(
-    `[products-endpoint:respond] items=${responsePayload.items.length} hasNextPage=${responsePayload.hasNextPage} durationMs=${durationMs}`,
-  );
-  return responsePayload;
+  try {
+    const emergencyPage = await productsStreamRepo.getProductsEmergencyPage({
+      page,
+      pageSize,
+      matchItem,
+      shouldStop,
+      maxScanItems,
+      mapItem: (product) => {
+        const mapped = typeof mapItem === "function" ? mapItem(product) : product;
+        if (!firstItemLogged) {
+          firstItemLogged = true;
+          console.log("[products-endpoint:first-item]");
+        }
+        return mapped;
+      },
+    });
+    const manifest = productsStreamRepo.safeReadManifest() || null;
+    const manifestCount = Number(manifest?.productCount);
+    const estimatedTotalItems = Number.isFinite(manifestCount) ? manifestCount : null;
+    const totalPages =
+      Number.isFinite(estimatedTotalItems) && estimatedTotalItems > 0
+        ? Math.ceil(estimatedTotalItems / pageSize)
+        : null;
+    const responsePayload = {
+      items: emergencyPage.items,
+      page,
+      pageSize,
+      totalItems: estimatedTotalItems,
+      totalPages,
+      hasNextPage: Boolean(emergencyPage.hasNextPage),
+      hasPrevPage: Boolean(emergencyPage.hasPrevPage || page > 1),
+      totalItemsUnknown: estimatedTotalItems == null,
+      mode: EMERGENCY_PRODUCTS_MODE ? "emergency_streaming" : "standard",
+    };
+    if (warning) responsePayload.warning = warning;
+    if (ignoredSort) responsePayload.ignoredSort = ignoredSort;
+    if (maxScanItems && emergencyPage.stoppedEarly && !emergencyPage.cancelled) {
+      responsePayload.warning = responsePayload.warning || "public_filter_scan_limit_reached";
+    }
+    const durationMs = Date.now() - startedAt;
+    if (endpoint === "/api/products" && emergencyPage.scannedCount > 1000 && emergencyPage.matchedCount < pageSize) {
+      console.warn(
+        `[products-endpoint:slow-public-filter] scanned=${emergencyPage.scannedCount} matched=${emergencyPage.matchedCount} pageSize=${pageSize}`,
+      );
+    }
+    if (emergencyPage.cancelled || (typeof shouldStop === "function" && shouldStop())) {
+      console.info(
+        `[products-endpoint:cancelled] endpoint=${endpoint} page=${page} pageSize=${pageSize} durationMs=${durationMs}`,
+      );
+      return null;
+    }
+    console.log(
+      `[products-endpoint:respond] endpoint=${endpoint} items=${responsePayload.items.length} matched=${emergencyPage.matchedCount} scanned=${emergencyPage.scannedCount} hasNextPage=${responsePayload.hasNextPage} durationMs=${durationMs}`,
+    );
+    return responsePayload;
+  } catch (error) {
+    const durationMs = Date.now() - startedAt;
+    console.error(
+      `[products-endpoint:failed] endpoint=${endpoint} page=${page} pageSize=${pageSize} error=${error?.message || error} durationMs=${durationMs}`,
+    );
+    throw error;
+  }
 }
 
 // Guardar productos en el archivo JSON
@@ -6043,23 +6102,32 @@ async function requestHandler(req, res) {
         maxPageSize: 96,
       });
       const { storage } = await loadProductsStrict();
-      const { warning, effectiveQuery } = resolveStreamingSortPolicy({
+      const { warning, ignoredSort, effectiveQuery } = resolveStreamingSortPolicy({
         endpoint: "/api/products",
         query: parsedUrl.query || {},
         storage,
       });
       const withWholesale = canSeeWholesalePrices(req);
+      const shouldStop = () =>
+        req.aborted || req.destroyed || res.destroyed || res.writableEnded;
       const pageData = await getProductsEmergencyResponse({
         endpoint: "/api/products",
         page,
         pageSize,
+        shouldStop,
+        maxScanItems:
+          parsedUrl?.query?.search || parsedUrl?.query?.q || parsedUrl?.query?.brand
+            ? null
+            : 5000,
         matchItem: buildCatalogStreamFilter(effectiveQuery || {}),
         mapItem: (product) => {
           if (withWholesale) return normalizeProductImages(product);
           return normalizeProductImages(sanitizePublicProducts([product])[0]);
         },
         warning,
+        ignoredSort,
       });
+      if (pageData === null) return;
       const responsePayload = {
         ...pageData,
         usingFallback: storage.usingFallback,
@@ -6107,19 +6175,24 @@ async function requestHandler(req, res) {
         maxPageSize: 250,
       });
       const { storage } = await loadProductsStrict();
-      const { warning, effectiveQuery } = resolveStreamingSortPolicy({
+      const { warning, ignoredSort, effectiveQuery } = resolveStreamingSortPolicy({
         endpoint: "/api/admin/products",
         query: parsedUrl.query || {},
         storage,
       });
+      const shouldStop = () =>
+        req.aborted || req.destroyed || res.destroyed || res.writableEnded;
       const pageData = await getProductsEmergencyResponse({
         endpoint: "/api/admin/products",
         page,
         pageSize,
+        shouldStop,
         matchItem: buildAdminStreamFilter(effectiveQuery || {}),
         mapItem: (product) => normalizeProductImages(product),
         warning,
+        ignoredSort,
       });
+      if (pageData === null) return;
       const responsePayload = {
         ...pageData,
         usingFallback: storage.usingFallback,

--- a/nerin_final_updated/frontend/admin.html
+++ b/nerin_final_updated/frontend/admin.html
@@ -394,9 +394,9 @@
               <option value="100" selected>100</option>
               <option value="250">250</option>
             </select>
-            <button id="adminProductsPrevPage" class="button secondary" type="button">Anterior</button>
-            <span id="adminProductsPageInfo">Página 1 / 1</span>
-            <button id="adminProductsNextPage" class="button secondary" type="button">Siguiente</button>
+            <button id="adminProductsPrevPage" class="button secondary" type="button">Página anterior</button>
+            <span id="adminProductsPageInfo">Página 1 · total no calculado · 0 productos en esta página</span>
+            <button id="adminProductsNextPage" class="button secondary" type="button">Siguiente página</button>
           </div>
         </div>
         <div class="product-actions">

--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -1780,8 +1780,10 @@ let productFilters = {
 };
 let productsPage = 1;
 let productsPageSize = Number(adminProductsPageSize?.value || 100);
-let productsTotalItems = 0;
-let productsTotalPages = 1;
+let productsHasNextPage = false;
+let productsHasPrevPage = false;
+let productsTotalItems = null;
+let productsTotalPages = null;
 let productsLoadErrorMessage = "";
 
 let isApplyingAutoSeo = false;
@@ -2217,21 +2219,28 @@ if (adminProductsPageSize) {
 }
 if (adminProductsPrevPage) {
   adminProductsPrevPage.addEventListener("click", () => {
-    if (productsPage <= 1) return;
+    console.info("[admin-products] prev clicked", {
+      currentPage: productsPage,
+      hasPrevPage: productsHasPrevPage,
+    });
+    if (!productsHasPrevPage || productsPage <= 1) return;
     productsPage -= 1;
-    loadProducts();
+    loadProducts().catch((error) => {
+      console.error("[admin-products] prev page failed", error);
+    });
   });
 }
 if (adminProductsNextPage) {
   adminProductsNextPage.addEventListener("click", () => {
-    if (
-      Number.isFinite(Number(productsTotalPages)) &&
-      productsPage >= Number(productsTotalPages)
-    ) {
-      return;
-    }
+    console.info("[admin-products] next clicked", {
+      currentPage: productsPage,
+      hasNextPage: productsHasNextPage,
+    });
+    if (!productsHasNextPage) return;
     productsPage += 1;
-    loadProducts();
+    loadProducts().catch((error) => {
+      console.error("[admin-products] next page failed", error);
+    });
   });
 }
 
@@ -3348,10 +3357,34 @@ if (suggestFulfillmentBtn) {
   suggestFulfillmentBtn.addEventListener("click", applySuggestedFulfillment);
 }
 
+function updateProductsPaginationControls() {
+  if (adminProductsNextPage) {
+    adminProductsNextPage.disabled = !productsHasNextPage;
+    adminProductsNextPage.hidden = false;
+  }
+
+  if (adminProductsPrevPage) {
+    adminProductsPrevPage.disabled = !productsHasPrevPage;
+    adminProductsPrevPage.hidden = false;
+  }
+
+  if (adminProductsPageInfo) {
+    const totalText = productsTotalPages
+      ? `Página ${productsPage} de ${productsTotalPages}`
+      : `Página ${productsPage} · total no calculado`;
+    adminProductsPageInfo.textContent =
+      `${totalText} · ${productsCache.length} productos en esta página`;
+  }
+}
+
 async function loadProducts(options = {}) {
   if (!productsTableBody) return;
   const { highlightId } = options;
   try {
+    console.info("[admin-products] load", {
+      page: productsPage,
+      pageSize: productsPageSize,
+    });
     productsTableBody.innerHTML =
       '<tr><td colspan="15">Cargando productos…</td></tr>';
     const query = new URLSearchParams({
@@ -3375,22 +3408,36 @@ async function loadProducts(options = {}) {
     const data = await res.json();
     productsLoadErrorMessage = "";
     productsCache = Array.isArray(data.items) ? data.items : [];
-    const rawTotal = data.totalItems;
-    const hasKnownTotal =
-      rawTotal !== null &&
-      rawTotal !== undefined &&
-      rawTotal !== "" &&
-      Number.isFinite(Number(rawTotal));
-    productsTotalItems = hasKnownTotal ? Number(rawTotal) : null;
+    productsPage = Number(data.page || productsPage);
+    productsPageSize = Number(data.pageSize || productsPageSize);
+    productsHasNextPage = data.hasNextPage === true;
+    productsHasPrevPage = data.hasPrevPage === true || productsPage > 1;
+    productsTotalItems =
+      data.totalItems !== null &&
+      data.totalItems !== undefined &&
+      data.totalItems !== "" &&
+      Number.isFinite(Number(data.totalItems))
+        ? Number(data.totalItems)
+        : null;
     productsTotalPages =
       data.totalPages !== null &&
       data.totalPages !== undefined &&
+      data.totalPages !== "" &&
       Number.isFinite(Number(data.totalPages))
         ? Number(data.totalPages)
         : null;
-    productsPage = Number(data.page || productsPage);
     syncProductTaxonomies(productsCache);
     renderProductsTable();
+    updateProductsPaginationControls();
+    console.info("[admin-products] loaded", {
+      page: productsPage,
+      pageSize: productsPageSize,
+      items: productsCache.length,
+      hasNextPage: productsHasNextPage,
+      hasPrevPage: productsHasPrevPage,
+      totalItems: productsTotalItems,
+      totalPages: productsTotalPages,
+    });
     const start = productsCache.length ? (productsPage - 1) * productsPageSize + 1 : 0;
     const end = productsCache.length ? start + productsCache.length - 1 : 0;
     if (adminProductsRange) {
@@ -3403,20 +3450,6 @@ async function loadProducts(options = {}) {
       } else {
         adminProductsRange.textContent = `Mostrando ${start}-${end} de ${productsTotalItems} productos`;
       }
-    }
-    if (adminProductsPageInfo) {
-      adminProductsPageInfo.textContent =
-        productsTotalPages == null
-          ? `Página ${productsPage}`
-          : `Página ${productsPage} / ${productsTotalPages}`;
-    }
-    if (adminProductsPrevPage) adminProductsPrevPage.disabled = productsPage <= 1;
-    if (adminProductsNextPage) {
-      const hasExplicitHasNextPage = typeof data.hasNextPage === "boolean";
-      const hasNextPage = hasExplicitHasNextPage
-        ? data.hasNextPage
-        : productsCache.length >= productsPageSize;
-      adminProductsNextPage.disabled = !hasNextPage;
     }
     if (highlightId) {
       highlightProductRow(highlightId);

--- a/nerin_final_updated/frontend/js/shop.js
+++ b/nerin_final_updated/frontend/js/shop.js
@@ -698,9 +698,18 @@ async function renderProducts({ append = false } = {}) {
     productsAbortController.abort();
   }
   productsAbortController = new AbortController();
-  const response = await fetchProductsPage(requestParams, {
-    signal: productsAbortController.signal,
-  });
+  let response;
+  try {
+    response = await fetchProductsPage(requestParams, {
+      signal: productsAbortController.signal,
+    });
+  } catch (error) {
+    if (error?.name === "AbortError") {
+      shopLog("request:aborted", { requestId });
+      return;
+    }
+    throw error;
+  }
   shopLog("response", {
     requestId,
     status: "ok",
@@ -774,6 +783,16 @@ async function renderProducts({ append = false } = {}) {
   syncQueryParams(filters);
 }
 
+function safelyRenderProducts(options) {
+  void renderProducts(options).catch((error) => {
+    if (error?.name === "AbortError") return;
+    console.error("[shop] renderProducts failed", error);
+    if (productGrid) {
+      productGrid.innerHTML = `<p>Error al cargar productos: ${error.message || "Error desconocido"}</p>`;
+    }
+  });
+}
+
 function applyInitialFilters() {
   const params = new URLSearchParams(window.location.search);
   if (searchInput && params.get("q")) searchInput.value = params.get("q");
@@ -819,14 +838,14 @@ function setupFiltersUi() {
   if (filtersBackdrop) filtersBackdrop.addEventListener("click", closeDrawer);
   if (applyFiltersBtn) {
     applyFiltersBtn.addEventListener("click", () => {
-      renderProducts();
+      safelyRenderProducts();
       closeDrawer();
     });
   }
   if (clearFiltersBtn) {
     clearFiltersBtn.addEventListener("click", () => {
       resetAllFilters();
-      renderProducts();
+      safelyRenderProducts();
       closeDrawer();
     });
   }
@@ -845,33 +864,33 @@ async function initShop() {
     searchInput?.addEventListener("input", () => {
       clearTimeout(searchDebounceTimer);
       searchDebounceTimer = window.setTimeout(() => {
-        renderProducts();
+        safelyRenderProducts();
       }, INPUT_DEBOUNCE_MS);
     });
     searchClear?.addEventListener("click", () => {
       searchInput.value = "";
-      renderProducts();
+      safelyRenderProducts();
     });
     brandFilter?.addEventListener("change", () => {
       updateModelOptions(brandFilter.value);
-      renderProducts();
+      safelyRenderProducts();
     });
-    modelFilter?.addEventListener("change", () => renderProducts());
-    categoryFilter?.addEventListener("change", () => renderProducts());
-    stockFilter?.addEventListener("change", () => renderProducts());
-    sortSelect?.addEventListener("change", () => renderProducts());
+    modelFilter?.addEventListener("change", () => safelyRenderProducts());
+    categoryFilter?.addEventListener("change", () => safelyRenderProducts());
+    stockFilter?.addEventListener("change", () => safelyRenderProducts());
+    sortSelect?.addEventListener("change", () => safelyRenderProducts());
     pageSizeSelect?.addEventListener("change", () => {
       currentPageSize = Number(pageSizeSelect.value) || 24;
-      renderProducts();
+      safelyRenderProducts();
     });
-    loadMoreBtn.addEventListener("click", () => renderProducts({ append: true }));
+    loadMoreBtn.addEventListener("click", () => safelyRenderProducts({ append: true }));
     priceRange?.addEventListener("input", () => {
       priceFilterTouched = true;
       updatePriceRangeDisplay();
       if (!mobileLayoutQuery.matches) {
         clearTimeout(priceDebounceTimer);
         priceDebounceTimer = window.setTimeout(() => {
-          renderProducts();
+          safelyRenderProducts();
         }, INPUT_DEBOUNCE_MS);
       }
     });

--- a/nerin_final_updated/scripts/test-products-stream-early-stop.js
+++ b/nerin_final_updated/scripts/test-products-stream-early-stop.js
@@ -36,14 +36,14 @@ async function main() {
   const page1Duration = Date.now() - page1Start;
   assert(Array.isArray(page1.items) && page1.items.length === 24, "page=1 debe devolver 24 items");
   assert(page1.hasNextPage === true, "page=1 debe informar hasNextPage=true");
-  assert(page1.matchedCountScanned < productCount, "page=1 no debe escanear los 10.000 productos");
+  assert(page1.matchedCount < productCount, "page=1 no debe escanear los 10.000 productos");
 
   const page2Start = Date.now();
   const page2 = await getProductsEmergencyPage({ page: 2, pageSize: 24, filePath });
   const page2Duration = Date.now() - page2Start;
   assert(Array.isArray(page2.items) && page2.items.length === 24, "page=2 debe devolver 24 items");
   assert(page2.hasNextPage === true, "page=2 debe informar hasNextPage=true");
-  assert(page2.matchedCountScanned < productCount, "page=2 no debe escanear los 10.000 productos");
+  assert(page2.matchedCount < productCount, "page=2 no debe escanear los 10.000 productos");
 
   const slugNearStart = "producto-5";
   const slugNearStartStart = Date.now();
@@ -61,12 +61,12 @@ async function main() {
     productCount,
     page1: {
       durationMs: page1Duration,
-      matchedCountScanned: page1.matchedCountScanned,
+      matchedCount: page1.matchedCount,
       hasNextPage: page1.hasNextPage,
     },
     page2: {
       durationMs: page2Duration,
-      matchedCountScanned: page2.matchedCountScanned,
+      matchedCount: page2.matchedCount,
       hasNextPage: page2.hasNextPage,
     },
     slugNearStart: {


### PR DESCRIPTION
### Motivation

- Evitar que `/api/products` y `/api/admin/products` queden iniciadas sin cerrarse (start/first-item sin respond/cancelled/failed) y prevenir lecturas completas de `products.json` de 101 MB que provoquen latencia/heap OOM.
- Restaurar paginación real en el admin (botón Siguiente/Anterior funcional) y eliminar la tormenta de requests desde el storefront que generaba abortos y promesas flotantes.

### Description

- Streaming lifecycle: `getProductsEmergencyPage` ahora acepta `shouldStop` y `maxScanItems`, cuenta `scannedCount`/`matchedCount`, reporta `stoppedEarly`/`cancelled` y corta el stream limpiamente cuando corresponde (no se lanza throw para flujo normal). (backend/data/productsStreamRepo.js)
- Endpoint lifecycle y logs: `/api/products` y `/api/admin/products` pasan `shouldStop` para cortar en abortos de cliente; `getProductsEmergencyResponse` asegura logs determinísticos `[products-endpoint:start|first-item|respond|cancelled|failed]` y añade diagnósticos (`slow-public-filter`, warnings por límite de escaneo). (backend/server.js)
- Defensa pública: catálogo público aplica `maxScanItems` defensivo (5000) para consultas sin “señal fuerte” y devuelve lo que encontró más una warning `public_filter_scan_limit_reached` si se cortó por límite. (backend/server.js)
- Sort en streaming: política de ordenamiento para catálogos grandes ahora ignora sorts globales no soportados y devuelve `warning: sort_not_supported_in_streaming_mode` y `ignoredSort` en respuesta en lugar de intentar sort en memoria. (backend/server.js)
- Public product tolerance: `isProductPublic` ampliado para aceptar productos importados (no exigir slug) y rechazar explícitos (`private/hidden/draft/archived/disabled`, `enabled=false`, `vip_only`, `wholesaleOnly`). (backend/server.js)
- Admin frontend pagination: estado de paginación reparado para usar `hasNextPage`/`hasPrevPage` booleanos, parseo seguro de `totalItems/totalPages`, controles visibles/habilitados y logs de click para diagnosticar pedidos de página. (frontend/js/admin.js, frontend/admin.html)
- Shop frontend stability: se agregó `safelyRenderProducts` y se sustituyeron listeners/debounces para evitar storms; `AbortError` se trata como flujo normal (no error visual ni unhandled rejection). `fetchProductsPage` ya acepta `signal`. (frontend/js/shop.js, frontend/js/api.js)
- Tests y ajustes de scripts: sincronizado `scripts/test-products-stream-early-stop.js` con los campos nuevos (`matchedCount`) y mantenido `scripts/check-no-products-full-parse.js`. (scripts/test-products-stream-early-stop.js)

Archivos cambiados (resumen):
- backend/data/productsStreamRepo.js
- backend/server.js
- frontend/js/admin.js
- frontend/admin.html
- frontend/js/shop.js
- scripts/test-products-stream-early-stop.js

### Testing

- Comandos ejecutados:
  - `node --check nerin_final_updated/backend/server.js`
  - `node --check nerin_final_updated/backend/data/productsStreamRepo.js`
  - `node --check nerin_final_updated/frontend/js/admin.js`
  - `node --check nerin_final_updated/frontend/js/shop.js`
  - `node --check nerin_final_updated/frontend/js/api.js`
  - `node nerin_final_updated/scripts/check-no-products-full-parse.js`
  - `node nerin_final_updated/scripts/test-products-stream-early-stop.js`
  - búsquedas para patrones riesgosos (`rg` para `loadProducts()`, `getProducts()`, `readJsonFile(...products)`, `renderProducts()` listeners, etc.)

- Resultados automatizados:
  - `node --check` en los módulos listados: OK (sin errores de sintaxis).
  - `scripts/check-no-products-full-parse.js`: OK.
  - `scripts/test-products-stream-early-stop.js`: OK after fixes (validó que page=1/2 devuelvan 24 items, que `matchedCount` sea menor que total y que `getProductBySlug` encuentre slugs tempranos sin escanear todo).
  - `rg` checks: se auditó y el guard contra carga completa permanece activo; endpoints críticos usan streaming y no reintroducen parseo completo.

Limitaciones conocidas

- No se verificó en el entorno Render en producción (logs reales) desde aquí; añadí la instrumentación necesaria para que puedas confirmar los mensajes en Render inmediatamente tras deploy.
- El ajuste defensivo `maxScanItems` para el storefront está diseñado para evitar bloqueos en exploración de bajo-signal; en casos de requerir cobertura completa de búsqueda pública se debería agregar un índice/manifest con `productCount` y/o un motor de búsqueda.

Si quieres, puedo preparar un despliegue rápido (instrucciones de build/start) o añadir verbosos adicionales en logs para una ventana de diagnóstico en Render.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef607439d48331b6c1448a9a738650)