### PR TITLE
Fix resolvedCart scope leak that crashed server startup

### DIFF
--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -12379,15 +12379,3 @@ if (require.main === module) {
     });
   })();
 }
-            console.log("[checkout-payment:create-preference]", {
-              paymentMethod: "mercado_pago",
-              itemCount: resolvedCart.length,
-              total,
-              source: "sqlite",
-            });
-            console.log("[checkout-payment:create-preference]", {
-              paymentMethod,
-              itemCount: resolvedItems.length,
-              total: grandTotal,
-              source: "sqlite",
-            });


### PR DESCRIPTION
### Motivation
- El arranque fallaba con `ReferenceError: resolvedCart is not defined` debido a logs de checkout que quedaron fuera del scope del handler y se ejecutaban en carga de módulo, por lo que el servidor no podía iniciar.

### Description
- Eliminé dos llamadas a `console.log` colgadas al final de `nerin_final_updated/backend/server.js` que referenciaban `resolvedCart` y `resolvedItems` en scope global, manteniendo intacto el flujo de checkout que resuelve productos vía SQLite.

### Testing
- Ejecutado `node --check nerin_final_updated/backend/server.js` y pasó correctamente.
- Ejecutado `node --check nerin_final_updated/backend/data/productsSqliteRepo.js` y pasó correctamente.
- Verificado con `grep -n "resolvedCart" nerin_final_updated/backend/server.js` que las referencias quedan dentro del handler de `/api/checkout` donde se declara la variable.
- `cd nerin_final_updated && timeout 12s npm start` arranca el servidor sin `ReferenceError` (timeout esperado para cortar el proceso que queda escuchando).
- `node nerin_final_updated/scripts/test-checkout-no-full-catalog-load.js` pasó OK.
- `node nerin_final_updated/scripts/test-checkout-payment-methods-sqlite.js` pasó OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3c6d13a7483319b5dc7d2df9ed471)