### PR TITLE
Fix SQLite price mapping, visibility audit and admin edit flow

### DIFF
--- a/nerin_final_updated/backend/data/productsSqliteRepo.js
+++ b/nerin_final_updated/backend/data/productsSqliteRepo.js
@@ -58,6 +58,99 @@ function toNumber(value, fallback = 0) {
   return Number.isFinite(parsed) ? parsed : fallback;
 }
 
+function toFiniteNumberOrNull(value) {
+  if (value == null || value === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function firstNumber(values = []) {
+  for (const value of values) {
+    const parsed = toFiniteNumberOrNull(value);
+    if (parsed !== null) return parsed;
+  }
+  return null;
+}
+
+function resolvePriceFields(product = {}) {
+  const priceMinorista = firstNumber([
+    product.price_minorista,
+    product.precio_minorista,
+    product.precioMinorista,
+    product.finalPrice,
+    product.salePrice,
+    product.precioFinal,
+    product.precio_final,
+    product.priceArs,
+    product.precioARS,
+    product.precio_ars,
+    product.finalPriceArs,
+    product.precioConIva,
+    product.price,
+    product.precio,
+  ]);
+  const priceMayorista = firstNumber([
+    product.price_mayorista,
+    product.precio_mayorista,
+    product.precioMayorista,
+    product.price_wholesale,
+    product.wholesale_price,
+  ]);
+  const pricePublic = firstNumber([
+    priceMinorista,
+    product.price,
+    product.precio,
+    product.finalPrice,
+    product.salePrice,
+    product.precioFinal,
+    product.precio_final,
+    product.priceArs,
+    product.precioARS,
+    product.precio_ars,
+    product.finalPriceArs,
+    product.precioConIva,
+  ]);
+  return {
+    price: pricePublic,
+    price_minorista: priceMinorista,
+    price_mayorista: priceMayorista,
+    precio_minorista: firstNumber([product.precio_minorista, priceMinorista]),
+    precio_mayorista: firstNumber([product.precio_mayorista, priceMayorista]),
+    precio_final: firstNumber([product.precio_final, product.precioFinal, product.finalPrice, pricePublic]),
+    precio_sin_impuestos: firstNumber([
+      product.precio_sin_impuestos,
+      product.precioSinImpuestos,
+      product.precio_sin_impuesto,
+    ]),
+    cost: firstNumber([product.cost, product.costo, product.costoCaja, product.costo_caja]),
+    currency: toNullableText(product.currency || product.moneda || "ARS"),
+    rawPriceFields: {
+      price_minorista: product.price_minorista,
+      price_mayorista: product.price_mayorista,
+      precio_minorista: product.precio_minorista,
+      precio_mayorista: product.precio_mayorista,
+      price: product.price,
+      precio: product.precio,
+      finalPrice: product.finalPrice,
+      salePrice: product.salePrice,
+      precioFinal: product.precioFinal,
+      precio_final: product.precio_final,
+      priceArs: product.priceArs,
+      precioARS: product.precioARS,
+      precio_ars: product.precio_ars,
+      finalPriceArs: product.finalPriceArs,
+      precioConIva: product.precioConIva,
+      precio_sin_impuestos: product.precio_sin_impuestos,
+      precioSinImpuestos: product.precioSinImpuestos,
+      costo: product.costo,
+      costoCaja: product.costoCaja,
+      costo_caja: product.costo_caja,
+      cost: product.cost,
+      currency: product.currency,
+    },
+  };
+}
+
 function logBusyIfNeeded(error) {
   const message = String(error?.message || error || "");
   if (/busy|locked/i.test(message)) {
@@ -168,6 +261,13 @@ async function createSchema(db) {
       visibility TEXT,
       stock INTEGER,
       price REAL,
+      price_minorista REAL,
+      price_mayorista REAL,
+      precio_minorista REAL,
+      precio_mayorista REAL,
+      precio_final REAL,
+      precio_sin_impuestos REAL,
+      cost REAL,
       currency TEXT,
       is_public INTEGER,
       enabled INTEGER,
@@ -190,6 +290,13 @@ async function createSchema(db) {
     "ean",
     "gtin",
     "supplier_code",
+    "price_minorista",
+    "price_mayorista",
+    "precio_minorista",
+    "precio_mayorista",
+    "precio_final",
+    "precio_sin_impuestos",
+    "cost",
   ];
   for (const col of optionalColumns) {
     if (!columnSet.has(col)) {
@@ -341,8 +448,18 @@ function mapProductRow(product = {}, options = {}) {
     slugCounts.set(publicSlug, current);
     if (current > 1) publicSlug = `${publicSlug}-${current}`;
   }
-  const price = toNumber(product.price_minorista ?? product.price, 0);
+  const priceFields = resolvePriceFields(product);
   const stock = Math.trunc(toNumber(product.stock, 0));
+  if (rowNumber != null && rowNumber <= 3) {
+    console.log("[products-price-map]", {
+      id: toNullableText(product.id),
+      sku: toNullableText(product.sku),
+      rawPriceFields: priceFields.rawPriceFields,
+      mappedPrice: priceFields.price,
+      mappedPriceMinorista: priceFields.price_minorista,
+      mappedPriceMayorista: priceFields.price_mayorista,
+    });
+  }
   return {
     id: toNullableText(product.id),
     sku: toNullableText(product.sku),
@@ -369,8 +486,15 @@ function mapProductRow(product = {}, options = {}) {
     status: normalizeQueryText(toNullableText(product.status)),
     visibility: normalizeQueryText(toNullableText(product.visibility)),
     stock,
-    price,
-    currency: toNullableText(product.currency || "ARS"),
+    price: priceFields.price,
+    price_minorista: priceFields.price_minorista,
+    price_mayorista: priceFields.price_mayorista,
+    precio_minorista: priceFields.precio_minorista,
+    precio_mayorista: priceFields.precio_mayorista,
+    precio_final: priceFields.precio_final,
+    precio_sin_impuestos: priceFields.precio_sin_impuestos,
+    cost: priceFields.cost,
+    currency: priceFields.currency,
     is_public: isProductPublic(product) ? 1 : 0,
     enabled: boolToInt(product.enabled, 1),
     deleted: boolToInt(product.deleted, 0),
@@ -403,6 +527,7 @@ function parseImageLikeField(value) {
 
 function normalizeProductForPublic(product = {}, meta = {}) {
   const safe = product && typeof product === "object" ? { ...product } : {};
+  const priceFields = resolvePriceFields(safe);
   const name = firstText([safe.name, safe.title, safe.productName, safe.nombre, safe.model]) || "Producto";
   const brand = firstText([safe.brand, safe.marca, safe.manufacturer]) || "";
   const description =
@@ -436,10 +561,6 @@ function normalizeProductForPublic(product = {}, meta = {}) {
     ),
   );
   const image = firstText([safe.image, images[0]]) || "";
-  const price = toNumber(
-    safe.price ?? safe.precio ?? safe.salePrice ?? safe.finalPrice ?? safe.price_minorista,
-    0,
-  );
   const stock = Math.trunc(
     toNumber(
       safe.stock ?? safe.quantity ?? safe.qty ?? safe.availableQuantity ?? safe.stockQty,
@@ -454,7 +575,15 @@ function normalizeProductForPublic(product = {}, meta = {}) {
     description,
     images,
     image,
-    price,
+    price: priceFields.price,
+    price_minorista: priceFields.price_minorista,
+    price_mayorista: priceFields.price_mayorista,
+    precio_minorista: priceFields.precio_minorista,
+    precio_mayorista: priceFields.precio_mayorista,
+    precio_final: priceFields.precio_final,
+    precio_sin_impuestos: priceFields.precio_sin_impuestos,
+    cost: priceFields.cost,
+    currency: priceFields.currency || safe.currency || "ARS",
     stock,
     publicSlug,
     public_slug: publicSlug,
@@ -480,6 +609,78 @@ function parseRawItems(rows = [], options = {}) {
       }
     })
     .filter(Boolean);
+}
+
+function normalizeProductForAdminList(product = {}, meta = {}) {
+  return normalizeProductForPublic(product, meta);
+}
+
+async function updateProductByIdentifier(identifier, patch = {}) {
+  await ensureDbReadyForRequest();
+  const db = await openDb();
+  const target = String(identifier || "").trim();
+  if (!target) throw new Error("identifier requerido");
+  const row = await get(
+    db,
+    `SELECT rowid, raw_json
+     FROM products
+     WHERE id = ? OR public_slug = ? OR slug = ? OR sku = ? OR code = ?
+     LIMIT 1`,
+    [target, target, target, target, target],
+  );
+  if (!row) return null;
+  const current = JSON.parse(row.raw_json || "{}");
+  const merged = { ...current, ...patch };
+  const mapped = mapProductRow(merged, { rowNumber: row.rowid });
+  await run(
+    db,
+    `UPDATE products SET
+      id = ?, sku = ?, code = ?, slug = ?, public_slug = ?, image = ?, name = ?, title = ?, brand = ?, model = ?, category = ?,
+      part_number = ?, mpn = ?, ean = ?, gtin = ?, supplier_code = ?, status = ?, visibility = ?,
+      stock = ?, price = ?, price_minorista = ?, price_mayorista = ?, precio_minorista = ?, precio_mayorista = ?, precio_final = ?, precio_sin_impuestos = ?, cost = ?, currency = ?, is_public = ?, enabled = ?, deleted = ?, archived = ?, vip_only = ?, wholesale_only = ?, search_text = ?, raw_json = ?
+      WHERE rowid = ?`,
+    [
+      mapped.id,
+      mapped.sku,
+      mapped.code,
+      mapped.slug,
+      mapped.public_slug,
+      mapped.image,
+      mapped.name,
+      mapped.title,
+      mapped.brand,
+      mapped.model,
+      mapped.category,
+      mapped.part_number,
+      mapped.mpn,
+      mapped.ean,
+      mapped.gtin,
+      mapped.supplier_code,
+      mapped.status,
+      mapped.visibility,
+      mapped.stock,
+      mapped.price,
+      mapped.price_minorista,
+      mapped.price_mayorista,
+      mapped.precio_minorista,
+      mapped.precio_mayorista,
+      mapped.precio_final,
+      mapped.precio_sin_impuestos,
+      mapped.cost,
+      mapped.currency,
+      mapped.is_public,
+      mapped.enabled,
+      mapped.deleted,
+      mapped.archived,
+      mapped.vip_only,
+      mapped.wholesale_only,
+      mapped.search_text,
+      mapped.raw_json,
+      row.rowid,
+    ],
+  );
+  countCache.clear();
+  return normalizeProductForAdminList(merged, { rowid: row.rowid, public_slug: mapped.public_slug });
 }
 
 function buildCatalogPathsInfo() {
@@ -529,9 +730,9 @@ async function rebuildProductsDbFromJson() {
       const insertSql = `INSERT INTO products (
         id, sku, code, slug, public_slug, image, name, title, brand, model, category,
         part_number, mpn, ean, gtin, supplier_code, status, visibility,
-        stock, price, currency, is_public, enabled, deleted, archived, vip_only, wholesale_only,
+        stock, price, price_minorista, price_mayorista, precio_minorista, precio_mayorista, precio_final, precio_sin_impuestos, cost, currency, is_public, enabled, deleted, archived, vip_only, wholesale_only,
         search_text, raw_json
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
 
       let count = 0;
       const slugCounts = new Map();
@@ -563,6 +764,13 @@ async function rebuildProductsDbFromJson() {
               item.visibility,
               item.stock,
               item.price,
+              item.price_minorista,
+              item.price_mayorista,
+              item.precio_minorista,
+              item.precio_mayorista,
+              item.precio_final,
+              item.precio_sin_impuestos,
+              item.cost,
               item.currency,
               item.is_public,
               item.enabled,
@@ -714,15 +922,16 @@ async function ensureDbReadyForRequest() {
 }
 
 function buildSort(sort) {
+  const priceExpr = "COALESCE(price_minorista, price, precio_minorista, precio_final)";
   const allowedSorts = {
-    price_asc: "price ASC, rowid ASC",
-    price_desc: "price DESC, rowid ASC",
+    price_asc: `${priceExpr} ASC, rowid ASC`,
+    price_desc: `${priceExpr} DESC, rowid ASC`,
     name_asc: "name ASC, rowid ASC",
     name_desc: "name DESC, rowid ASC",
     stock_desc: "stock DESC, rowid ASC",
     stock_asc: "stock ASC, rowid ASC",
-    "price-asc": "price ASC, rowid ASC",
-    "price-desc": "price DESC, rowid ASC",
+    "price-asc": `${priceExpr} ASC, rowid ASC`,
+    "price-desc": `${priceExpr} DESC, rowid ASC`,
     "stock-desc": "stock DESC, rowid ASC",
     name: "name ASC, rowid ASC",
   };
@@ -770,7 +979,7 @@ function buildWhereClause({
     where.push("stock <= 0");
   }
   if (priceMax !== null && Number.isFinite(Number(priceMax))) {
-    where.push("price <= ?");
+    where.push("COALESCE(price_minorista, price, precio_minorista, precio_final) <= ?");
     params.push(Number(priceMax));
   }
 
@@ -809,7 +1018,15 @@ function buildProductSummary(row = {}) {
     brand: row.brand || "",
     model: row.model || "",
     category: row.category || "",
-    price: toNumber(row.price, 0),
+    price: toFiniteNumberOrNull(row.price),
+    price_minorista: toFiniteNumberOrNull(row.price_minorista),
+    price_mayorista: toFiniteNumberOrNull(row.price_mayorista),
+    precio_minorista: toFiniteNumberOrNull(row.precio_minorista),
+    precio_mayorista: toFiniteNumberOrNull(row.precio_mayorista),
+    precio_final: toFiniteNumberOrNull(row.precio_final),
+    precio_sin_impuestos: toFiniteNumberOrNull(row.precio_sin_impuestos),
+    cost: toFiniteNumberOrNull(row.cost),
+    currency: row.currency || "ARS",
     stock: Math.trunc(toNumber(row.stock, 0)),
     status: row.status || "",
     visibility: row.visibility || "",
@@ -877,7 +1094,7 @@ async function queryBase({
   const selectStartedAt = Date.now();
   const rows = await all(
     db,
-    `SELECT rowid, id, sku, code, slug, public_slug, image, name, title, brand, model, category, status, visibility, stock, price
+    `SELECT rowid, id, sku, code, slug, public_slug, image, name, title, brand, model, category, status, visibility, stock, price, price_minorista, price_mayorista, precio_minorista, precio_mayorista, precio_final, precio_sin_impuestos, cost, currency
       FROM products ${whereClause.sql} ORDER BY ${orderBy} LIMIT ? OFFSET ?`,
     [...whereClause.params, safePageSize, offset],
   );
@@ -1014,14 +1231,88 @@ async function getCatalogHealth() {
   const db = await openDb();
   const totalRow = await get(db, "SELECT COUNT(*) AS total FROM products");
   const publicRow = await get(db, "SELECT COUNT(*) AS total FROM products WHERE is_public = 1");
+  const privateExplicitRow = await get(
+    db,
+    "SELECT COUNT(*) AS total FROM products WHERE visibility = 'private' OR status = 'private'",
+  );
+  const hiddenExplicitRow = await get(
+    db,
+    "SELECT COUNT(*) AS total FROM products WHERE visibility = 'hidden' OR status = 'hidden'",
+  );
+  const missingVisibilityRow = await get(
+    db,
+    "SELECT COUNT(*) AS total FROM products WHERE visibility IS NULL OR visibility = ''",
+  );
+  const missingStatusRow = await get(
+    db,
+    "SELECT COUNT(*) AS total FROM products WHERE status IS NULL OR status = ''",
+  );
   const manifest = await getManifestFromDb();
   return {
     source: "sqlite",
     sqlitePath: SQLITE_PATH,
     productCount: Number(totalRow?.total || 0),
     publicProductCount: Number(publicRow?.total || 0),
+    privateExplicitCount: Number(privateExplicitRow?.total || 0),
+    hiddenExplicitCount: Number(hiddenExplicitRow?.total || 0),
+    missingVisibilityCount: Number(missingVisibilityRow?.total || 0),
+    missingStatusCount: Number(missingStatusRow?.total || 0),
     manifest,
     lastBuilt: manifest?.sqliteBuiltAt || null,
+  };
+}
+
+async function getCatalogPublicityAudit() {
+  await ensureDbReadyForRequest();
+  const db = await openDb();
+  const summaryRows = await all(
+    db,
+    `SELECT
+      COUNT(*) AS productCount,
+      SUM(CASE WHEN is_public = 1 THEN 1 ELSE 0 END) AS publicProductCount,
+      SUM(CASE WHEN enabled = 0 THEN 1 ELSE 0 END) AS enabledFalse,
+      SUM(CASE WHEN deleted = 1 THEN 1 ELSE 0 END) AS deleted,
+      SUM(CASE WHEN archived = 1 THEN 1 ELSE 0 END) AS archived,
+      SUM(CASE WHEN vip_only = 1 THEN 1 ELSE 0 END) AS vipOnly,
+      SUM(CASE WHEN wholesale_only = 1 THEN 1 ELSE 0 END) AS wholesaleOnly,
+      SUM(CASE WHEN visibility = 'private' OR status = 'private' THEN 1 ELSE 0 END) AS privateVisibility,
+      SUM(CASE WHEN visibility = 'hidden' OR status = 'hidden' THEN 1 ELSE 0 END) AS hiddenVisibility,
+      SUM(CASE WHEN status = 'draft' OR visibility = 'draft' THEN 1 ELSE 0 END) AS draftStatus
+    FROM products`,
+  );
+  const missingNameRow = await get(
+    db,
+    "SELECT COUNT(*) AS total FROM products WHERE COALESCE(NULLIF(TRIM(name), ''), NULLIF(TRIM(title), '')) IS NULL",
+  );
+  const missingIdentifierRow = await get(
+    db,
+    "SELECT COUNT(*) AS total FROM products WHERE COALESCE(NULLIF(TRIM(id), ''), NULLIF(TRIM(sku), ''), NULLIF(TRIM(code), ''), NULLIF(TRIM(part_number), ''), NULLIF(TRIM(mpn), ''), NULLIF(TRIM(ean), ''), NULLIF(TRIM(gtin), ''), NULLIF(TRIM(supplier_code), '')) IS NULL",
+  );
+  const examplesRejected = await all(
+    db,
+    `SELECT id, sku, code, name, title, status, visibility, enabled, deleted, archived, vip_only, wholesale_only
+     FROM products
+     WHERE is_public = 0
+     ORDER BY rowid ASC
+     LIMIT 20`,
+  );
+  const summary = summaryRows[0] || {};
+  return {
+    productCount: Number(summary.productCount || 0),
+    publicProductCount: Number(summary.publicProductCount || 0),
+    rejectedCounts: {
+      enabledFalse: Number(summary.enabledFalse || 0),
+      deleted: Number(summary.deleted || 0),
+      archived: Number(summary.archived || 0),
+      vipOnly: Number(summary.vipOnly || 0),
+      wholesaleOnly: Number(summary.wholesaleOnly || 0),
+      privateVisibility: Number(summary.privateVisibility || 0),
+      hiddenVisibility: Number(summary.hiddenVisibility || 0),
+      draftStatus: Number(summary.draftStatus || 0),
+      missingName: Number(missingNameRow?.total || 0),
+      missingIdentifier: Number(missingIdentifierRow?.total || 0),
+    },
+    examplesRejected,
   };
 }
 
@@ -1037,7 +1328,10 @@ module.exports = {
   getProductByPublicSlugOrAnyIdentifier,
   getManifestFromDb,
   getCatalogHealth,
+  getCatalogPublicityAudit,
+  updateProductByIdentifier,
   normalizeProductForPublic,
+  normalizeProductForAdminList,
   normalizeQueryText,
   SQLITE_PATH,
   createInitializingError,

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -2041,7 +2041,7 @@ function parseBody(req) {
   return new Promise((resolve) => {
     const chunks = [];
     req.on("data", (c) => chunks.push(c));
-    req.on("end", () => {
+    req.on("end", async () => {
       const buf = Buffer.concat(chunks);
       req.rawBody = buf;
       const type = req.headers["content-type"] || "";
@@ -6144,6 +6144,10 @@ async function requestHandler(req, res) {
         sqliteExists,
         productCount: Number(health?.productCount || 0),
         publicProductCount: Number(health?.publicProductCount || 0),
+        privateExplicitCount: Number(health?.privateExplicitCount || 0),
+        hiddenExplicitCount: Number(health?.hiddenExplicitCount || 0),
+        missingVisibilityCount: Number(health?.missingVisibilityCount || 0),
+        missingStatusCount: Number(health?.missingStatusCount || 0),
         sqlitePath: health?.sqlitePath || null,
         sqliteBuiltAt: health?.lastBuilt || null,
         manifest: health?.manifest || null,
@@ -6153,6 +6157,20 @@ async function requestHandler(req, res) {
         ok: false,
         source: "sqlite",
         error: error?.message || "SQLite unavailable",
+      });
+    }
+  }
+
+  if (pathname === "/api/catalog/publicity-audit" && req.method === "GET") {
+    if (!requireAdmin(req, res)) return;
+    try {
+      const audit = await productsSqliteRepo.getCatalogPublicityAudit();
+      return sendJson(res, 200, { ok: true, source: "sqlite", ...audit });
+    } catch (error) {
+      return sendJson(res, 500, {
+        ok: false,
+        source: "sqlite",
+        error: error?.message || "No se pudo auditar visibilidad",
       });
     }
   }
@@ -7180,7 +7198,7 @@ async function requestHandler(req, res) {
     req.on("data", (chunk) => {
       body += chunk;
     });
-    req.on("end", () => {
+    req.on("end", async () => {
       try {
         const payload = JSON.parse(body || "{}");
         const updates = payload.documents;
@@ -7995,7 +8013,7 @@ async function requestHandler(req, res) {
     req.on("data", (chunk) => {
       body += chunk;
     });
-    req.on("end", () => {
+    req.on("end", async () => {
       try {
         const { email, password, name, role, profile: profilePayload } = JSON.parse(body || "{}");
         if (!email || !password) {
@@ -9753,20 +9771,11 @@ async function requestHandler(req, res) {
     });
     req.on("end", () => {
       try {
-        const newProduct = JSON.parse(body || "{}");
-        const products = getProducts();
-        // Asignar un ID autoincremental sencillo
-        const newId = (
-          products.length
-            ? Math.max(...products.map((p) => parseInt(p.id, 10))) + 1
-            : 1
-        ).toString();
-        newProduct.id = newId;
-        const slug = ensureProductSlug(products, newProduct, newId) || `producto-${newId}`;
-        newProduct.slug = slug;
-        products.push(newProduct);
-        saveProducts(products);
-        return sendJson(res, 201, { success: true, product: newProduct });
+        JSON.parse(body || "{}");
+        return sendJson(res, 503, {
+          error:
+            "Alta no disponible en modo SQLite-only. Usá importación controlada para evitar carga completa de products.json.",
+        });
       } catch (err) {
         console.error("products-create-error", err);
         if (err?.code === "MEMORY_GUARD_BLOCKED") {
@@ -9830,20 +9839,27 @@ async function requestHandler(req, res) {
     req.on("data", (chunk) => {
       body += chunk;
     });
-    req.on("end", () => {
+    req.on("end", async () => {
       try {
         const update = JSON.parse(body || "{}");
-        const products = getProducts();
-        const index = products.findIndex((p) => p.id === id);
-        if (index === -1) {
+        const hasPriceField =
+          Object.prototype.hasOwnProperty.call(update, "price_minorista") ||
+          Object.prototype.hasOwnProperty.call(update, "price_mayorista");
+        if (hasPriceField) {
+          const hasAnyValidPrice =
+            Number.isFinite(Number(update.price_minorista)) ||
+            Number.isFinite(Number(update.price_mayorista));
+          if (!hasAnyValidPrice) {
+            return sendJson(res, 400, {
+              error: "No se puede guardar porque faltan campos de precio del producto. Revisar mapeo.",
+            });
+          }
+        }
+        const updated = await productsSqliteRepo.updateProductByIdentifier(id, update);
+        if (!updated) {
           return sendJson(res, 404, { error: "Producto no encontrado" });
         }
-        const merged = { ...products[index], ...update, id };
-        const safeSlug = ensureProductSlug(products, merged, id);
-        if (safeSlug) merged.slug = safeSlug;
-        products[index] = merged;
-        saveProducts(products);
-        return sendJson(res, 200, { success: true, product: products[index] });
+        return sendJson(res, 200, { success: true, product: normalizeProductImages(updated), source: "sqlite" });
       } catch (err) {
         console.error("products-update-error", err);
         if (err?.code === "MEMORY_GUARD_BLOCKED") {
@@ -9852,7 +9868,8 @@ async function requestHandler(req, res) {
           });
         }
         return sendJson(res, 500, {
-          error: "No se pudo cargar el catálogo para actualizar el producto",
+          error:
+            err?.message || "No se pudo actualizar el producto en SQLite. Intentá nuevamente o reconstruí el índice.",
         });
       }
     });
@@ -9863,14 +9880,10 @@ async function requestHandler(req, res) {
   if (pathname.startsWith("/api/products/") && req.method === "DELETE") {
     const id = pathname.split("/").pop();
     try {
-      const products = getProducts();
-      const index = products.findIndex((p) => p.id === id);
-      if (index === -1) {
-        return sendJson(res, 404, { error: "Producto no encontrado" });
-      }
-      const removed = products.splice(index, 1)[0];
-      saveProducts(products);
-      return sendJson(res, 200, { success: true, product: removed });
+      return sendJson(res, 503, {
+        error:
+          `Baja no disponible para ${id} en modo SQLite-only. Ejecutá una sincronización controlada para mantener integridad.`,
+      });
     } catch (err) {
       console.error(err);
       if (err?.code === "MEMORY_GUARD_BLOCKED") {

--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -2073,7 +2073,14 @@ function buildProductRow(product) {
   const safeModel = escapeHtml(compactText(product.model || "", 42));
   const safeCategory = escapeHtml(compactText(product.category || "", 30));
   const safeSubcategory = escapeHtml(compactText(product.subcategory || "", 42));
-  const safeVisibility = escapeHtml(product.visibility || "");
+  const visibilityLabel = cleanLabel(product.visibility || "") || "public(default)";
+  const safeVisibility = escapeHtml(visibilityLabel);
+  const minorValue = Number.isFinite(Number(product.price_minorista))
+    ? Number(product.price_minorista)
+    : "";
+  const mayorValue = Number.isFinite(Number(product.price_mayorista))
+    ? Number(product.price_mayorista)
+    : "";
   const explorerParts = [
     resolveCatalogBrand(product),
     resolveCatalogModel(product),
@@ -2101,8 +2108,8 @@ function buildProductRow(product) {
     <td class="product-cell" title="${escapeHtml(tagsArray.join(", "))}">${safeTags}</td>
     <td><input type="number" class="inline-edit inline-edit--compact" data-field="stock" min="0" value="${product.stock ?? 0}" />${stockBadge}</td>
     <td>${product.min_stock ?? ""}</td>
-    <td><input type="number" class="inline-edit inline-edit--compact" data-field="price_minorista" min="0" value="${product.price_minorista ?? 0}" /></td>
-    <td><input type="number" class="inline-edit inline-edit--compact" data-field="price_mayorista" min="0" value="${product.price_mayorista ?? 0}" /></td>
+    <td><input type="number" class="inline-edit inline-edit--compact" data-field="price_minorista" min="0" value="${minorValue}" placeholder="Consultar" /></td>
+    <td><input type="number" class="inline-edit inline-edit--compact" data-field="price_mayorista" min="0" value="${mayorValue}" placeholder="Consultar" /></td>
     <td>${safeVisibility}</td>
     <td><button class="edit-btn" data-id="${safeIdAttr}">Editar</button> <button class="delete-btn" data-id="${safeIdAttr}">Eliminar</button></td>`;
   const editBtn = tr.querySelector(".edit-btn");
@@ -3178,7 +3185,9 @@ function renderProductFormPreview() {
         ? "Visibilidad: Privado"
         : visibility === "draft"
         ? "Visibilidad: Borrador"
-        : "Visibilidad: Público";
+        : visibility
+        ? `Visibilidad: ${visibility}`
+        : "Visibilidad: Público por defecto";
     metaParts.push(visibilityLabel);
     if (slug) {
       metaParts.push(`URL: /productos/${slug}`);
@@ -3531,17 +3540,31 @@ function debounce(fn, t = 600) {
 
 async function patchField(id, field, value, input) {
   const old = input.dataset.original;
+  if ((field === "price_minorista" || field === "price_mayorista") && input.value === "") {
+    if (window.showToast) {
+      showToast("No se puede guardar porque faltan campos de precio del producto. Revisar mapeo.");
+    }
+    input.value = old;
+    return;
+  }
   try {
     const r = await apiFetch(`${API_BASE}/${id}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ [field]: value }),
     });
-    if (!r.ok) throw new Error("patch fail");
+    if (!r.ok) {
+      let message = "No se pudo actualizar";
+      try {
+        const data = await r.json();
+        if (data?.error) message = data.error;
+      } catch {}
+      throw new Error(message);
+    }
     highlightProductRow(id);
   } catch (e) {
     console.error(e);
-    if (window.showToast) showToast("No se pudo actualizar");
+    if (window.showToast) showToast(e.message || "No se pudo actualizar");
     input.value = old;
   }
 }
@@ -3562,7 +3585,12 @@ if (productsTableBody) {
     if (!row) return;
     const id = row.dataset.id;
     const field = input.dataset.field;
-    const value = input.type === "number" ? Number(input.value) : input.value;
+    const value =
+      input.type === "number"
+        ? input.value === ""
+          ? null
+          : Number(input.value)
+        : input.value;
     debouncedPatch(id, field, value, input);
     const product = productsCache.find((item) => String(item.id) === String(id));
     if (product) {

--- a/nerin_final_updated/frontend/js/product.js
+++ b/nerin_final_updated/frontend/js/product.js
@@ -82,9 +82,13 @@ function normalizeProductPayload(product) {
 }
 
 function resolveProductPriceContext(product) {
-  const retailRaw = Number(product?.price_minorista ?? product?.price);
-  const wholesaleRaw = Number(product?.price_mayorista ?? product?.price_wholesale);
-  const retail = Number.isFinite(retailRaw) && retailRaw >= 0 ? retailRaw : 0;
+  const retailRaw = Number(
+    product?.price_minorista ?? product?.price ?? product?.precio_minorista ?? product?.precio_final,
+  );
+  const wholesaleRaw = Number(
+    product?.price_mayorista ?? product?.price_wholesale ?? product?.precio_mayorista,
+  );
+  const retail = Number.isFinite(retailRaw) && retailRaw >= 0 ? retailRaw : null;
   const canUseWholesale =
     isWholesale() && Number.isFinite(wholesaleRaw) && wholesaleRaw >= 0;
   const wholesale = canUseWholesale ? wholesaleRaw : null;
@@ -1007,7 +1011,8 @@ function buildAttributes(product) {
 }
 
 function formatPrice(value) {
-  return `$${priceFormatter.format(Number(value || 0))}`;
+  if (!Number.isFinite(Number(value))) return "Consultar";
+  return `$${priceFormatter.format(Number(value))}`;
 }
 
 function getRetailUnitPrice(product) {
@@ -1298,11 +1303,18 @@ function renderProduct(product) {
   priceGrid.className = "product-buy-price-grid";
 
   const priceFinal = resolveProductDisplayPrice(product);
-  const legalPriceBlock = createPriceLegalBlock({
-    priceFinal,
-    priceNetNoNationalTaxes: calculateNetNoNationalTaxes(priceFinal),
-  });
-  priceGrid.appendChild(legalPriceBlock);
+  if (Number.isFinite(priceFinal)) {
+    const legalPriceBlock = createPriceLegalBlock({
+      priceFinal,
+      priceNetNoNationalTaxes: calculateNetNoNationalTaxes(priceFinal),
+    });
+    priceGrid.appendChild(legalPriceBlock);
+  } else {
+    const consult = document.createElement("p");
+    consult.className = "product-price-footnote";
+    consult.textContent = "Precio a consultar";
+    priceGrid.appendChild(consult);
+  }
 
   const priceComparison = document.createElement("div");
   priceComparison.className = "product-price-comparison";

--- a/nerin_final_updated/frontend/js/shop.js
+++ b/nerin_final_updated/frontend/js/shop.js
@@ -257,11 +257,13 @@ function sanitizePublicProduct(product) {
 }
 
 function resolvePriceContext(product) {
-  const retail = Number(product.price_minorista);
-  const wholesale = Number(product.price_mayorista ?? product.price_wholesale);
+  const retail = Number(
+    product.price_minorista ?? product.price ?? product.precio_minorista ?? product.precio_final,
+  );
+  const wholesale = Number(product.price_mayorista ?? product.price_wholesale ?? product.precio_mayorista);
   const canUseWholesale =
     isWholesale() && Number.isFinite(wholesale) && wholesale >= 0;
-  const safeRetail = Number.isFinite(retail) && retail >= 0 ? retail : 0;
+  const safeRetail = Number.isFinite(retail) && retail >= 0 ? retail : null;
   const safeWholesale = canUseWholesale ? wholesale : null;
   const active = canUseWholesale ? safeWholesale : safeRetail;
   const discountAmount =
@@ -313,7 +315,7 @@ function createPriceTierCard(label, value, modifier) {
   labelEl.textContent = label;
   const valueEl = document.createElement("span");
   valueEl.className = "price-tier__value";
-  valueEl.textContent = formatCurrency(value);
+  valueEl.textContent = Number.isFinite(value) ? formatCurrency(value) : "Consultar";
   tier.append(labelEl, valueEl);
   return tier;
 }
@@ -512,12 +514,19 @@ function createProductCard(product) {
     priceBlock.classList.add("price-block--wholesale");
   }
   const priceFinal = display.active;
-  const legalPrice = createPriceLegalBlock({
-    priceFinal,
-    priceNetNoNationalTaxes: calculateNetNoNationalTaxes(priceFinal),
-    compact: true,
-  });
-  priceBlock.appendChild(legalPrice);
+  if (Number.isFinite(priceFinal)) {
+    const legalPrice = createPriceLegalBlock({
+      priceFinal,
+      priceNetNoNationalTaxes: calculateNetNoNationalTaxes(priceFinal),
+      compact: true,
+    });
+    priceBlock.appendChild(legalPrice);
+  } else {
+    const consult = document.createElement("p");
+    consult.className = "price-comparison-locked";
+    consult.textContent = "Precio a consultar";
+    priceBlock.appendChild(consult);
+  }
   if (display.mode === "wholesale" && Number.isFinite(display.retail)) {
     const comparison = document.createElement("div");
     comparison.className = "price-comparison-grid";

--- a/nerin_final_updated/scripts/test-products-sqlite-query.js
+++ b/nerin_final_updated/scripts/test-products-sqlite-query.js
@@ -89,6 +89,71 @@ async function main() {
     assert(importedDetail.result.product != null, "imported CSV/Excel candidate should resolve detail");
   }
 
+  const productWithRealPrice = adminPage1.result.items.find((item) => {
+    const values = [
+      item.price_minorista,
+      item.price,
+      item.precio_minorista,
+      item.precio_final,
+      item.price_mayorista,
+    ];
+    return values.some((value) => Number.isFinite(Number(value)) && Number(value) > 0);
+  });
+  assert(productWithRealPrice, "debe existir al menos un producto con precio real > 0");
+  const adminPrice = Number(
+    productWithRealPrice.price_minorista ??
+      productWithRealPrice.price ??
+      productWithRealPrice.precio_minorista ??
+      productWithRealPrice.precio_final,
+  );
+  assert(Number.isFinite(adminPrice) && adminPrice > 0, "queryAdminProducts debe devolver precio real > 0");
+
+  const publicById = await timed("public query by id for priced product", () =>
+    productsSqliteRepo.queryProducts({
+      page: 1,
+      pageSize: 1,
+      search:
+        productWithRealPrice.id ||
+        productWithRealPrice.sku ||
+        productWithRealPrice.code ||
+        productWithRealPrice.publicSlug,
+    }),
+  );
+  const publicPriced = publicById.result.items[0] || null;
+  assert(publicPriced, "queryProducts debe devolver el producto con precio");
+  const publicPrice = Number(
+    publicPriced.price_minorista ??
+      publicPriced.price ??
+      publicPriced.precio_minorista ??
+      publicPriced.precio_final,
+  );
+  assert(Number.isFinite(publicPrice) && publicPrice > 0, "queryProducts debe devolver precio público correcto");
+
+  const withMinorMayor = adminPage1.result.items.find(
+    (item) =>
+      Number.isFinite(Number(item.price_minorista)) || Number.isFinite(Number(item.price_mayorista)),
+  );
+  assert(withMinorMayor, "queryAdminProducts debe incluir price_minorista/price_mayorista cuando existan");
+
+  const visibilityDefaultPublicAudit = await timed("publicity audit", () =>
+    productsSqliteRepo.getCatalogPublicityAudit(),
+  );
+  assert(
+    visibilityDefaultPublicAudit.result.productCount >= visibilityDefaultPublicAudit.result.publicProductCount,
+    "publicity-audit debe reportar conteos coherentes",
+  );
+  assert(
+    health.result.publicProductCount > 125 || health.result.publicProductCount === health.result.productCount,
+    "publicProductCount no debe quedar artificialmente en 125",
+  );
+
+  const firstTen = publicPage1.result.items.slice(0, 10);
+  for (const item of firstTen) {
+    assert(item.url && item.publicSlug, "cada producto de grilla debe incluir url/publicSlug");
+    const found = await productsSqliteRepo.getProductByPublicSlugOrAnyIdentifier(item.publicSlug);
+    assert(found?.product, `detalle debe resolver para ${item.publicSlug}`);
+  }
+
   console.log("[test-products-sqlite-query] ok", {
     productCount: health.result.productCount,
     publicProductCount: health.result.publicProductCount,


### PR DESCRIPTION
### Motivation
- After migrating to SQLite the public catalog and admin showed wrong prices (`$0`) and many products appeared non-public due to incomplete price projection and strict visibility filtering. The goal was to preserve performance while restoring data fidelity and safe admin edits. 

### Description
- Map and persist all price aliases during rebuild and in the SQLite schema by adding dedicated columns (`price_minorista`, `price_mayorista`, `precio_*`, `cost`, etc.) and a `resolvePriceFields` mapper so missing prices stay `null` (not forced to `0`), and emit temporary `[products-price-map]` logs for first rows; changes in `backend/data/productsSqliteRepo.js` include schema, mapping, selection, and summary fields.  
- Return full price columns from SQLite list queries and use `COALESCE(...)` for price ordering/filtering so `queryProducts`/`queryAdminProducts` and sorting use real aliases instead of a single `price` projection.  
- Add visibility observability: extend `getCatalogHealth` with additional counts and add a new endpoint `GET /api/catalog/publicity-audit` to report rejected counts and examples (SQLite-only). Changes in `backend/server.js` and new `getCatalogPublicityAudit` in the repo.  
- Change admin edit flow to avoid loading `products.json`: implement `updateProductByIdentifier` which updates a single SQLite row (`raw_json` + summary columns) and wire `PATCH/PUT /api/products/:id` to use it; block `POST`/`DELETE` in SQLite-only mode with explicit guardrail messages. (backend `server.js` + `productsSqliteRepo.js`).  
- Frontend fixes to avoid showing `$0` and to indicate missing price as “Consultar”: update `frontend/js/admin.js` (inline edits, visibility labels, prevent saving empty price), `frontend/js/shop.js` (display logic, price tiers), and `frontend/js/product.js` (detail rendering).  
- Add tests and audit assertions in `scripts/test-products-sqlite-query.js` covering real-price mapping, admin/public price fields, publicity-audit coherence and that list items resolve to detail.  
- Files changed (high level): `backend/data/productsSqliteRepo.js`, `backend/server.js`, `frontend/js/admin.js`, `frontend/js/shop.js`, `frontend/js/product.js`, `scripts/test-products-sqlite-query.js`.

### Testing
- Ran static checks and fixed an `await` placement issue: `node --check nerin_final_updated/backend/server.js` and `node --check` for the modified modules succeeded after the fix. (initial run failed due to non-async callback, then corrected).  
- Rebuilt the SQLite index with `node nerin_final_updated/scripts/rebuild-products-db.js` and observed sample `[products-price-map]` logs showing mapped prices and successful rebuild: rebuild completed (`[products-db] rebuild done count=...`).  
- Executed `node nerin_final_updated/scripts/test-products-sqlite-query.js` which exercised `queryProducts`, `queryAdminProducts`, `getProductByPublicSlugOrAnyIdentifier` and the new publicity audit; all assertions passed and the script printed an `ok` summary.  
- Ran `node nerin_final_updated/scripts/check-no-products-full-parse.js` to validate no full-parse fallback; it completed OK.  

All automated tests listed above passed after the adjustments; initial syntax error was fixed during the rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f019d5fe2c833197778a2efb3604e6)