### PR TITLE
Auto-bootstrap products sqlite when first request hits cold instance

### DIFF
--- a/nerin_final_updated/backend/data/productsSqliteRepo.js
+++ b/nerin_final_updated/backend/data/productsSqliteRepo.js
@@ -986,10 +986,32 @@ async function ensureProductsDbOnce() {
   }
 }
 
+function ensureProductsDbInBackground(trigger = "request") {
+  if (dbReady || dbReadyPromise) return;
+  dbReadyPromise = ensureProductsDb({ allowRebuild: true });
+  dbReadyPromise
+    .then(() => {
+      console.log(`[products-db] background ensure completed trigger=${trigger}`);
+    })
+    .catch((error) => {
+      console.warn(`[products-db] background ensure failed trigger=${trigger} reason=${error?.message || error}`);
+    })
+    .finally(() => {
+      dbReadyPromise = null;
+    });
+}
+
 async function ensureDbReadyForRequest() {
   if (dbReady) return;
   if (dbReadyPromise) throw createInitializingError("sqlite_bootstrap_in_progress");
-  await ensureProductsDb({ allowRebuild: false });
+  try {
+    await ensureProductsDb({ allowRebuild: false });
+  } catch (error) {
+    if (error?.code === "CATALOG_INITIALIZING") {
+      ensureProductsDbInBackground("request-auto-bootstrap");
+    }
+    throw error;
+  }
 }
 
 function buildSort(sort) {


### PR DESCRIPTION
### Motivation
- Some deployments never run the process startup path that triggers the products sqlite bootstrap, leaving the catalog uninitialized and requests returning a permanent 503 (`Catálogo rápido inicializando`).
- The change aims to start the catalog bootstrap asynchronously when the first incoming request detects initialization is required so the instance can self-recover without manual startup hooks.

### Description
- Added `ensureProductsDbInBackground(trigger)` which starts `ensureProductsDb({ allowRebuild: true })` asynchronously and logs completion or failure, and clears `dbReadyPromise` when finished, in `nerin_final_updated/backend/data/productsSqliteRepo.js`.
- Updated `ensureDbReadyForRequest()` to catch `CATALOG_INITIALIZING` errors and invoke `ensureProductsDbInBackground("request-auto-bootstrap")`, while re-throwing the original error to preserve the existing transient 503 behavior for the first request.
- Changes preserve existing `CATALOG_INITIALIZING` semantics and the `dbReady` / `dbReadyPromise` lifecycle to avoid concurrent rebuild races.

### Testing
- Ran `node --check nerin_final_updated/backend/data/productsSqliteRepo.js` which succeeded.
- Ran `npm test -- --runTestsByPath __tests__/backend/seo-endpoints.test.js` which failed due to an unrelated existing sitemap expectation in the test fixture and not due to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a232d48483319b25561d0e881ab6)