### PR TITLE
Mostrar claramente stock remoto y plazos de entrega en catálogo

### DIFF
--- a/nerin_final_updated/frontend/js/shop.js
+++ b/nerin_final_updated/frontend/js/shop.js
@@ -233,7 +233,7 @@ function getRemoteLeadTimeCopy(product) {
     if (maxDays === minDays) return `Entrega estimada: ${minDays} día${minDays === 1 ? "" : "s"}.`;
     return `Entrega estimada: ${minDays} a ${maxDays} días.`;
   }
-  return "Entrega estimada: 4 a 10 días (incluye preparación del proveedor).";
+  return "Entrega estimada: 20 a 30 días (importación a pedido + preparación).";
 }
 
 function getStockStatus(product) {
@@ -495,7 +495,12 @@ function createProductCard(product) {
   availability.className = "description";
   const status = getStockStatus(product);
   const fulfillmentMode = getFulfillmentMode(product);
-  if (status === "out") availability.textContent = "Sin stock";
+  if (fulfillmentMode === "remote") {
+    availability.textContent =
+      status === "out"
+        ? "Stock remoto (a pedido)"
+        : `Stock remoto: ${resolveStockQuantity(product) || 0} unidades`;
+  } else if (status === "out") availability.textContent = "Sin stock";
   else if (status === "low") availability.textContent = `Pocas unidades (${product.stock})`;
   else availability.textContent = `Stock: ${resolveStockQuantity(product) || 0} unidades`;
   card.appendChild(availability);


### PR DESCRIPTION
### Motivation
- Evitar que los productos que se venden "a pedido" aparezcan como "Sin stock" en el catálogo y así reducir confusión entre stock físico y stock remoto.
- Hacer visible un plazo estimado coherente para productos importados cuando no hay plazos específicos cargados.

### Description
- Cambié el mensaje por defecto en `getRemoteLeadTimeCopy` a `"Entrega estimada: 20 a 30 días (importación a pedido + preparación)."` dentro de `nerin_final_updated/frontend/js/shop.js`.
- Actualicé `createProductCard` en `nerin_final_updated/frontend/js/shop.js` para que cuando `getFulfillmentMode(product) === "remote"` muestre `"Stock remoto (a pedido)"` o `"Stock remoto: X unidades"` según corresponda.
- Mantengo la nota de cumplimiento bajo la disponibilidad que incluye `getRemoteLeadTimeCopy(product)` para dejar constancia del plazo y la condición de disponibilidad del proveedor.

### Testing
- Ejecuté `node --check nerin_final_updated/frontend/js/shop.js` para verificar la sintaxis del archivo modificado y retornó sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f24dab64b88331bdef8f437c6b7b1d)