### PR TITLE
Rediseño comercial de la HOME: búsqueda protagonista, CTAs y UX premium

### DIFF
--- a/nerin_final_updated/frontend/index.html
+++ b/nerin_final_updated/frontend/index.html
@@ -164,55 +164,58 @@
     </script>
 </head>
   <body>
-    <header>
+    <header class="site-header">
       <div class="header-inner">
-        <div class="logo"><a href="/index.html" class="brand"><img src="../assets/IMG_3086.png" alt="NERIN" class="site-logo" /></a></div>
+        <div class="logo"><a href="/index.html" class="brand"><img src="../assets/IMG_3086.png" alt="NERIN Parts" class="site-logo" /></a></div>
         <button class="menu-toggle" id="navToggle">&#9776;</button>
         <nav id="mainNav">
           <ul>
             <li><a href="/index.html">Inicio</a></li>
             <li><a href="/shop.html">Productos</a></li>
-            <li><a href="/contact.html">Contacto</a></li>
             <li><a href="/seguimiento.html">Seguir mi pedido</a></li>
+            <li><a href="/contact.html">Contacto</a></li>
             <li><a href="/cart.html">Carrito</a></li>
+            <li><a href="/admin.html">Admin</a></li>
             <li><a href="/login.html">Acceder</a></li>
           </ul>
         </nav>
-        <a href="/arrepentimiento.html" class="button outline header-repent-link">BOTÓN DE ARREPENTIMIENTO</a>
+        <a href="https://wa.me/541112345678" target="_blank" rel="noopener" class="button outline header-repent-link">WhatsApp</a>
       </div>
     </header>
     <main class="home">
       <section class="home-hero" data-home-section="hero">
         <div class="home-hero__content">
-          <p class="eyebrow" data-home-text="hero.eyebrow">
-            Operamos para laboratorios y cadenas
-          </p>
+          <p class="eyebrow" data-home-text="hero.eyebrow">NERIN Parts · Repuestos para celular</p>
           <h1 data-home-text="hero.title">
-            Pantallas y repuestos originales listos para instalar
+            Encontrá el repuesto exacto sin perder tiempo
           </h1>
           <p class="lead" data-home-text="hero.description">
-            Nacimos atendiendo la demanda de pantallas Samsung Service Pack y
-            hoy ampliamos el catálogo con líneas Apple, Motorola y soluciones
-            corporativas. Todo con control técnico propio y despacho en horas,
-            no en días.
+            Buscá por modelo, código de pieza o SKU. Displays, módulos, baterías y repuestos para reparación profesional, con catálogo online, stock visible y atención real.
           </p>
+          <form class="home-hero__search" action="/shop.html" method="get">
+            <input type="search" name="search" placeholder="Buscá por modelo, SKU, GH82 o componente…" aria-label="Buscar repuesto" required />
+            <button type="submit" class="button primary">Buscar en catálogo</button>
+          </form>
           <ul class="home-hero__bullets" data-home-list="hero.bullets">
-            <li>Stock auditado en CABA con envíos al país</li>
-            <li>Laboratorio interno para validar cada lote</li>
-            <li>Plan de expansión a nuevas marcas premium</li>
+            <li>Stock visible</li>
+            <li>Factura A/B</li>
+            <li>Envíos</li>
+            <li>Atención técnica</li>
           </ul>
           <div class="buttons">
             <a
               href="/shop.html"
               class="button primary"
               data-home-cta="hero.primary"
-              >Ver catálogo</a
+              >Buscar en catálogo</a
             >
             <a
-              href="/contact.html"
+              href="https://wa.me/541112345678"
               class="button secondary"
               data-home-cta="hero.secondary"
-              >Hablar con un asesor</a
+              target="_blank"
+              rel="noopener"
+              >Consultar por WhatsApp</a
             >
           </div>
         </div>
@@ -234,6 +237,21 @@
 
       <section class="home-highlights" data-home-section="highlights">
         <div class="home-highlights__grid" id="homeHighlights"></div>
+      </section>
+
+      <section class="home-categories" data-home-section="categories">
+        <div class="home-section-head">
+          <p class="eyebrow">Accesos rápidos</p>
+          <h2>Buscá por tipo de repuesto</h2>
+        </div>
+        <div class="home-categories__grid">
+          <a href="/shop.html?search=modulo%20display" class="home-categories__card">Módulos / Displays</a>
+          <a href="/shop.html?search=bateria" class="home-categories__card">Baterías</a>
+          <a href="/shop.html?search=tapa" class="home-categories__card">Tapas</a>
+          <a href="/shop.html?search=flex%20conector" class="home-categories__card">Flex y conectores</a>
+          <a href="/shop.html?search=camara" class="home-categories__card">Cámaras</a>
+          <a href="/shop.html?search=repuesto" class="home-categories__card">Otros repuestos</a>
+        </div>
       </section>
 
       <section class="home-about" id="quienes-somos" data-home-section="about">
@@ -290,6 +308,31 @@
         <div id="featuredGrid" class="product-grid premium-grid" role="list"></div>
         <div class="home-featured__cta">
           <a href="/shop.html" class="button secondary">Ver catálogo completo</a>
+        </div>
+      </section>
+
+      <section class="home-steps">
+        <div class="home-section-head">
+          <p class="eyebrow">Proceso</p>
+          <h2>Comprar sin vueltas</h2>
+        </div>
+        <ol class="home-steps__list">
+          <li>Buscá el repuesto por modelo o código.</li>
+          <li>Revisá stock, precio y compatibilidad.</li>
+          <li>Comprá online o consultá por WhatsApp.</li>
+          <li>Coordinamos envío o retiro.</li>
+        </ol>
+      </section>
+
+      <section class="home-segments">
+        <div class="home-section-head">
+          <p class="eyebrow">Atención por perfil</p>
+          <h2>Para técnicos, revendedores y particulares</h2>
+        </div>
+        <div class="home-segments__grid">
+          <article><h3>Técnicos</h3><p>Buscá por código, modelo o SKU. Ideal para reparaciones con compatibilidad clara.</p></article>
+          <article><h3>Revendedores</h3><p>Consultá precio por cantidad y disponibilidad.</p></article>
+          <article><h3>Particulares</h3><p>Te ayudamos a confirmar el repuesto correcto antes de comprar.</p></article>
         </div>
       </section>
 
@@ -390,6 +433,7 @@
             <button type="submit" class="button primary">
               Solicitar cotización
             </button>
+            <a class="button secondary" href="https://wa.me/541112345678?text=Hola%20NERIN%20Parts%2C%20quiero%20cotizar%20un%20repuesto" target="_blank" rel="noopener">Enviar por WhatsApp</a>
             <p id="contactFeedback" class="form-feedback" aria-live="polite"></p>
           </div>
         </form>

--- a/nerin_final_updated/frontend/js/index.js
+++ b/nerin_final_updated/frontend/js/index.js
@@ -37,17 +37,18 @@ const PLACEHOLDER_IMAGE =
 
 const DEFAULT_HOME_CONTENT = {
   hero: {
-    eyebrow: "Operamos para laboratorios y cadenas",
-    title: "Pantallas y repuestos originales listos para instalar",
+    eyebrow: "NERIN Parts · Repuestos para celular",
+    title: "Encontrá el repuesto exacto sin perder tiempo",
     description:
-      "Nacimos atendiendo la demanda de pantallas Samsung Service Pack y hoy ampliamos el catálogo con líneas Apple, Motorola y soluciones corporativas. Todo con control técnico propio y despacho en horas, no en días.",
+      "Buscá por modelo, código de pieza o SKU. Displays, módulos, baterías y repuestos para reparación profesional, con catálogo online, stock visible y atención real.",
     bullets: [
-      "Stock auditado en CABA con envíos al país",
-      "Laboratorio interno para validar cada lote",
-      "Plan de expansión a nuevas marcas premium",
+      "Stock visible",
+      "Factura A/B",
+      "Envíos",
+      "Atención técnica",
     ],
-    primaryCta: { label: "Ver catálogo", href: "/shop.html" },
-    secondaryCta: { label: "Hablar con un asesor", href: "/contact.html" },
+    primaryCta: { label: "Buscar en catálogo", href: "/shop.html" },
+    secondaryCta: { label: "Consultar por WhatsApp", href: "https://wa.me/541112345678" },
     media: {
       desktop: "/assets/hero.png",
       mobile: "/assets/hero.png",
@@ -56,22 +57,20 @@ const DEFAULT_HOME_CONTENT = {
   },
   highlights: [
     {
-      icon: "📦",
-      title: "Stock auditado cada mañana",
-      description:
-        "Inventario real de Service Pack y módulos OEM con controles de lote y trazabilidad.",
+      title: "Stock visible y catálogo actualizado",
+      description: "Publicaciones con precio, stock y datos técnicos visibles.",
     },
     {
-      icon: "🛠️",
-      title: "Garantía laboratorio",
-      description:
-        "Probamos módulos y flex antes de despachar para reducir DOA en los talleres que atendemos.",
+      title: "Repuestos originales / premium",
+      description: "Lotes verificados con foco en compatibilidad real.",
     },
     {
-      icon: "🚚",
-      title: "Logística en 24/48 hs",
-      description:
-        "Despachos en el día para CABA y GBA y operadores nacionales para llegar a cada provincia.",
+      title: "Envíos y retiro coordinado",
+      description: "Despacho por correo o retiro con coordinación comercial.",
+    },
+    {
+      title: "Factura A/B y atención comercial",
+      description: "Respuesta real antes de comprar para técnicos y revendedores.",
     },
   ],
   about: {
@@ -498,7 +497,7 @@ function getProductDescription(product) {
       if (trimmed) return trimmed;
     }
   }
-  return "Descripción no disponible.";
+  return "";
 }
 
 function createDescriptionPreview(description, maxLength = 200) {
@@ -673,9 +672,12 @@ function createFeaturedCard(product) {
   const desc = document.createElement("p");
   desc.className = "description";
   const descriptionText = getProductDescription(product);
-  desc.textContent = createDescriptionPreview(descriptionText);
-  desc.title = descriptionText;
-  card.appendChild(desc);
+  const previewText = createDescriptionPreview(descriptionText);
+  if (previewText) {
+    desc.textContent = previewText;
+    desc.title = descriptionText;
+    card.appendChild(desc);
+  }
 
   const availability = document.createElement("div");
   availability.className = "availability-badges";

--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -9461,3 +9461,46 @@ html, body{ max-width:100%; overflow-x:hidden; }
 .product-page .product-fulfillment-trust p + p {
   margin-top: 0.35rem;
 }
+
+/* Home redesign 2026 */
+.site-header { position: sticky; top: 0; z-index: 100; backdrop-filter: blur(10px); background: rgba(255,255,255,0.92); border-bottom: 1px solid #e8ecf5; }
+#mainNav a { white-space: nowrap; }
+.home { background: linear-gradient(180deg,#f8faff 0%,#ffffff 35%); }
+.home-hero { margin-top: 0.5rem; padding: 1.5rem; border: 1px solid #e8ecf5; border-radius: 24px; gap: 1.2rem; }
+.home-hero__content h1 { font-size: clamp(1.8rem,4vw,2.9rem); letter-spacing: -0.03em; }
+.home-hero__search { display: grid; grid-template-columns: 1fr; gap: 0.7rem; margin: 1rem 0; }
+.home-hero__search input { border: 1px solid #d3daea; border-radius: 12px; padding: 0.9rem 1rem; font-size: 0.96rem; }
+.home-hero__bullets { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 0.5rem; }
+.home-hero__bullets li { margin: 0; padding: 0.5rem 0.7rem; background: #f3f6fd; border: 1px solid #e2e8f6; border-radius: 10px; }
+.home-highlights__grid { grid-template-columns: repeat(4,minmax(0,1fr)); gap: 0.7rem; }
+.home-highlight { padding: 0.9rem; border-radius: 12px; }
+.home-highlight__icon { display:none; }
+.home-highlight h3 { font-size: 0.97rem; }
+.home-highlight p { font-size: 0.86rem; }
+.home-categories,.home-steps,.home-segments { margin-top: 1.4rem; }
+.home-section-head h2 { margin: 0.25rem 0 0; font-size: clamp(1.35rem,2.5vw,1.8rem); }
+.home-categories__grid { display:grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 0.7rem; }
+.home-categories__card { display:block; padding: 0.95rem; background: #fff; border:1px solid #e4eaf8; border-radius: 12px; text-decoration:none; color:#12203f; font-weight:600; }
+.home-categories__card:hover { border-color:#b9c9ef; transform: translateY(-1px); }
+.home-featured .product-card { min-height: auto; padding: 0.7rem; }
+.home-featured .product-card img { height: 170px; object-fit: contain; }
+.home-featured .product-card .description { display:none; }
+.home-featured .product-actions .button.primary { background:#111827; color:#fff; opacity:1; }
+.home-steps__list { list-style:none; padding:0; margin:1rem 0 0; display:grid; gap:0.65rem; counter-reset:step; }
+.home-steps__list li { border:1px solid #e4eaf8; border-radius:12px; padding:0.8rem 0.9rem 0.8rem 2.3rem; position:relative; background:#fff; }
+.home-steps__list li::before { counter-increment:step; content: counter(step); position:absolute; left:0.7rem; top:0.67rem; width:1.2rem; height:1.2rem; border-radius:50%; background:#0f172a; color:#fff; font-size:0.75rem; display:grid; place-items:center; }
+.home-about { padding: 1.2rem; gap: 1.1rem; }
+.home-about .lead { margin-bottom:0.6rem; }
+.home-milestones { margin-top:0.7rem; }
+.home-segments__grid { display:grid; grid-template-columns: 1fr; gap:0.7rem; margin-top:1rem; }
+.home-segments__grid article { border:1px solid #e4eaf8; border-radius:12px; padding:1rem; background:#fff; }
+.home-contact { margin-top: 1.4rem; }
+.home-contact .contact-form { background:#fff; border:1px solid #e4eaf8; border-radius:16px; }
+.home-contact .contact-form__actions { display:flex; flex-wrap:wrap; gap:0.6rem; align-items:center; }
+
+@media (min-width: 900px){
+  .home-hero__search { grid-template-columns: 1fr auto; }
+  .home-categories__grid { grid-template-columns: repeat(6,minmax(0,1fr)); }
+  .home-featured #featuredGrid { grid-template-columns: repeat(4,minmax(0,1fr)); }
+  .home-segments__grid { grid-template-columns: repeat(3,minmax(0,1fr)); }
+}


### PR DESCRIPTION
### Motivation
- Mejorar la primera impresión de la HOME para comunicar en <5s qué vende NERIN Parts y orientar al usuario a buscar, consultar por WhatsApp o ver productos.  
- Mantener intacta la lógica crítica y backend mientras se optimiza la experiencia visual y comercial del frontend.

### Description
- Actualicé la estructura y copy del hero en `frontend/index.html` para mostrar título fuerte, subtítulo directo y una barra de búsqueda prominente que envía a `shop.html?search=...`, con CTAs claros a catálogo y WhatsApp.  
- Reorganicé el header (sticky, texto de logo, acceso a Admin visible y CTA de WhatsApp) y añadí secciones nuevas: accesos rápidos por categoría, pasos de compra y segmentos por perfil (técnicos/revendedores/particulares).  
- Mejoré la renderización de productos en `frontend/js/index.js` evitando mostrar “Descripción no disponible” y mostrando la descripción en cards solo si existe, además de actualizar el `DEFAULT_HOME_CONTENT` con copy y beneficios más concretos y CTA a WhatsApp.  
- Añadí estilos encapsulados en `frontend/style.css` para un look premium y mobile-first: header sticky con backdrop, hero compacto, búsqueda destacada, grillas de categorías y featured compactas, y ajustes responsive para 900px+.  
- Cambios limitados exclusivamente al frontend de la HOME: `frontend/index.html`, `frontend/js/index.js`, `frontend/style.css`; no se tocaron APIs ni lógica de catálogo/producto/carrito/DB/backend.

### Testing
- Ejecuté la verificación de sintaxis JavaScript con `node --check frontend/js/index.js`, y la comprobación finalizó sin errores.  
- Se validó en el árbol de trabajo que solo los archivos de frontend mencionados fueron modificados (estado de cambios confirmado automáticamente).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20b1e219c83318b310b139384bba1)