### PR TITLE
Fix checkout cart identifier loss and add defensive cart migration

### DIFF
--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -5484,7 +5484,11 @@ async function resolveCheckoutCartItems(cart = []) {
     if (!identifier) {
       console.warn("[checkout-cart-item-invalid]", {
         itemKeys: Object.keys(item || {}),
-        quantity: item?.quantity ?? item?.qty ?? null,
+        originalItem: item,
+        normalizedPreview: {
+          identifier,
+          quantity: item?.quantity ?? item?.qty ?? null,
+        },
       });
       const error = new Error("El carrito contiene un producto sin identificador. Eliminá ese item y volvé a agregarlo desde el catálogo.");
       error.statusCode = 400;

--- a/nerin_final_updated/frontend/js/cart-utils.js
+++ b/nerin_final_updated/frontend/js/cart-utils.js
@@ -1,0 +1,94 @@
+const CART_KEY = "nerinCart";
+
+const IDENTIFIER_FIELDS = [
+  "id",
+  "productId",
+  "product_id",
+  "sku",
+  "code",
+  "slug",
+  "publicSlug",
+  "public_slug",
+  "partNumber",
+  "mpn",
+  "ean",
+  "gtin",
+  "supplierCode",
+];
+
+function pickIdentifier(item = {}) {
+  for (const key of IDENTIFIER_FIELDS) {
+    const value = String(item?.[key] ?? "").trim();
+    if (value) return value;
+  }
+  return "";
+}
+
+export function normalizeCartItem(item = {}) {
+  const normalized = {
+    ...item,
+    id: String(item?.id ?? item?.productId ?? item?.product_id ?? "").trim(),
+    productId: String(item?.productId ?? item?.product_id ?? item?.id ?? "").trim(),
+    product_id: String(item?.product_id ?? item?.productId ?? item?.id ?? "").trim(),
+    publicSlug: String(item?.publicSlug ?? item?.public_slug ?? "").trim(),
+    public_slug: String(item?.public_slug ?? item?.publicSlug ?? "").trim(),
+    quantity: Number(item?.quantity ?? item?.qty ?? 1),
+  };
+  const identifier = pickIdentifier(normalized);
+  normalized.identifier = identifier;
+  return normalized;
+}
+
+export function isValidCartItem(item = {}) {
+  const normalized = normalizeCartItem(item);
+  return Boolean(normalized.identifier && Number.isFinite(normalized.quantity) && normalized.quantity > 0);
+}
+
+export function sanitizeCart(items = []) {
+  const src = Array.isArray(items) ? items : [];
+  return src
+    .map((item) => normalizeCartItem(item))
+    .filter((item) => isValidCartItem(item));
+}
+
+export function readCart({ migrate = true, onInvalidItems = null } = {}) {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(CART_KEY) || "[]");
+    const items = Array.isArray(parsed) ? parsed : [];
+    const valid = sanitizeCart(items);
+    if (migrate && valid.length !== items.length) {
+      localStorage.setItem(CART_KEY, JSON.stringify(valid));
+      if (typeof onInvalidItems === "function") onInvalidItems(items.length - valid.length);
+    }
+    return valid;
+  } catch (_err) {
+    localStorage.removeItem(CART_KEY);
+    return [];
+  }
+}
+
+export function writeCart(items = []) {
+  const valid = sanitizeCart(items);
+  localStorage.setItem(CART_KEY, JSON.stringify(valid));
+  return valid;
+}
+
+export function buildCartItemFromProduct(product = {}, extras = {}) {
+  const base = normalizeCartItem({
+    id: product?.id,
+    productId: product?.productId,
+    product_id: product?.product_id,
+    sku: product?.sku,
+    code: product?.code,
+    slug: product?.slug,
+    publicSlug: product?.publicSlug,
+    public_slug: product?.public_slug,
+    partNumber: product?.partNumber,
+    mpn: product?.mpn,
+    ean: product?.ean,
+    gtin: product?.gtin,
+    supplierCode: product?.supplierCode,
+    ...extras,
+  });
+  return base;
+}

--- a/nerin_final_updated/frontend/js/cart.js
+++ b/nerin_final_updated/frontend/js/cart.js
@@ -13,6 +13,7 @@ import { isWholesale, fetchProducts } from "./api.js";
 import { createPriceLegalBlock } from "./components/PriceLegalBlock.js";
 import { calculateNetNoNationalTaxes, formatArs } from "./utils/pricing.js";
 import { buildPixelContents, trackPixelOnce } from "./meta-pixel.js";
+import { readCart, writeCart } from "./cart-utils.js";
 
 // Referencias a los elementos del DOM
 const itemsContainer = document.getElementById("cartItems");
@@ -38,16 +39,14 @@ function calculateDiscountedPrice(basePrice, quantity) {
 function getStoredCart() {
   try {
     const raw = localStorage.getItem("nerinCart");
-    const cart = JSON.parse(raw || "[]");
-    const items = Array.isArray(cart) ? cart : [];
-    const valid = items.filter((item) => String(item?.identifier || "").trim());
-    if (valid.length !== items.length) {
-      localStorage.setItem("nerinCart", JSON.stringify(valid));
-      if (typeof window !== "undefined" && typeof window.alert === "function") {
-        window.alert("Algunos productos viejos del carrito fueron removidos porque faltaba información. Volvé a agregarlos desde el catálogo.");
-      }
-    }
-    return valid;
+    return readCart({
+      migrate: true,
+      onInvalidItems: () => {
+        if (typeof window !== "undefined" && typeof window.alert === "function") {
+          window.alert("Algunos productos viejos del carrito fueron removidos porque faltaba información. Volvé a agregarlos desde el catálogo.");
+        }
+      },
+    });
   } catch (err) {
     console.warn("Cart storage corrupt, resetting", err);
     localStorage.removeItem("nerinCart");
@@ -94,7 +93,7 @@ async function renderCart() {
     const available = stockMap[item.id] ?? Infinity;
     if (item.quantity > available) {
       item.quantity = available;
-      localStorage.setItem("nerinCart", JSON.stringify(cart));
+      writeCart(cart);
     }
 
     if (item.image) {
@@ -157,7 +156,7 @@ async function renderCart() {
     minus.addEventListener("click", () => {
       if (cart[index].quantity > 1) {
         cart[index].quantity -= 1;
-        localStorage.setItem("nerinCart", JSON.stringify(cart));
+        writeCart(cart);
         renderCart();
       }
     });
@@ -176,7 +175,7 @@ async function renderCart() {
         alert(`Stock disponible: ${available}`);
       }
       cart[index].quantity = qty;
-      localStorage.setItem("nerinCart", JSON.stringify(cart));
+      writeCart(cart);
       renderCart();
     });
     const plus = document.createElement("button");
@@ -185,7 +184,7 @@ async function renderCart() {
     plus.addEventListener("click", () => {
       if (cart[index].quantity < available) {
         cart[index].quantity += 1;
-        localStorage.setItem("nerinCart", JSON.stringify(cart));
+        writeCart(cart);
         renderCart();
       } else {
         alert(`Stock disponible: ${available}`);
@@ -208,7 +207,7 @@ async function renderCart() {
     removeBtn.textContent = "Eliminar";
     removeBtn.addEventListener("click", () => {
       cart.splice(index, 1);
-      localStorage.setItem("nerinCart", JSON.stringify(cart));
+      writeCart(cart);
       renderCart();
     });
     controls.appendChild(removeBtn);

--- a/nerin_final_updated/frontend/js/checkout-steps.js
+++ b/nerin_final_updated/frontend/js/checkout-steps.js
@@ -1,6 +1,7 @@
 import { apiFetch } from "./api.js";
 import { buildPixelContents, trackPixelOnce } from "./meta-pixel.js";
 import { calculateNetNoNationalTaxes, formatArs } from "./utils/pricing.js";
+import { readCart } from "./cart-utils.js";
 
 const API_BASE_URL = ''; // dejamos vacío para usar rutas relativas
 const step1 = document.getElementById('step1');
@@ -19,7 +20,7 @@ const pagoRadios = document.getElementsByName('pago');
 const protectionNote = document.getElementById('protectionNote');
 const metodoInfo = document.getElementById('metodoInfo');
 
-const cart = JSON.parse(localStorage.getItem('nerinCart') || '[]');
+const cart = readCart({ migrate: true, onInvalidItems: () => window.alert('Se removieron productos inválidos del carrito. Volvé a agregarlos desde el catálogo.') });
 if (cart.length === 0) {
   window.location.href = '/cart.html';
 }
@@ -425,10 +426,24 @@ async function submitMercadoPago() {
   confirmarBtn.textContent = 'Procesando...';
   try {
     console.log('Creando preferencia MP', { cart, customer });
-    const carritoBackend = cart.map(({ name, price, quantity }) => ({
-      titulo: name,
-      precio: price,
-      cantidad: quantity,
+    const carritoBackend = cart.map((item) => ({
+      id: item.id,
+      productId: item.productId,
+      product_id: item.product_id,
+      sku: item.sku,
+      code: item.code,
+      slug: item.slug,
+      publicSlug: item.publicSlug,
+      public_slug: item.public_slug,
+      partNumber: item.partNumber,
+      mpn: item.mpn,
+      ean: item.ean,
+      gtin: item.gtin,
+      supplierCode: item.supplierCode,
+      titulo: item.name,
+      precio: item.price,
+      cantidad: item.quantity,
+      quantity: item.quantity,
     }));
     const res = await apiFetch('/api/mercado-pago/crear-preferencia', {
       method: 'POST',

--- a/nerin_final_updated/frontend/js/config.js
+++ b/nerin_final_updated/frontend/js/config.js
@@ -247,24 +247,18 @@ let lastToastInstance = null;
 let cartPreviewHideTimer = null;
 
 function readCartItems() {
-  try {
-    const parsed = JSON.parse(localStorage.getItem("nerinCart") || "[]");
-    const cart = Array.isArray(parsed) ? parsed : [];
-    const valid = cart.filter((item) => String(item?.identifier || "").trim());
-    if (valid.length !== cart.length) {
-      localStorage.setItem("nerinCart", JSON.stringify(valid));
+  return readCart({
+    migrate: true,
+    onInvalidItems: () => {
       if (typeof window !== "undefined" && typeof window.showToast === "function") {
         window.showToast("Algunos productos viejos del carrito fueron removidos porque faltaba información. Volvé a agregarlos desde el catálogo.");
       }
-    }
-    return valid;
-  } catch (_err) {
-    return [];
-  }
+    },
+  });
 }
 
 function saveCartItems(items) {
-  localStorage.setItem("nerinCart", JSON.stringify(items));
+  writeCart(items);
   updateNav();
 }
 

--- a/nerin_final_updated/frontend/js/index.js
+++ b/nerin_final_updated/frontend/js/index.js
@@ -1,5 +1,6 @@
 import { fetchProducts, isWholesale, getUserRole } from "./api.js";
 import { createPriceLegalBlock } from "./components/PriceLegalBlock.js";
+import { buildCartItemFromProduct, readCart, writeCart } from "./cart-utils.js";
 import { calculateNetNoNationalTaxes } from "./utils/pricing.js";
 
 const CONFIG_CACHE_KEY = "nerin:config-cache";
@@ -536,24 +537,14 @@ function resolveDisplayPrice(product) {
 }
 
 function addToCart(product, quantity = 1) {
-  const identifier = String(
-    product?.adminIdentifier ||
-      product?.identifier ||
-      product?.id ||
-      product?.sku ||
-      product?.code ||
-      product?.publicSlug ||
-      product?.public_slug ||
-      product?.slug ||
-      product?.url ||
-      "",
-  ).trim();
+  const cartItem = buildCartItemFromProduct(product);
+  const identifier = cartItem.identifier;
   if (!identifier) {
     alert("No se pudo agregar el producto porque falta identificador.");
     return;
   }
-  const cart = JSON.parse(localStorage.getItem("nerinCart") || "[]");
-  const existing = cart.find((item) => item.id === product.id);
+  const cart = readCart();
+  const existing = cart.find((item) => item.identifier === cartItem.identifier || item.id === String(product.id || ""));
   const qty = Number.isFinite(quantity) && quantity > 0 ? quantity : 1;
   const available =
     typeof product.stock === "number" && product.stock >= 0
@@ -568,20 +559,18 @@ function addToCart(product, quantity = 1) {
   } else {
     const price = resolveDisplayPrice(product);
     cart.push({
-      id: product.id,
+      ...cartItem,
       identifier,
       sku: product.sku || "",
-      code: product.code || "",
       publicSlug: product.publicSlug || product.public_slug || "",
-      slug: product.slug || "",
-      url: buildProductUrl(product),
       name: product.name,
       price,
       quantity: Math.min(qty, available),
+      url: buildProductUrl(product),
       image: getPrimaryImage(product) || PLACEHOLDER_IMAGE,
     });
   }
-  localStorage.setItem("nerinCart", JSON.stringify(cart));
+  writeCart(cart);
   if (window.updateNav) window.updateNav();
   if (window.showCartIndicator) {
     window.showCartIndicator({

--- a/nerin_final_updated/frontend/js/product.js
+++ b/nerin_final_updated/frontend/js/product.js
@@ -10,6 +10,7 @@ import {
   removeQualitySelector,
 } from "./components/ComparisonQualityTable.js";
 import { createPriceLegalBlock } from "./components/PriceLegalBlock.js";
+import { buildCartItemFromProduct, readCart, writeCart } from "./cart-utils.js";
 import { calculateNetNoNationalTaxes } from "./utils/pricing.js";
 
 const detailSection = document.getElementById("productDetail");
@@ -1373,20 +1374,8 @@ function renderProduct(product) {
   `;
 
   const handleAddToCart = () => {
-    const identifier = String(
-      product?.adminIdentifier ||
-        product?.identifier ||
-        product?.id ||
-        skuValue ||
-        product?.sku ||
-        product?.code ||
-        product?.publicSlug ||
-        product?.public_slug ||
-        product?.slug ||
-        product?.url ||
-        "",
-    ).trim();
-    if (!identifier) {
+    const cartItem = buildCartItemFromProduct(product, { sku: skuValue || product?.sku });
+    if (!cartItem.identifier) {
       alert("No se pudo agregar el producto porque falta identificador.");
       return;
     }
@@ -1395,8 +1384,8 @@ function renderProduct(product) {
       alert(`No hay stock suficiente. Disponibles: ${product.stock || 0}`);
       return;
     }
-    const cart = JSON.parse(localStorage.getItem("nerinCart") || "[]");
-    const existing = cart.find((item) => item.id === product.id);
+    const cart = readCart();
+    const existing = cart.find((item) => item.identifier === cartItem.identifier || item.id === String(product.id || ""));
     const available = product.stock;
     if (existing) {
       if (existing.quantity + qty > available) {
@@ -1410,21 +1399,9 @@ function renderProduct(product) {
         existing.sku = skuValue;
       }
     } else {
-      cart.push({
-        id: product.id,
-        identifier,
-        sku: skuValue || product.id,
-        code: product.code || "",
-        publicSlug: product.publicSlug || product.public_slug || "",
-        slug: product.slug || "",
-        url: buildRelativeProductUrl(product),
-        name: product.name,
-        price: resolveProductDisplayPrice(product),
-        quantity: qty,
-        image: cartImage,
-      });
+      cart.push({ ...cartItem, url: buildRelativeProductUrl(product), name: product.name, price: resolveProductDisplayPrice(product), quantity: qty, image: cartImage });
     }
-    localStorage.setItem("nerinCart", JSON.stringify(cart));
+    writeCart(cart);
     if (window.updateNav) window.updateNav();
     if (window.showCartIndicator) {
       window.showCartIndicator({

--- a/nerin_final_updated/frontend/js/shop.js
+++ b/nerin_final_updated/frontend/js/shop.js
@@ -443,19 +443,8 @@ function resetAllFilters() {
 }
 
 function addToCart(product) {
-  const identifier = String(
-    product?.adminIdentifier ||
-      product?.identifier ||
-      product?.id ||
-      product?.sku ||
-      product?.code ||
-      product?.publicSlug ||
-      product?.public_slug ||
-      product?.slug ||
-      product?.url ||
-      "",
-  ).trim();
-  if (!identifier) {
+  const cartItem = buildCartItemFromProduct(product);
+  if (!cartItem.identifier) {
     alert("No se pudo agregar el producto porque falta identificador.");
     return;
   }
@@ -468,8 +457,8 @@ function addToCart(product) {
     alert("Sin stock disponible");
     return;
   }
-  const cart = JSON.parse(localStorage.getItem("nerinCart") || "[]");
-  const existing = cart.find((item) => item.id === product.id);
+  const cart = readCart();
+  const existing = cart.find((item) => item.identifier === cartItem.identifier || item.id === String(product.id || ""));
   const available = typeof product.stock === "number" ? product.stock : Infinity;
   if (existing) {
     if (existing.quantity + 1 > available) {
@@ -480,21 +469,9 @@ function addToCart(product) {
   } else {
     const display = resolveDisplayPrice(product);
     const url = buildProductUrl(product);
-    cart.push({
-      id: product.id,
-      identifier,
-      sku: product.sku || "",
-      code: product.code || "",
-      publicSlug: product.publicSlug || product.public_slug || "",
-      slug: product.slug || "",
-      url,
-      name: product.name,
-      price: display.active,
-      quantity: 1,
-      image: getPrimaryImage(product) || PLACEHOLDER_IMAGE,
-    });
+    cart.push({ ...cartItem, url, name: product.name, price: display.active, quantity: 1, image: getPrimaryImage(product) || PLACEHOLDER_IMAGE });
   }
-  localStorage.setItem("nerinCart", JSON.stringify(cart));
+  writeCart(cart);
   if (window.updateNav) window.updateNav();
   if (window.showCartIndicator) {
     window.showCartIndicator({


### PR DESCRIPTION
### Motivation

- Los logs mostraban items en checkout con solo `quantity` sin identificador, provocando fallos en `resolveCheckoutCartItems` antes de crear la preferencia de pago.
- Se necesitaba garantizar que cualquier item guardado en `localStorage` tenga un identificador válido (varias formas: camelCase/snake_case) y cantidad razonable.

### Description

- Añadí `frontend/js/cart-utils.js` que normaliza y sanea items de carrito, unifica `id/productId/product_id` y `publicSlug/public_slug` y valida campos de identificador entre: `id`, `productId`, `product_id`, `sku`, `code`, `slug`, `publicSlug`, `public_slug`, `partNumber`, `mpn`, `ean`, `gtin`, `supplierCode`.
- Reemplacé accesos directos a `localStorage` por `readCart`/`writeCart` y usé `buildCartItemFromProduct` en los flujos de agregar al carrito (`shop.js`, `index.js`, `product.js`) para bloquear altas sin identificador y evitar inconsistencias camelCase/snake_case.
- Agregué migración defensiva al leer el carrito para eliminar automáticamente items antiguos inválidos y mostrar un mensaje amigable al usuario desde `cart`, `config` y `checkout-steps` cuando ocurra limpieza.
- Modifiqué el payload de checkout (`checkout-steps.js`) para enviar al backend items con los campos de identificador y `quantity` explícitos, y mejoré el log del backend (`resolveCheckoutCartItems`) para incluir el `originalItem` recibido y un `normalizedPreview` cuando falta identificador.

### Testing

- Ejecuté `node scripts/test-cart-add-item-contract.js` y el test pasó correctamente (`[test-cart-add-item-contract] ok`).
- Ejecuté `node scripts/test-checkout-cart-identifier-resolution.js` y el test pasó correctamente (`[test-checkout-cart-identifier-resolution] ok`).
- Los cambios fueron validados localmente con los scripts de prueba incluidos en el repo y no se observaron fallos automáticos en los tests ejecutados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7475514088331b9280e7fa89e6e85)