### PR TITLE
Add lead-time notice, legal banner and acceptance for remote (delayed) products

### DIFF
--- a/nerin_final_updated/frontend/js/shop.js
+++ b/nerin_final_updated/frontend/js/shop.js
@@ -243,6 +243,23 @@ function getDeliveryPromiseCopy(product, fulfillmentMode) {
   return "24 a 48 hs hábiles.";
 }
 
+
+function shouldRequireDelayTermsAcceptance(product, fulfillmentMode = getFulfillmentMode(product)) {
+  if (fulfillmentMode !== "remote") return false;
+  return true;
+}
+
+function buildDelayTermsMessage(product) {
+  const deliveryCopy = getDeliveryPromiseCopy(product, "remote");
+  return [
+    `Este producto es con demora: ${deliveryCopy}`,
+    "Condiciones legales (AR): la publicación es informativa y está sujeta a disponibilidad real del proveedor.",
+    "Si no hay stock al momento de confirmar, la operación puede cancelarse y se reintegra el 100% del dinero abonado por el mismo medio de pago.",
+    "Antes de pagar, te recomendamos confirmar por WhatsApp.",
+    "Al continuar, confirmás que leíste y aceptás estos términos para productos con demora."
+  ].join("\n\n");
+}
+
 function matchesStockFilter(product, stockFilterValue) {
   if (!stockFilterValue) return true;
   const fulfillmentMode = getFulfillmentMode(product);
@@ -426,7 +443,12 @@ function resetAllFilters() {
 }
 
 function addToCart(product) {
-  if (typeof product.stock === "number" && product.stock <= 0) {
+  const fulfillmentMode = getFulfillmentMode(product);
+  if (shouldRequireDelayTermsAcceptance(product, fulfillmentMode)) {
+    const acceptedTerms = window.confirm(buildDelayTermsMessage(product));
+    if (!acceptedTerms) return;
+  }
+  if (typeof product.stock === "number" && product.stock <= 0 && fulfillmentMode !== "remote") {
     alert("Sin stock disponible");
     return;
   }
@@ -533,8 +555,21 @@ function createProductCard(product) {
 
   const deliveryPromise = document.createElement("p");
   deliveryPromise.className = "product-delivery-promise";
-  deliveryPromise.textContent = `Entrega estimada: ${getDeliveryPromiseCopy(product, fulfillmentMode)}`;
+  deliveryPromise.textContent =
+    fulfillmentMode === "remote"
+      ? `El vendedor necesita ${getDeliveryPromiseCopy(product, fulfillmentMode)} para tener listo este producto.`
+      : `Entrega estimada: ${getDeliveryPromiseCopy(product, fulfillmentMode)}`;
   card.appendChild(deliveryPromise);
+
+  if (fulfillmentMode === "remote") {
+    const legalBanner = document.createElement("div");
+    legalBanner.className = "product-legal-banner";
+    legalBanner.innerHTML =
+      '<strong>Importante:</strong> Publicación sujeta a disponibilidad del distribuidor oficial. ' +
+      'Si no hay stock, la compra puede cancelarse y se reintegra el dinero. ' +
+      'Consultá por WhatsApp antes de pagar. Al agregar al carrito aceptás estos términos.';
+    card.appendChild(legalBanner);
+  }
 
   const priceBlock = document.createElement("div");
   priceBlock.className = "price-block";

--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -875,14 +875,30 @@ body.cart-indicator-visible .toastify {
 }
 
 .product-card .product-delivery-promise {
-  margin: 0 0 0.75rem;
-  padding: 0.45rem 0.6rem;
+  margin: 0 0 0.45rem;
+  padding: 0.4rem 0.55rem;
   border-radius: 10px;
   background: #eff6ff;
   border: 1px solid #bfdbfe;
   color: #1d4ed8;
-  font-size: 0.82rem;
+  font-size: 0.78rem;
+  line-height: 1.35;
   font-weight: 700;
+}
+
+.product-card .product-legal-banner {
+  margin: 0 0 0.8rem;
+  padding: 0.5rem 0.6rem;
+  border-radius: 10px;
+  border: 1px solid #f59e0b;
+  background: #fffbeb;
+  color: #92400e;
+  font-size: 0.72rem;
+  line-height: 1.4;
+}
+
+.product-card .product-legal-banner strong {
+  font-weight: 800;
 }
 
 .price {


### PR DESCRIPTION
### Motivation
- Mostrar en el catálogo la demora real de los productos importados/`remote` y dejar constancia legal para evitar compras sorpresivas cuando el proveedor no tenga stock.
- Exigir aceptación explícita de condiciones al agregar al carrito productos con tiempo de demora para reducir cancelaciones y consultas posteriores.

### Description
- Añadí `shouldRequireDelayTermsAcceptance` y `buildDelayTermsMessage` en `frontend/js/shop.js` y pedí confirmación (`window.confirm`) antes de `addToCart` para productos con `fulfillmentMode === 'remote'`.
- Cambié el copy del bloque de entrega en la card a formato marketplace: ahora muestra `El vendedor necesita X días para tener listo este producto.` usando `getDeliveryPromiseCopy`.
- Inserté un banner legal dentro de cada `product-card` para productos `remote` con el mensaje de disponibilidad sujeta a proveedor, posible cancelación y reintegro, y recomendación de consultar por WhatsApp.
- Ajusté estilos en `frontend/style.css` para compactar la apariencia del bloque de entrega y añadí reglas para `.product-legal-banner` (colores, tipografía y espaciado) para que encaje con el diseño existente.

### Testing
- Ejecuté una comprobación de sintaxis JavaScript con `node --check frontend/js/shop.js`, que pasó correctamente.
- Realicé una verificación manual de que las funciones nuevas (`buildDelayTermsMessage`, `shouldRequireDelayTermsAcceptance`) se integran en el flujo de `createProductCard` y `addToCart` sin errores de carga en el bundle JS.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3442801948331ac4ee9a44a61728e)