### PR TITLE
Fix checkout identifier fallbacks for Mercado Pago preference

### DIFF
--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -11361,11 +11361,14 @@ async function requestHandler(req, res) {
         }
 
         const cartItemsForLookup = carrito.map((item) => ({
-          id: item.id || item.productId,
-          sku: item.sku,
-          code: item.code,
+          id: item.id || item.productId || item.product_id || item.identifier,
+          productId: item.productId || item.product_id || item.id || item.identifier,
+          product_id: item.product_id || item.productId || item.id || item.identifier,
+          sku: item.sku || item.identifier,
+          code: item.code || item.identifier,
           publicSlug: item.publicSlug || item.public_slug,
-          slug: item.slug,
+          public_slug: item.public_slug || item.publicSlug,
+          slug: item.slug || item.identifier,
           partNumber: item.partNumber,
           mpn: item.mpn,
           ean: item.ean,


### PR DESCRIPTION
### Motivation
- Prevent 400 errors (`El carrito contiene un producto sin identificador`) when partially-shaped or legacy cart items are posted to the Mercado Pago preference endpoint by ensuring the backend can derive an identifier from multiple fallback fields.

### Description
- Update mapping in `nerin_final_updated/backend/server.js` so `cartItemsForLookup` populates `id`, `productId`, and `product_id` from `id`, `productId`, `product_id` or `identifier`, mirrors `public_slug`, and provides fallbacks for `sku`, `code`, and `slug` to avoid losing identifiers before calling `resolveCheckoutCartItems`.

### Testing
- Ran `node --check nerin_final_updated/backend/server.js` and the syntax check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f74f81e984833183e914d40960e8ef)