### PR TITLE
Fix SQLite catalog bottlenecks: guard rebuilds, block heavy fallbacks and stabilize public catalog

### DIFF
--- a/nerin_final_updated/backend/data/productsSqliteRepo.js
+++ b/nerin_final_updated/backend/data/productsSqliteRepo.js
@@ -8,6 +8,7 @@ const { dataPath } = require("../utils/dataDir");
 const PRODUCTS_JSON_PATH = dataPath("products.json");
 const SQLITE_PATH = dataPath("products.sqlite");
 const MANIFEST_PATH = dataPath("products.manifest.json");
+const COUNT_CACHE_TTL_MS = 60_000;
 
 const REJECTED_STATE_VALUES = new Set([
   "hidden",
@@ -22,7 +23,10 @@ const PUBLIC_DESCRIPTION_FALLBACK =
 
 let dbInstance = null;
 let ftsEnabled = false;
-let ensuringPromise = null;
+let dbReadyPromise = null;
+let dbReady = false;
+let rebuildPromise = null;
+const countCache = new Map();
 
 function normalizeQueryText(value) {
   const text = String(value || "")
@@ -54,11 +58,22 @@ function toNumber(value, fallback = 0) {
   return Number.isFinite(parsed) ? parsed : fallback;
 }
 
+function logBusyIfNeeded(error) {
+  const message = String(error?.message || error || "");
+  if (/busy|locked/i.test(message)) {
+    console.warn("[products-db] sqlite busy/locked");
+  }
+}
+
 function run(db, sql, params = []) {
   return new Promise((resolve, reject) => {
     db.run(sql, params, function onRun(error) {
-      if (error) reject(error);
-      else resolve(this);
+      if (error) {
+        logBusyIfNeeded(error);
+        reject(error);
+      } else {
+        resolve(this);
+      }
     });
   });
 }
@@ -66,8 +81,12 @@ function run(db, sql, params = []) {
 function get(db, sql, params = []) {
   return new Promise((resolve, reject) => {
     db.get(sql, params, (error, row) => {
-      if (error) reject(error);
-      else resolve(row || null);
+      if (error) {
+        logBusyIfNeeded(error);
+        reject(error);
+      } else {
+        resolve(row || null);
+      }
     });
   });
 }
@@ -75,8 +94,12 @@ function get(db, sql, params = []) {
 function all(db, sql, params = []) {
   return new Promise((resolve, reject) => {
     db.all(sql, params, (error, rows) => {
-      if (error) reject(error);
-      else resolve(Array.isArray(rows) ? rows : []);
+      if (error) {
+        logBusyIfNeeded(error);
+        reject(error);
+      } else {
+        resolve(Array.isArray(rows) ? rows : []);
+      }
     });
   });
 }
@@ -104,6 +127,7 @@ async function openDb() {
   });
   await run(dbInstance, "PRAGMA journal_mode = WAL");
   await run(dbInstance, "PRAGMA synchronous = NORMAL");
+  await run(dbInstance, "PRAGMA busy_timeout = 5000");
   await run(dbInstance, "PRAGMA temp_store = MEMORY");
   return dbInstance;
 }
@@ -129,11 +153,17 @@ async function createSchema(db) {
       code TEXT,
       slug TEXT,
       public_slug TEXT,
+      image TEXT,
       name TEXT,
       title TEXT,
       brand TEXT,
       model TEXT,
       category TEXT,
+      part_number TEXT,
+      mpn TEXT,
+      ean TEXT,
+      gtin TEXT,
+      supplier_code TEXT,
       status TEXT,
       visibility TEXT,
       stock INTEGER,
@@ -152,8 +182,19 @@ async function createSchema(db) {
 
   const columns = await all(db, "PRAGMA table_info(products)");
   const columnSet = new Set(columns.map((col) => String(col?.name || "").toLowerCase()));
-  if (!columnSet.has("public_slug")) {
-    await run(db, "ALTER TABLE products ADD COLUMN public_slug TEXT");
+  const optionalColumns = [
+    "public_slug",
+    "image",
+    "part_number",
+    "mpn",
+    "ean",
+    "gtin",
+    "supplier_code",
+  ];
+  for (const col of optionalColumns) {
+    if (!columnSet.has(col)) {
+      await run(db, `ALTER TABLE products ADD COLUMN ${col} TEXT`);
+    }
   }
 
   const indexSql = [
@@ -162,6 +203,11 @@ async function createSchema(db) {
     "CREATE INDEX IF NOT EXISTS idx_products_code ON products(code)",
     "CREATE INDEX IF NOT EXISTS idx_products_slug ON products(slug)",
     "CREATE INDEX IF NOT EXISTS idx_products_public_slug ON products(public_slug)",
+    "CREATE INDEX IF NOT EXISTS idx_products_part_number ON products(part_number)",
+    "CREATE INDEX IF NOT EXISTS idx_products_mpn ON products(mpn)",
+    "CREATE INDEX IF NOT EXISTS idx_products_ean ON products(ean)",
+    "CREATE INDEX IF NOT EXISTS idx_products_gtin ON products(gtin)",
+    "CREATE INDEX IF NOT EXISTS idx_products_supplier_code ON products(supplier_code)",
     "CREATE INDEX IF NOT EXISTS idx_products_brand ON products(brand)",
     "CREATE INDEX IF NOT EXISTS idx_products_category ON products(category)",
     "CREATE INDEX IF NOT EXISTS idx_products_is_public ON products(is_public)",
@@ -251,6 +297,14 @@ function slugifyValue(value) {
     .replace(/^-+|-+$/g, "");
 }
 
+function firstText(values = []) {
+  for (const value of values) {
+    const parsed = toNullableText(value);
+    if (parsed) return parsed;
+  }
+  return null;
+}
+
 function getProductIdentifier(product = {}, fallbackRow = null) {
   const candidates = [
     product.id,
@@ -285,9 +339,7 @@ function mapProductRow(product = {}, options = {}) {
   if (slugCounts instanceof Map) {
     const current = Number(slugCounts.get(publicSlug) || 0) + 1;
     slugCounts.set(publicSlug, current);
-    if (current > 1) {
-      publicSlug = `${publicSlug}-${current}`;
-    }
+    if (current > 1) publicSlug = `${publicSlug}-${current}`;
   }
   const price = toNumber(product.price_minorista ?? product.price, 0);
   const stock = Math.trunc(toNumber(product.stock, 0));
@@ -297,11 +349,23 @@ function mapProductRow(product = {}, options = {}) {
     code: toNullableText(product.code),
     slug: toNullableText(product.slug),
     public_slug: publicSlug,
+    image: firstText([
+      product.image,
+      product.image_url,
+      product.thumbnail,
+      product.picture,
+      Array.isArray(product.images) ? product.images[0] : null,
+    ]),
     name: toNullableText(product.name),
     title: toNullableText(product.title),
     brand: normalizeQueryText(toNullableText(product.brand)),
     model: normalizeQueryText(toNullableText(product.model)),
     category: normalizeQueryText(toNullableText(product.category)),
+    part_number: toNullableText(product.partNumber),
+    mpn: toNullableText(product.mpn),
+    ean: toNullableText(product.ean),
+    gtin: toNullableText(product.gtin),
+    supplier_code: toNullableText(product.supplierCode),
     status: normalizeQueryText(toNullableText(product.status)),
     visibility: normalizeQueryText(toNullableText(product.visibility)),
     stock,
@@ -316,14 +380,6 @@ function mapProductRow(product = {}, options = {}) {
     search_text: buildSearchText(product),
     raw_json: JSON.stringify(product),
   };
-}
-
-function firstText(values = []) {
-  for (const value of values) {
-    const parsed = toNullableText(value);
-    if (parsed) return parsed;
-  }
-  return null;
 }
 
 function parseImageLikeField(value) {
@@ -426,186 +482,235 @@ function parseRawItems(rows = [], options = {}) {
     .filter(Boolean);
 }
 
-async function rebuildProductsDbFromJson() {
-  const startedAt = Date.now();
-  const db = await openDb();
-  const productsStats = await fsp.stat(PRODUCTS_JSON_PATH);
-  const tmpDbPath = `${SQLITE_PATH}.tmp-${process.pid}-${Date.now()}`;
-
-  console.log(`[products-db] rebuild start productsFilePath=${PRODUCTS_JSON_PATH}`);
-
-  const tmpDb = await new Promise((resolve, reject) => {
-    const conn = new sqlite3.Database(tmpDbPath, (error) => {
-      if (error) reject(error);
-      else resolve(conn);
-    });
-  });
-
-  try {
-    await run(tmpDb, "PRAGMA journal_mode = OFF");
-    await run(tmpDb, "PRAGMA synchronous = OFF");
-    await run(tmpDb, "PRAGMA temp_store = MEMORY");
-    await createSchema(tmpDb);
-    const insertSql = `INSERT INTO products (
-      id, sku, code, slug, public_slug, name, title, brand, model, category, status, visibility,
-      stock, price, currency, is_public, enabled, deleted, archived, vip_only, wholesale_only,
-      search_text, raw_json
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
-
-    let count = 0;
-    const slugCounts = new Map();
-    const batch = [];
-    const BATCH_SIZE = 500;
-
-    const flush = async () => {
-      if (!batch.length) return;
-      await withTransaction(tmpDb, async () => {
-        for (const item of batch) {
-          await run(tmpDb, insertSql, [
-            item.id,
-            item.sku,
-            item.code,
-            item.slug,
-            item.public_slug,
-            item.name,
-            item.title,
-            item.brand,
-            item.model,
-            item.category,
-            item.status,
-            item.visibility,
-            item.stock,
-            item.price,
-            item.currency,
-            item.is_public,
-            item.enabled,
-            item.deleted,
-            item.archived,
-            item.vip_only,
-            item.wholesale_only,
-            item.search_text,
-            item.raw_json,
-          ]);
-        }
-      });
-      batch.length = 0;
-    };
-
-    await productsStreamRepo.streamProducts({
-      filePath: PRODUCTS_JSON_PATH,
-      onProduct: async (product) => {
-        batch.push(mapProductRow(product, { rowNumber: count + 1, slugCounts }));
-        count += 1;
-        if (count % 5000 === 0) {
-          console.log(`[products-db] rebuild progress count=${count}`);
-        }
-        if (batch.length >= BATCH_SIZE) {
-          await flush();
-        }
-        return true;
-      },
-    });
-
-    await flush();
-
-    if (ftsEnabled) {
-      await run(tmpDb, "DELETE FROM products_fts");
-      await run(
-        tmpDb,
-        `INSERT INTO products_fts(rowid, id, sku, code, slug, name, title, brand, model, category, search_text)
-         SELECT rowid, id, sku, code, slug, name, title, brand, model, category, search_text FROM products`,
-      );
-    }
-
-    const manifest = {
-      productCount: count,
-      productsJsonSizeBytes: Number(productsStats.size || 0),
-      productsJsonMtimeMs: Number(productsStats.mtimeMs || 0),
-      sqliteBuiltAt: new Date().toISOString(),
-      sqlitePath: SQLITE_PATH,
-      sqliteFtsEnabled: ftsEnabled,
-    };
-
-    await fsp.writeFile(MANIFEST_PATH, JSON.stringify(manifest, null, 2), "utf8");
-
-    await new Promise((resolve, reject) => {
-      tmpDb.close((error) => {
-        if (error) reject(error);
-        else resolve();
-      });
-    });
-
-    if (fs.existsSync(SQLITE_PATH)) {
-      await fsp.unlink(SQLITE_PATH);
-    }
-    await fsp.rename(tmpDbPath, SQLITE_PATH);
-
-    if (dbInstance) {
-      await new Promise((resolve) => {
-        dbInstance.close(() => resolve());
-      });
-      dbInstance = null;
-    }
-
-    const durationMs = Date.now() - startedAt;
-    console.log(`[products-db] rebuild done count=${count} durationMs=${durationMs}`);
-    return manifest;
-  } catch (error) {
-    try {
-      await new Promise((resolve) => {
-        tmpDb.close(() => resolve());
-      });
-    } catch {}
-    try {
-      if (fs.existsSync(tmpDbPath)) await fsp.unlink(tmpDbPath);
-    } catch {}
-    throw error;
-  }
+function buildCatalogPathsInfo() {
+  const renderDiskMountPath = (process.env.RENDER_DISK_MOUNT_PATH || "").trim() || null;
+  return {
+    DATA_DIR: path.dirname(SQLITE_PATH),
+    dbPath: SQLITE_PATH,
+    productsFilePath: PRODUCTS_JSON_PATH,
+    renderDiskMountPath,
+    dbExists: fs.existsSync(SQLITE_PATH),
+    manifestExists: fs.existsSync(MANIFEST_PATH),
+  };
 }
 
-async function ensureProductsDb() {
-  if (ensuringPromise) return ensuringPromise;
-  ensuringPromise = (async () => {
-    console.log("[products-db] checking sqlite catalog");
-    const productsStats = await fsp.stat(PRODUCTS_JSON_PATH);
-    let manifest = null;
-    try {
-      manifest = JSON.parse(await fsp.readFile(MANIFEST_PATH, "utf8"));
-    } catch {
-      manifest = null;
-    }
+function createInitializingError(reason = "sqlite_not_ready") {
+  const error = new Error("Catálogo rápido inicializando");
+  error.code = "CATALOG_INITIALIZING";
+  error.reason = reason;
+  return error;
+}
 
-    let reason = "";
-    if (!fs.existsSync(SQLITE_PATH)) {
-      reason = "sqlite_missing";
-    } else if (!manifest) {
-      reason = "manifest_missing";
-    } else if (Number(manifest.productsJsonSizeBytes || -1) !== Number(productsStats.size || 0)) {
-      reason = "products_json_size_changed";
-    } else if (Math.floor(Number(manifest.productsJsonMtimeMs || -1)) !== Math.floor(Number(productsStats.mtimeMs || 0))) {
-      reason = "products_json_mtime_changed";
-    }
-
-    if (reason) {
-      console.log(`[products-db] rebuild required reason=${reason}`);
-      await rebuildProductsDbFromJson();
-    }
-
+async function rebuildProductsDbFromJson() {
+  if (rebuildPromise) {
+    console.log("[products-db] rebuild already in progress; waiting");
+    return rebuildPromise;
+  }
+  rebuildPromise = (async () => {
+    const startedAt = Date.now();
     const db = await openDb();
-    await createSchema(db);
-    console.log(`[products-db] ready dbPath=${SQLITE_PATH}`);
-    return {
-      dbPath: SQLITE_PATH,
-      manifest: await getManifestFromDb(),
-      ftsEnabled,
-    };
+    const productsStats = await fsp.stat(PRODUCTS_JSON_PATH);
+    const tmpDbPath = `${SQLITE_PATH}.tmp-${process.pid}-${Date.now()}`;
+
+    console.log(`[products-db] rebuild start productsFilePath=${PRODUCTS_JSON_PATH}`);
+
+    const tmpDb = await new Promise((resolve, reject) => {
+      const conn = new sqlite3.Database(tmpDbPath, (error) => {
+        if (error) reject(error);
+        else resolve(conn);
+      });
+    });
+
+    try {
+      await run(tmpDb, "PRAGMA journal_mode = OFF");
+      await run(tmpDb, "PRAGMA synchronous = OFF");
+      await run(tmpDb, "PRAGMA temp_store = MEMORY");
+      await createSchema(tmpDb);
+      const insertSql = `INSERT INTO products (
+        id, sku, code, slug, public_slug, image, name, title, brand, model, category,
+        part_number, mpn, ean, gtin, supplier_code, status, visibility,
+        stock, price, currency, is_public, enabled, deleted, archived, vip_only, wholesale_only,
+        search_text, raw_json
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
+
+      let count = 0;
+      const slugCounts = new Map();
+      const batch = [];
+      const BATCH_SIZE = 500;
+
+      const flush = async () => {
+        if (!batch.length) return;
+        await withTransaction(tmpDb, async () => {
+          for (const item of batch) {
+            await run(tmpDb, insertSql, [
+              item.id,
+              item.sku,
+              item.code,
+              item.slug,
+              item.public_slug,
+              item.image,
+              item.name,
+              item.title,
+              item.brand,
+              item.model,
+              item.category,
+              item.part_number,
+              item.mpn,
+              item.ean,
+              item.gtin,
+              item.supplier_code,
+              item.status,
+              item.visibility,
+              item.stock,
+              item.price,
+              item.currency,
+              item.is_public,
+              item.enabled,
+              item.deleted,
+              item.archived,
+              item.vip_only,
+              item.wholesale_only,
+              item.search_text,
+              item.raw_json,
+            ]);
+          }
+        });
+        batch.length = 0;
+      };
+
+      await productsStreamRepo.streamProducts({
+        filePath: PRODUCTS_JSON_PATH,
+        onProduct: async (product) => {
+          batch.push(mapProductRow(product, { rowNumber: count + 1, slugCounts }));
+          count += 1;
+          if (count % 5000 === 0) {
+            console.log(`[products-db] rebuild progress count=${count}`);
+          }
+          if (batch.length >= BATCH_SIZE) {
+            await flush();
+          }
+          return true;
+        },
+      });
+
+      await flush();
+
+      if (ftsEnabled) {
+        await run(tmpDb, "DELETE FROM products_fts");
+        await run(
+          tmpDb,
+          `INSERT INTO products_fts(rowid, id, sku, code, slug, name, title, brand, model, category, search_text)
+          SELECT rowid, id, sku, code, slug, name, title, brand, model, category, search_text FROM products`,
+        );
+      }
+
+      const manifest = {
+        productCount: count,
+        productsJsonSizeBytes: Number(productsStats.size || 0),
+        productsJsonMtimeMs: Number(productsStats.mtimeMs || 0),
+        sqliteBuiltAt: new Date().toISOString(),
+        sqlitePath: SQLITE_PATH,
+        sqliteFtsEnabled: ftsEnabled,
+      };
+
+      await fsp.writeFile(MANIFEST_PATH, JSON.stringify(manifest, null, 2), "utf8");
+
+      await new Promise((resolve, reject) => {
+        tmpDb.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+
+      if (fs.existsSync(SQLITE_PATH)) await fsp.unlink(SQLITE_PATH);
+      await fsp.rename(tmpDbPath, SQLITE_PATH);
+
+      if (dbInstance) {
+        await new Promise((resolve) => dbInstance.close(() => resolve()));
+        dbInstance = null;
+      }
+
+      const durationMs = Date.now() - startedAt;
+      console.log(`[products-db] rebuild done count=${count} durationMs=${durationMs}`);
+      countCache.clear();
+      dbReady = true;
+      return manifest;
+    } catch (error) {
+      try {
+        await new Promise((resolve) => tmpDb.close(() => resolve()));
+      } catch {}
+      try {
+        if (fs.existsSync(tmpDbPath)) await fsp.unlink(tmpDbPath);
+      } catch {}
+      throw error;
+    }
   })();
 
   try {
-    return await ensuringPromise;
+    return await rebuildPromise;
   } finally {
-    ensuringPromise = null;
+    rebuildPromise = null;
   }
+}
+
+async function ensureProductsDb({ allowRebuild = true } = {}) {
+  console.log("[products-db] paths", buildCatalogPathsInfo());
+  console.log("[products-db] ensure start");
+  const productsStats = await fsp.stat(PRODUCTS_JSON_PATH);
+  let manifest = null;
+  try {
+    manifest = JSON.parse(await fsp.readFile(MANIFEST_PATH, "utf8"));
+  } catch {
+    manifest = null;
+  }
+
+  let reason = "";
+  if (!fs.existsSync(SQLITE_PATH)) {
+    reason = "sqlite_missing";
+  } else if (!manifest) {
+    reason = "manifest_missing";
+  } else if (Number(manifest.productsJsonSizeBytes || -1) !== Number(productsStats.size || 0)) {
+    reason = "products_json_size_changed";
+  } else if (
+    Math.floor(Number(manifest.productsJsonMtimeMs || -1)) !==
+    Math.floor(Number(productsStats.mtimeMs || 0))
+  ) {
+    reason = "products_json_mtime_changed";
+  }
+
+  if (reason) {
+    console.log(`[products-db] rebuild required reason=${reason}`);
+    if (!allowRebuild) throw createInitializingError(reason);
+    await rebuildProductsDbFromJson();
+  } else {
+    console.log("[products-db] already fresh");
+  }
+
+  const db = await openDb();
+  await createSchema(db);
+  dbReady = true;
+  return {
+    dbPath: SQLITE_PATH,
+    manifest: await getManifestFromDb(),
+    ftsEnabled,
+  };
+}
+
+async function ensureProductsDbOnce() {
+  if (dbReady) return { dbPath: SQLITE_PATH, source: "sqlite", ready: true };
+  if (dbReadyPromise) return dbReadyPromise;
+  dbReadyPromise = ensureProductsDb({ allowRebuild: true });
+  try {
+    return await dbReadyPromise;
+  } finally {
+    dbReadyPromise = null;
+  }
+}
+
+async function ensureDbReadyForRequest() {
+  if (dbReady) return;
+  if (dbReadyPromise) throw createInitializingError("sqlite_bootstrap_in_progress");
+  await ensureProductsDb({ allowRebuild: false });
 }
 
 function buildSort(sort) {
@@ -624,7 +729,17 @@ function buildSort(sort) {
   return allowedSorts[String(sort || "").trim().toLowerCase()] || "rowid ASC";
 }
 
-async function buildWhereClause({ search = "", isPublicOnly = false, category = "", brand = "", model = "", visibility = "", status = "", stock = "", priceMax = null } = {}) {
+function buildWhereClause({
+  search = "",
+  isPublicOnly = false,
+  category = "",
+  brand = "",
+  model = "",
+  visibility = "",
+  status = "",
+  stock = "",
+  priceMax = null,
+} = {}) {
   const where = [];
   const params = [];
 
@@ -669,7 +784,7 @@ async function buildWhereClause({ search = "", isPublicOnly = false, category = 
         .filter(Boolean)
         .map((token) => `${token}*`)
         .join(" AND ");
-      params.push(tokens || normalizedSearch.replace(/[^a-z0-9\s]/gi, " ").trim() || normalizedSearch);
+      params.push(tokens || normalizedSearch);
     } else {
       where.push("search_text LIKE ?");
       params.push(`%${normalizedSearch}%`);
@@ -682,13 +797,52 @@ async function buildWhereClause({ search = "", isPublicOnly = false, category = 
   };
 }
 
-async function queryBase({ page = 1, pageSize = 24, search = "", sort = "", isPublicOnly = false, category = "", brand = "", model = "", visibility = "", status = "", stock = "", priceMax = null } = {}) {
-  await ensureProductsDb();
+function buildProductSummary(row = {}) {
+  const publicSlug = firstText([row.public_slug, row.slug]) || "";
+  const fallbackId = String(row.id || row.sku || row.code || "producto");
+  return {
+    id: firstText([row.id]) || "",
+    sku: firstText([row.sku]) || "",
+    code: firstText([row.code]) || "",
+    name: firstText([row.name, row.title]) || "Producto",
+    title: firstText([row.title, row.name]) || "Producto",
+    brand: row.brand || "",
+    model: row.model || "",
+    category: row.category || "",
+    price: toNumber(row.price, 0),
+    stock: Math.trunc(toNumber(row.stock, 0)),
+    status: row.status || "",
+    visibility: row.visibility || "",
+    image: row.image || "",
+    thumbnail: row.image || "",
+    publicSlug,
+    public_slug: publicSlug,
+    slug: firstText([row.slug, publicSlug]) || "",
+    url: `/p/${encodeURIComponent(publicSlug || fallbackId)}`,
+    source: "sqlite",
+  };
+}
+
+async function queryBase({
+  page = 1,
+  pageSize = 24,
+  search = "",
+  sort = "",
+  isPublicOnly = false,
+  category = "",
+  brand = "",
+  model = "",
+  visibility = "",
+  status = "",
+  stock = "",
+  priceMax = null,
+} = {}) {
+  await ensureDbReadyForRequest();
   const db = await openDb();
   const safePage = Math.max(1, Number(page) || 1);
   const safePageSize = Math.max(1, Number(pageSize) || 24);
   const offset = (safePage - 1) * safePageSize;
-  const whereClause = await buildWhereClause({
+  const whereClause = buildWhereClause({
     search,
     isPublicOnly,
     category: normalizeQueryText(category),
@@ -701,21 +855,44 @@ async function queryBase({ page = 1, pageSize = 24, search = "", sort = "", isPu
   });
 
   const orderBy = buildSort(sort);
+  const totalStartedAt = Date.now();
+
+  const countStartedAt = Date.now();
+  const countKey = JSON.stringify({ whereSql: whereClause.sql, whereParams: whereClause.params });
+  const cachedCount = countCache.get(countKey);
+  let totalItems = 0;
+  if (cachedCount && Date.now() - cachedCount.t < COUNT_CACHE_TTL_MS) {
+    totalItems = Number(cachedCount.totalItems || 0);
+  } else {
+    const totalRow = await get(
+      db,
+      `SELECT COUNT(*) AS totalItems FROM products ${whereClause.sql}`,
+      whereClause.params,
+    );
+    totalItems = Number(totalRow?.totalItems || 0);
+    countCache.set(countKey, { t: Date.now(), totalItems });
+  }
+  const countMs = Date.now() - countStartedAt;
+
+  const selectStartedAt = Date.now();
   const rows = await all(
     db,
-    `SELECT rowid, raw_json, public_slug FROM products ${whereClause.sql} ORDER BY ${orderBy} LIMIT ? OFFSET ?`,
+    `SELECT rowid, id, sku, code, slug, public_slug, image, name, title, brand, model, category, status, visibility, stock, price
+      FROM products ${whereClause.sql} ORDER BY ${orderBy} LIMIT ? OFFSET ?`,
     [...whereClause.params, safePageSize, offset],
   );
-  const totalRow = await get(
-    db,
-    `SELECT COUNT(*) AS totalItems FROM products ${whereClause.sql}`,
-    whereClause.params,
-  );
-  const totalItems = Number(totalRow?.totalItems || 0);
+  const selectMs = Date.now() - selectStartedAt;
+
+  const parseStartedAt = Date.now();
+  const items = rows.map((row) => buildProductSummary(row));
+  const parseItemsMs = Date.now() - parseStartedAt;
+
   const totalPages = Math.max(1, Math.ceil(totalItems / safePageSize));
+  const totalDurationMs = Date.now() - totalStartedAt;
 
   return {
     rows,
+    items,
     page: safePage,
     pageSize: safePageSize,
     totalItems,
@@ -724,27 +901,49 @@ async function queryBase({ page = 1, pageSize = 24, search = "", sort = "", isPu
     hasPrevPage: safePage > 1,
     source: "sqlite",
     search: search || undefined,
+    countMs,
+    selectMs,
+    parseItemsMs,
+    totalDurationMs,
   };
 }
 
 async function queryProducts(params = {}) {
   const result = await queryBase({ ...params, isPublicOnly: true });
-  return {
-    ...result,
-    items: parseRawItems(result.rows, { normalizePublic: true }),
-  };
+  console.log("[products-sqlite:queryProducts]", {
+    page: result.page,
+    pageSize: result.pageSize,
+    search: params.search || "",
+    sort: params.sort || "",
+    totalItems: result.totalItems,
+    rows: result.rows.length,
+    countMs: result.countMs,
+    selectMs: result.selectMs,
+    parseItemsMs: result.parseItemsMs,
+    totalDurationMs: result.totalDurationMs,
+  });
+  return result;
 }
 
 async function queryAdminProducts(params = {}) {
   const result = await queryBase({ ...params, isPublicOnly: false });
-  return {
-    ...result,
-    items: parseRawItems(result.rows),
-  };
+  console.log("[products-sqlite:queryAdminProducts]", {
+    page: result.page,
+    pageSize: result.pageSize,
+    search: params.search || "",
+    sort: params.sort || "",
+    totalItems: result.totalItems,
+    rows: result.rows.length,
+    countMs: result.countMs,
+    selectMs: result.selectMs,
+    parseItemsMs: result.parseItemsMs,
+    totalDurationMs: result.totalDurationMs,
+  });
+  return result;
 }
 
 async function getProductBySlug(slug) {
-  await ensureProductsDb();
+  await ensureDbReadyForRequest();
   const db = await openDb();
   const row = await get(
     db,
@@ -755,14 +954,14 @@ async function getProductBySlug(slug) {
 }
 
 async function getProductById(id) {
-  await ensureProductsDb();
+  await ensureDbReadyForRequest();
   const db = await openDb();
   const row = await get(db, "SELECT rowid, raw_json, public_slug FROM products WHERE id = ? LIMIT 1", [String(id || "").trim()]);
   return parseRawItems(row ? [row] : [], { normalizePublic: true })[0] || null;
 }
 
 async function getProductByCode(code) {
-  await ensureProductsDb();
+  await ensureDbReadyForRequest();
   const db = await openDb();
   const target = String(code || "").trim();
   const row = await get(
@@ -774,7 +973,7 @@ async function getProductByCode(code) {
 }
 
 async function getProductByPublicSlugOrAnyIdentifier(value) {
-  await ensureProductsDb();
+  await ensureDbReadyForRequest();
   const db = await openDb();
   const target = String(value || "").trim();
   if (!target) return { foundBy: "none", source: "sqlite", product: null };
@@ -784,6 +983,11 @@ async function getProductByPublicSlugOrAnyIdentifier(value) {
     { field: "id", sql: "SELECT rowid, raw_json, public_slug FROM products WHERE id = ? LIMIT 1" },
     { field: "sku", sql: "SELECT rowid, raw_json, public_slug FROM products WHERE sku = ? LIMIT 1" },
     { field: "code", sql: "SELECT rowid, raw_json, public_slug FROM products WHERE code = ? LIMIT 1" },
+    { field: "partNumber", sql: "SELECT rowid, raw_json, public_slug FROM products WHERE part_number = ? LIMIT 1" },
+    { field: "mpn", sql: "SELECT rowid, raw_json, public_slug FROM products WHERE mpn = ? LIMIT 1" },
+    { field: "ean", sql: "SELECT rowid, raw_json, public_slug FROM products WHERE ean = ? LIMIT 1" },
+    { field: "gtin", sql: "SELECT rowid, raw_json, public_slug FROM products WHERE gtin = ? LIMIT 1" },
+    { field: "supplierCode", sql: "SELECT rowid, raw_json, public_slug FROM products WHERE supplier_code = ? LIMIT 1" },
   ];
   for (const check of checks) {
     const row = await get(db, check.sql, [target]);
@@ -804,7 +1008,9 @@ async function getManifestFromDb() {
 }
 
 async function getCatalogHealth() {
-  await ensureProductsDb();
+  if (!fs.existsSync(SQLITE_PATH)) {
+    throw createInitializingError("sqlite_missing");
+  }
   const db = await openDb();
   const totalRow = await get(db, "SELECT COUNT(*) AS total FROM products");
   const publicRow = await get(db, "SELECT COUNT(*) AS total FROM products WHERE is_public = 1");
@@ -821,6 +1027,7 @@ async function getCatalogHealth() {
 
 module.exports = {
   ensureProductsDb,
+  ensureProductsDbOnce,
   rebuildProductsDbFromJson,
   queryProducts,
   queryAdminProducts,
@@ -833,4 +1040,5 @@ module.exports = {
   normalizeProductForPublic,
   normalizeQueryText,
   SQLITE_PATH,
+  createInitializingError,
 };

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -216,6 +216,8 @@ const DISABLE_HEAVY_ANALYTICS = true;
 const HEAVY_ANALYTICS_PRODUCTS_SIZE_LIMIT_BYTES = 5 * 1024 * 1024;
 const ANALYTICS_DISABLED_REASON = "disabled_for_large_catalog";
 const EMERGENCY_PRODUCTS_MODE = true;
+const DISABLE_PRODUCTS_STREAMING_FALLBACK =
+  String(process.env.DISABLE_PRODUCTS_STREAMING_FALLBACK || "true").trim().toLowerCase() === "true";
 const REVIEW_TOKEN_TTL_DAYS =
   parseInt(process.env.REVIEW_TOKEN_TTL_DAYS, 10) || 14;
 
@@ -232,6 +234,11 @@ const importJobLastPersistAt = new Map();
 const IMPORT_JOB_TTL_MS = 24 * 60 * 60 * 1000;
 const IMPORT_JOBS_DIR = dataPath("import-jobs");
 const IMPORT_JOB_LOG_STEP = 10;
+const productsTraffic = {
+  publicRequests: [],
+  adminRequests: [],
+  lastLogAt: 0,
+};
 
 fsp.mkdir(IMPORT_JOBS_DIR, { recursive: true }).catch((error) => {
   console.warn("[import-job] no se pudo inicializar carpeta persistente", error?.message || error);
@@ -282,6 +289,22 @@ function isLargeCatalogFile(filePath = PRODUCTS_FILE_PATH) {
     sizeBytes,
     isLarge: sizeBytes > LARGE_CATALOG_THRESHOLD_BYTES,
   };
+}
+
+function registerProductsTraffic(kind = "public") {
+  const now = Date.now();
+  const oneMinuteAgo = now - 60_000;
+  const bucket = kind === "admin" ? productsTraffic.adminRequests : productsTraffic.publicRequests;
+  bucket.push(now);
+  productsTraffic.publicRequests = productsTraffic.publicRequests.filter((ts) => ts >= oneMinuteAgo);
+  productsTraffic.adminRequests = productsTraffic.adminRequests.filter((ts) => ts >= oneMinuteAgo);
+  if (now - productsTraffic.lastLogAt > 30_000) {
+    productsTraffic.lastLogAt = now;
+    console.info("[products-traffic]", {
+      publicRequestsLastMinute: productsTraffic.publicRequests.length,
+      adminRequestsLastMinute: productsTraffic.adminRequests.length,
+    });
+  }
 }
 
 function loadSmallCatalogProducts({ filePath = PRODUCTS_FILE_PATH } = {}) {
@@ -6128,8 +6151,53 @@ async function requestHandler(req, res) {
     } catch (error) {
       return sendJson(res, 503, {
         ok: false,
-        source: "streaming_fallback",
+        source: "sqlite",
         error: error?.message || "SQLite unavailable",
+      });
+    }
+  }
+
+  if (pathname === "/api/catalog/performance-test" && req.method === "GET") {
+    try {
+      const perfStartedAt = Date.now();
+      const publicNoSearchStart = Date.now();
+      await productsSqliteRepo.queryProducts({ page: 1, pageSize: 24 });
+      const publicNoSearchMs = Date.now() - publicNoSearchStart;
+
+      const publicSearchStart = Date.now();
+      await productsSqliteRepo.queryProducts({ page: 1, pageSize: 24, search: "filtro" });
+      const publicSearchMs = Date.now() - publicSearchStart;
+
+      const adminNoSearchStart = Date.now();
+      await productsSqliteRepo.queryAdminProducts({ page: 1, pageSize: 100 });
+      const adminNoSearchMs = Date.now() - adminNoSearchStart;
+
+      const adminSearchStart = Date.now();
+      await productsSqliteRepo.queryAdminProducts({ page: 1, pageSize: 100, search: "filtro" });
+      const adminSearchMs = Date.now() - adminSearchStart;
+
+      const healthStart = Date.now();
+      await productsSqliteRepo.getCatalogHealth();
+      const healthMs = Date.now() - healthStart;
+
+      const dbPath = productsSqliteRepo.SQLITE_PATH;
+      return sendJson(res, 200, {
+        ok: true,
+        source: "sqlite",
+        dbPath,
+        sqliteExists: Boolean(dbPath && fs.existsSync(dbPath)),
+        publicNoSearchMs,
+        publicSearchMs,
+        adminNoSearchMs,
+        adminSearchMs,
+        healthMs,
+        totalMs: Date.now() - perfStartedAt,
+      });
+    } catch (error) {
+      return sendJson(res, 503, {
+        ok: false,
+        source: "sqlite",
+        error: error?.message || "performance test unavailable",
       });
     }
   }
@@ -6206,6 +6274,7 @@ async function requestHandler(req, res) {
 
   // API: obtener productos
   if (pathname === "/api/products" && req.method === "GET") {
+    registerProductsTraffic("public");
     try {
       const { page, pageSize } = parsePaginationParams(parsedUrl.query, {
         page: 1,
@@ -6214,7 +6283,20 @@ async function requestHandler(req, res) {
       });
       const queryParams = parsedUrl.query || {};
       const startedAt = Date.now();
-      console.log(`[products-endpoint:start] /api/products page=${page} pageSize=${pageSize} source=sqlite`);
+      console.info("[public-products:start]", {
+        page,
+        pageSize,
+        search: queryParams.search || queryParams.q || "",
+        sort: queryParams.sort || "",
+        filters: {
+          category: queryParams.category || "",
+          brand: queryParams.brand || "",
+          model: queryParams.model || "",
+          stock: queryParams.stock || "",
+          priceMax: queryParams.price_max ?? queryParams.priceMax ?? "",
+        },
+      });
+      console.info("[public-products:sqlite-query:start]");
       const withWholesale = canSeeWholesalePrices(req);
       const sqliteData = await productsSqliteRepo.queryProducts({
         page,
@@ -6239,14 +6321,35 @@ async function requestHandler(req, res) {
         source: "sqlite",
       };
       const durationMs = Date.now() - startedAt;
-      console.log(
-        `[products-endpoint:respond] endpoint=/api/products source=sqlite items=${items.length} totalItems=${responsePayload.totalItems} totalPages=${responsePayload.totalPages} hasNextPage=${responsePayload.hasNextPage} durationMs=${durationMs}`,
-      );
+      console.info("[public-products:respond]", {
+        source: responsePayload.source,
+        items: items.length,
+        totalItems: responsePayload.totalItems,
+        totalPages: responsePayload.totalPages,
+        durationMs,
+      });
       return sendJson(res, 200, responsePayload, {
         "Cache-Control": "no-store, no-cache, must-revalidate",
       });
     } catch (err) {
-      console.warn(`[products-db] unavailable fallback=streaming reason=${err?.message || err}`);
+      const { sizeBytes, isLarge } = isLargeCatalogFile(PRODUCTS_FILE_PATH);
+      const shouldBlockFallback = DISABLE_PRODUCTS_STREAMING_FALLBACK || isLarge;
+      const reason = err?.code === "CATALOG_INITIALIZING" ? err?.reason || "initializing" : err?.message || String(err);
+      if (shouldBlockFallback) {
+        console.warn("[products-endpoint:fallback-blocked-large-catalog]", {
+          endpoint: "/api/products",
+          sizeBytes,
+          disableStreamingFallback: DISABLE_PRODUCTS_STREAMING_FALLBACK,
+          reason,
+        });
+        return sendJson(res, 503, {
+          ok: false,
+          source: "sqlite",
+          error: "Catálogo rápido inicializando",
+          message: "Catálogo rápido inicializando",
+        });
+      }
+      console.warn("[public-products:fallback-streaming]", { reason });
       try {
         const { page, pageSize } = parsePaginationParams(parsedUrl.query, {
           page: 1,
@@ -6282,6 +6385,7 @@ async function requestHandler(req, res) {
 
   if (pathname === "/api/admin/products" && req.method === "GET") {
     if (!requireAdmin(req, res)) return;
+    registerProductsTraffic("admin");
     try {
       const { page, pageSize } = parsePaginationParams(parsedUrl.query, {
         page: 1,
@@ -6290,9 +6394,19 @@ async function requestHandler(req, res) {
       });
       const queryParams = parsedUrl.query || {};
       const startedAt = Date.now();
-      console.log(
-        `[products-endpoint:start] /api/admin/products page=${page} pageSize=${pageSize} source=sqlite`,
-      );
+      console.info("[admin-products:start]", {
+        page,
+        pageSize,
+        search: queryParams.search || queryParams.q || "",
+        sort: queryParams.sort || "",
+        filters: {
+          category: queryParams.category || "",
+          brand: queryParams.brand || "",
+          visibility: queryParams.visibility || "",
+          status: queryParams.status || "",
+          stock: queryParams.stockStatus || queryParams.stock || "",
+        },
+      });
       const sqliteData = await productsSqliteRepo.queryAdminProducts({
         page,
         pageSize,
@@ -6310,14 +6424,35 @@ async function requestHandler(req, res) {
         source: "sqlite",
       };
       const durationMs = Date.now() - startedAt;
-      console.log(
-        `[products-endpoint:respond] endpoint=/api/admin/products source=sqlite items=${responsePayload.items.length} totalItems=${responsePayload.totalItems} totalPages=${responsePayload.totalPages} hasNextPage=${responsePayload.hasNextPage} durationMs=${durationMs}`,
-      );
+      console.info("[admin-products:respond]", {
+        source: responsePayload.source,
+        items: responsePayload.items.length,
+        totalItems: responsePayload.totalItems,
+        totalPages: responsePayload.totalPages,
+        durationMs,
+      });
       return sendJson(res, 200, responsePayload, {
         "Cache-Control": "no-store, no-cache, must-revalidate",
       });
     } catch (err) {
-      console.warn(`[products-db] unavailable fallback=streaming reason=${err?.message || err}`);
+      const { sizeBytes, isLarge } = isLargeCatalogFile(PRODUCTS_FILE_PATH);
+      const shouldBlockFallback = DISABLE_PRODUCTS_STREAMING_FALLBACK || isLarge;
+      const reason = err?.code === "CATALOG_INITIALIZING" ? err?.reason || "initializing" : err?.message || String(err);
+      if (shouldBlockFallback) {
+        console.warn("[products-endpoint:fallback-blocked-large-catalog]", {
+          endpoint: "/api/admin/products",
+          sizeBytes,
+          disableStreamingFallback: DISABLE_PRODUCTS_STREAMING_FALLBACK,
+          reason,
+        });
+        return sendJson(res, 503, {
+          ok: false,
+          source: "sqlite",
+          error: "Catálogo rápido inicializando",
+          message: "Catálogo rápido inicializando",
+        });
+      }
+      console.warn("[admin-products:fallback-streaming]", { reason });
       try {
         const { page, pageSize } = parsePaginationParams(parsedUrl.query, {
           page: 1,
@@ -11959,7 +12094,7 @@ module.exports = { createServer };
 if (require.main === module) {
   (async () => {
     try {
-      await productsSqliteRepo.ensureProductsDb();
+      await productsSqliteRepo.ensureProductsDbOnce();
     } catch (error) {
       console.warn(`[products-db] unavailable fallback=streaming reason=${error?.message || error}`);
     }

--- a/nerin_final_updated/frontend/js/product.js
+++ b/nerin_final_updated/frontend/js/product.js
@@ -247,7 +247,12 @@ async function loadReviews(productId) {
 }
 
 function getProductSlug(product) {
-  if (!product || typeof product.slug !== "string") return null;
+  if (!product) return null;
+  const fromPublicSlug = typeof product.publicSlug === "string" ? product.publicSlug.trim() : "";
+  if (fromPublicSlug) return fromPublicSlug;
+  const fromPublicSlugSnake = typeof product.public_slug === "string" ? product.public_slug.trim() : "";
+  if (fromPublicSlugSnake) return fromPublicSlugSnake;
+  if (typeof product.slug !== "string") return null;
   const slug = product.slug.trim();
   return slug || null;
 }

--- a/nerin_final_updated/frontend/js/shop.js
+++ b/nerin_final_updated/frontend/js/shop.js
@@ -2,6 +2,11 @@ import { fetchProductsPage, getUserRole, isWholesale } from "./api.js";
 import { createPriceLegalBlock } from "./components/PriceLegalBlock.js";
 import { calculateNetNoNationalTaxes } from "./utils/pricing.js";
 
+console.info("[shop-products] shop.js loaded", {
+  version: "sqlite-public-debug-v3",
+  timestamp: new Date().toISOString(),
+});
+
 const currencyFormatter = new Intl.NumberFormat("es-AR", {
   style: "currency",
   currency: "ARS",
@@ -792,6 +797,7 @@ async function renderProducts({ page = currentProductsPage, scrollToTop = false 
   } catch (error) {
     if (error?.name === "AbortError") {
       shopLog("request:aborted", { requestId });
+      console.info("[shop-products] request aborted");
       return;
     }
     throw error;
@@ -858,11 +864,13 @@ async function renderProducts({ page = currentProductsPage, scrollToTop = false 
 
   totalFilteredItems = publicProductsTotalItems ?? allProducts.length;
   productGrid.innerHTML = "";
+  console.info("[shop-products] render start");
   if (!allProducts.length) {
     productGrid.innerHTML = "<p>No encontramos productos para esos filtros.</p>";
   } else {
     allProducts.forEach((product) => productGrid.appendChild(createProductCard(product)));
   }
+  console.info("[shop-products] render done");
   renderPublicProductsPagination();
   shopLog("renderProducts", {
     requestId,

--- a/nerin_final_updated/frontend/shop.html
+++ b/nerin_final_updated/frontend/shop.html
@@ -281,7 +281,7 @@
         <img src="/assets/whatsapp.svg" alt="WhatsApp" />
       </a>
     </div>
-    <script type="module" src="/js/shop.js"></script>
+    <script type="module" src="/js/shop.js?v=sqlite-public-debug-v3"></script>
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
     <script type="module" src="/js/config.js"></script>
   </body>


### PR DESCRIPTION
### Motivation
- Reducir CPU al 100% evitando que listados públicos/admin disparen reconstrucciones o caigan a streaming completo del `products.json`. 
- Garantizar que `/api/products` y `/api/admin/products` respondan desde SQLite con payloads livianos y sin parsear `raw_json` en cada request.
- Evitar rebuilds concurrentes y loops de reconstrucción que degradan la instancia en producción.
- Alinear URLs/identificadores para que los productos que aparecen en la grilla abran su detalle correctamente.

### Description
- En `backend/data/productsSqliteRepo.js` se añadieron guards de inicialización y rebuild (`dbReady`, `dbReadyPromise`, `rebuildPromise`), la función `ensureProductsDbOnce()` y `ensureDbReadyForRequest()` y la excepción controlada `createInitializingError()` para que requests normales no lancen reconstrucciones concurrentes; `rebuildProductsDbFromJson()` ahora reusea `rebuildPromise`. 
- Lista y performance: `queryBase` ahora hace `SELECT` de columnas resumidas (no `raw_json`), crea resúmenes con `buildProductSummary`, cachea `COUNT` por 60s (`COUNT_CACHE_TTL_MS`) y expone métricas `countMs/selectMs/parseItemsMs/totalDurationMs`, además se añadieron columnas/índices nuevos (`image`, `part_number`, `mpn`, `ean`, `gtin`, `supplier_code`) para búsquedas/resolve rápidas. 
- SQLite tuning y seguridad: al abrir DB se aplican `PRAGMA journal_mode = WAL`, `PRAGMA synchronous = NORMAL`, `PRAGMA busy_timeout = 5000` y `PRAGMA temp_store = MEMORY`, y se loguean condiciones `busy/locked`. 
- Server: en `backend/server.js` se agregó `DISABLE_PRODUCTS_STREAMING_FALLBACK` (por defecto `true`), telemetry `registerProductsTraffic()`, logs estructurados para `/api/products` y `/api/admin/products` (`[public-products:start]`, `[public-products:sqlite-query:start]`, `[public-products:respond]`, `[products-endpoint:fallback-blocked-large-catalog]`, etc.), bloqueo controlado del fallback en listados grandes (responde `503` con mensaje `Catálogo rápido inicializando` en vez de iniciar streaming pesado) y se añadió `GET /api/catalog/performance-test` que devuelve tiempos de consulta y metadatos sqlite. 
- Frontend: en `frontend/js/shop.js` se añadió banner/log `console.info("[shop-products] shop.js loaded" ...)`, logs de load/render/abort y el `shop.html` ahora carga `shop.js?v=sqlite-public-debug-v3` para cache-busting; en `frontend/js/product.js` la resolución de slug prioriza `publicSlug`/`public_slug` antes de `slug` para alinear grilla y detalle. 
- Archivos modificados (principales): `backend/data/productsSqliteRepo.js`, `backend/server.js`, `frontend/js/shop.js`, `frontend/js/product.js`, `frontend/shop.html`.

### Testing
- Ejecutados checks de sintaxis con `node --check` para `backend/server.js`, `backend/data/productsSqliteRepo.js`, `frontend/js/shop.js`, `frontend/js/product.js` y `frontend/js/admin.js` y todos pasaron exitosamente. 
- Se ejecutó `node nerin_final_updated/scripts/test-products-sqlite-query.js` y el script confirmó que `/api` usa `sqlite`, que hay productos públicos con `publicSlug`/`url` y devolvió tiempos; la prueba pasó (`ok`).
- Se ejecutó `node nerin_final_updated/scripts/check-no-products-full-parse.js` para asegurar que no se parsea `products.json` entero en rutas públicas y el check pasó (`ok`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f00d30c0b483319d5a8a96512b1014)