### PR TITLE
Ensure admin publication forces enabled=true and validates final public state

### DIFF
--- a/nerin_final_updated/backend/data/productsSqliteRepo.js
+++ b/nerin_final_updated/backend/data/productsSqliteRepo.js
@@ -796,8 +796,13 @@ async function updateProductByIdentifier(identifier, patch = {}) {
   );
   if (!row) return null;
   const current = JSON.parse(row.raw_json || "{}");
+  const patchVisibility = normalizeQueryText(patch?.visibility);
+  const patchStatus = normalizeQueryText(patch?.status);
   const shouldForceEnabledTrue =
-    normalizeQueryText(patch?.visibility) === "public" ||
+    patchVisibility === "public" ||
+    patchVisibility === "visible" ||
+    patchStatus === "active" ||
+    patchStatus === "published" ||
     patch?.is_public === true ||
     patch?.published === true ||
     patch?.visible === true;

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -9951,6 +9951,17 @@ async function requestHandler(req, res) {
         const hasPriceField =
           Object.prototype.hasOwnProperty.call(update, "price_minorista") ||
           Object.prototype.hasOwnProperty.call(update, "price_mayorista");
+        const normalizedVisibility = productsSqliteRepo.normalizeQueryText(update?.visibility || "");
+        const normalizedStatus = productsSqliteRepo.normalizeQueryText(update?.status || "");
+        const isPublishAction = Boolean(
+          normalizedVisibility === "public" ||
+          normalizedVisibility === "visible" ||
+          normalizedStatus === "active" ||
+          normalizedStatus === "published" ||
+          update?.is_public === true ||
+          update?.published === true ||
+          update?.visible === true,
+        );
         if (hasPriceField) {
           const hasAnyValidPrice =
             Number.isFinite(Number(update.price_minorista)) ||
@@ -9964,6 +9975,15 @@ async function requestHandler(req, res) {
         const updated = await productsSqliteRepo.updateProductByIdentifier(id, update);
         if (!updated) {
           return sendJson(res, 404, { error: "Producto no encontrado" });
+        }
+        if (isPublishAction) {
+          const publicationDebug = await productsSqliteRepo.debugPublicationByIdentifier(id);
+          if (publicationDebug?.found && publicationDebug?.computed?.isPublic === false && publicationDebug?.computed?.reason === "enabled_false") {
+            return sendJson(res, 409, {
+              error: "No se pudo publicar el producto porque quedó enabled=false",
+              publication: publicationDebug,
+            });
+          }
         }
         invalidateCatalogCaches("admin_product_update");
         return sendJson(res, 200, { success: true, product: normalizeProductImages(updated), source: "sqlite" });

--- a/nerin_final_updated/scripts/test-products-enabled-publication-sync.js
+++ b/nerin_final_updated/scripts/test-products-enabled-publication-sync.js
@@ -1,52 +1,74 @@
-const assert = require('assert');
-const productsSqliteRepo = require('../backend/data/productsSqliteRepo');
+const assert = require("assert");
+const productsSqliteRepo = require("../backend/data/productsSqliteRepo");
 
 (async () => {
   await productsSqliteRepo.ensureProductsDb();
-  const identifier = 'GH82-36387A';
-  let debug = await productsSqliteRepo.debugPublicationByIdentifier(identifier);
-  let targetIdentifier = identifier;
+  const identifier = "GH82-36387A";
 
-  if (!debug?.found) {
+  const beforeHealth = await productsSqliteRepo.getCatalogHealth();
+  let originalDebug = await productsSqliteRepo.debugPublicationByIdentifier(identifier);
+  if (!originalDebug?.found) {
     const admin = await productsSqliteRepo.queryAdminProducts({ page: 1, pageSize: 1 });
-    assert(admin.items.length > 0, 'sin productos para test');
-    targetIdentifier = admin.items[0].id || admin.items[0].sku;
-    await productsSqliteRepo.updateProductByIdentifier(targetIdentifier, {
+    assert(admin.items.length > 0, "sin productos base para preparar test");
+    const seedIdentifier = admin.items[0].id || admin.items[0].sku || admin.items[0].code;
+    await productsSqliteRepo.updateProductByIdentifier(seedIdentifier, {
       sku: identifier,
-      name: 'Display Samsung S25 Ultra',
-      visibility: 'public',
+      code: identifier,
+      name: "Display Samsung S25 Ultra",
+      visibility: "private",
       enabled: false,
-      status: 'active',
+      status: "active",
     });
-    targetIdentifier = identifier;
+    originalDebug = await productsSqliteRepo.debugPublicationByIdentifier(identifier);
   }
+  assert.equal(originalDebug?.found, true, "GH82-36387A debe existir en SQLite");
 
-  const initialPublic = await productsSqliteRepo.getCatalogHealth();
-  await productsSqliteRepo.updateProductByIdentifier(targetIdentifier, { visibility: 'public', status: 'active' });
-  await productsSqliteRepo.updateProductByIdentifier(targetIdentifier, {
-    enabled: false,
-    status: 'active',
+  const originalRaw = originalDebug.raw || {};
+  const restorePatch = {
+    visibility: originalRaw.visibility ?? null,
+    status: originalRaw.status ?? null,
+    enabled: originalRaw.enabled,
+  };
+
+  await productsSqliteRepo.updateProductByIdentifier(identifier, {
+    sku: identifier,
+    name: "Display Samsung S25 Ultra",
+    visibility: "public",
+    enabled: true,
+    status: "active",
   });
-  const privateDebug = await productsSqliteRepo.debugPublicationByIdentifier(targetIdentifier);
-  assert.equal(privateDebug.computed.isPublic, false);
-  assert.equal(privateDebug.computed.reason, 'enabled_false');
+  await productsSqliteRepo.updateProductByIdentifier(identifier, { enabled: false });
+  const beforePublishHealth = await productsSqliteRepo.getCatalogHealth();
 
-  await productsSqliteRepo.updateProductByIdentifier(targetIdentifier, { visibility: 'public' });
-  const publicDebug = await productsSqliteRepo.debugPublicationByIdentifier(targetIdentifier);
-  assert.equal(publicDebug.computed.isPublic, true);
-  assert.equal(publicDebug.computed.reason, 'public');
+  const initialDebug = await productsSqliteRepo.debugPublicationByIdentifier(identifier);
+  assert.equal(initialDebug.computed.isPublic, false, "estado inicial debe ser no público");
+  assert.equal(initialDebug.computed.reason, "enabled_false", "reason inicial esperado");
 
-  const searchableDebug = await productsSqliteRepo.debugPublicationByIdentifier(targetIdentifier);
-  assert.equal(searchableDebug.wouldAppearInPublicQuery, true, 'no aparece en query pública');
+  await productsSqliteRepo.updateProductByIdentifier(identifier, { visibility: "public" });
 
-  const afterPublic = await productsSqliteRepo.getCatalogHealth();
-  assert(Number(afterPublic.publicProductCount) >= Number(initialPublic.publicProductCount), 'publicProductCount no subió o se mantuvo');
+  const afterPublishDebug = await productsSqliteRepo.debugPublicationByIdentifier(identifier);
+  assert.equal(afterPublishDebug.sqlite.visibility, "public", "sqlite.visibility debe ser public");
+  assert.equal(Number(afterPublishDebug.sqlite.enabled), 1, "sqlite.enabled debe ser 1");
+  assert.equal(Number(afterPublishDebug.sqlite.is_public), 1, "sqlite.is_public debe ser 1");
+  assert.equal(afterPublishDebug.computed.isPublic, true, "computed.isPublic debe ser true");
+  assert.equal(afterPublishDebug.wouldAppearInPublicQuery, true, "debe aparecer en query pública");
+  assert.equal(afterPublishDebug.wouldMatchSearch, true, "debe matchear search_text");
 
-  await productsSqliteRepo.updateProductByIdentifier(targetIdentifier, { visibility: 'private' });
-  const finalDebug = await productsSqliteRepo.debugPublicationByIdentifier(targetIdentifier);
-  assert.equal(finalDebug.computed.isPublic, false);
+  const searchDebug = await productsSqliteRepo.debugCatalogSearch(identifier);
+  assert.notEqual(searchDebug.diagnosis, "matchea_pero_is_public_0", "search no debe quedar bloqueado por is_public=0");
 
-  console.log('OK test-products-enabled-publication-sync');
+  const afterHealth = await productsSqliteRepo.getCatalogHealth();
+  assert(
+    Number(afterHealth.publicProductCount) >= Number(beforePublishHealth.publicProductCount) + 1,
+    "publicProductCount debe subir +1",
+  );
+
+  await productsSqliteRepo.updateProductByIdentifier(identifier, restorePatch);
+  console.log("OK test-products-enabled-publication-sync", {
+    beforePublicProductCount: Number(beforeHealth.publicProductCount),
+    beforePublishPublicProductCount: Number(beforePublishHealth.publicProductCount),
+    afterPublicProductCount: Number(afterHealth.publicProductCount),
+  });
 })().catch((err) => {
   console.error(err);
   process.exit(1);


### PR DESCRIPTION
### Motivation
- Evitar estados inconsistentes donde `visibility: "public"` queda con `enabled: false` y `computed.isPublic = false`, lo que provoca que el producto no aparezca en `/api/products` aunque `wouldMatchSearch=true`.
- Hacer que el backend infiera intención de publicación incluso si el frontend no envía `enabled`, para que las señales de publicación (visibilidad/estado/flags) activen `enabled=true` antes de recalcular flags públicos.
- Evitar respuestas de éxito engañosas desde el admin cuando la publicación no se aplicó correctamente por `enabled=false`.

### Description
- En `backend/data/productsSqliteRepo.js` se amplió la detección de intención de publicar en `updateProductByIdentifier` para considerar `visibility = public|visible`, `status = active|published` y flags `is_public/published/visible`, y en esos casos se fuerza `enabled: true` antes de mapear y persistir.
- En `backend/server.js` se añade una verificación posterior al `PUT/PATCH /api/products/:id` que, si la acción solicitada era una publicación y el `debugPublication` final indica `computed.reason === "enabled_false"`, responde con `409` y un mensaje claro en vez de `200`.
- Se añadió/ajustó `scripts/test-products-enabled-publication-sync.js` para reproducir el caso real `GH82-36387A`, incluyendo preparación del estado, la publicación, validaciones de `sqlite.enabled`, `sqlite.is_public`, `computed.isPublic`, diagnóstico de búsqueda y verificación de que `publicProductCount` aumente.

### Testing
- Ejecuté el script de validación real con `node nerin_final_updated/scripts/test-products-enabled-publication-sync.js` y finalizó correctamente sin errores.
- El test verificó que tras publicar: `sqlite.visibility === "public"`, `sqlite.enabled === 1`, `sqlite.is_public === 1`, `computed.isPublic === true` y `wouldAppearInPublicQuery === true`.
- El test también confirmó que `publicProductCount` aumentó respecto al estado inmediato anterior a la publicación, y dejó el producto restaurado al estado original al final del test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1fa7cb66c8331be185be8416605d9)