### PR TITLE
Add SQLite-backed products catalog with FTS and integrate into API/endpoints

### DIFF
--- a/nerin_final_updated/backend/data/productsSqliteRepo.js
+++ b/nerin_final_updated/backend/data/productsSqliteRepo.js
@@ -1,0 +1,620 @@
+const fs = require("fs");
+const fsp = fs.promises;
+const path = require("path");
+const sqlite3 = require("sqlite3");
+const productsStreamRepo = require("./productsStreamRepo");
+const { dataPath } = require("../utils/dataDir");
+
+const PRODUCTS_JSON_PATH = dataPath("products.json");
+const SQLITE_PATH = dataPath("products.sqlite");
+const MANIFEST_PATH = dataPath("products.manifest.json");
+
+const REJECTED_STATE_VALUES = new Set([
+  "hidden",
+  "private",
+  "draft",
+  "disabled",
+  "archived",
+  "deleted",
+]);
+
+let dbInstance = null;
+let ftsEnabled = false;
+let ensuringPromise = null;
+
+function normalizeQueryText(value) {
+  const text = String(value || "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+  if (!text) return "";
+  try {
+    return text.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+  } catch {
+    return text;
+  }
+}
+
+function boolToInt(value, fallback = 0) {
+  if (value === true) return 1;
+  if (value === false) return 0;
+  return fallback;
+}
+
+function toNullableText(value) {
+  if (value == null) return null;
+  const text = String(value).trim();
+  return text || null;
+}
+
+function toNumber(value, fallback = 0) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function run(db, sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.run(sql, params, function onRun(error) {
+      if (error) reject(error);
+      else resolve(this);
+    });
+  });
+}
+
+function get(db, sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.get(sql, params, (error, row) => {
+      if (error) reject(error);
+      else resolve(row || null);
+    });
+  });
+}
+
+function all(db, sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.all(sql, params, (error, rows) => {
+      if (error) reject(error);
+      else resolve(Array.isArray(rows) ? rows : []);
+    });
+  });
+}
+
+async function withTransaction(db, callback) {
+  await run(db, "BEGIN");
+  try {
+    const result = await callback();
+    await run(db, "COMMIT");
+    return result;
+  } catch (error) {
+    await run(db, "ROLLBACK");
+    throw error;
+  }
+}
+
+async function openDb() {
+  if (dbInstance) return dbInstance;
+  await fsp.mkdir(path.dirname(SQLITE_PATH), { recursive: true });
+  dbInstance = await new Promise((resolve, reject) => {
+    const db = new sqlite3.Database(SQLITE_PATH, (error) => {
+      if (error) reject(error);
+      else resolve(db);
+    });
+  });
+  await run(dbInstance, "PRAGMA journal_mode = WAL");
+  await run(dbInstance, "PRAGMA synchronous = NORMAL");
+  await run(dbInstance, "PRAGMA temp_store = MEMORY");
+  return dbInstance;
+}
+
+async function detectFtsAvailability(db) {
+  try {
+    await run(
+      db,
+      "CREATE VIRTUAL TABLE IF NOT EXISTS products_fts USING fts5(id, sku, code, slug, name, title, brand, model, category, search_text)",
+    );
+    ftsEnabled = true;
+  } catch {
+    ftsEnabled = false;
+  }
+}
+
+async function createSchema(db) {
+  await run(
+    db,
+    `CREATE TABLE IF NOT EXISTS products (
+      id TEXT,
+      sku TEXT,
+      code TEXT,
+      slug TEXT,
+      name TEXT,
+      title TEXT,
+      brand TEXT,
+      model TEXT,
+      category TEXT,
+      status TEXT,
+      visibility TEXT,
+      stock INTEGER,
+      price REAL,
+      currency TEXT,
+      is_public INTEGER,
+      enabled INTEGER,
+      deleted INTEGER,
+      archived INTEGER,
+      vip_only INTEGER,
+      wholesale_only INTEGER,
+      search_text TEXT,
+      raw_json TEXT
+    )`,
+  );
+
+  const indexSql = [
+    "CREATE INDEX IF NOT EXISTS idx_products_id ON products(id)",
+    "CREATE INDEX IF NOT EXISTS idx_products_sku ON products(sku)",
+    "CREATE INDEX IF NOT EXISTS idx_products_code ON products(code)",
+    "CREATE INDEX IF NOT EXISTS idx_products_slug ON products(slug)",
+    "CREATE INDEX IF NOT EXISTS idx_products_brand ON products(brand)",
+    "CREATE INDEX IF NOT EXISTS idx_products_category ON products(category)",
+    "CREATE INDEX IF NOT EXISTS idx_products_is_public ON products(is_public)",
+    "CREATE INDEX IF NOT EXISTS idx_products_stock ON products(stock)",
+    "CREATE INDEX IF NOT EXISTS idx_products_price ON products(price)",
+    "CREATE INDEX IF NOT EXISTS idx_products_name ON products(name)",
+  ];
+
+  for (const sql of indexSql) {
+    await run(db, sql);
+  }
+
+  await detectFtsAvailability(db);
+}
+
+function isProductPublic(product) {
+  if (!product || typeof product !== "object") return false;
+
+  const visibility = normalizeQueryText(product.visibility || "");
+  if (visibility && REJECTED_STATE_VALUES.has(visibility)) return false;
+
+  const status = normalizeQueryText(product.status || "");
+  if (status && REJECTED_STATE_VALUES.has(status)) return false;
+
+  if (product.enabled === false) return false;
+  if (product.deleted === true) return false;
+  if (product.archived === true) return false;
+  if (product.vip_only === true) return false;
+  if (product.wholesaleOnly === true || product.wholesale_only === true) return false;
+
+  const hasTitle = Boolean(toNullableText(product.name) || toNullableText(product.title));
+  if (!hasTitle) return false;
+
+  const hasIdentifier = Boolean(
+    toNullableText(product.id) ||
+      toNullableText(product.sku) ||
+      toNullableText(product.code) ||
+      toNullableText(product.slug) ||
+      toNullableText(product.partNumber),
+  );
+
+  return hasIdentifier;
+}
+
+function buildSearchText(product = {}) {
+  const fields = [
+    product.name,
+    product.title,
+    product.brand,
+    product.model,
+    product.category,
+    product.sku,
+    product.code,
+    product.id,
+    product.slug,
+    product.partNumber,
+    product.ean,
+    product.gtin,
+    product.mpn,
+    product.supplierCode,
+    product?.metadata?.supplierPartNumber,
+    product?.metadata?.supplierImport?.supplierPartNumber,
+  ];
+  return normalizeQueryText(fields.filter(Boolean).join(" "));
+}
+
+function mapProductRow(product = {}) {
+  const price = toNumber(product.price_minorista ?? product.price, 0);
+  const stock = Math.trunc(toNumber(product.stock, 0));
+  return {
+    id: toNullableText(product.id),
+    sku: toNullableText(product.sku),
+    code: toNullableText(product.code),
+    slug: toNullableText(product.slug),
+    name: toNullableText(product.name),
+    title: toNullableText(product.title),
+    brand: normalizeQueryText(toNullableText(product.brand)),
+    model: normalizeQueryText(toNullableText(product.model)),
+    category: normalizeQueryText(toNullableText(product.category)),
+    status: normalizeQueryText(toNullableText(product.status)),
+    visibility: normalizeQueryText(toNullableText(product.visibility)),
+    stock,
+    price,
+    currency: toNullableText(product.currency || "ARS"),
+    is_public: isProductPublic(product) ? 1 : 0,
+    enabled: boolToInt(product.enabled, 1),
+    deleted: boolToInt(product.deleted, 0),
+    archived: boolToInt(product.archived, 0),
+    vip_only: boolToInt(product.vip_only, 0),
+    wholesale_only: boolToInt(product.wholesaleOnly === true || product.wholesale_only === true, 0),
+    search_text: buildSearchText(product),
+    raw_json: JSON.stringify(product),
+  };
+}
+
+function parseRawItems(rows = []) {
+  return rows
+    .map((row) => {
+      try {
+        return JSON.parse(row.raw_json);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+async function rebuildProductsDbFromJson() {
+  const startedAt = Date.now();
+  const db = await openDb();
+  const productsStats = await fsp.stat(PRODUCTS_JSON_PATH);
+  const tmpDbPath = `${SQLITE_PATH}.tmp-${process.pid}-${Date.now()}`;
+
+  console.log(`[products-db] rebuild start productsFilePath=${PRODUCTS_JSON_PATH}`);
+
+  const tmpDb = await new Promise((resolve, reject) => {
+    const conn = new sqlite3.Database(tmpDbPath, (error) => {
+      if (error) reject(error);
+      else resolve(conn);
+    });
+  });
+
+  try {
+    await run(tmpDb, "PRAGMA journal_mode = OFF");
+    await run(tmpDb, "PRAGMA synchronous = OFF");
+    await run(tmpDb, "PRAGMA temp_store = MEMORY");
+    await createSchema(tmpDb);
+    const insertSql = `INSERT INTO products (
+      id, sku, code, slug, name, title, brand, model, category, status, visibility,
+      stock, price, currency, is_public, enabled, deleted, archived, vip_only, wholesale_only,
+      search_text, raw_json
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
+
+    let count = 0;
+    const batch = [];
+    const BATCH_SIZE = 500;
+
+    const flush = async () => {
+      if (!batch.length) return;
+      await withTransaction(tmpDb, async () => {
+        for (const item of batch) {
+          await run(tmpDb, insertSql, [
+            item.id,
+            item.sku,
+            item.code,
+            item.slug,
+            item.name,
+            item.title,
+            item.brand,
+            item.model,
+            item.category,
+            item.status,
+            item.visibility,
+            item.stock,
+            item.price,
+            item.currency,
+            item.is_public,
+            item.enabled,
+            item.deleted,
+            item.archived,
+            item.vip_only,
+            item.wholesale_only,
+            item.search_text,
+            item.raw_json,
+          ]);
+        }
+      });
+      batch.length = 0;
+    };
+
+    await productsStreamRepo.streamProducts({
+      filePath: PRODUCTS_JSON_PATH,
+      onProduct: async (product) => {
+        batch.push(mapProductRow(product));
+        count += 1;
+        if (count % 5000 === 0) {
+          console.log(`[products-db] rebuild progress count=${count}`);
+        }
+        if (batch.length >= BATCH_SIZE) {
+          await flush();
+        }
+        return true;
+      },
+    });
+
+    await flush();
+
+    if (ftsEnabled) {
+      await run(tmpDb, "DELETE FROM products_fts");
+      await run(
+        tmpDb,
+        `INSERT INTO products_fts(rowid, id, sku, code, slug, name, title, brand, model, category, search_text)
+         SELECT rowid, id, sku, code, slug, name, title, brand, model, category, search_text FROM products`,
+      );
+    }
+
+    const manifest = {
+      productCount: count,
+      productsJsonSizeBytes: Number(productsStats.size || 0),
+      productsJsonMtimeMs: Number(productsStats.mtimeMs || 0),
+      sqliteBuiltAt: new Date().toISOString(),
+      sqlitePath: SQLITE_PATH,
+      sqliteFtsEnabled: ftsEnabled,
+    };
+
+    await fsp.writeFile(MANIFEST_PATH, JSON.stringify(manifest, null, 2), "utf8");
+
+    await new Promise((resolve, reject) => {
+      tmpDb.close((error) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    });
+
+    if (fs.existsSync(SQLITE_PATH)) {
+      await fsp.unlink(SQLITE_PATH);
+    }
+    await fsp.rename(tmpDbPath, SQLITE_PATH);
+
+    if (dbInstance) {
+      await new Promise((resolve) => {
+        dbInstance.close(() => resolve());
+      });
+      dbInstance = null;
+    }
+
+    const durationMs = Date.now() - startedAt;
+    console.log(`[products-db] rebuild done count=${count} durationMs=${durationMs}`);
+    return manifest;
+  } catch (error) {
+    try {
+      await new Promise((resolve) => {
+        tmpDb.close(() => resolve());
+      });
+    } catch {}
+    try {
+      if (fs.existsSync(tmpDbPath)) await fsp.unlink(tmpDbPath);
+    } catch {}
+    throw error;
+  }
+}
+
+async function ensureProductsDb() {
+  if (ensuringPromise) return ensuringPromise;
+  ensuringPromise = (async () => {
+    console.log("[products-db] checking sqlite catalog");
+    const productsStats = await fsp.stat(PRODUCTS_JSON_PATH);
+    let manifest = null;
+    try {
+      manifest = JSON.parse(await fsp.readFile(MANIFEST_PATH, "utf8"));
+    } catch {
+      manifest = null;
+    }
+
+    let reason = "";
+    if (!fs.existsSync(SQLITE_PATH)) {
+      reason = "sqlite_missing";
+    } else if (!manifest) {
+      reason = "manifest_missing";
+    } else if (Number(manifest.productsJsonSizeBytes || -1) !== Number(productsStats.size || 0)) {
+      reason = "products_json_size_changed";
+    } else if (Math.floor(Number(manifest.productsJsonMtimeMs || -1)) !== Math.floor(Number(productsStats.mtimeMs || 0))) {
+      reason = "products_json_mtime_changed";
+    }
+
+    if (reason) {
+      console.log(`[products-db] rebuild required reason=${reason}`);
+      await rebuildProductsDbFromJson();
+    }
+
+    const db = await openDb();
+    await createSchema(db);
+    console.log(`[products-db] ready dbPath=${SQLITE_PATH}`);
+    return {
+      dbPath: SQLITE_PATH,
+      manifest: await getManifestFromDb(),
+      ftsEnabled,
+    };
+  })();
+
+  try {
+    return await ensuringPromise;
+  } finally {
+    ensuringPromise = null;
+  }
+}
+
+function buildSort(sort) {
+  const allowedSorts = {
+    price_asc: "price ASC, rowid ASC",
+    price_desc: "price DESC, rowid ASC",
+    name_asc: "name ASC, rowid ASC",
+    name_desc: "name DESC, rowid ASC",
+    stock_desc: "stock DESC, rowid ASC",
+    stock_asc: "stock ASC, rowid ASC",
+    "price-asc": "price ASC, rowid ASC",
+    "price-desc": "price DESC, rowid ASC",
+    "stock-desc": "stock DESC, rowid ASC",
+    name: "name ASC, rowid ASC",
+  };
+  return allowedSorts[String(sort || "").trim().toLowerCase()] || "rowid ASC";
+}
+
+async function buildWhereClause({ search = "", isPublicOnly = false, category = "", brand = "", model = "", visibility = "", status = "", stock = "", priceMax = null } = {}) {
+  const where = [];
+  const params = [];
+
+  if (isPublicOnly) where.push("is_public = 1");
+  if (category) {
+    where.push("category = ?");
+    params.push(category);
+  }
+  if (brand) {
+    where.push("brand = ?");
+    params.push(brand);
+  }
+  if (model) {
+    where.push("model = ?");
+    params.push(model);
+  }
+  if (visibility) {
+    where.push("visibility = ?");
+    params.push(visibility);
+  }
+  if (status) {
+    where.push("status = ?");
+    params.push(status);
+  }
+  if (stock === "in-stock" || stock === "in") {
+    where.push("stock > 0");
+  } else if (stock === "out") {
+    where.push("stock <= 0");
+  }
+  if (priceMax !== null && Number.isFinite(Number(priceMax))) {
+    where.push("price <= ?");
+    params.push(Number(priceMax));
+  }
+
+  const normalizedSearch = normalizeQueryText(search);
+  if (normalizedSearch) {
+    if (ftsEnabled) {
+      where.push("rowid IN (SELECT rowid FROM products_fts WHERE products_fts MATCH ?)");
+      const tokens = normalizedSearch
+        .replace(/[^a-z0-9\s]/gi, " ")
+        .split(" ")
+        .filter(Boolean)
+        .map((token) => `${token}*`)
+        .join(" AND ");
+      params.push(tokens || normalizedSearch.replace(/[^a-z0-9\s]/gi, " ").trim() || normalizedSearch);
+    } else {
+      where.push("search_text LIKE ?");
+      params.push(`%${normalizedSearch}%`);
+    }
+  }
+
+  return {
+    sql: where.length ? `WHERE ${where.join(" AND ")}` : "",
+    params,
+  };
+}
+
+async function queryBase({ page = 1, pageSize = 24, search = "", sort = "", isPublicOnly = false, category = "", brand = "", model = "", visibility = "", status = "", stock = "", priceMax = null } = {}) {
+  await ensureProductsDb();
+  const db = await openDb();
+  const safePage = Math.max(1, Number(page) || 1);
+  const safePageSize = Math.max(1, Number(pageSize) || 24);
+  const offset = (safePage - 1) * safePageSize;
+  const whereClause = await buildWhereClause({
+    search,
+    isPublicOnly,
+    category: normalizeQueryText(category),
+    brand: normalizeQueryText(brand),
+    model: normalizeQueryText(model),
+    visibility: normalizeQueryText(visibility),
+    status: normalizeQueryText(status),
+    stock: normalizeQueryText(stock),
+    priceMax,
+  });
+
+  const orderBy = buildSort(sort);
+  const rows = await all(
+    db,
+    `SELECT raw_json FROM products ${whereClause.sql} ORDER BY ${orderBy} LIMIT ? OFFSET ?`,
+    [...whereClause.params, safePageSize, offset],
+  );
+  const totalRow = await get(
+    db,
+    `SELECT COUNT(*) AS totalItems FROM products ${whereClause.sql}`,
+    whereClause.params,
+  );
+  const totalItems = Number(totalRow?.totalItems || 0);
+  const totalPages = Math.max(1, Math.ceil(totalItems / safePageSize));
+
+  return {
+    items: parseRawItems(rows),
+    page: safePage,
+    pageSize: safePageSize,
+    totalItems,
+    totalPages,
+    hasNextPage: safePage < totalPages,
+    hasPrevPage: safePage > 1,
+    source: "sqlite",
+    search: search || undefined,
+  };
+}
+
+async function queryProducts(params = {}) {
+  return queryBase({ ...params, isPublicOnly: true });
+}
+
+async function queryAdminProducts(params = {}) {
+  return queryBase({ ...params, isPublicOnly: false });
+}
+
+async function getProductBySlug(slug) {
+  await ensureProductsDb();
+  const db = await openDb();
+  const row = await get(
+    db,
+    "SELECT raw_json FROM products WHERE slug = ? LIMIT 1",
+    [String(slug || "").trim()],
+  );
+  return parseRawItems(row ? [row] : [])[0] || null;
+}
+
+async function getProductById(id) {
+  await ensureProductsDb();
+  const db = await openDb();
+  const row = await get(db, "SELECT raw_json FROM products WHERE id = ? LIMIT 1", [String(id || "").trim()]);
+  return parseRawItems(row ? [row] : [])[0] || null;
+}
+
+async function getProductByCode(code) {
+  await ensureProductsDb();
+  const db = await openDb();
+  const target = String(code || "").trim();
+  const row = await get(
+    db,
+    "SELECT raw_json FROM products WHERE code = ? OR sku = ? LIMIT 1",
+    [target, target],
+  );
+  return parseRawItems(row ? [row] : [])[0] || null;
+}
+
+async function getManifestFromDb() {
+  try {
+    const raw = await fsp.readFile(MANIFEST_PATH, "utf8");
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+module.exports = {
+  ensureProductsDb,
+  rebuildProductsDbFromJson,
+  queryProducts,
+  queryAdminProducts,
+  getProductBySlug,
+  getProductById,
+  getProductByCode,
+  getManifestFromDb,
+  normalizeQueryText,
+  SQLITE_PATH,
+};

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -63,6 +63,7 @@ const {
 } = require("./utils/reviewValidation");
 const { importStockXlsxFile } = require("./services/stockXlsxImport");
 const productsStreamRepo = require("./data/productsStreamRepo");
+const productsSqliteRepo = require("./data/productsSqliteRepo");
 const { readJsonFile } = require("./utils/jsonFile");
 const {
   appendEvent,
@@ -6104,6 +6105,32 @@ async function requestHandler(req, res) {
     return sendJson(res, 200, { ok: true, ts: Date.now() });
   }
 
+  if (pathname === "/api/catalog/health" && req.method === "GET") {
+    try {
+      await productsSqliteRepo.ensureProductsDb();
+      const manifest = await productsSqliteRepo.getManifestFromDb();
+      const productsJsonExists = fs.existsSync(PRODUCTS_FILE_PATH);
+      const sqlitePath = manifest?.sqlitePath || productsSqliteRepo.SQLITE_PATH;
+      const sqliteExists = Boolean(sqlitePath && fs.existsSync(sqlitePath));
+      return sendJson(res, 200, {
+        ok: true,
+        source: "sqlite",
+        productsJsonExists,
+        sqliteExists,
+        productCount: Number(manifest?.productCount || 0),
+        sqliteBuiltAt: manifest?.sqliteBuiltAt || null,
+        productsJsonSizeBytes: Number(manifest?.productsJsonSizeBytes || 0),
+        productsJsonMtimeMs: Number(manifest?.productsJsonMtimeMs || 0),
+      });
+    } catch (error) {
+      return sendJson(res, 503, {
+        ok: false,
+        source: "streaming_fallback",
+        error: error?.message || "SQLite unavailable",
+      });
+    }
+  }
+
   if (pathname === "/api/test-email" && req.method === "GET") {
     const requestUrl = new URL(req.url, "http://localhost");
     const to = requestUrl.searchParams.get("to") || "tuemail@ejemplo.com";
@@ -6153,81 +6180,68 @@ async function requestHandler(req, res) {
         pageSize: 24,
         maxPageSize: 96,
       });
-      const { storage } = await loadProductsStrict();
-      const { warning, ignoredSort, effectiveQuery } = resolveStreamingSortPolicy({
-        endpoint: "/api/products",
-        query: parsedUrl.query || {},
-        storage,
-      });
+      const queryParams = parsedUrl.query || {};
+      const startedAt = Date.now();
+      console.log(`[products-endpoint:start] /api/products page=${page} pageSize=${pageSize} source=sqlite`);
       const withWholesale = canSeeWholesalePrices(req);
-      const shouldStop = () =>
-        req.aborted || req.destroyed || res.destroyed || res.writableEnded;
-      const effectivePublicQuery = effectiveQuery || {};
-      const hasActivePublicFilters = Boolean(
-        normalizeQueryText(effectivePublicQuery.search || effectivePublicQuery.q || "") ||
-          normalizeQueryText(effectivePublicQuery.category || "") ||
-          normalizeQueryText(effectivePublicQuery.brand || "") ||
-          normalizeQueryText(effectivePublicQuery.model || "") ||
-          normalizeQueryText(effectivePublicQuery.stock || "") ||
-          Number.isFinite(Number(effectivePublicQuery.price_max ?? effectivePublicQuery.priceMax)),
-      );
-      const manifest = productsStreamRepo.safeReadManifest() || null;
-      const manifestCount = Number(manifest?.productCount);
-      const canUseManifestTotals = !hasActivePublicFilters && Number.isFinite(manifestCount) && manifestCount >= 0;
-      const totalItems = canUseManifestTotals ? manifestCount : null;
-      const totalPages = canUseManifestTotals ? Math.max(1, Math.ceil(manifestCount / pageSize)) : null;
-      const pageData = await getProductsEmergencyResponse({
-        endpoint: "/api/products",
+      const sqliteData = await productsSqliteRepo.queryProducts({
         page,
         pageSize,
-        shouldStop,
-        maxScanItems: null,
-        matchItem: buildCatalogStreamFilter(effectivePublicQuery),
-        mapItem: (product) => {
-          if (withWholesale) return normalizeProductImages(product);
-          return normalizeProductImages(sanitizePublicProducts([product])[0]);
-        },
-        warning,
-        ignoredSort,
-        totalItems,
-        totalPages,
+        search: queryParams.search || queryParams.q || "",
+        category: queryParams.category || "",
+        brand: queryParams.brand || "",
+        model: queryParams.model || "",
+        stock: queryParams.stock || "",
+        priceMax: queryParams.price_max ?? queryParams.priceMax,
+        sort: queryParams.sort || "",
       });
-      if (pageData === null) return;
+      const items = withWholesale
+        ? sqliteData.items.map((item) => normalizeProductImages(item))
+        : sqliteData.items.map((item) =>
+            normalizeProductImages(sanitizePublicProducts([item])[0]),
+          );
       const responsePayload = {
-        ...pageData,
-        usingFallback: storage.usingFallback,
-        source: path.basename(storage.productsFilePath || PRODUCTS_FILE_PATH),
+        ...sqliteData,
+        items,
+        source: "sqlite",
       };
-      logProductsServe("serve", {
-        endpoint: "/api/products",
-        productsFilePath: storage.productsFilePath,
-        exists: storage.exists,
-        productCount: storage.productCount,
-        page,
-        pageSize,
-        totalItems: pageData.totalItems,
-        usingFallback: storage.usingFallback,
-      });
+      const durationMs = Date.now() - startedAt;
+      console.log(
+        `[products-endpoint:respond] endpoint=/api/products source=sqlite items=${items.length} totalItems=${responsePayload.totalItems} totalPages=${responsePayload.totalPages} hasNextPage=${responsePayload.hasNextPage} durationMs=${durationMs}`,
+      );
       return sendJson(res, 200, responsePayload, {
         "Cache-Control": "no-store, no-cache, must-revalidate",
       });
     } catch (err) {
-      console.error("[products-endpoint:failed]", err?.stack || err);
-      const storage = await inspectProductsStorage();
-      logProductsServe("error", {
-        endpoint: "/api/products",
-        productsFilePath: storage.productsFilePath,
-        exists: storage.exists,
-        productCount: storage.productCount,
-        page: parsedUrl?.query?.page || 1,
-        pageSize: parsedUrl?.query?.pageSize || 24,
-        totalItems: 0,
-        usingFallback: storage.usingFallback,
-      });
-      console.error("products-public-read-error", err);
-      return sendJson(res, 500, {
-        error: "No se pudieron cargar los productos",
-      });
+      console.warn(`[products-db] unavailable fallback=streaming reason=${err?.message || err}`);
+      try {
+        const { page, pageSize } = parsePaginationParams(parsedUrl.query, {
+          page: 1,
+          pageSize: 24,
+          maxPageSize: 96,
+        });
+        const withWholesale = canSeeWholesalePrices(req);
+        const pageData = await getProductsEmergencyResponse({
+          endpoint: "/api/products",
+          page,
+          pageSize,
+          matchItem: buildCatalogStreamFilter(parsedUrl.query || {}),
+          mapItem: (product) =>
+            withWholesale
+              ? normalizeProductImages(product)
+              : normalizeProductImages(sanitizePublicProducts([product])[0]),
+        });
+        if (pageData === null) return;
+        return sendJson(res, 200, {
+          ...pageData,
+          source: "streaming_fallback",
+        });
+      } catch (fallbackError) {
+        console.error("products-public-read-error", fallbackError);
+        return sendJson(res, 500, {
+          error: "No se pudieron cargar los productos",
+        });
+      }
     }
   }
 
@@ -6239,67 +6253,58 @@ async function requestHandler(req, res) {
         pageSize: 100,
         maxPageSize: 250,
       });
-      const { storage } = await loadProductsStrict();
-      const { warning, ignoredSort, effectiveQuery } = resolveStreamingSortPolicy({
-        endpoint: "/api/admin/products",
-        query: parsedUrl.query || {},
-        storage,
-      });
-      const adminFilterMeta = getAdminFilterMeta(effectiveQuery || {});
-      console.info("[admin-products-filter]", adminFilterMeta);
-      const shouldStop = () =>
-        req.aborted || req.destroyed || res.destroyed || res.writableEnded;
-      const pageData = await getProductsEmergencyResponse({
-        endpoint: "/api/admin/products",
+      const queryParams = parsedUrl.query || {};
+      const startedAt = Date.now();
+      console.log(
+        `[products-endpoint:start] /api/admin/products page=${page} pageSize=${pageSize} source=sqlite`,
+      );
+      const sqliteData = await productsSqliteRepo.queryAdminProducts({
         page,
         pageSize,
-        shouldStop,
-        matchItem: buildAdminStreamFilter(effectiveQuery || {}),
-        mapItem: (product) => normalizeProductImages(product),
-        warning,
-        ignoredSort,
+        search: queryParams.search || queryParams.q || "",
+        category: queryParams.category || "",
+        brand: queryParams.brand || "",
+        visibility: queryParams.visibility || "",
+        status: queryParams.status || "",
+        stock: queryParams.stockStatus || queryParams.stock || "",
+        sort: queryParams.sort || "",
       });
-      if (pageData === null) return;
-      if (!adminFilterMeta.hasActiveFilters && Number(pageData.scannedCount || 0) > pageSize + 5) {
-        console.warn("[admin-products-filter-bug] no filters but scanned too many", {
-          scannedCount: pageData.scannedCount,
-          pageSize,
-          page,
-        });
-      }
       const responsePayload = {
-        ...pageData,
-        usingFallback: storage.usingFallback,
-        source: path.basename(storage.productsFilePath || PRODUCTS_FILE_PATH),
+        ...sqliteData,
+        items: sqliteData.items.map((item) => normalizeProductImages(item)),
+        source: "sqlite",
       };
-      logProductsServe("serve", {
-        endpoint: "/api/admin/products",
-        productsFilePath: storage.productsFilePath,
-        exists: storage.exists,
-        productCount: storage.productCount,
-        page,
-        pageSize,
-        totalItems: pageData.totalItems,
-        usingFallback: storage.usingFallback,
-      });
+      const durationMs = Date.now() - startedAt;
+      console.log(
+        `[products-endpoint:respond] endpoint=/api/admin/products source=sqlite items=${responsePayload.items.length} totalItems=${responsePayload.totalItems} totalPages=${responsePayload.totalPages} hasNextPage=${responsePayload.hasNextPage} durationMs=${durationMs}`,
+      );
       return sendJson(res, 200, responsePayload, {
         "Cache-Control": "no-store, no-cache, must-revalidate",
       });
     } catch (err) {
-      console.error("[products-endpoint:failed]", err?.stack || err);
-      const storage = await inspectProductsStorage();
-      logProductsServe("error", {
-        endpoint: "/api/admin/products",
-        productsFilePath: storage.productsFilePath,
-        exists: storage.exists,
-        productCount: storage.productCount,
-        page: parsedUrl?.query?.page || 1,
-        pageSize: parsedUrl?.query?.pageSize || 100,
-        totalItems: 0,
-        usingFallback: storage.usingFallback,
-      });
-      console.error("admin-products-list", err);
-      return sendJson(res, 500, { error: "No se pudieron cargar los productos del admin" });
+      console.warn(`[products-db] unavailable fallback=streaming reason=${err?.message || err}`);
+      try {
+        const { page, pageSize } = parsePaginationParams(parsedUrl.query, {
+          page: 1,
+          pageSize: 100,
+          maxPageSize: 250,
+        });
+        const pageData = await getProductsEmergencyResponse({
+          endpoint: "/api/admin/products",
+          page,
+          pageSize,
+          matchItem: buildAdminStreamFilter(parsedUrl.query || {}),
+          mapItem: (product) => normalizeProductImages(product),
+        });
+        if (pageData === null) return;
+        return sendJson(res, 200, {
+          ...pageData,
+          source: "streaming_fallback",
+        });
+      } catch (fallbackError) {
+        console.error("admin-products-list", fallbackError);
+        return sendJson(res, 500, { error: "No se pudieron cargar los productos del admin" });
+      }
     }
   }
 
@@ -6354,7 +6359,10 @@ async function requestHandler(req, res) {
   if (pathname.startsWith("/api/products/by-code/") && req.method === "GET") {
     const code = decodeURIComponent(pathname.split("/").pop() || "");
     try {
-      const product = await productsStreamRepo.getProductByCode(code);
+      let product = await productsSqliteRepo.getProductByCode(code);
+      if (!product) {
+        product = await productsStreamRepo.getProductByCode(code);
+      }
       if (!product) {
         return sendJson(res, 404, { error: "Producto no encontrado" });
       }
@@ -6380,7 +6388,10 @@ async function requestHandler(req, res) {
   if (pathname.startsWith("/api/products/") && req.method === "GET") {
     const id = decodeURIComponent(pathname.split("/").pop() || "");
     try {
-      const product = await productsStreamRepo.getProductById(id);
+      let product = await productsSqliteRepo.getProductById(id);
+      if (!product) {
+        product = await productsStreamRepo.getProductById(id);
+      }
       if (!product || !isProductPublic(product)) {
         return sendJson(res, 404, { error: "Producto no encontrado" });
       }
@@ -6768,6 +6779,17 @@ async function requestHandler(req, res) {
         .trim()
         .toLowerCase(),
     );
+    const incrementalRequested = ["1", "true", "yes", "si"].includes(
+      String(parsedUrl.query.incremental || "").trim().toLowerCase(),
+    );
+    if (incrementalRequested) {
+      return sendJson(res, 503, {
+        ok: false,
+        code: "INCREMENTAL_IMPORT_NOT_SUPPORTED_FOR_LARGE_CATALOG",
+        error:
+          "La importación incremental requiere merge streaming o SQLite. Usá reemplazo completo o implementá merge SQLite.",
+      });
+    }
 
     stockXlsxUpload.single("file")(req, res, async (err) => {
       if (err) {
@@ -11868,8 +11890,15 @@ function createServer() {
 module.exports = { createServer };
 
 if (require.main === module) {
-  const server = createServer();
-  server.listen(APP_PORT, () => {
-    console.log(`Servidor de NERIN corriendo en http://localhost:${APP_PORT}`);
-  });
+  (async () => {
+    try {
+      await productsSqliteRepo.ensureProductsDb();
+    } catch (error) {
+      console.warn(`[products-db] unavailable fallback=streaming reason=${error?.message || error}`);
+    }
+    const server = createServer();
+    server.listen(APP_PORT, () => {
+      console.log(`Servidor de NERIN corriendo en http://localhost:${APP_PORT}`);
+    });
+  })();
 }

--- a/nerin_final_updated/backend/services/stockXlsxImport.js
+++ b/nerin_final_updated/backend/services/stockXlsxImport.js
@@ -3,6 +3,7 @@ const path = require("path");
 const XLSX = require("xlsx");
 const { DATA_DIR } = require("../utils/dataDir");
 const { readJsonFile } = require("../utils/jsonFile");
+const productsSqliteRepo = require("../data/productsSqliteRepo");
 const LARGE_CATALOG_THRESHOLD_BYTES = 20 * 1024 * 1024;
 
 const REQUIRED_COLUMNS = ["Article number", "Quantity in stock (NL)"];
@@ -226,8 +227,10 @@ async function importStockXlsxFile({
   onProgress = null,
   progressEveryRows = 250,
 }) {
+  console.log("[products-import:start]");
   const summary = createBaseSummary();
   const { rows, articleIndex, stockIndex } = readWorksheet(filePath, "Price list");
+  console.log(`[products-import:parsed] rows=${Math.max(0, rows.length - 1)} products=${Math.max(0, rows.length - 1)}`);
   const persistence = await buildJsonPersistenceLayer();
 
   const updates = [];
@@ -308,8 +311,11 @@ async function importStockXlsxFile({
   }
 
   await persistence.finalize();
+  console.log("[products-import:json-written]");
+  await productsSqliteRepo.rebuildProductsDbFromJson();
   processedRows = summary.totalRows;
   notifyProgress();
+  console.log("[products-import:done]");
   return summary;
 }
 

--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -3378,8 +3378,10 @@ function updateProductsPaginationControls() {
     const totalText = productsTotalPages
       ? `Página ${productsPage} de ${productsTotalPages}`
       : `Página ${productsPage} · total no calculado`;
+    const totalItemsText =
+      productsTotalItems == null ? "total desconocido" : `total ${productsTotalItems} productos`;
     adminProductsPageInfo.textContent =
-      `${totalText} · ${productsCache.length} productos en esta página`;
+      `${totalText} · ${productsCache.length} productos en esta página · ${totalItemsText}`;
   }
 }
 

--- a/nerin_final_updated/frontend/js/shop.js
+++ b/nerin_final_updated/frontend/js/shop.js
@@ -563,42 +563,6 @@ function createProductCard(product) {
   return card;
 }
 
-function computeRelevance(product, searchTerm) {
-  if (!searchTerm) return 0;
-  const term = searchTerm.toLowerCase();
-  const fields = [
-    product.name,
-    product.sku,
-    getCatalogBrand(product),
-    getCatalogModel(product),
-    getPartLabel(product),
-  ];
-  return fields.reduce((score, field) => {
-    if (typeof field !== "string") return score;
-    const normalized = field.toLowerCase();
-    if (normalized === term) return score + 8;
-    if (normalized.startsWith(term)) return score + 4;
-    if (normalized.includes(term)) return score + 2;
-    return score;
-  }, 0);
-}
-
-function sortProducts(products, sortMode, searchTerm) {
-  const copy = [...products];
-  const getPrice = (product) => resolveDisplayPrice(product).active;
-  const getStock = (product) => Number(product.stock) || 0;
-  switch (sortMode) {
-    case "price-asc":
-      return copy.sort((a, b) => getPrice(a) - getPrice(b));
-    case "price-desc":
-      return copy.sort((a, b) => getPrice(b) - getPrice(a));
-    case "stock-desc":
-      return copy.sort((a, b) => getStock(b) - getStock(a));
-    default:
-      return copy.sort((a, b) => computeRelevance(b, searchTerm) - computeRelevance(a, searchTerm));
-  }
-}
-
 function updateResultSummary({ displayedCount = 0, totalCount = 0, hasKnownTotal = false } = {}) {
   if (!resultCountEl) return;
   const parent = resultCountEl.parentElement;
@@ -607,10 +571,10 @@ function updateResultSummary({ displayedCount = 0, totalCount = 0, hasKnownTotal
     return;
   }
   if (hasKnownTotal) {
-    resultCountEl.textContent = String(totalCount);
+    resultCountEl.textContent = `${displayedCount} de ${totalCount}`;
     parent.textContent = "";
     parent.appendChild(resultCountEl);
-    parent.append(" coincidencias encontradas.");
+    parent.append(" productos.");
     return;
   }
   resultCountEl.textContent = String(displayedCount);
@@ -670,6 +634,23 @@ function getCurrentFilters() {
   const priceMax = Number(priceRange?.max) || 0;
   const priceActive = priceFilterTouched && priceMax > 0 && price < priceMax;
   return { search, brand, model, category, stock, sort, price, priceActive };
+}
+
+function mapSortForBackend(sortValue) {
+  const sortMap = {
+    price_asc: "price_asc",
+    price_desc: "price_desc",
+    name_asc: "name_asc",
+    name_desc: "name_desc",
+    stock_desc: "stock_desc",
+    stock_asc: "stock_asc",
+    "price-asc": "price_asc",
+    "price-desc": "price_desc",
+    "stock-desc": "stock_desc",
+    "stock-asc": "stock_asc",
+    name: "name_asc",
+  };
+  return sortMap[String(sortValue || "").trim()] || "";
 }
 
 function scrollToCatalogTop() {
@@ -784,8 +765,14 @@ async function renderProducts({ page = currentProductsPage, scrollToTop = false 
     model: filters.model,
     stock: filters.stock,
     price_max: filters.priceActive ? filters.price : "",
-    sort: filters.sort,
+    sort: mapSortForBackend(filters.sort),
   };
+  console.info("[shop-products] load", {
+    page: currentProductsPage,
+    pageSize: productsPageSize,
+    search: filters.search,
+    sort: requestParams.sort || "",
+  });
   shopLog("loadProducts:start", { requestId, requestParams });
   if (productsAbortController) {
     productsAbortController.abort();
@@ -832,6 +819,9 @@ async function renderProducts({ page = currentProductsPage, scrollToTop = false 
   } else if (hasRealCatalogResponse) {
     shopLog("response:ignored-fallback-after-real", { requestId });
     return;
+  }
+  if (response?.source !== "sqlite") {
+    console.warn("[shop-products] backend did not use sqlite", response?.source);
   }
 
   const normalizedItems = (response.items || [])
@@ -882,6 +872,13 @@ async function renderProducts({ page = currentProductsPage, scrollToTop = false 
     displayedCount: allProducts.length,
     totalCount: totalFilteredItems,
     hasKnownTotal: publicProductsTotalItems !== null,
+  });
+  console.info("[shop-products] loaded", {
+    page: currentProductsPage,
+    items: allProducts.length,
+    totalItems: publicProductsTotalItems,
+    totalPages: publicProductsTotalPages,
+    source: response?.source || null,
   });
   updateActiveFilters(filters);
   syncQueryParams(filters);

--- a/nerin_final_updated/frontend/shop.html
+++ b/nerin_final_updated/frontend/shop.html
@@ -254,9 +254,12 @@
               <label for="sortSelect" class="visually-hidden">Ordenar</label>
               <select id="sortSelect">
                 <option value="relevance">Orden recomendado</option>
-                <option value="price-asc">Precio: menor a mayor</option>
-                <option value="price-desc">Precio: mayor a menor</option>
-                <option value="stock-desc">Stock: mayor disponibilidad</option>
+                <option value="price_asc">Precio: menor a mayor</option>
+                <option value="price_desc">Precio: mayor a menor</option>
+                <option value="name_asc">Nombre: A → Z</option>
+                <option value="name_desc">Nombre: Z → A</option>
+                <option value="stock_desc">Stock: mayor disponibilidad</option>
+                <option value="stock_asc">Stock: menor disponibilidad</option>
               </select>
             </div>
           </div>

--- a/nerin_final_updated/package.json
+++ b/nerin_final_updated/package.json
@@ -27,10 +27,11 @@
     "pg": "^8.13.0",
     "resend": "^4.7.0",
     "sharp": "^0.33.3",
-    "yaml": "^2.6.0",
-    "xlsx": "^0.18.5",
+    "sqlite3": "^5.1.7",
     "stream-chain": "^2.2.5",
-    "stream-json": "^1.9.1"
+    "stream-json": "^1.9.1",
+    "xlsx": "^0.18.5",
+    "yaml": "^2.6.0"
   },
   "devDependencies": {
     "jest": "^30.0.5",

--- a/nerin_final_updated/scripts/rebuild-products-db.js
+++ b/nerin_final_updated/scripts/rebuild-products-db.js
@@ -1,0 +1,17 @@
+const productsSqliteRepo = require("../backend/data/productsSqliteRepo");
+
+async function main() {
+  const startedAt = Date.now();
+  await productsSqliteRepo.rebuildProductsDbFromJson();
+  const manifest = await productsSqliteRepo.getManifestFromDb();
+  console.log("[rebuild-products-db] ok", {
+    durationMs: Date.now() - startedAt,
+    productCount: manifest?.productCount ?? null,
+    sqlitePath: manifest?.sqlitePath || productsSqliteRepo.SQLITE_PATH,
+  });
+}
+
+main().catch((error) => {
+  console.error("[rebuild-products-db] failed", error?.message || error);
+  process.exit(1);
+});

--- a/nerin_final_updated/scripts/test-products-sqlite-query.js
+++ b/nerin_final_updated/scripts/test-products-sqlite-query.js
@@ -1,0 +1,68 @@
+const productsSqliteRepo = require("../backend/data/productsSqliteRepo");
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+async function timed(label, fn) {
+  const startedAt = Date.now();
+  const result = await fn();
+  const durationMs = Date.now() - startedAt;
+  console.log(`[test-products-sqlite-query] ${label} durationMs=${durationMs}`);
+  return { result, durationMs };
+}
+
+async function main() {
+  await productsSqliteRepo.ensureProductsDb();
+
+  const publicPage1 = await timed("public page=1", () =>
+    productsSqliteRepo.queryProducts({ page: 1, pageSize: 24 }),
+  );
+  assert(publicPage1.result.source === "sqlite", "public page 1 source must be sqlite");
+  assert(publicPage1.result.totalItems > 0, "public totalItems must be > 0");
+
+  const publicPage2 = await timed("public page=2", () =>
+    productsSqliteRepo.queryProducts({ page: 2, pageSize: 24 }),
+  );
+  assert(publicPage2.result.page === 2, "public page 2 must return page=2");
+
+  const firstPublic = publicPage1.result.items[0] || null;
+  const searchTerm = String(firstPublic?.brand || firstPublic?.name || "").split(" ")[0].trim();
+  if (searchTerm) {
+    const searched = await timed(`public search=${searchTerm}`, () =>
+      productsSqliteRepo.queryProducts({ page: 1, pageSize: 24, search: searchTerm }),
+    );
+    assert(Array.isArray(searched.result.items), "public search must return items array");
+  }
+
+  const adminPage1 = await timed("admin page=1", () =>
+    productsSqliteRepo.queryAdminProducts({ page: 1, pageSize: 100 }),
+  );
+  assert(adminPage1.result.source === "sqlite", "admin page source must be sqlite");
+
+  const adminSearchTerm =
+    String(adminPage1.result.items[0]?.sku || adminPage1.result.items[0]?.name || "")
+      .split(" ")[0]
+      .trim();
+  if (adminSearchTerm) {
+    const adminSearch = await timed(`admin search=${adminSearchTerm}`, () =>
+      productsSqliteRepo.queryAdminProducts({ page: 1, pageSize: 100, search: adminSearchTerm }),
+    );
+    assert(adminSearch.result.totalItems >= 1, "admin search should find at least one result");
+  }
+
+  const slugCandidate = adminPage1.result.items.find((item) => item?.slug);
+  if (slugCandidate?.slug) {
+    const bySlug = await timed(`getBySlug=${slugCandidate.slug}`, () =>
+      productsSqliteRepo.getProductBySlug(slugCandidate.slug),
+    );
+    assert(bySlug.result != null, "getProductBySlug should return product for known slug");
+  }
+
+  console.log("[test-products-sqlite-query] ok");
+}
+
+main().catch((error) => {
+  console.error("[test-products-sqlite-query] failed", error?.message || error);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation
- Provide a fast, queryable products catalog optimized for large catalogs by building a local SQLite database with optional FTS index from `products.json`.
- Use SQLite as the primary source for public and admin product queries while keeping a streaming fallback for environments without SQLite support.
- Integrate import workflow so stock XLSX imports update the underlying SQLite catalog and expose a health endpoint for catalog readiness.

### Description
- Added a new repository `backend/data/productsSqliteRepo.js` that manages SQLite lifecycle, schema, FTS detection, manifest, mapping of product JSON to normalized rows, queries (`queryProducts`, `queryAdminProducts`) and single-item lookups (`getProductById`, `getProductBySlug`, `getProductByCode`).
- The server now attempts to ensure and use the SQLite catalog on startup and in product endpoints; added `/api/catalog/health` to report manifest and SQLite state, and integrated fallback to streaming when SQLite is unavailable.
- Replaced previous streaming-only product listing logic for `/api/products` and `/api/admin/products` with calls to the SQLite repo and preserved a streaming fallback path on error.
- Lookups by code and id now try SQLite first and fall back to `productsStreamRepo` if needed.
- After XLSX stock imports, the import flow now triggers a full rebuild of the SQLite DB via `rebuildProductsDbFromJson` to keep SQLite in sync.
- Frontend changes: updated public sorting UI and mapping (`shop.html`, `shop.js`) to match backend sort keys, improved result summary wording, added logging for product loads, and improved admin pagination info in `frontend/js/admin.js`.
- Added scripts: `scripts/rebuild-products-db.js` and `scripts/test-products-sqlite-query.js` to build and validate the SQLite catalog, and added `sqlite3` to `package.json` dependencies.

### Testing
- Ran the rebuild script `node scripts/rebuild-products-db.js` to generate the SQLite file from `products.json`, which completed successfully and produced a manifest.
- Executed the validation script `node scripts/test-products-sqlite-query.js` against the generated DB, which exercised pagination, searching and lookups and passed its assertions.
- Ran the existing automated test suite with `npm test` (Jest) and observed no regressions in the unit tests after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efb17e4acc833195af9f6ce2c8a988)