### PR TITLE
Ajusta opciones Data Fiscal en admin y agrega carga de imagen

### DIFF
--- a/nerin_final_updated/frontend/admin-footer.js
+++ b/nerin_final_updated/frontend/admin-footer.js
@@ -109,9 +109,14 @@ const resetBtn = document.getElementById('footerReset');
 const viewBtn = document.getElementById('footerView');
 const BADGE_KEYS = ["mercadoPago", "andreani", "efectivo", "transferencia"];
 let badgeUploadsInProgress = 0;
+let dataFiscalUploadInProgress = 0;
 
 function isBadgeUploadInProgress() {
   return badgeUploadsInProgress > 0;
+}
+
+function isDataFiscalUploadInProgress() {
+  return dataFiscalUploadInProgress > 0;
 }
 
 async function loadFooterConfig() {
@@ -148,7 +153,8 @@ function fillForm(cfg) {
   form.legalInvoice.value = cfg.legalDetails?.invoice || "";
   form.legalPayments.value = cfg.legalDetails?.payments || "";
   form.legalShipping.value = cfg.legalDetails?.shipping || "";
-  form.dataFiscalMode.value = cfg.dataFiscal?.mode || "placeholder";
+  const fiscalMode = cfg.dataFiscal?.mode || "image";
+  form.dataFiscalMode.value = fiscalMode === "placeholder" ? "image" : fiscalMode;
   form.dataFiscalLabel.value = cfg.dataFiscal?.label || "";
   form.dataFiscalPlaceholder.value = cfg.dataFiscal?.placeholder || "";
   form.dataFiscalHtml.value = cfg.dataFiscal?.html || "";
@@ -228,7 +234,7 @@ function collectForm() {
   };
   cfg.dataFiscal = {
     enabled: true,
-    mode: form.dataFiscalMode.value || "placeholder",
+    mode: form.dataFiscalMode.value || "image",
     label: form.dataFiscalLabel.value.trim(),
     placeholder: form.dataFiscalPlaceholder.value.trim(),
     html: form.dataFiscalHtml.value.trim(),
@@ -288,7 +294,7 @@ async function persistFooterConfig({ showSuccessAlert = true } = {}) {
 
 form.addEventListener('submit', async (e) => {
   e.preventDefault();
-  if (isBadgeUploadInProgress()) {
+  if (isBadgeUploadInProgress() || isDataFiscalUploadInProgress()) {
     alert('Esperá a que termine la carga de la imagen antes de guardar.');
     return;
   }
@@ -386,6 +392,64 @@ async function handleBadgeFileChange(event) {
   }
 }
 
+
+async function persistDataFiscalImageOnly(url) {
+  const headers = { 'Content-Type': 'application/json' };
+  const token = localStorage.getItem('nerinToken');
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  const currentRes = await fetch('/api/footer', { headers });
+  const current = await currentRes.json().catch(() => ({}));
+  if (!currentRes.ok) {
+    throw new Error('No se pudo leer la configuración actual del footer');
+  }
+
+  const payload = {
+    ...defaultConfig,
+    ...current,
+    dataFiscal: {
+      ...defaultConfig.dataFiscal,
+      ...(current?.dataFiscal || {}),
+      mode: 'image',
+      image: url,
+    },
+  };
+
+  const res = await fetch('/api/footer', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(payload),
+  });
+
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(data.error || 'No se pudo guardar la imagen de data fiscal');
+  }
+
+  return data;
+}
+
+async function handleDataFiscalFileChange(event) {
+  const input = event.target;
+  if (input?.name !== 'dataFiscalImageFile' || !input.files?.length) return;
+  try {
+    dataFiscalUploadInProgress += 1;
+    input.disabled = true;
+    const file = input.files[0];
+    const url = await uploadBadgeImage(file);
+    form.dataFiscalImage.value = url;
+    form.dataFiscalMode.value = 'image';
+    await persistDataFiscalImageOnly(url);
+  } catch (err) {
+    console.error('footer-datafiscal-upload', err);
+    alert(err.message || 'Error al subir la imagen de data fiscal');
+  } finally {
+    dataFiscalUploadInProgress = Math.max(0, dataFiscalUploadInProgress - 1);
+    input.value = '';
+    input.disabled = false;
+  }
+}
 if (form) {
   form.addEventListener("change", handleBadgeFileChange);
+  form.addEventListener("change", handleDataFiscalFileChange);
 }

--- a/nerin_final_updated/frontend/admin.html
+++ b/nerin_final_updated/frontend/admin.html
@@ -1501,7 +1501,6 @@
           <label>
             Modo Data Fiscal
             <select name="dataFiscalMode">
-              <option value="placeholder">Placeholder</option>
               <option value="html">HTML embebido</option>
               <option value="image">Imagen + link</option>
             </select>
@@ -1510,6 +1509,7 @@
           <input type="text" name="dataFiscalPlaceholder" placeholder="Texto placeholder Data Fiscal" />
           <textarea name="dataFiscalHtml" placeholder="Pegar aquí HTML oficial Formulario 960/D" style="min-height:120px"></textarea>
           <input type="text" name="dataFiscalImage" placeholder="URL imagen QR/insignia oficial" />
+          <input type="file" name="dataFiscalImageFile" accept="image/*" />
           <input type="text" name="dataFiscalLink" placeholder="URL destino verificación ARCA/AFIP (opcional)" />
           <div style="display:flex; gap:0.5rem; flex-wrap:wrap;">
             <button type="submit" class="button primary">Guardar</button>


### PR DESCRIPTION
### Motivation
- Simplificar la gestión de la sección “Data Fiscal” en el admin permitiendo subir la insignia/QR desde el panel y mostrar solo las opciones relevantes en la UI.
- Evitar inconsistencias al guardar la configuración mientras hay una subida de imagen en curso.

### Description
- Elimina la opción `placeholder` del select `dataFiscalMode` y deja solo `HTML embebido` y `Imagen + link` en `nerin_final_updated/frontend/admin.html` y añade un `input type="file"` llamado `dataFiscalImageFile` para subir la imagen/QR.
- Añade estado de subida `dataFiscalUploadInProgress` y la función `isDataFiscalUploadInProgress()` en `nerin_final_updated/frontend/admin-footer.js` para bloquear el guardado mientras haya subidas activas.
- Implementa `persistDataFiscalImageOnly(url)` y `handleDataFiscalFileChange(event)` que reutilizan `uploadBadgeImage(file)` para subir a `/api/upload`, completar `dataFiscalImage`, forzar `mode: 'image'` y persistir el cambio a `/api/footer`.
- Mantiene compatibilidad con configuraciones antiguas mapeando `placeholder` a `image` al cargar el formulario y agrega el listener `form.addEventListener('change', handleDataFiscalFileChange)`.

### Testing
- Revisé el diff generado con `git diff -- nerin_final_updated/frontend/admin.html nerin_final_updated/frontend/admin-footer.js` y mostró las inserciones esperadas (éxito).
- Verifiqué el contenido de los archivos modificados con comandos de inspección de archivos (`sed`/`nl`) para confirmar que las funciones y el input fueron añadidos correctamente (éxito).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f234cde2488331b2b59c36212a0b0f)