### PR TITLE
Fix homepage responsive layout for desktop, tablet and mobile

### DIFF
--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -9505,63 +9505,72 @@ html, body{ max-width:100%; overflow-x:hidden; }
   .home-segments__grid { grid-template-columns: repeat(3,minmax(0,1fr)); }
 }
 
-/* ===== Home simplificada 2026 ===== */
-.site-header .header-inner{max-width:1200px;padding:.75rem 1rem;gap:.75rem;}
+/* ===== Home responsive refinement 2026 ===== */
+.site-header .header-inner{max-width:1280px;padding:.75rem 1rem;gap:.75rem;}
 .site-header .site-logo{height:30px;}
-.site-header nav ul{gap:.9rem;flex-wrap:wrap;justify-content:flex-end;}
-.site-header nav a{font-size:.93rem;white-space:nowrap;}
-.header-repent-link{padding:.5rem .8rem;font-size:.9rem;white-space:nowrap;}
+.site-header nav ul{gap:.8rem;flex-wrap:wrap;justify-content:flex-end;}
+.site-header nav a{font-size:.92rem;white-space:nowrap;}
+.header-repent-link{padding:.5rem .8rem;font-size:.88rem;white-space:nowrap;}
 
-.home{max-width:1200px;margin:0 auto;padding:1rem;}
+.home{max-width:1280px;margin:0 auto;padding:1rem clamp(.9rem,2.2vw,1.4rem) 1.5rem;}
 .home section{margin-top:1.25rem;}
-.home-hero{display:grid;grid-template-columns:1.1fr .9fr;gap:1.2rem;align-items:center;padding:1.25rem;border:1px solid #e7eaf0;border-radius:18px;background:#fff;}
-.home-hero__content h1{font-size:clamp(1.7rem,3.2vw,2.5rem);line-height:1.15;margin:.25rem 0 .7rem;}
-.home-hero__content .lead{font-size:1rem;color:#475569;margin:0 0 .9rem;}
-.home-hero__search{display:grid;grid-template-columns:1fr auto;gap:.6rem;margin:.8rem 0;}
-.home-hero__search input{min-width:0;padding:.85rem .95rem;border:1px solid #d8dfea;border-radius:10px;}
-.home-hero__search .button{padding:.85rem 1rem;opacity:1;}
+.home-hero{display:grid;grid-template-columns:minmax(0,1.06fr) minmax(300px,.94fr);gap:1.4rem;align-items:center;padding:1.35rem;border:1px solid #e7eaf0;border-radius:18px;background:#fff;}
+.home-hero__content h1{font-size:clamp(1.8rem,2.6vw,2.6rem);line-height:1.14;margin:.25rem 0 .75rem;}
+.home-hero__content .lead{font-size:1rem;color:#475569;margin:0 0 1rem;max-width:62ch;}
+.home-hero__search{display:grid;grid-template-columns:minmax(0,1fr) auto;gap:.6rem;margin:.8rem 0;}
+.home-hero__search input{min-width:0;padding:.9rem 1rem;border:1px solid #d8dfea;border-radius:10px;}
+.home-hero__search .button{padding:.9rem 1rem;opacity:1;}
 .home-hero .buttons{display:flex;flex-wrap:wrap;gap:.55rem;}
-.home-hero__media img{width:100%;max-height:300px;object-fit:cover;border-radius:14px;}
+.home-hero__media img{width:100%;max-height:360px;object-fit:cover;border-radius:14px;}
 
-.home-highlights__grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:.65rem;}
-.home-highlight{padding:.9rem;border:1px solid #e8ecf3;border-radius:12px;background:#fff;}
+.home-highlights__grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:.7rem;}
+.home-highlight{padding:.95rem;border:1px solid #e8ecf3;border-radius:12px;background:#fff;}
 .home-highlight h3{margin:0 0 .3rem;font-size:1rem;}
 .home-highlight p{margin:0;color:#64748b;font-size:.92rem;}
 
-.home-categories__grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:.55rem;}
-.home-categories__card{padding:.75rem .85rem;border-radius:10px;border:1px solid #e3e8f4;font-size:.93rem;background:#fff;}
+.home-categories__grid{display:grid;grid-template-columns:repeat(6,minmax(0,1fr));gap:.6rem;}
+.home-categories__card{padding:.8rem .85rem;border-radius:10px;border:1px solid #e3e8f4;font-size:.93rem;background:#fff;}
 
-.home-featured #featuredGrid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:.65rem;}
-.home-featured .product-card{padding:.7rem;border-radius:12px;border:1px solid #e5eaf4;box-shadow:none;min-height:0;}
-.home-featured .product-card img{height:150px;object-fit:contain;background:#f8fafc;border-radius:8px;}
+.home-featured #featuredGrid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:.7rem;}
+.home-featured .product-card{padding:.72rem;border-radius:12px;border:1px solid #e5eaf4;box-shadow:none;min-height:0;}
+.home-featured .product-card img{height:156px;object-fit:contain;background:#f8fafc;border-radius:8px;}
 .home-featured .product-card h3{font-size:.95rem;line-height:1.3;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;min-height:2.4em;}
 .home-featured .product-card .description{display:none !important;}
 .home-featured .product-meta .sku,.home-featured .product-meta .chip{font-size:.75rem;}
 .home-featured .product-actions{display:block;}
 .home-featured .product-actions .button{width:100%;text-align:center;padding:.62rem .75rem;opacity:1;}
 
-.home-cta{display:flex;justify-content:space-between;align-items:center;gap:.9rem;padding:1rem;border:1px solid #e3e8f4;border-radius:14px;background:#f8fafc;}
+.home-cta{display:flex;justify-content:space-between;align-items:center;gap:1rem;padding:1.1rem;border:1px solid #e3e8f4;border-radius:14px;background:#f8fafc;}
 .home-cta h2{margin:0 0 .35rem;font-size:1.35rem;}
-.home-cta p{margin:0;color:#475569;}
+.home-cta p{margin:0;color:#475569;max-width:62ch;}
 .home-cta__actions{display:flex;gap:.55rem;flex-wrap:wrap;}
 
-@media (max-width:1024px){
+@media (max-width:1199px){
+  .site-header .header-inner{padding:.72rem .9rem;}
+  .home{padding:1rem .95rem 1.35rem;}
+  .home-hero{grid-template-columns:1fr;gap:1rem;}
+  .home-hero__media{order:-1;}
+  .home-highlights__grid{grid-template-columns:repeat(2,minmax(0,1fr));}
+  .home-categories__grid{grid-template-columns:repeat(3,minmax(0,1fr));}
   .home-featured #featuredGrid{grid-template-columns:repeat(3,minmax(0,1fr));}
 }
-@media (max-width:768px){
-  .site-header .header-inner{padding:.65rem .8rem;}
+
+@media (max-width:767px){
+  .site-header .header-inner{padding:.62rem .78rem;}
   .menu-toggle{display:block;}
-  header nav{display:none;position:absolute;left:0;right:0;top:100%;background:#fff;border-bottom:1px solid #e5e7eb;padding:.7rem 1rem;}
+  header nav{display:none;position:absolute;left:0;right:0;top:100%;background:#fff;border-bottom:1px solid #e5e7eb;padding:.7rem .9rem;}
   header nav.open{display:block;}
   nav ul{flex-direction:column;gap:.5rem;}
   .header-repent-link{display:none;}
-  .home{padding:.8rem;}
-  .home-hero{grid-template-columns:1fr;padding:1rem;}
+  .home{padding:.75rem .78rem 1.2rem;}
+  .home section{margin-top:1rem;}
+  .home-hero{padding:1rem;border-radius:14px;}
+  .home-hero__content h1{font-size:clamp(1.55rem,7.2vw,2rem);}
   .home-hero__search{grid-template-columns:1fr;}
   .home-highlights__grid{grid-template-columns:1fr;}
   .home-categories__grid{grid-template-columns:repeat(2,minmax(0,1fr));}
   .home-featured #featuredGrid{grid-template-columns:1fr;}
-  .home-cta{flex-direction:column;align-items:flex-start;}
+  .home-cta{flex-direction:column;align-items:flex-start;padding:1rem;}
   .home-cta__actions{width:100%;}
   .home-cta__actions .button{flex:1 1 100%;text-align:center;}
 }


### PR DESCRIPTION
### Motivation
- Mejorar la adaptación de la página principal a PC, iPad/tablet y iPhone porque el diseño actual tenía problemas de escala y disposición en distintos breakpoints.

### Description
- Reemplacé el bloque de estilos "Home simplificada 2026" por un nuevo bloque `/* ===== Home responsive refinement 2026 ===== */` y ajusté `frontend/style.css` para ampliar el ancho máximo del contenedor y los paddings fluidos (`max-width` a 1280px y `padding` con `clamp`).
- Refiné la sección hero cambiando la rejilla a `grid-template-columns: minmax(0,1.06fr) minmax(300px,.94fr)`, ajusté la `h1` con `clamp()`, el `lead` (anchura máxima) y la altura máxima de la imagen (`max-height`) para evitar desbordes y mejorar la legibilidad en escritorio y tablet.
- Ajusté los grids de contenidos y tarjetas para distintos viewports — highlights, categorías y featured — incrementando columnas en desktop y definiendo reflows en breakpoints medios y móviles, además de pulir tamaños de imágenes y paddings (ej. highlights 4, categories 6, featured 4 en desktop; reflow a 2/3/1 en tablet/mobile según breakpoint).
- Añadí y afiné reglas para `@media (max-width:1199px)` y `@media (max-width:767px)` para controlar el reordenamiento del hero, el orden del media, espaciados y el comportamiento del CTA en móvil (botones full-width y columnas).

### Testing
- No se ejecutó ninguna suite de tests automatizados porque es un cambio CSS únicamente. 
- El parche se aplicó con el script de reemplazo (salida: `patched`) y el archivo modificado fue verificado con `nl -ba frontend/style.css | sed -n '9500,9625p'` mostrando las líneas actualizadas.
- Los cambios fueron añadidos y el commit se creó con `git add frontend/style.css` y `git commit -m "Fix homepage responsive layout for desktop, tablet and mobile"` exitosamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f222ac43bc833183fbe54385557922)