### PR TITLE
Simplify homepage structure and improve responsive layout

### DIFF
--- a/nerin_final_updated/frontend/index.html
+++ b/nerin_final_updated/frontend/index.html
@@ -190,18 +190,12 @@
             Encontrá el repuesto exacto sin perder tiempo
           </h1>
           <p class="lead" data-home-text="hero.description">
-            Buscá por modelo, código de pieza o SKU. Displays, módulos, baterías y repuestos para reparación profesional, con catálogo online, stock visible y atención real.
+            Buscá por modelo, código de pieza o SKU. Displays, módulos, baterías y repuestos para reparación profesional, con stock visible y atención real.
           </p>
           <form class="home-hero__search" action="/shop.html" method="get">
-            <input type="search" name="search" placeholder="Buscá por modelo, SKU, GH82 o componente…" aria-label="Buscar repuesto" required />
+            <input type="search" name="search" placeholder="Modelo, SKU, GH82 o componente…" aria-label="Buscar repuesto" required />
             <button type="submit" class="button primary">Buscar en catálogo</button>
           </form>
-          <ul class="home-hero__bullets" data-home-list="hero.bullets">
-            <li>Stock visible</li>
-            <li>Factura A/B</li>
-            <li>Envíos</li>
-            <li>Atención técnica</li>
-          </ul>
           <div class="buttons">
             <a
               href="/shop.html"
@@ -254,55 +248,12 @@
         </div>
       </section>
 
-      <section class="home-about" id="quienes-somos" data-home-section="about">
-        <div class="home-about__media">
-          <picture>
-            <img
-              src="/assets/product1.png"
-              alt="Equipo calibrando módulos para el relanzamiento"
-              data-home-image="about.image"
-            />
-          </picture>
-        </div>
-        <div class="home-about__content">
-          <p class="eyebrow">Nuestra historia</p>
-          <h2 data-home-text="about.title">
-            De Mercado Libre a un laboratorio integral
-          </h2>
-          <p class="lead" data-home-text="about.lead">
-            Arrancamos en 2021 vendiendo repuestos a través de Mercado Libre.
-            Las restricciones a las importaciones frenaron el proyecto, pero
-            volvimos en 2025 mejor preparados.
-          </p>
-          <p data-home-text="about.body">
-            El relanzamiento de NERIN combina procesos de control renovados,
-            acuerdos logísticos ágiles y un sistema pensado para técnicos y
-            cadenas. Apostamos a calidad sostenible, servicio responsable y un
-            ecosistema que pueda escalar sin perder cercanía.
-          </p>
-          <ul class="home-milestones" id="homeMilestones"></ul>
-        </div>
-      </section>
-
-      <section class="home-why" data-home-section="why">
-        <div class="home-why__header">
-          <p class="eyebrow">Por qué elegir NERIN</p>
-          <h2 data-home-text="why.title">Por qué elegir NERIN</h2>
-          <p data-home-text="why.description">
-            Diseñamos una experiencia alineada con la operación técnica: datos
-            reales, logística predecible y soporte especializado.
-          </p>
-        </div>
-        <div class="home-why__grid" id="homeWhyCards"></div>
-      </section>
-
       <section class="home-featured" data-home-section="featured">
         <div class="home-featured__header">
-          <p class="eyebrow">Selección del laboratorio</p>
+          <p class="eyebrow">Destacados</p>
           <h2 data-home-text="featured.title">Productos destacados</h2>
           <p data-home-text="featured.description">
-            Seleccionamos los módulos con mejor rendimiento y disponibilidad
-            inmediata.
+            Repuestos con salida rápida para técnicos, revendedores y clientes finales.
           </p>
         </div>
         <div id="featuredGrid" class="product-grid premium-grid" role="list"></div>
@@ -311,132 +262,15 @@
         </div>
       </section>
 
-      <section class="home-steps">
-        <div class="home-section-head">
-          <p class="eyebrow">Proceso</p>
-          <h2>Comprar sin vueltas</h2>
+      <section class="home-cta" data-home-section="cta">
+        <div class="home-cta__content">
+          <h2>¿No encontrás el repuesto?</h2>
+          <p>Mandanos modelo, código de pieza o foto del repuesto y te confirmamos disponibilidad.</p>
         </div>
-        <ol class="home-steps__list">
-          <li>Buscá el repuesto por modelo o código.</li>
-          <li>Revisá stock, precio y compatibilidad.</li>
-          <li>Comprá online o consultá por WhatsApp.</li>
-          <li>Coordinamos envío o retiro.</li>
-        </ol>
-      </section>
-
-      <section class="home-segments">
-        <div class="home-section-head">
-          <p class="eyebrow">Atención por perfil</p>
-          <h2>Para técnicos, revendedores y particulares</h2>
+        <div class="home-cta__actions">
+          <a class="button primary" href="https://wa.me/541112345678?text=Hola%20NERIN%2C%20necesito%20ayuda%20para%20encontrar%20un%20repuesto" target="_blank" rel="noopener">Consultar por WhatsApp</a>
+          <a class="button secondary" href="/shop.html">Ver catálogo</a>
         </div>
-        <div class="home-segments__grid">
-          <article><h3>Técnicos</h3><p>Buscá por código, modelo o SKU. Ideal para reparaciones con compatibilidad clara.</p></article>
-          <article><h3>Revendedores</h3><p>Consultá precio por cantidad y disponibilidad.</p></article>
-          <article><h3>Particulares</h3><p>Te ayudamos a confirmar el repuesto correcto antes de comprar.</p></article>
-        </div>
-      </section>
-
-      <section class="home-contact" id="contacto" data-home-section="contact">
-        <div class="home-contact__intro">
-          <p class="eyebrow" data-home-text="contact.eyebrow">Cotizá en segundos</p>
-          <h2 data-home-text="contact.title">
-            Contanos qué necesitás y coordinamos la entrega
-          </h2>
-          <p data-home-text="contact.description">
-            Respondemos con precio, stock y opciones de retiro o envío en
-            horario comercial.
-          </p>
-          <ul class="home-contact__bullets" id="homeContactBullets"></ul>
-          <p class="home-contact__note" data-home-text="contact.note">
-            Si lo necesitás urgente marcá la opción correspondiente y
-            priorizamos tu caso.
-          </p>
-        </div>
-        <form id="contactForm" class="contact-form">
-          <div class="contact-form__row">
-            <label class="contact-form__field">
-              <span>Nombre y apellido</span>
-              <input
-                type="text"
-                id="contactName"
-                name="name"
-                autocomplete="name"
-                placeholder="Ej.: Laura González"
-                required
-              />
-            </label>
-            <label class="contact-form__field">
-              <span>Modelo exacto</span>
-              <input
-                type="text"
-                id="contactModel"
-                name="model"
-                placeholder="Ej.: SM-A546"
-                autocomplete="off"
-                required
-              />
-            </label>
-          </div>
-          <div class="contact-form__row">
-            <label class="contact-form__field">
-              <span>Cantidad estimada</span>
-              <input
-                type="number"
-                id="contactQuantity"
-                name="quantity"
-                min="1"
-                value="1"
-                inputmode="numeric"
-              />
-            </label>
-            <label class="contact-form__field">
-              <span>Necesito el repuesto para</span>
-              <select id="contactUrgency" name="urgency">
-                <option value="hoy">Entregarlo hoy</option>
-                <option value="48hs">Programar en 48 hs</option>
-                <option value="planificar">Planificar stock</option>
-              </select>
-            </label>
-          </div>
-          <fieldset class="contact-form__fieldset">
-            <legend>Perfil</legend>
-            <div class="contact-form__chips" id="contactRoleGroup">
-              <label class="chip">
-                <input
-                  type="radio"
-                  name="contactRole"
-                  value="tecnico"
-                  checked
-                />
-                <span>Técnico</span>
-              </label>
-              <label class="chip">
-                <input type="radio" name="contactRole" value="revendedor" />
-                <span>Revendedor</span>
-              </label>
-              <label class="chip">
-                <input type="radio" name="contactRole" value="particular" />
-                <span>Particular</span>
-              </label>
-            </div>
-          </fieldset>
-          <label class="contact-form__field contact-form__field--full">
-            <span>Detalles adicionales (opcional)</span>
-            <textarea
-              id="contactMessage"
-              name="message"
-              rows="3"
-              placeholder="Indicá color, serie u otra necesidad"
-            ></textarea>
-          </label>
-          <div class="contact-form__actions">
-            <button type="submit" class="button primary">
-              Solicitar cotización
-            </button>
-            <a class="button secondary" href="https://wa.me/541112345678?text=Hola%20NERIN%20Parts%2C%20quiero%20cotizar%20un%20repuesto" target="_blank" rel="noopener">Enviar por WhatsApp</a>
-            <p id="contactFeedback" class="form-feedback" aria-live="polite"></p>
-          </div>
-        </form>
       </section>
     </main>
 

--- a/nerin_final_updated/frontend/js/index.js
+++ b/nerin_final_updated/frontend/js/index.js
@@ -396,33 +396,19 @@ function renderContactBullets(bullets) {
 
 function applyHomeContent(source) {
   currentHomeContent = getResolvedHomeConfig(source);
-  const { hero, highlights, about, why, contact } = currentHomeContent;
+  const { hero, highlights } = currentHomeContent;
   updateText("hero.eyebrow", hero.eyebrow);
   updateText("hero.title", hero.title);
   updateText("hero.description", hero.description);
-  updateList("hero.bullets", hero.bullets);
   updateCta("hero.primary", hero.primaryCta);
   updateCta("hero.secondary", hero.secondaryCta);
   updateHeroMedia(hero.media);
   renderHighlights(highlights);
-  updateText("about.title", about.title);
-  updateText("about.lead", about.lead);
-  updateText("about.body", about.body);
-  renderMilestones(about.milestones);
-  updateAboutImage(about.image, about.imageAlt);
-  updateText("why.title", why.title);
-  updateText("why.description", why.description);
-  renderWhyCards(why.cards);
   updateText("featured.title", currentHomeContent.featured?.title);
   updateText(
     "featured.description",
     currentHomeContent.featured?.description,
   );
-  updateText("contact.eyebrow", contact.eyebrow);
-  updateText("contact.title", contact.title);
-  updateText("contact.description", contact.description);
-  updateText("contact.note", contact.note);
-  renderContactBullets(contact.bulletPoints);
 }
 
 function cleanLabel(value) {
@@ -715,20 +701,6 @@ function createFeaturedCard(product) {
   more.className = "button secondary";
   more.textContent = "Ver detalle";
   actions.appendChild(more);
-
-  const addBtn = document.createElement("button");
-  addBtn.type = "button";
-  addBtn.className = "button primary";
-  addBtn.textContent = "Agregar";
-  addBtn.addEventListener("click", (event) => {
-    event.stopPropagation();
-    addToCart(product, 1);
-    addBtn.textContent = "Añadido";
-    setTimeout(() => {
-      addBtn.textContent = "Agregar";
-    }, 1600);
-  });
-  actions.appendChild(addBtn);
   card.appendChild(actions);
 
   card.addEventListener("click", (event) => {
@@ -979,7 +951,6 @@ document.addEventListener("nerin:config-loaded", (event) => {
 
 document.addEventListener("DOMContentLoaded", () => {
   applyHomeContent();
-  setupContactForm();
   initPopupListeners();
   loadFeatured();
   showPopupIfNeeded();

--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -9504,3 +9504,64 @@ html, body{ max-width:100%; overflow-x:hidden; }
   .home-featured #featuredGrid { grid-template-columns: repeat(4,minmax(0,1fr)); }
   .home-segments__grid { grid-template-columns: repeat(3,minmax(0,1fr)); }
 }
+
+/* ===== Home simplificada 2026 ===== */
+.site-header .header-inner{max-width:1200px;padding:.75rem 1rem;gap:.75rem;}
+.site-header .site-logo{height:30px;}
+.site-header nav ul{gap:.9rem;flex-wrap:wrap;justify-content:flex-end;}
+.site-header nav a{font-size:.93rem;white-space:nowrap;}
+.header-repent-link{padding:.5rem .8rem;font-size:.9rem;white-space:nowrap;}
+
+.home{max-width:1200px;margin:0 auto;padding:1rem;}
+.home section{margin-top:1.25rem;}
+.home-hero{display:grid;grid-template-columns:1.1fr .9fr;gap:1.2rem;align-items:center;padding:1.25rem;border:1px solid #e7eaf0;border-radius:18px;background:#fff;}
+.home-hero__content h1{font-size:clamp(1.7rem,3.2vw,2.5rem);line-height:1.15;margin:.25rem 0 .7rem;}
+.home-hero__content .lead{font-size:1rem;color:#475569;margin:0 0 .9rem;}
+.home-hero__search{display:grid;grid-template-columns:1fr auto;gap:.6rem;margin:.8rem 0;}
+.home-hero__search input{min-width:0;padding:.85rem .95rem;border:1px solid #d8dfea;border-radius:10px;}
+.home-hero__search .button{padding:.85rem 1rem;opacity:1;}
+.home-hero .buttons{display:flex;flex-wrap:wrap;gap:.55rem;}
+.home-hero__media img{width:100%;max-height:300px;object-fit:cover;border-radius:14px;}
+
+.home-highlights__grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:.65rem;}
+.home-highlight{padding:.9rem;border:1px solid #e8ecf3;border-radius:12px;background:#fff;}
+.home-highlight h3{margin:0 0 .3rem;font-size:1rem;}
+.home-highlight p{margin:0;color:#64748b;font-size:.92rem;}
+
+.home-categories__grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:.55rem;}
+.home-categories__card{padding:.75rem .85rem;border-radius:10px;border:1px solid #e3e8f4;font-size:.93rem;background:#fff;}
+
+.home-featured #featuredGrid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:.65rem;}
+.home-featured .product-card{padding:.7rem;border-radius:12px;border:1px solid #e5eaf4;box-shadow:none;min-height:0;}
+.home-featured .product-card img{height:150px;object-fit:contain;background:#f8fafc;border-radius:8px;}
+.home-featured .product-card h3{font-size:.95rem;line-height:1.3;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;min-height:2.4em;}
+.home-featured .product-card .description{display:none !important;}
+.home-featured .product-meta .sku,.home-featured .product-meta .chip{font-size:.75rem;}
+.home-featured .product-actions{display:block;}
+.home-featured .product-actions .button{width:100%;text-align:center;padding:.62rem .75rem;opacity:1;}
+
+.home-cta{display:flex;justify-content:space-between;align-items:center;gap:.9rem;padding:1rem;border:1px solid #e3e8f4;border-radius:14px;background:#f8fafc;}
+.home-cta h2{margin:0 0 .35rem;font-size:1.35rem;}
+.home-cta p{margin:0;color:#475569;}
+.home-cta__actions{display:flex;gap:.55rem;flex-wrap:wrap;}
+
+@media (max-width:1024px){
+  .home-featured #featuredGrid{grid-template-columns:repeat(3,minmax(0,1fr));}
+}
+@media (max-width:768px){
+  .site-header .header-inner{padding:.65rem .8rem;}
+  .menu-toggle{display:block;}
+  header nav{display:none;position:absolute;left:0;right:0;top:100%;background:#fff;border-bottom:1px solid #e5e7eb;padding:.7rem 1rem;}
+  header nav.open{display:block;}
+  nav ul{flex-direction:column;gap:.5rem;}
+  .header-repent-link{display:none;}
+  .home{padding:.8rem;}
+  .home-hero{grid-template-columns:1fr;padding:1rem;}
+  .home-hero__search{grid-template-columns:1fr;}
+  .home-highlights__grid{grid-template-columns:1fr;}
+  .home-categories__grid{grid-template-columns:repeat(2,minmax(0,1fr));}
+  .home-featured #featuredGrid{grid-template-columns:1fr;}
+  .home-cta{flex-direction:column;align-items:flex-start;}
+  .home-cta__actions{width:100%;}
+  .home-cta__actions .button{flex:1 1 100%;text-align:center;}
+}


### PR DESCRIPTION
### Motivation
- The home was visually crowded and not properly responsive, so the goal was to produce a simpler, cleaner, and more technical-first home focused on discovery and quick access to the catalog. 
- Keep all backend, DB and catalog logic untouched and only modify the home presentation (structure, CSS, responsive behavior, copy and client-side rendering). 

### Description
- Reworked the home page HTML to a compact flow: header, hero with functional search, three concise highlights, quick categories, compact featured products grid, WhatsApp/CTA block and footer; removed long history, why-us, process, profile blocks and the long contact form from the home. (modified: `nerin_final_updated/frontend/index.html`).
- Updated hero copy and placeholder and ensured the search form sends a real `GET` to `shop.html?search=...`. (modified: `nerin_final_updated/frontend/index.html`).
- Simplified client JS home rendering to match the reduced sections and removed the in-home “Agregar” button from featured cards so the main action is `Ver detalle`. Also removed the contact form setup from the home flow while keeping featured products loading. (modified: `nerin_final_updated/frontend/js/index.js`).
- Added a focused, minimal CSS block for the simplified home to tighten spacing, reduce card sizes, ensure two-column hero on desktop and stacked layout on mobile, and provide sensible breakpoints for multiple widths. (modified: `nerin_final_updated/frontend/style.css`).

### Testing
- Performed a static JS syntax check with `node --check nerin_final_updated/frontend/js/index.js`, which completed without syntax errors. 
- Verified the change set touches only frontend home files and no backend/DB/catalog/admin/cart/product logic was modified. 
- Manually inspected the updated HTML/CSS/JS to confirm the hero search posts to `shop.html`, featured products still load, and the home layout adapts at common breakpoints (desktop, tablet, mobile).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f218132e588331b146eb16b97be96c)