### PR TITLE
Remove misleading highlights cards from storefront homepage

### DIFF
--- a/nerin_final_updated/frontend/index.html
+++ b/nerin_final_updated/frontend/index.html
@@ -228,11 +228,6 @@
           </picture>
         </figure>
       </section>
-
-      <section class="home-highlights" data-home-section="highlights">
-        <div class="home-highlights__grid" id="homeHighlights"></div>
-      </section>
-
       <section class="home-categories" data-home-section="categories">
         <div class="home-section-head">
           <p class="eyebrow">Accesos rápidos</p>


### PR DESCRIPTION
### Motivation
- The homepage displayed a `home-highlights` cards block (e.g. “Stock real / Verificación / Retiro…”) that rendered poorly on mobile and did not represent the actual state, so it was removed to avoid misleading users.

### Description
- Deleted the `<section class="home-highlights" data-home-section="highlights">` container from `nerin_final_updated/frontend/index.html`, making the page flow go from the hero directly to the `home-categories` section.

### Testing
- Verified the change with `git status --short` and inspected the updated file region using `nl -ba nerin_final_updated/frontend/index.html | sed -n '220,255p'` to confirm the `home-highlights` block is gone and the commit was recorded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f23505de58833187322339be66b9fe)