### PR TITLE
Update Mercado Pago preference payload to use `usuario` and `carrito` with `currency_id`

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -50,23 +50,17 @@
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
-              titulo: producto.titulo,
-              precio: producto.precio,
-              cantidad: producto.cantidad,
-              datos: {
-                nombre: saved.nombre,
-                apellido: saved.apellido,
+              usuario: {
                 email: saved.email,
-                telefono: saved.telefono,
               },
-              envio: {
-                provincia: saved.provincia,
-                localidad: saved.localidad,
-                direccion: saved.direccion,
-                cp: saved.cp,
-                metodo: saved.metodo,
-                costo: saved.costo,
-              },
+              carrito: [
+                {
+                  titulo: producto.titulo,
+                  precio: producto.precio,
+                  cantidad: producto.cantidad,
+                  currency_id: 'ARS',
+                },
+              ],
             }),
           });
           const data = await res.json();


### PR DESCRIPTION
### Motivation

- Align the frontend request payload with the expected backend/checkout API for Mercado Pago by replacing the previous flat product and user fields with structured `usuario` and `carrito` objects.  
- Add `currency_id` to the item to ensure the currency is explicitly provided to the payment provider.

### Description

- Replaced the previous POST body fields (`titulo`, `precio`, `cantidad`, `datos`, and `envio`) with a `usuario` object that currently contains `email` only.  
- Introduced a `carrito` array containing the product as an item with `titulo`, `precio`, `cantidad`, and `currency_id: 'ARS'`.  
- Kept the flow that stores the product in `localStorage` and redirects to the returned `init_point` when the API responds successfully.  
- Removed sending of extra user/address fields (`nombre`, `apellido`, `telefono`, `provincia`, `localidad`, `direccion`, `cp`, `metodo`, `costo`) from the frontend request payload.

### Testing

- No automated tests were added or run for this frontend HTML change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f36b8588048331a98c807cfc87a861)