### PR TITLE
Invalidate catalog caches and recalc is_public on admin product updates

### DIFF
--- a/nerin_final_updated/backend/data/productsSqliteRepo.js
+++ b/nerin_final_updated/backend/data/productsSqliteRepo.js
@@ -764,6 +764,13 @@ async function updateProductByIdentifier(identifier, patch = {}) {
   const current = JSON.parse(row.raw_json || "{}");
   const merged = { ...current, ...patch };
   const mapped = mapProductRow(merged, { rowNumber: row.rowid });
+  const changedFields = Object.keys(patch || {}).filter((field) => current[field] !== patch[field]);
+  const oldVisibility = firstText([current.visibility, current.Visibility, ""]) || "";
+  const newVisibility = firstText([merged.visibility, merged.Visibility, ""]) || "";
+  const oldStatus = firstText([current.status, current.Status, ""]) || "";
+  const newStatus = firstText([merged.status, merged.Status, ""]) || "";
+  const oldIsPublic = isProductPublic(current);
+  const newIsPublic = Boolean(mapped.is_public);
   await run(
     db,
     `UPDATE products SET
@@ -812,6 +819,16 @@ async function updateProductByIdentifier(identifier, patch = {}) {
     ],
   );
   countCache.clear();
+  console.log("[products-admin-update]", {
+    identifier: target,
+    changedFields,
+    oldVisibility,
+    newVisibility,
+    oldStatus,
+    newStatus,
+    oldIsPublic,
+    newIsPublic,
+  });
   return normalizeProductForAdminList(merged, { rowid: row.rowid, public_slug: mapped.public_slug });
 }
 

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -227,6 +227,11 @@ const REVIEW_STATUSES = ["PENDING", "PUBLISHED", "FLAGGED", "REMOVED"];
 
 let _cache = { t: 0, data: null };
 let metaFeedCache = { t: 0, baseUrl: null, csv: null, count: 0, inStockCount: 0 };
+function invalidateCatalogCaches(reason = "unknown") {
+  _cache = { t: 0, data: null };
+  metaFeedCache = { t: 0, baseUrl: null, csv: null, count: 0, inStockCount: 0 };
+  console.log(`[catalog-cache] invalidated reason=${reason}`);
+}
 const importJobs = new Map();
 const importWorkers = new Map();
 const importJobLogBuckets = new Map();
@@ -4038,6 +4043,7 @@ function saveProducts(products) {
     "utf8",
   );
   _cache = { t: Date.now(), data: normalized };
+  invalidateCatalogCaches("saveProducts");
 }
 
 // Leer pedidos desde el archivo JSON
@@ -6321,8 +6327,16 @@ async function requestHandler(req, res) {
           ? {
               id: product.id || "",
               sku: product.sku || "",
+              code: product.code || "",
               slug: product.slug || "",
               publicSlug: product.publicSlug || "",
+              visibility: product.visibility || "",
+              status: product.status || "",
+              stock: Number.isFinite(Number(product.stock)) ? Number(product.stock) : null,
+              price: Number.isFinite(Number(product.price)) ? Number(product.price) : null,
+              title: product.title || product.name || "",
+              seoTitle: product.seoTitle || product.seo_title || "",
+              updatedAt: product.updatedAt || product.modifiedAt || null,
               name: product.name || "",
               is_public: isProductPublic(product),
             }
@@ -9891,6 +9905,7 @@ async function requestHandler(req, res) {
         if (!updated) {
           return sendJson(res, 404, { error: "Producto no encontrado" });
         }
+        invalidateCatalogCaches("admin_product_update");
         return sendJson(res, 200, { success: true, product: normalizeProductImages(updated), source: "sqlite" });
       } catch (err) {
         console.error("products-update-error", err);

--- a/nerin_final_updated/scripts/test-products-admin-update-sync.js
+++ b/nerin_final_updated/scripts/test-products-admin-update-sync.js
@@ -1,0 +1,59 @@
+const productsSqliteRepo = require('../backend/data/productsSqliteRepo');
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+async function main() {
+  await productsSqliteRepo.ensureProductsDb();
+  const adminPage = await productsSqliteRepo.queryAdminProducts({ page: 1, pageSize: 250 });
+  const sample = adminPage.items.find((p) => p && (p.id || p.sku || p.code || p.publicSlug));
+  assert(sample, 'No se encontró producto de prueba');
+  const identifier = sample.id || sample.sku || sample.code || sample.publicSlug;
+
+  const initialDetail = await productsSqliteRepo.getProductByPublicSlugOrAnyIdentifier(identifier);
+  assert(initialDetail?.product, 'No se pudo obtener detalle inicial');
+  const original = initialDetail.product;
+
+  const patched = {
+    visibility: 'public',
+    status: 'active',
+    stock: 77,
+    seo_title: 'SEO Sync Test',
+    title: 'Titulo Sync Test'
+  };
+
+  const updated = await productsSqliteRepo.updateProductByIdentifier(identifier, patched);
+  assert(updated, 'updateProductByIdentifier no devolvió producto');
+
+  const debug = await productsSqliteRepo.getProductByPublicSlugOrAnyIdentifier(identifier);
+  assert(debug?.product, 'No se pudo obtener detalle luego de update');
+  const product = debug.product;
+
+  assert(productsSqliteRepo.isProductPublic(product) === true, 'is_public debe recalcularse a true');
+  assert(Number(product.stock) === 77, 'stock público debe reflejar update');
+  assert((product.seo_title || product.seoTitle || '').includes('SEO Sync Test'), 'seo title debe reflejar update');
+  assert((product.title || '').includes('Titulo Sync Test'), 'title debe reflejar update');
+
+  const publicSearch = await productsSqliteRepo.queryProducts({ page: 1, pageSize: 20, search: identifier });
+  const found = (publicSearch.items || []).find((item) =>
+    [item.id, item.sku, item.code, item.publicSlug].map((v) => String(v || '')).includes(String(identifier)),
+  );
+  assert(found, 'producto actualizado debe aparecer en /api/products');
+  assert(Number(found.stock) === 77, 'query pública debe reflejar stock actualizado');
+
+  await productsSqliteRepo.updateProductByIdentifier(identifier, {
+    visibility: original.visibility,
+    status: original.status,
+    stock: original.stock,
+    seo_title: original.seo_title || original.seoTitle || '',
+    title: original.title || original.name || '',
+  });
+
+  console.log('[test-products-admin-update-sync] ok identifier=%s', identifier);
+}
+
+main().catch((error) => {
+  console.error('[test-products-admin-update-sync] fail', error);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation
- Admin edits (visibility/stock/price/SEO) were being persisted but public `/api/products` responses could remain stale due to cached SQLite-derived data. 
- Updates must be reflected quickly and consistently in the public catalog without triggering full rebuilds for single-item edits. 
- `is_public` must be recalculated after edits when visibility/status change so public listing logic is correct.

### Description
- Added `invalidateCatalogCaches(reason)` to clear in-memory `_cache` and `metaFeedCache` and log the invalidation, and called it after `saveProducts()` and after admin `PUT/PATCH /api/products/:id` updates to avoid stale public responses. 
- Enhanced `updateProductByIdentifier()` to compute `changedFields`, capture `oldVisibility/newVisibility`, `oldStatus/newStatus`, `oldIsPublic/newIsPublic`, log a structured `[products-admin-update]` event, and continue updating summarized columns in SQLite. 
- Extended `GET /api/catalog/debug-product?identifier=...` response to include `code`, `visibility`, `status`, `stock`, `price`, `title`, `seoTitle`, and `updatedAt` to help compare admin vs public state. 
- Added regression test script `scripts/test-products-admin-update-sync.js` that performs an admin update and verifies `is_public`, `stock`, `seo/title`, and presence in public `queryProducts` are updated.

### Testing
- Ran syntax checks with `node --check nerin_final_updated/backend/data/productsSqliteRepo.js` and `node --check nerin_final_updated/backend/server.js`, both succeeded. 
- Executed existing smoke/regression scripts `node nerin_final_updated/scripts/test-products-sqlite-query.js` and `node nerin_final_updated/scripts/test-products-sqlite-corruption-repair.js`, both passed. 
- Ran the new `node nerin_final_updated/scripts/test-products-admin-update-sync.js` which validated visibility→`is_public`, stock, SEO/title, and that the product appears in public queries, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f138e1f76c83318ba21d95a2a6c2cc)