### PR TITLE
Home: remove top WhatsApp CTAs and add CABA legal strip

### DIFF
--- a/nerin_final_updated/frontend/index.html
+++ b/nerin_final_updated/frontend/index.html
@@ -179,9 +179,12 @@
             <li><a href="/login.html">Acceder</a></li>
           </ul>
         </nav>
-        <a href="https://wa.me/541112345678" target="_blank" rel="noopener" class="button outline header-repent-link">WhatsApp</a>
-      </div>
+              </div>
     </header>
+    <section class="home-legal-strip" aria-label="Información legal del local en CABA">
+      <p><strong>NERIN PARTS</strong> · CUIT 30-93002432-2 · IIBB CABA 901-117119-4 · Dirección comercial: CABA, Argentina.</p>
+      <p><a href="/pages/terminos.html">Términos y condiciones</a> · <a href="/pages/terminos.html#datos">Política de privacidad</a> · Factura A/B</p>
+    </section>
     <main class="home">
       <section class="home-hero" data-home-section="hero">
         <div class="home-hero__content">
@@ -204,12 +207,10 @@
               >Buscar en catálogo</a
             >
             <a
-              href="https://wa.me/541112345678"
+              href="/pages/terminos.html"
               class="button secondary"
               data-home-cta="hero.secondary"
-              target="_blank"
-              rel="noopener"
-              >Consultar por WhatsApp</a
+              >Ver términos y garantías</a
             >
           </div>
         </div>
@@ -303,11 +304,6 @@
     </div>
 
     <div id="footer-root"></div>
-    <div id="whatsapp-button">
-      <a href="https://wa.me/541112345678" target="_blank" data-whatsapp-link>
-        <img src="/assets/whatsapp.svg" alt="WhatsApp" />
-      </a>
-    </div>
     <!-- Configuración y analíticas -->
     <script type="module" src="/js/index.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>

--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -9565,3 +9565,32 @@ html, body{ max-width:100%; overflow-x:hidden; }
   .home-cta__actions{width:100%;}
   .home-cta__actions .button{flex:1 1 100%;text-align:center;}
 }
+
+.home-legal-strip {
+  max-width: 1200px;
+  margin: 0.65rem auto 0;
+  padding: 0.7rem 1rem;
+  border: 1px solid #d8e0ee;
+  border-radius: 12px;
+  background: #f8fbff;
+  color: #334155;
+  font-size: 0.84rem;
+  line-height: 1.45;
+}
+.home-legal-strip p {
+  margin: 0.1rem 0;
+}
+.home-legal-strip a {
+  color: #1d4ed8;
+  font-weight: 600;
+  text-decoration: none;
+}
+.home-legal-strip a:hover {
+  text-decoration: underline;
+}
+@media (max-width: 760px) {
+  .home-legal-strip {
+    margin: 0.4rem 0.8rem 0;
+    font-size: 0.78rem;
+  }
+}


### PR DESCRIPTION
### Motivation
- Clean the top of the home page by removing the prominent WhatsApp CTA and instead surface the legally required information for a brick-and-mortar in CABA.
- Ensure the hero area no longer shows a “Consultar por WhatsApp” primary link at the top and replace it with a link to the terms/guarantees so the header looks professional and compliant.

### Description
- Removed the header WhatsApp CTA and the floating WhatsApp button from `nerin_final_updated/frontend/index.html`.
- Replaced the hero’s secondary CTA to point to `/pages/terminos.html` and changed its label to “Ver términos y garantías” in `nerin_final_updated/frontend/index.html`.
- Inserted a new visible legal strip with CUIT, IIBB CABA, commercial address and links to Terms/Privacy immediately after the header in `nerin_final_updated/frontend/index.html`.
- Added responsive styles for the new `.home-legal-strip` in `nerin_final_updated/frontend/style.css`.

### Testing
- Ran `rg -n "header-repent-link|whatsapp-button|Consultar por WhatsApp|home-legal-strip|CUIT 30-93002432-2"` to verify the header WhatsApp link and floating button were removed and the legal strip was added, and the search returned the expected hits for the new elements (success).
- Inspected the updated markup with `nl`/`sed` to confirm the legal strip is placed after the header and the hero CTA was updated (success).
- Checked repository status with `git status --short` and committed the two modified files to ensure the changes are tracked (commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f222edb59483319e91aa0a3d00b6d7)