### PR TITLE
Rediseña home premium y centraliza legalidad en footer con soporte Data Fiscal

### DIFF
--- a/nerin_final_updated/README.txt
+++ b/nerin_final_updated/README.txt
@@ -165,7 +165,7 @@ Una vez configurado, desde el frontend puedes crear una preferencia de pago envi
 El archivo `frontend/cart.html` incluye dos botones: **Enviar por
 WhatsApp** y **Confirmar pedido**. El primero genera un enlace a la API
 de WhatsApp con el resumen de la compra. Por defecto envía el mensaje al
-número `541112345678`. Puedes cambiar este teléfono editando el valor
+número `5491130341550`. Puedes cambiar este teléfono editando el valor
 `phone` en `frontend/js/cart.js` (variable dentro del método
 `whatsappBtn.onclick`). El botón **Confirmar pedido** envía una petición
 POST a `/api/checkout`. A partir de allí puedes invocar el endpoint de

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -2017,6 +2017,26 @@ const DEFAULT_FOOTER = {
     terms: "/pages/terminos.html",
     privacy: "/pages/terminos.html#datos",
   },
+  legalDetails: {
+    title: "Información fiscal y comercial",
+    businessName: "NERIN PARTS",
+    cuit: "30-93002432-2",
+    iibb: "901-117119-4",
+    condition: "Venta online · Depósito en CABA · Retiro con turno · Sin local a la calle",
+    address: "CABA, Argentina",
+    invoice: "Factura A/B",
+    payments: "Mercado Pago, transferencia bancaria y efectivo",
+    shipping: "Andreani · Envíos a todo el país",
+  },
+  dataFiscal: {
+    enabled: true,
+    mode: "placeholder",
+    label: "Data Fiscal ARCA / AFIP",
+    placeholder: "Data Fiscal ARCA / AFIP pendiente de carga",
+    html: "",
+    image: "",
+    link: "",
+  },
   show: {
     cta: true,
     branding: true,
@@ -5475,6 +5495,30 @@ function normalizeFooter(data) {
     iibb: String(data?.legal?.iibb || ""),
     terms: String(data?.legal?.terms || ""),
     privacy: String(data?.legal?.privacy || ""),
+  };
+  out.legalDetails = {
+    title: String(data?.legalDetails?.title || base?.legalDetails?.title || "Información fiscal y comercial"),
+    businessName: String(data?.legalDetails?.businessName || base?.legalDetails?.businessName || out.brand || "NERIN PARTS"),
+    cuit: String(data?.legalDetails?.cuit || data?.legal?.cuit || base?.legalDetails?.cuit || ""),
+    iibb: String(data?.legalDetails?.iibb || data?.legal?.iibb || base?.legalDetails?.iibb || "").replace(/^IIBB CABA\s*/i, ""),
+    condition: String(data?.legalDetails?.condition || base?.legalDetails?.condition || ""),
+    address: String(data?.legalDetails?.address || base?.legalDetails?.address || out.contact.address || ""),
+    invoice: String(data?.legalDetails?.invoice || base?.legalDetails?.invoice || "Factura A/B"),
+    payments: String(data?.legalDetails?.payments || base?.legalDetails?.payments || ""),
+    shipping: String(data?.legalDetails?.shipping || base?.legalDetails?.shipping || ""),
+  };
+  out.dataFiscal = {
+    enabled: true,
+    mode: String(data?.dataFiscal?.mode || base?.dataFiscal?.mode || "placeholder"),
+    label: String(data?.dataFiscal?.label || base?.dataFiscal?.label || "Data Fiscal ARCA / AFIP"),
+    placeholder: String(
+      data?.dataFiscal?.placeholder ||
+        base?.dataFiscal?.placeholder ||
+        "Data Fiscal ARCA / AFIP pendiente de carga",
+    ),
+    html: String(data?.dataFiscal?.html || base?.dataFiscal?.html || ""),
+    image: String(data?.dataFiscal?.image || base?.dataFiscal?.image || ""),
+    link: String(data?.dataFiscal?.link || base?.dataFiscal?.link || ""),
   };
   out.show = {
     cta: Boolean(data?.show?.cta),

--- a/nerin_final_updated/data/config.json
+++ b/nerin_final_updated/data/config.json
@@ -1,35 +1,39 @@
 {
   "googleAnalyticsId": "",
   "metaPixelId": "2627676134264110",
-  "whatsappNumber": "541112345678",
-  "defaultCarriers": ["Andreani", "Correo Argentino", "OCA"],
+  "whatsappNumber": "5491130341550",
+  "defaultCarriers": [
+    "Andreani",
+    "Correo Argentino",
+    "OCA"
+  ],
   "mercadoPagoToken": "",
   "afipCUIT": "",
   "afipCert": "",
   "afipKey": "",
   "resendApiKey": "",
-  "supportEmail": "soporte@nerinparts.com.ar",
+  "supportEmail": "ventas@nerinparts.com.ar",
   "fromEmailContacto": "NERIN Soporte <soporte@nerinparts.com.ar>",
   "wholesaleNotificationEmails": [],
   "publicUrl": "https://nerinparts.com.ar",
   "apiBase": "",
   "homePage": {
     "hero": {
-      "eyebrow": "Operamos para laboratorios y cadenas",
-      "title": "Pantallas y repuestos originales listos para instalar",
-      "description": "Nacimos atendiendo la demanda de pantallas Samsung Service Pack y hoy ampliamos el catálogo con líneas Apple, Motorola y soluciones corporativas. Todo con control técnico propio y despacho en horas, no en días.",
+      "eyebrow": "NERIN Parts · Repuestos originales para reparación profesional",
+      "title": "Pantallas Samsung Service Pack originales, con stock real y factura A/B",
+      "description": "Trabajamos repuestos originales y verificados para técnicos, talleres, revendedores y clientes finales. Coordinamos retiro con turno en CABA o envío a todo el país.",
       "bullets": [
         "Stock auditado en CABA con envíos al país",
         "Laboratorio interno para validar cada lote",
         "Plan de expansión a nuevas marcas premium"
       ],
       "primaryCta": {
-        "label": "Ver catálogo",
+        "label": "Buscar en catálogo",
         "href": "/shop.html"
       },
       "secondaryCta": {
-        "label": "Hablar con un asesor",
-        "href": "/contact.html"
+        "label": "Consultar por WhatsApp",
+        "href": "https://wa.me/5491130341550"
       },
       "media": {
         "desktop": "/assets/hero.png",

--- a/nerin_final_updated/data/footer.json
+++ b/nerin_final_updated/data/footer.json
@@ -130,5 +130,25 @@
     "andreani": "/assets/footer-badges/andreani.png",
     "efectivo": "/assets/footer-badges/efectivo.png",
     "transferencia": "/assets/footer-badges/transferencia.png"
+  },
+  "legalDetails": {
+    "title": "Información fiscal y comercial",
+    "businessName": "NERIN PARTS",
+    "cuit": "30-93002432-2",
+    "iibb": "901-117119-4",
+    "condition": "Venta online · Depósito en CABA · Retiro con turno · Sin local a la calle",
+    "address": "CABA, Argentina",
+    "invoice": "Factura A/B",
+    "payments": "Mercado Pago, transferencia bancaria y efectivo",
+    "shipping": "Andreani · Envíos a todo el país"
+  },
+  "dataFiscal": {
+    "enabled": true,
+    "mode": "placeholder",
+    "label": "Data Fiscal ARCA / AFIP",
+    "placeholder": "Data Fiscal ARCA / AFIP pendiente de carga",
+    "html": "",
+    "image": "",
+    "link": ""
   }
 }

--- a/nerin_final_updated/frontend/admin-footer.js
+++ b/nerin_final_updated/frontend/admin-footer.js
@@ -70,6 +70,26 @@ const defaultConfig = {
     terms: "/pages/terminos.html",
     privacy: "/pages/terminos.html#datos",
   },
+  legalDetails: {
+    title: "Información fiscal y comercial",
+    businessName: "NERIN PARTS",
+    cuit: "30-93002432-2",
+    iibb: "901-117119-4",
+    condition: "Venta online · Depósito en CABA · Retiro con turno · Sin local a la calle",
+    address: "CABA, Argentina",
+    invoice: "Factura A/B",
+    payments: "Mercado Pago, transferencia bancaria y efectivo",
+    shipping: "Andreani · Envíos a todo el país",
+  },
+  dataFiscal: {
+    enabled: true,
+    mode: "placeholder",
+    label: "Data Fiscal ARCA / AFIP",
+    placeholder: "Data Fiscal ARCA / AFIP pendiente de carga",
+    html: "",
+    image: "",
+    link: "",
+  },
   show: { cta: true, branding: true, columns: true, contact: true, social: true, badges: true, newsletter: false, legal: true },
   theme: {
     accentFrom: "#60a5fa",
@@ -121,6 +141,19 @@ function fillForm(cfg) {
   form.iibb.value = cfg.legal.iibb;
   form.terms.value = cfg.legal.terms;
   form.privacy.value = cfg.legal.privacy;
+  form.legalTitle.value = cfg.legalDetails?.title || "";
+  form.businessName.value = cfg.legalDetails?.businessName || "";
+  form.legalCondition.value = cfg.legalDetails?.condition || "";
+  form.legalAddress.value = cfg.legalDetails?.address || "";
+  form.legalInvoice.value = cfg.legalDetails?.invoice || "";
+  form.legalPayments.value = cfg.legalDetails?.payments || "";
+  form.legalShipping.value = cfg.legalDetails?.shipping || "";
+  form.dataFiscalMode.value = cfg.dataFiscal?.mode || "placeholder";
+  form.dataFiscalLabel.value = cfg.dataFiscal?.label || "";
+  form.dataFiscalPlaceholder.value = cfg.dataFiscal?.placeholder || "";
+  form.dataFiscalHtml.value = cfg.dataFiscal?.html || "";
+  form.dataFiscalImage.value = cfg.dataFiscal?.image || "";
+  form.dataFiscalLink.value = cfg.dataFiscal?.link || "";
   form.accentFrom.value = cfg.theme.accentFrom;
   form.accentTo.value = cfg.theme.accentTo;
   form.bg.value = cfg.theme.bg;
@@ -181,6 +214,26 @@ function collectForm() {
     iibb: form.iibb.value.trim(),
     terms: form.terms.value.trim(),
     privacy: form.privacy.value.trim(),
+  };
+  cfg.legalDetails = {
+    title: form.legalTitle.value.trim(),
+    businessName: form.businessName.value.trim(),
+    cuit: form.cuit.value.trim(),
+    iibb: form.iibb.value.trim().replace(/^IIBB CABA\s*/i, ""),
+    condition: form.legalCondition.value.trim(),
+    address: form.legalAddress.value.trim() || form.address.value.trim(),
+    invoice: form.legalInvoice.value.trim(),
+    payments: form.legalPayments.value.trim(),
+    shipping: form.legalShipping.value.trim(),
+  };
+  cfg.dataFiscal = {
+    enabled: true,
+    mode: form.dataFiscalMode.value || "placeholder",
+    label: form.dataFiscalLabel.value.trim(),
+    placeholder: form.dataFiscalPlaceholder.value.trim(),
+    html: form.dataFiscalHtml.value.trim(),
+    image: form.dataFiscalImage.value.trim(),
+    link: form.dataFiscalLink.value.trim(),
   };
   cfg.theme = {
     accentFrom: form.accentFrom.value,

--- a/nerin_final_updated/frontend/admin.html
+++ b/nerin_final_updated/frontend/admin.html
@@ -1489,6 +1489,28 @@
           <input type="text" name="iibb" placeholder="IIBB" />
           <input type="text" name="terms" placeholder="URL Términos" />
           <input type="text" name="privacy" placeholder="URL Privacidad" />
+          <h4>Información fiscal y comercial (footer)</h4>
+          <input type="text" name="legalTitle" placeholder="Título bloque legal" />
+          <input type="text" name="businessName" placeholder="Razón / nombre comercial" />
+          <input type="text" name="legalCondition" placeholder="Condición comercial" />
+          <input type="text" name="legalAddress" placeholder="Dirección comercial" />
+          <input type="text" name="legalInvoice" placeholder="Comprobantes (ej: Factura A/B)" />
+          <input type="text" name="legalPayments" placeholder="Medios de pago" />
+          <input type="text" name="legalShipping" placeholder="Envíos" />
+          <h4>Data Fiscal / Formulario 960D</h4>
+          <label>
+            Modo Data Fiscal
+            <select name="dataFiscalMode">
+              <option value="placeholder">Placeholder</option>
+              <option value="html">HTML embebido</option>
+              <option value="image">Imagen + link</option>
+            </select>
+          </label>
+          <input type="text" name="dataFiscalLabel" placeholder="Etiqueta Data Fiscal" />
+          <input type="text" name="dataFiscalPlaceholder" placeholder="Texto placeholder Data Fiscal" />
+          <textarea name="dataFiscalHtml" placeholder="Pegar aquí HTML oficial Formulario 960/D" style="min-height:120px"></textarea>
+          <input type="text" name="dataFiscalImage" placeholder="URL imagen QR/insignia oficial" />
+          <input type="text" name="dataFiscalLink" placeholder="URL destino verificación ARCA/AFIP (opcional)" />
           <div style="display:flex; gap:0.5rem; flex-wrap:wrap;">
             <button type="submit" class="button primary">Guardar</button>
             <button type="button" id="footerReset" class="button">Restaurar defaults</button>

--- a/nerin_final_updated/frontend/cart.html
+++ b/nerin_final_updated/frontend/cart.html
@@ -113,7 +113,7 @@
       </div>
     </main>
     <div id="whatsapp-button">
-      <a href="https://wa.me/541112345678" target="_blank" data-whatsapp-link>
+      <a href="https://wa.me/5491130341550" target="_blank" data-whatsapp-link>
         <img src="/assets/whatsapp.svg" alt="WhatsApp" />
       </a>
     </div>

--- a/nerin_final_updated/frontend/checkout-steps.html
+++ b/nerin_final_updated/frontend/checkout-steps.html
@@ -170,7 +170,7 @@
     </main>
     <div id="footer-root"></div>
     <div id="whatsapp-button">
-      <a href="https://wa.me/541112345678" target="_blank" data-whatsapp-link>
+      <a href="https://wa.me/5491130341550" target="_blank" data-whatsapp-link>
         <img src="/assets/whatsapp.svg" alt="WhatsApp" />
       </a>
     </div>

--- a/nerin_final_updated/frontend/components/np-footer.css
+++ b/nerin_final_updated/frontend/components/np-footer.css
@@ -394,3 +394,15 @@
     transition: none !important;
   }
 }
+
+.np-footer__legal{display:grid;gap:.75rem;border-top:1px solid var(--np-border);padding-top:1rem}
+.np-footer__legal-title{margin:0;font-size:1rem;letter-spacing:.01em}
+.np-footer__legal-list{margin:0;padding:0;list-style:none;display:grid;gap:.35rem;color:var(--np-muted)}
+.np-footer__legal-list strong{color:var(--np-fg)}
+.np-footer__legal-links{margin:0;font-size:.88rem;color:var(--np-muted)}
+.np-footer__legal-links a{color:var(--np-link);text-decoration:none}
+.np-footer__legal-links a:hover{text-decoration:underline}
+.np-footer__data-fiscal{border:1px dashed var(--np-border);border-radius:12px;padding:.85rem;background:rgba(255,255,255,.03);max-width:320px}
+.np-footer__data-fiscal h4{margin:0 0 .35rem;font-size:.88rem}
+.np-footer__data-fiscal p{margin:0;color:var(--np-muted);font-size:.84rem}
+.np-footer__data-fiscal img{max-width:180px;height:auto;display:block}

--- a/nerin_final_updated/frontend/components/np-footer.js
+++ b/nerin_final_updated/frontend/components/np-footer.js
@@ -142,6 +142,27 @@
           terms: "/pages/terminos.html",
           privacy: "/pages/terminos.html#datos",
         },
+        legalDetails: {
+          title: "Información fiscal y comercial",
+          businessName: "NERIN PARTS",
+          cuit: "30-93002432-2",
+          iibb: "901-117119-4",
+          condition:
+            "Venta online · Depósito en CABA · Retiro con turno · Sin local a la calle",
+          address: "CABA, Argentina",
+          invoice: "Factura A/B",
+          payments: "Mercado Pago, transferencia bancaria y efectivo",
+          shipping: "Andreani · Envíos a todo el país",
+        },
+        dataFiscal: {
+          enabled: true,
+          mode: "placeholder",
+          label: "Data Fiscal ARCA / AFIP",
+          placeholder: "Data Fiscal ARCA / AFIP pendiente de carga",
+          html: "",
+          image: "",
+          link: "",
+        },
         show: {
           cta: true,
           branding: true,
@@ -432,36 +453,95 @@
       // Legal
       const legal = footerEl.querySelector(".np-footer__legal");
       if (legal && show.legal && cfg.legal) {
+        legal.innerHTML = "";
         legal.hidden = false;
         const y = new Date().getFullYear();
-        const brand = cfg.brand || "NERIN PARTS";
-        legal.appendChild(document.createTextNode(`© ${y} ${brand}`));
-        if (cfg.legal.cuit) {
-          legal.appendChild(
-            document.createTextNode(` – CUIT ${cfg.legal.cuit}`),
-          );
+        const legalDetails = cfg.legalDetails || {};
+        const businessName = legalDetails.businessName || cfg.brand || "NERIN PARTS";
+        const cuit = legalDetails.cuit || cfg.legal.cuit || "";
+        const iibb = legalDetails.iibb || String(cfg.legal.iibb || "").replace("IIBB CABA", "").trim();
+
+        const title = document.createElement("h3");
+        title.className = "np-footer__legal-title";
+        title.textContent = legalDetails.title || "Información fiscal y comercial";
+        legal.appendChild(title);
+
+        const list = document.createElement("ul");
+        list.className = "np-footer__legal-list";
+        const rows = [
+          ["Razón comercial", businessName],
+          ["CUIT", cuit],
+          ["IIBB CABA", iibb],
+          ["Condición comercial", legalDetails.condition],
+          ["Dirección comercial", legalDetails.address || cfg.contact?.address || ""],
+          ["Comprobantes", legalDetails.invoice || "Factura A/B"],
+          ["Medios de pago", legalDetails.payments],
+          ["Envíos", legalDetails.shipping],
+        ];
+        rows.forEach(([label, value]) => {
+          if (!value) return;
+          const li = document.createElement("li");
+          li.innerHTML = `<strong>${label}:</strong> ${value}`;
+          list.appendChild(li);
+        });
+        legal.appendChild(list);
+
+        const links = document.createElement("p");
+        links.className = "np-footer__legal-links";
+        links.append(`© ${y} ${businessName} · `);
+        const terms = document.createElement("a");
+        terms.href = cfg.legal.terms || "/pages/terminos.html";
+        terms.textContent = "Términos y condiciones";
+        terms.rel = "noopener";
+        const privacy = document.createElement("a");
+        privacy.href = cfg.legal.privacy || "/pages/terminos.html#datos";
+        privacy.textContent = "Política de privacidad";
+        privacy.rel = "noopener";
+        const warranty = document.createElement("a");
+        warranty.href = "/garantia.html";
+        warranty.textContent = "Garantía y devoluciones";
+        warranty.rel = "noopener";
+        const tracking = document.createElement("a");
+        tracking.href = "/seguimiento.html";
+        tracking.textContent = "Seguimiento de pedido";
+        tracking.rel = "noopener";
+        const contact = document.createElement("a");
+        contact.href = "/contact.html";
+        contact.textContent = "Contacto";
+        contact.rel = "noopener";
+        links.append(terms, " · ", privacy, " · ", warranty, " · ", tracking, " · ", contact);
+        legal.appendChild(links);
+
+        const fiscal = document.createElement("div");
+        fiscal.className = "np-footer__data-fiscal";
+        const fiscalLabel = document.createElement("h4");
+        fiscalLabel.textContent = cfg.dataFiscal?.label || "Data Fiscal ARCA / AFIP";
+        fiscal.appendChild(fiscalLabel);
+        if (cfg.dataFiscal?.mode === "html" && cfg.dataFiscal?.html) {
+          fiscal.insertAdjacentHTML("beforeend", cfg.dataFiscal.html);
+        } else if (cfg.dataFiscal?.mode === "image" && cfg.dataFiscal?.image) {
+          const img = document.createElement("img");
+          img.src = cfg.dataFiscal.image;
+          img.alt = cfg.dataFiscal.label || "Data Fiscal";
+          img.loading = "lazy";
+          img.decoding = "async";
+          if (cfg.dataFiscal?.link) {
+            const a = document.createElement("a");
+            a.href = cfg.dataFiscal.link;
+            a.target = "_blank";
+            a.rel = "noopener noreferrer";
+            a.appendChild(img);
+            fiscal.appendChild(a);
+          } else {
+            fiscal.appendChild(img);
+          }
+        } else {
+          const placeholder = document.createElement("p");
+          placeholder.textContent =
+            cfg.dataFiscal?.placeholder || "Data Fiscal ARCA / AFIP pendiente de carga";
+          fiscal.appendChild(placeholder);
         }
-        if (cfg.legal.iibb) {
-          legal.appendChild(
-            document.createTextNode(` – IIBB ${cfg.legal.iibb}`),
-          );
-        }
-        if (cfg.legal.terms) {
-          legal.appendChild(document.createTextNode(" – "));
-          const terms = document.createElement("a");
-          terms.href = cfg.legal.terms;
-          terms.textContent = "Términos";
-          terms.rel = "noopener";
-          legal.appendChild(terms);
-        }
-        if (cfg.legal.privacy) {
-          legal.appendChild(document.createTextNode(" – "));
-          const priv = document.createElement("a");
-          priv.href = cfg.legal.privacy;
-          priv.textContent = "Privacidad";
-          priv.rel = "noopener";
-          legal.appendChild(priv);
-        }
+        legal.appendChild(fiscal);
       }
 
       // Theme

--- a/nerin_final_updated/frontend/contact.html
+++ b/nerin_final_updated/frontend/contact.html
@@ -162,7 +162,7 @@
             <div class="contact-hero__actions">
               <a
                 class="button primary contact-hero__cta"
-                href="https://wa.me/541112345678"
+                href="https://wa.me/5491130341550"
                 target="_blank"
                 rel="noopener noreferrer"
                 data-whatsapp-link
@@ -491,7 +491,7 @@
             <div class="final-actions">
               <a
                 class="button primary"
-                href="https://wa.me/541112345678"
+                href="https://wa.me/5491130341550"
                 target="_blank"
                 rel="noopener noreferrer"
                 data-whatsapp-link

--- a/nerin_final_updated/frontend/garantia.html
+++ b/nerin_final_updated/frontend/garantia.html
@@ -233,7 +233,7 @@
     </main>
 
     <div id="whatsapp-button">
-      <a href="https://wa.me/541112345678" target="_blank" data-whatsapp-link>
+      <a href="https://wa.me/5491130341550" target="_blank" data-whatsapp-link>
         <img src="/assets/whatsapp.svg" alt="WhatsApp" />
       </a>
     </div>

--- a/nerin_final_updated/frontend/index.html
+++ b/nerin_final_updated/frontend/index.html
@@ -131,13 +131,13 @@
   "sameAs": [
     "https://www.instagram.com/nerin",
     "https://www.facebook.com/nerin",
-    "https://wa.me/541112345678"
+    "https://wa.me/5491130341550"
   ],
   "contactPoint": [
     {
       "@type": "ContactPoint",
-      "telephone": "+54 11 1234-5678",
-      "email": "info@nerinparts.com",
+      "telephone": "+54 9 11 3034-1550",
+      "email": "ventas@nerinparts.com.ar",
       "contactType": "customer service",
       "areaServed": "AR",
       "availableLanguage": ["es-AR"]
@@ -181,19 +181,15 @@
         </nav>
               </div>
     </header>
-    <section class="home-legal-strip" aria-label="Información legal del local en CABA">
-      <p><strong>NERIN PARTS</strong> · CUIT 30-93002432-2 · IIBB CABA 901-117119-4 · Dirección comercial: CABA, Argentina.</p>
-      <p><a href="/pages/terminos.html">Términos y condiciones</a> · <a href="/pages/terminos.html#datos">Política de privacidad</a> · Factura A/B</p>
-    </section>
-    <main class="home">
+<main class="home">
       <section class="home-hero" data-home-section="hero">
         <div class="home-hero__content">
-          <p class="eyebrow" data-home-text="hero.eyebrow">NERIN Parts · Repuestos para celular</p>
+          <p class="eyebrow" data-home-text="hero.eyebrow">NERIN Parts · Repuestos originales para reparación profesional</p>
           <h1 data-home-text="hero.title">
-            Encontrá el repuesto exacto sin perder tiempo
+            Pantallas Samsung Service Pack originales, con stock real y factura A/B
           </h1>
           <p class="lead" data-home-text="hero.description">
-            Buscá por modelo, código de pieza o SKU. Displays, módulos, baterías y repuestos para reparación profesional, con stock visible y atención real.
+            Trabajamos repuestos originales y verificados para técnicos, talleres, revendedores y clientes finales. Coordinamos retiro con turno en CABA o envío a todo el país.
           </p>
           <form class="home-hero__search" action="/shop.html" method="get">
             <input type="search" name="search" placeholder="Modelo, SKU, GH82 o componente…" aria-label="Buscar repuesto" required />
@@ -207,14 +203,17 @@
               >Buscar en catálogo</a
             >
             <a
-              href="/pages/terminos.html"
+              href="https://wa.me/5491130341550?text=Hola%20NERIN%2C%20quiero%20consultar%20por%20un%20repuesto"
               class="button secondary"
-              data-home-cta="hero.secondary"
-              >Ver términos y garantías</a
+              data-home-cta="hero.secondary" target="_blank" rel="noopener"
+              >Consultar por WhatsApp</a
             >
           </div>
+          <ul class="home-hero__badges" aria-label="Beneficios NERIN">
+            <li>Stock real</li><li>Factura A/B</li><li>Retiro con turno</li><li>Envíos a todo el país</li>
+          </ul>
         </div>
-        <figure class="home-hero__media">
+        <figure class="home-hero__media" aria-label="Producto destacado">
           <picture data-home-picture="hero.media">
             <source
               media="(min-width: 900px)"
@@ -269,7 +268,7 @@
           <p>Mandanos modelo, código de pieza o foto del repuesto y te confirmamos disponibilidad.</p>
         </div>
         <div class="home-cta__actions">
-          <a class="button primary" href="https://wa.me/541112345678?text=Hola%20NERIN%2C%20necesito%20ayuda%20para%20encontrar%20un%20repuesto" target="_blank" rel="noopener">Consultar por WhatsApp</a>
+          <a class="button primary" href="https://wa.me/5491130341550?text=Hola%20NERIN%2C%20necesito%20ayuda%20para%20encontrar%20un%20repuesto" target="_blank" rel="noopener">Consultar por WhatsApp</a>
           <a class="button secondary" href="/shop.html">Ver catálogo</a>
         </div>
       </section>

--- a/nerin_final_updated/frontend/js/account-minorista.js
+++ b/nerin_final_updated/frontend/js/account-minorista.js
@@ -555,7 +555,7 @@ async function initMinorAccount() {
       (typeof cfg.whatsappNumber === "string"
         ? cfg.whatsappNumber.replace(/[^0-9]/g, "")
         : "");
-    const phone = sanitized || "541112345678";
+    const phone = sanitized || "5491130341550";
     supportBtn.href = `https://wa.me/${phone}`;
   }
 

--- a/nerin_final_updated/frontend/js/account.js
+++ b/nerin_final_updated/frontend/js/account.js
@@ -1639,7 +1639,7 @@ async function initAccount() {
       (typeof cfg.whatsappNumber === "string"
         ? cfg.whatsappNumber.replace(/[^0-9]/g, "")
         : "");
-    const phone = sanitized || "541112345678";
+    const phone = sanitized || "5491130341550";
     supportBtn.href = `https://wa.me/${phone}`;
   }
 

--- a/nerin_final_updated/frontend/js/cart.js
+++ b/nerin_final_updated/frontend/js/cart.js
@@ -236,7 +236,7 @@ async function renderCart() {
     const phone =
       fromDataset ||
       sanitizedCfg ||
-      (rawCfg ? rawCfg.replace(/[^0-9]/g, "") : "541112345678");
+      (rawCfg ? rawCfg.replace(/[^0-9]/g, "") : "5491130341550");
     let message = "Hola! Deseo hacer un pedido:%0A";
     cart.forEach((item) => {
       const basePrice = item.price;

--- a/nerin_final_updated/frontend/js/index.js
+++ b/nerin_final_updated/frontend/js/index.js
@@ -37,10 +37,10 @@ const PLACEHOLDER_IMAGE =
 
 const DEFAULT_HOME_CONTENT = {
   hero: {
-    eyebrow: "NERIN Parts · Repuestos para celular",
-    title: "Encontrá el repuesto exacto sin perder tiempo",
+    eyebrow: "NERIN Parts · Repuestos originales para reparación profesional",
+    title: "Pantallas Samsung Service Pack originales, con stock real y factura A/B",
     description:
-      "Buscá por modelo, código de pieza o SKU. Displays, módulos, baterías y repuestos para reparación profesional, con catálogo online, stock visible y atención real.",
+      "Trabajamos repuestos originales y verificados para técnicos, talleres, revendedores y clientes finales. Coordinamos retiro con turno en CABA o envío a todo el país.",
     bullets: [
       "Stock visible",
       "Factura A/B",
@@ -48,7 +48,7 @@ const DEFAULT_HOME_CONTENT = {
       "Atención técnica",
     ],
     primaryCta: { label: "Buscar en catálogo", href: "/shop.html" },
-    secondaryCta: { label: "Consultar por WhatsApp", href: "https://wa.me/541112345678" },
+    secondaryCta: { label: "Consultar por WhatsApp", href: "https://wa.me/5491130341550" },
     media: {
       desktop: "/assets/hero.png",
       mobile: "/assets/hero.png",
@@ -787,7 +787,7 @@ function resolveWhatsAppNumber() {
     const sanitized = cfg.whatsappNumber.replace(/[^0-9]/g, "");
     if (sanitized) return sanitized;
   }
-  return "541112345678";
+  return "5491130341550";
 }
 
 function setupContactForm() {

--- a/nerin_final_updated/frontend/login.html
+++ b/nerin_final_updated/frontend/login.html
@@ -105,7 +105,7 @@
       </section>
     </main>
     <div id="whatsapp-button">
-      <a href="https://wa.me/541112345678" target="_blank" data-whatsapp-link>
+      <a href="https://wa.me/5491130341550" target="_blank" data-whatsapp-link>
         <img src="/assets/whatsapp.svg" alt="WhatsApp" />
       </a>
     </div>

--- a/nerin_final_updated/frontend/product.html
+++ b/nerin_final_updated/frontend/product.html
@@ -151,7 +151,7 @@
       aria-label="Galería de imágenes"
     ></div>
     <div id="whatsapp-button">
-      <a href="https://wa.me/541112345678" target="_blank" data-whatsapp-link>
+      <a href="https://wa.me/5491130341550" target="_blank" data-whatsapp-link>
         <img src="/assets/whatsapp.svg" alt="WhatsApp" />
       </a>
     </div>

--- a/nerin_final_updated/frontend/register.html
+++ b/nerin_final_updated/frontend/register.html
@@ -296,7 +296,7 @@
                   id="wholesalePhone"
                   name="phone"
                   autocomplete="tel"
-                  placeholder="Ej: +54 11 1234-5678"
+                  placeholder="Ej: +54 9 11 3034-1550"
                   required
                 />
               </div>

--- a/nerin_final_updated/frontend/shop.html
+++ b/nerin_final_updated/frontend/shop.html
@@ -277,7 +277,7 @@
       <div class="shop-filters-backdrop" id="filtersBackdrop" hidden></div>
     </main>
     <div id="whatsapp-button">
-      <a href="https://wa.me/541112345678" target="_blank" data-whatsapp-link>
+      <a href="https://wa.me/5491130341550" target="_blank" data-whatsapp-link>
         <img src="/assets/whatsapp.svg" alt="WhatsApp" />
       </a>
     </div>

--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -9603,3 +9603,17 @@ html, body{ max-width:100%; overflow-x:hidden; }
     font-size: 0.78rem;
   }
 }
+
+
+/* Home refresh premium */
+.home-legal-strip{display:none!important;}
+.home-hero{position:relative;overflow:hidden;grid-template-columns:minmax(0,1fr) minmax(300px,0.9fr);padding:clamp(1.2rem,2.8vw,2.2rem)!important;background:linear-gradient(180deg,#fff,#f8fafc);border:1px solid #e5e7eb;border-radius:24px;box-shadow:0 12px 36px rgba(15,23,42,.08)!important;}
+.home-hero::before,.home-hero::after{content:none!important;display:none!important;}
+.home-hero__content{display:grid;gap:.9rem;}
+.home-hero__media{background:#fff;border:1px solid #e5e7eb;border-radius:20px;padding:1rem;box-shadow:0 10px 26px rgba(2,6,23,.08);}
+.home-hero__media img{object-fit:contain!important;max-height:380px;background:#fff;}
+.home-hero__badges{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.55rem;list-style:none;padding:0;margin:.3rem 0 0;}
+.home-hero__badges li{font-size:.88rem;background:#f8fafc;border:1px solid #dbe3ef;border-radius:999px;padding:.45rem .75rem;text-align:center;font-weight:600;color:#0f172a;}
+.home-highlights__grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:.85rem;}
+@media (max-width:1100px){.home-highlights__grid{grid-template-columns:repeat(2,minmax(0,1fr));}.home-hero{grid-template-columns:1fr;}.home-hero__media{order:-1;}}
+@media (max-width:640px){.home-hero{border-radius:18px;padding:1rem!important}.home-hero__search{grid-template-columns:1fr!important}.home-hero__badges{grid-template-columns:1fr;}}


### PR DESCRIPTION
### Motivation
- Limpiar y relanzar la experiencia visual de la home para transmitir una estética premium, minimalista y ordenada evitando overlays y manchas que tapan contenido. 
- Quitar la franja legal superior que rompe la primera impresión y mover la legalidad a un footer centralizado y coherente con la web. 
- Unificar la fuente de verdad para datos comerciales (CUIT, IIBB, teléfono, email) y preparar un bloque configurable para publicar el Data Fiscal / QR oficial sin hardcodear información falsa.

### Description
- Se ocultó la franja legal superior y se rehízo el hero: ajustes en `frontend/index.html` y reglas nuevas en `frontend/style.css` para tarjeta de media, espaciado, CTA principal/secundario y badges de confianza. 
- Se actualizó la configuración y contenidos por defecto en `data/config.json` y `data/footer.json` para unificar `whatsappNumber`, `supportEmail` y los textos del `homePage.hero`. 
- Se extendió el componente de footer (`frontend/components/np-footer.js` y `frontend/components/np-footer.css`) para renderizar un bloque estructurado `Información fiscal y comercial` y para soportar `dataFiscal` en modos `html`, `image` o `placeholder` (sin QR inventado). 
- Se normalizaron enlaces y fallbacks para WhatsApp/email en varios templates y scripts (`frontend/*.html`, `frontend/js/*.js`) y se reforzaron condiciones para que `window.NERIN_CONFIG` o `/api/footer` no rompan el layout cuando traigan valores remotos.

### Testing
- Validé que los JSON de configuración se parsean correctamente ejecutando `node -e "JSON.parse(require('fs').readFileSync('data/config.json','utf8'));JSON.parse(require('fs').readFileSync('data/footer.json','utf8'));console.log('json ok')"`, que devolvió éxito. 
- Ejecuté búsquedas automáticas con `rg` para detectar apariciones antiguas de CUIT/teléfonos/strip y comprobé que las instancias puntuales han sido unificadas o ocultadas (p. ej. `home-legal-strip` ahora está oculto). 
- Comprobé en caliente que el footer dinámico monta el nuevo bloque `legalDetails` y muestra el placeholder de `dataFiscal` cuando no hay `html`/`image`, sin errores en la consola en el arranque del script del footer.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f225d2a8e883318b350543774f8285)