### PR TITLE
Diagnosticar pérdida de identificadores del carrito y endurecer normalización

### DIFF
--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -6698,6 +6698,10 @@ async function requestHandler(req, res) {
         totalPages: responsePayload.totalPages,
         durationMs,
       });
+      console.log("[public-products:first-item-shape]", {
+        keys: items?.[0] ? Object.keys(items[0]) : [],
+        sample: items?.[0],
+      });
       return sendJson(res, 200, responsePayload, {
         "Cache-Control": "no-store, no-cache, must-revalidate",
       });
@@ -8432,6 +8436,7 @@ async function requestHandler(req, res) {
     req.on("end", async () => {
       try {
         const parsed = JSON.parse(body || "{}");
+        console.log("[checkout:raw-body]", JSON.stringify(parsed, null, 2));
         const cart = parsed.cart;
         const customer = parsed.customer;
         if (!Array.isArray(cart) || cart.length === 0) {

--- a/nerin_final_updated/frontend/js/cart-utils.js
+++ b/nerin_final_updated/frontend/js/cart-utils.js
@@ -1,42 +1,53 @@
 const CART_KEY = "nerinCart";
 
-const IDENTIFIER_FIELDS = [
-  "id",
-  "productId",
-  "product_id",
-  "sku",
-  "code",
-  "slug",
-  "publicSlug",
-  "public_slug",
-  "partNumber",
-  "mpn",
-  "ean",
-  "gtin",
-  "supplierCode",
-];
-
-function pickIdentifier(item = {}) {
-  for (const key of IDENTIFIER_FIELDS) {
-    const value = String(item?.[key] ?? "").trim();
-    if (value) return value;
+export function getProductIdentifier(product = {}) {
+  const candidates = [
+    product?.id,
+    product?.productId,
+    product?.product_id,
+    product?.sku,
+    product?.code,
+    product?.publicSlug,
+    product?.public_slug,
+    product?.slug,
+    product?.partNumber,
+    product?.part_number,
+    product?.mpn,
+    product?.ean,
+    product?.gtin,
+    product?.supplierCode,
+    product?.supplier_code,
+  ];
+  for (const value of candidates) {
+    const normalized = String(value ?? "").trim();
+    if (normalized) return normalized;
   }
   return "";
 }
 
 export function normalizeCartItem(item = {}) {
-  const normalized = {
+  const identifier = getProductIdentifier(item);
+  if (!identifier) {
+    console.error("[add-to-cart:invalid-product]", item);
+    throw new Error("No se puede agregar al carrito un producto sin identificador");
+  }
+  return {
     ...item,
-    id: String(item?.id ?? item?.productId ?? item?.product_id ?? "").trim(),
-    productId: String(item?.productId ?? item?.product_id ?? item?.id ?? "").trim(),
-    product_id: String(item?.product_id ?? item?.productId ?? item?.id ?? "").trim(),
-    publicSlug: String(item?.publicSlug ?? item?.public_slug ?? "").trim(),
-    public_slug: String(item?.public_slug ?? item?.publicSlug ?? "").trim(),
+    id: item?.id ?? item?.productId ?? item?.product_id ?? null,
+    sku: item?.sku ?? null,
+    code: item?.code ?? null,
+    publicSlug: item?.publicSlug ?? item?.public_slug ?? null,
+    slug: item?.slug ?? null,
+    partNumber: item?.partNumber ?? item?.part_number ?? null,
+    mpn: item?.mpn ?? null,
+    ean: item?.ean ?? null,
+    gtin: item?.gtin ?? null,
+    supplierCode: item?.supplierCode ?? item?.supplier_code ?? null,
+    productId: item?.productId ?? item?.product_id ?? item?.id ?? null,
+    product_id: item?.product_id ?? item?.productId ?? item?.id ?? null,
     quantity: Number(item?.quantity ?? item?.qty ?? 1),
+    identifier,
   };
-  const identifier = pickIdentifier(normalized);
-  normalized.identifier = identifier;
-  return normalized;
 }
 
 export function isValidCartItem(item = {}) {
@@ -47,8 +58,14 @@ export function isValidCartItem(item = {}) {
 export function sanitizeCart(items = []) {
   const src = Array.isArray(items) ? items : [];
   return src
-    .map((item) => normalizeCartItem(item))
-    .filter((item) => isValidCartItem(item));
+    .map((item) => {
+      try {
+        return normalizeCartItem(item);
+      } catch (_err) {
+        return null;
+      }
+    })
+    .filter((item) => item && isValidCartItem(item));
 }
 
 export function readCart({ migrate = true, onInvalidItems = null } = {}) {
@@ -58,6 +75,10 @@ export function readCart({ migrate = true, onInvalidItems = null } = {}) {
     const valid = sanitizeCart(items);
     if (migrate && valid.length !== items.length) {
       localStorage.setItem(CART_KEY, JSON.stringify(valid));
+      console.warn("[cart:removed-invalid-items]", {
+        before: items,
+        after: valid,
+      });
       if (typeof onInvalidItems === "function") onInvalidItems(items.length - valid.length);
     }
     return valid;
@@ -68,7 +89,16 @@ export function readCart({ migrate = true, onInvalidItems = null } = {}) {
 }
 
 export function writeCart(items = []) {
-  const valid = sanitizeCart(items);
+  const valid = sanitizeCart(
+    (Array.isArray(items) ? items : []).filter((item) => {
+      const identifier = getProductIdentifier(item);
+      if (!identifier) {
+        console.error("[cart:blocked-invalid-item]", item);
+        return false;
+      }
+      return true;
+    }),
+  );
   localStorage.setItem(CART_KEY, JSON.stringify(valid));
   return valid;
 }

--- a/nerin_final_updated/frontend/js/index.js
+++ b/nerin_final_updated/frontend/js/index.js
@@ -537,6 +537,8 @@ function resolveDisplayPrice(product) {
 }
 
 function addToCart(product, quantity = 1) {
+  console.log("[add-to-cart:received-product]", product);
+  console.log("[add-to-cart:received-product-keys]", product ? Object.keys(product) : null);
   const cartItem = buildCartItemFromProduct(product);
   const identifier = cartItem.identifier;
   if (!identifier) {

--- a/nerin_final_updated/frontend/js/product.js
+++ b/nerin_final_updated/frontend/js/product.js
@@ -1374,6 +1374,8 @@ function renderProduct(product) {
   `;
 
   const handleAddToCart = () => {
+    console.log("[add-to-cart:received-product]", product);
+    console.log("[add-to-cart:received-product-keys]", product ? Object.keys(product) : null);
     const cartItem = buildCartItemFromProduct(product, { sku: skuValue || product?.sku });
     if (!cartItem.identifier) {
       alert("No se pudo agregar el producto porque falta identificador.");

--- a/nerin_final_updated/frontend/js/shop.js
+++ b/nerin_final_updated/frontend/js/shop.js
@@ -443,6 +443,8 @@ function resetAllFilters() {
 }
 
 function addToCart(product) {
+  console.log("[add-to-cart:received-product]", product);
+  console.log("[add-to-cart:received-product-keys]", product ? Object.keys(product) : null);
   const cartItem = buildCartItemFromProduct(product);
   if (!cartItem.identifier) {
     alert("No se pudo agregar el producto porque falta identificador.");
@@ -914,6 +916,7 @@ async function renderProducts({ page = currentProductsPage, scrollToTop = false 
     .map(sanitizePublicProduct)
     .filter(Boolean);
   const filteredItems = normalizedItems.filter((product) => matchesStockFilter(product, filters.stock));
+  console.log("[catalog:first-product]", normalizedItems?.[0]);
 
   if (!filtersInitialized) {
     populateFilters(normalizedItems);


### PR DESCRIPTION
### Motivation
- Reproducir y localizar por qué al checkout llegan items sin identificador (`identifiers: []`) que provocan `[checkout-cart-item-invalid]`.
- Rastrear el shape de los productos desde el backend público hasta el `addToCart` en el frontend para detectar dónde se pierden `id/sku/slug/publicSlug/ean/gtin`.
- Evitar que items inválidos (por ejemplo `{ quantity: 1 }`) queden guardados en `localStorage` y lleguen al checkout.

### Description
- Agregué logs temporales en backend para inspección: `console.log('[public-products:first-item-shape]', ...)` en `GET /api/products` y `console.log('[checkout:raw-body]', ...)` en `POST /api/checkout` (archivo `backend/server.js`).
- Añadí logs en frontend para seguir el objeto producto durante el flujo: `console.log('[catalog:first-product]', ...)` en la carga de catálogo y `console.log('[add-to-cart:received-product]', ...)` y `console.log('[add-to-cart:received-product-keys]', ...)` en `index.js`, `shop.js` y `product.js`.
- Endurecí la normalización y persistencia del carrito en `frontend/js/cart-utils.js`: implementé `getProductIdentifier(product)` con múltiples campos fallback; `normalizeCartItem` ahora falla y loguea `"[add-to-cart:invalid-product]"` si no hay identificador; `writeCart` bloquea items sin identificador y loguea `"[cart:blocked-invalid-item]"`; `readCart` migra y registra `"[cart:removed-invalid-items]"` cuando limpia items inválidos.
- Cambios mínimos en UI/business logic: `addToCart`/handlers ahora emiten los logs añadidos pero conservan la lógica existente; no se realizaron cambios en la integración de Mercado Pago.

### Testing
- Ejecutados los scripts de validación automatizados y todos pasaron: `node scripts/test-cart-add-item-contract.js` (ok), `node scripts/test-checkout-cart-identifier-resolution.js` (ok), `node scripts/test-checkout-no-full-catalog-load.js` (ok).
- Confirmé que los cambios se comitearon localmente con el mensaje `Add cart identifier diagnostics and harden cart normalization`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f74d94108883319b681e7d2e5ef937)