### PR TITLE
Add production catalog verifier and strengthen admin product sync test

### DIFF
--- a/nerin_final_updated/scripts/test-products-admin-update-sync.js
+++ b/nerin_final_updated/scripts/test-products-admin-update-sync.js
@@ -10,45 +10,74 @@ async function main() {
   const sample = adminPage.items.find((p) => p && (p.id || p.sku || p.code || p.publicSlug));
   assert(sample, 'No se encontró producto de prueba');
   const identifier = sample.id || sample.sku || sample.code || sample.publicSlug;
+  const searchTerm = sample.sku || sample.code || sample.partNumber || sample.mpn || sample.ean || sample.gtin || sample.supplierCode || sample.publicSlug || identifier;
 
   const initialDetail = await productsSqliteRepo.getProductByPublicSlugOrAnyIdentifier(identifier);
   assert(initialDetail?.product, 'No se pudo obtener detalle inicial');
   const original = initialDetail.product;
 
-  const patched = {
+  const randomStock = 50 + Math.floor(Math.random() * 50);
+  const seoTitleValue = `SEO Sync Test ${Date.now()}`;
+  const titleValue = `Titulo Sync Test ${Date.now()}`;
+
+  try {
+    const updatedPrivate = await productsSqliteRepo.updateProductByIdentifier(identifier, {
+    visibility: 'private',
+    status: 'private',
+    });
+    assert(updatedPrivate, 'No se pudo pasar producto a private');
+
+    const privateDebug = await productsSqliteRepo.debugPublicationByIdentifier(identifier);
+    assert(privateDebug?.found === true, 'debug-publication private debe encontrar producto');
+    assert(privateDebug.computed?.isPublic === false, 'computed.isPublic debe ser false al poner private');
+    assert(Number(privateDebug.sqlite?.is_public) === 0, 'sqlite.is_public debe ser 0 al poner private');
+    const privateSearch = await productsSqliteRepo.queryProducts({ page: 1, pageSize: 20, search: searchTerm });
+    const privateFound = (privateSearch.items || []).find((item) =>
+      [item.id, item.sku, item.code, item.publicSlug].map((v) => String(v || '')).includes(String(identifier)),
+    );
+    assert(!privateFound, 'producto private no debe aparecer en query pública');
+
+    const updatedPublic = await productsSqliteRepo.updateProductByIdentifier(identifier, {
     visibility: 'public',
-    status: 'active',
-    stock: 77,
-    seo_title: 'SEO Sync Test',
-    title: 'Titulo Sync Test'
-  };
-
-  const updated = await productsSqliteRepo.updateProductByIdentifier(identifier, patched);
-  assert(updated, 'updateProductByIdentifier no devolvió producto');
-
-  const debug = await productsSqliteRepo.getProductByPublicSlugOrAnyIdentifier(identifier);
-  assert(debug?.product, 'No se pudo obtener detalle luego de update');
-  const product = debug.product;
-
-  assert(productsSqliteRepo.isProductPublic(product) === true, 'is_public debe recalcularse a true');
-  assert(Number(product.stock) === 77, 'stock público debe reflejar update');
-  assert((product.seo_title || product.seoTitle || '').includes('SEO Sync Test'), 'seo title debe reflejar update');
-  assert((product.title || '').includes('Titulo Sync Test'), 'title debe reflejar update');
-
-  const publicSearch = await productsSqliteRepo.queryProducts({ page: 1, pageSize: 20, search: identifier });
-  const found = (publicSearch.items || []).find((item) =>
-    [item.id, item.sku, item.code, item.publicSlug].map((v) => String(v || '')).includes(String(identifier)),
-  );
-  assert(found, 'producto actualizado debe aparecer en /api/products');
-  assert(Number(found.stock) === 77, 'query pública debe reflejar stock actualizado');
-
-  await productsSqliteRepo.updateProductByIdentifier(identifier, {
-    visibility: original.visibility,
-    status: original.status,
-    stock: original.stock,
-    seo_title: original.seo_title || original.seoTitle || '',
-    title: original.title || original.name || '',
+    status: '',
+    stock: randomStock,
+    seo_title: seoTitleValue,
+    title: titleValue,
   });
+    assert(updatedPublic, 'No se pudo pasar producto a public');
+
+    const publicDebug = await productsSqliteRepo.debugPublicationByIdentifier(identifier);
+    assert(publicDebug?.found === true, 'debug-publication public debe encontrar producto');
+    assert(publicDebug.computed?.isPublic === true, 'computed.isPublic debe ser true al poner public');
+    assert(Number(publicDebug.sqlite?.is_public) === 1, 'sqlite.is_public debe ser 1 al poner public');
+    assert(publicDebug.wouldAppearInPublicQuery === true, 'debe aparecer en query pública');
+
+    const publicSearch = await productsSqliteRepo.queryProducts({ page: 1, pageSize: 20, search: searchTerm });
+    const found = (publicSearch.items || []).find((item) =>
+      [item.id, item.sku, item.code, item.publicSlug].map((v) => String(v || '')).includes(String(identifier)),
+    );
+    assert(found, 'producto actualizado debe aparecer en /api/products');
+    assert(Number(found.stock) === randomStock, 'query pública debe reflejar stock actualizado');
+    assert((found.title || '').includes(titleValue), 'query pública debe reflejar title actualizado');
+
+    const adminSearch = await productsSqliteRepo.queryAdminProducts({ page: 1, pageSize: 20, search: searchTerm });
+    const adminFound = (adminSearch.items || [])[0];
+    assert(adminFound, 'admin query debe devolver producto actualizado');
+    assert(Number(adminFound.stock) === randomStock, 'admin query debe reflejar stock actualizado');
+
+    await productsSqliteRepo.repairPublicFlags();
+    const afterRepair = await productsSqliteRepo.debugPublicationByIdentifier(identifier);
+    assert(afterRepair?.computed?.isPublic === true, 'no debe perder estado public luego de repair');
+    assert((afterRepair.raw?.title || '').includes(titleValue), 'no debe perder title luego de repair');
+  } finally {
+    await productsSqliteRepo.updateProductByIdentifier(identifier, {
+      visibility: original.visibility,
+      status: original.status,
+      stock: original.stock,
+      seo_title: original.seo_title || original.seoTitle || '',
+      title: original.title || original.name || '',
+    });
+  }
 
   console.log('[test-products-admin-update-sync] ok identifier=%s', identifier);
 }

--- a/nerin_final_updated/scripts/verify-production-catalog.js
+++ b/nerin_final_updated/scripts/verify-production-catalog.js
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+const BASE_URL = (process.env.BASE_URL || 'https://nerinparts.com.ar').replace(/\/$/, '');
+const ADMIN_EMAIL = process.env.ADMIN_AUTH_EMAIL || 'admin@nerin.com';
+const ADMIN_BEARER_TOKEN = process.env.ADMIN_BEARER_TOKEN || Buffer.from(`${ADMIN_EMAIL}:script`).toString('base64');
+const RUN_REPAIR = String(process.env.RUN_REPAIR || '').toLowerCase() === 'true';
+
+const adminHeaders = {
+  authorization: `Bearer ${ADMIN_BEARER_TOKEN}`,
+  'content-type': 'application/json',
+};
+
+async function fetchJson(path, options = {}) {
+  try {
+    const res = await fetch(`${BASE_URL}${path}`, options);
+    let body = null;
+    try { body = await res.json(); } catch { body = { parseError: true }; }
+    return { ok: res.ok, status: res.status, body };
+  } catch (error) {
+    return {
+      ok: false,
+      status: 0,
+      body: { networkError: true, message: error?.message || String(error) },
+    };
+  }
+}
+
+function summarize(result) {
+  return {
+    ok: result.ok,
+    status: result.status,
+    body: result.body,
+  };
+}
+
+(async function main() {
+  const report = {
+    baseUrl: BASE_URL,
+    checkedAt: new Date().toISOString(),
+    authMode: 'Authorization: Bearer <base64(email:anything)>',
+    endpoints: {},
+    keyMetrics: {},
+    repair: null,
+    checks: {},
+  };
+
+  const health = await fetchJson('/api/catalog/health');
+  const publicityAudit = await fetchJson('/api/catalog/publicity-audit');
+  const performance = await fetchJson('/api/catalog/performance-test');
+  const publicPage = await fetchJson('/api/products?page=1&pageSize=24');
+  const adminPage = await fetchJson('/api/admin/products?page=1&pageSize=100', { headers: adminHeaders });
+  const debugGh82 = await fetchJson('/api/catalog/debug-search?search=GH82');
+  const debugS25 = await fetchJson('/api/catalog/debug-search?search=s25%20ultra');
+  const publicGh82 = await fetchJson('/api/products?page=1&pageSize=24&search=GH82');
+  const publicS25 = await fetchJson('/api/products?page=1&pageSize=24&search=s25%20ultra');
+
+  report.endpoints.health = summarize(health);
+  report.endpoints.publicityAudit = summarize(publicityAudit);
+  report.endpoints.performance = summarize(performance);
+  report.endpoints.publicProducts = summarize(publicPage);
+  report.endpoints.adminProducts = summarize(adminPage);
+  report.endpoints.debugGh82 = summarize(debugGh82);
+  report.endpoints.debugS25Ultra = summarize(debugS25);
+  report.endpoints.publicGh82 = summarize(publicGh82);
+  report.endpoints.publicS25Ultra = summarize(publicS25);
+
+  report.keyMetrics = {
+    health: {
+      ready: health.body?.ready,
+      source: health.body?.source,
+      sqliteExists: health.body?.sqliteExists,
+      corruptDetected: health.body?.corruptDetected,
+      productCount: health.body?.productCount,
+      publicProductCount: health.body?.publicProductCount,
+    },
+    adminTotalItems: adminPage.body?.totalItems,
+    adminSource: adminPage.body?.source,
+    publicTotalItems: publicPage.body?.totalItems,
+    publicSource: publicPage.body?.source,
+    rejectedCounts: publicityAudit.body?.rejectedCounts || null,
+    gh82: {
+      debugDiagnosis: debugGh82.body?.diagnosis,
+      debugTotalMatches: debugGh82.body?.totalMatches,
+      publicTotalItems: publicGh82.body?.totalItems,
+    },
+    s25Ultra: {
+      debugDiagnosis: debugS25.body?.diagnosis,
+      debugTotalMatches: debugS25.body?.totalMatches,
+      publicTotalItems: publicS25.body?.totalItems,
+    },
+  };
+
+  if (RUN_REPAIR) {
+    const repair = await fetchJson('/api/admin/catalog/repair-public-flags', {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({ reason: 'verify-production-catalog-script' }),
+    });
+    const postAudit = await fetchJson('/api/catalog/publicity-audit');
+    const postPublic = await fetchJson('/api/products?page=1&pageSize=24');
+    report.repair = {
+      call: summarize(repair),
+      postAudit: summarize(postAudit),
+      postPublic: summarize(postPublic),
+    };
+  }
+
+  report.checks = {
+    healthReady: health.body?.ready === true,
+    healthSourceSqlite: health.body?.source === 'sqlite',
+    adminSourceSqlite: adminPage.body?.source === 'sqlite',
+    publicSourceSqlite: publicPage.body?.source === 'sqlite',
+    adminVsPublicGap: {
+      adminTotalItems: adminPage.body?.totalItems,
+      publicTotalItems: publicPage.body?.totalItems,
+      gap: Number(adminPage.body?.totalItems || 0) - Number(publicPage.body?.totalItems || 0),
+    },
+  };
+
+  console.log(JSON.stringify(report, null, 2));
+})();


### PR DESCRIPTION
### Motivation

- Improve confidence that product publication flags and public queries stay consistent after admin updates by exercising visibility transitions and repair flows.  
- Provide a lightweight production-check script to validate catalog health, publicity audit, and targeted search/debug endpoints against a deployed site.  

### Description

- Enhance `scripts/test-products-admin-update-sync.js` to: toggle a sample product to `private` then back to `public`, apply randomized `stock`, `title`, and `seo_title` values, and assert via `debugPublicationByIdentifier`, public and admin queries, and `repairPublicFlags`; finally restore the original product values.  
- Add `scripts/verify-production-catalog.js`, a new CLI script that queries `/api/catalog/health`, `/api/catalog/publicity-audit`, `/api/catalog/performance-test`, public and admin product pages, targeted debug searches, and optionally posts to `/api/admin/catalog/repair-public-flags` when `RUN_REPAIR=true`.  
- Use base64 `Authorization: Bearer <base64(email:anything)>` admin header for admin endpoints and emit a JSON report summarizing endpoints, key metrics, and basic checks.  

### Testing

- Executed the updated test script `node scripts/test-products-admin-update-sync.js` to exercise private->public transitions, debug assertions, public/admin queries and `repairPublicFlags`, and the script completed the run asserting expected conditions.  
- Ran the new verifier `node scripts/verify-production-catalog.js` against a target base URL (with `ADMIN_BEARER_TOKEN` set) to generate a diagnostic JSON report and confirmed endpoint responses were captured.  
- No unit test files were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1534327248331a9371c66e955fdc4)