### PR TITLE
Arreglar add-to-cart desde product detail y asegurar identificadores en checkout MP

### DIFF
--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -11339,7 +11339,9 @@ async function requestHandler(req, res) {
     });
     req.on("end", async () => {
       try {
-        const { carrito, usuario } = JSON.parse(body || "{}");
+        const parsedBody = JSON.parse(body || "{}");
+        console.log("[checkout:raw-body]", JSON.stringify(parsedBody, null, 2));
+        const { carrito, usuario } = parsedBody;
         const hasValidItems =
           Array.isArray(carrito) &&
           carrito.length > 0 &&

--- a/nerin_final_updated/frontend/checkout-steps.html
+++ b/nerin_final_updated/frontend/checkout-steps.html
@@ -175,7 +175,7 @@
       </a>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
-    <script type="module" src="/js/checkout-steps.js"></script>
+    <script type="module" src="/js/checkout-steps.js?v=__BUILD_ID__"></script>
     <script type="module" src="/js/config.js"></script>
   </body>
 </html>

--- a/nerin_final_updated/frontend/js/checkout-form.js
+++ b/nerin_final_updated/frontend/js/checkout-form.js
@@ -1,3 +1,4 @@
+import { readCart } from "./cart-utils.js";
 document.addEventListener("DOMContentLoaded", () => {
   function buildApiUrl(path) {
     const builder = window.NERIN_BUILD_API_URL;
@@ -19,7 +20,12 @@ document.addEventListener("DOMContentLoaded", () => {
   const form = document.querySelector("form.shipping-form");
   const loading = document.getElementById("loading");
   if (!form) return;
-  const cartForTracking = JSON.parse(localStorage.getItem("nerinCart") || "[]");
+  const cartForTracking = readCart({
+    migrate: true,
+    onInvalidItems: () => {
+      alert("Se removieron productos inválidos del carrito. Volvé a agregarlos desde el catálogo.");
+    },
+  });
   if (typeof window.NERIN_TRACK_EVENT === "function") {
     const totalValue = cartForTracking.reduce(
       (acc, item) => acc + Number(item.price || 0) * Number(item.quantity || 0),
@@ -114,7 +120,12 @@ document.addEventListener("DOMContentLoaded", () => {
     if (!valid) return;
 
     try {
-      const cart = JSON.parse(localStorage.getItem("nerinCart") || "[]");
+      const cart = readCart({
+        migrate: true,
+        onInvalidItems: () => {
+          alert("Se removieron productos inválidos del carrito. Volvé a agregarlos desde el catálogo.");
+        },
+      });
       if (cart.length === 0) {
         alert("Carrito vacío");
         return;

--- a/nerin_final_updated/frontend/js/checkout-steps.js
+++ b/nerin_final_updated/frontend/js/checkout-steps.js
@@ -445,6 +445,7 @@ async function submitMercadoPago() {
       cantidad: item.quantity,
       quantity: item.quantity,
     }));
+    console.log("[checkout:mp-carritoBackend]", carritoBackend);
     const res = await apiFetch('/api/mercado-pago/crear-preferencia', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/nerin_final_updated/frontend/js/product.js
+++ b/nerin_final_updated/frontend/js/product.js
@@ -10,7 +10,7 @@ import {
   removeQualitySelector,
 } from "./components/ComparisonQualityTable.js";
 import { createPriceLegalBlock } from "./components/PriceLegalBlock.js";
-import { buildCartItemFromProduct, readCart, writeCart } from "./cart-utils.js";
+import { buildCartItemFromProduct, readCart, writeCart, getProductIdentifier } from "./cart-utils.js";
 import { calculateNetNoNationalTaxes } from "./utils/pricing.js";
 
 const detailSection = document.getElementById("productDetail");
@@ -1374,13 +1374,16 @@ function renderProduct(product) {
   `;
 
   const handleAddToCart = () => {
-    console.log("[add-to-cart:received-product]", product);
-    console.log("[add-to-cart:received-product-keys]", product ? Object.keys(product) : null);
-    const cartItem = buildCartItemFromProduct(product, { sku: skuValue || product?.sku });
-    if (!cartItem.identifier) {
+    console.log("[product-detail:add-to-cart:product]", product);
+    console.log("[product-detail:add-to-cart:product-keys]", product ? Object.keys(product) : null);
+    const identifier = getProductIdentifier(product);
+    if (!identifier) {
+      console.error("[product-detail:add-to-cart:blocked-invalid-product]", product);
       alert("No se pudo agregar el producto porque falta identificador.");
       return;
     }
+    const cartItem = buildCartItemFromProduct(product, { sku: skuValue || product?.sku });
+    console.log("[product-detail:add-to-cart:cart-item]", cartItem);
     const qty = qtyControl.getValue();
     if (qty > (product.stock || 0)) {
       alert(`No hay stock suficiente. Disponibles: ${product.stock || 0}`);
@@ -1403,6 +1406,7 @@ function renderProduct(product) {
     } else {
       cart.push({ ...cartItem, url: buildRelativeProductUrl(product), name: product.name, price: resolveProductDisplayPrice(product), quantity: qty, image: cartImage });
     }
+    console.log("[product-detail:cart:before-save]", cart);
     writeCart(cart);
     if (window.updateNav) window.updateNav();
     if (window.showCartIndicator) {

--- a/nerin_final_updated/frontend/product.html
+++ b/nerin_final_updated/frontend/product.html
@@ -155,7 +155,7 @@
         <img src="/assets/whatsapp.svg" alt="WhatsApp" />
       </a>
     </div>
-    <script type="module" src="/js/product.js"></script>
+    <script type="module" src="/js/product.js?v=__BUILD_ID__"></script>
     <!-- Configuración y analíticas globales -->
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
     <script type="module" src="/js/config.js"></script>

--- a/nerin_final_updated/frontend/shop.html
+++ b/nerin_final_updated/frontend/shop.html
@@ -278,7 +278,7 @@
         <img src="/assets/whatsapp.svg" alt="WhatsApp" />
       </a>
     </div>
-    <script type="module" src="/js/shop.js?v=sqlite-public-debug-v3"></script>
+    <script type="module" src="/js/shop.js?v=__BUILD_ID__"></script>
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
     <script type="module" src="/js/config.js"></script>
   </body>


### PR DESCRIPTION
### Motivation
- Render logs mostraban que `public-products` y `product-detail` resolvían productos completos pero el checkout recibía solo `{ quantity: 1 }`, indicando pérdida de identificador entre detalle y pago.
- Se buscó garantizar que el botón de la página `/p/...` agregue el producto completo al carrito y que todo el flujo de checkout use `cart-utils` para normalizar y validar los ítems.
- Se añadió trazabilidad para confirmar en cliente y servidor que los ítems enviados a Mercado Pago contienen `id/sku/slug` antes de mapearlos.

### Description
- En `frontend/js/product.js` se importó `getProductIdentifier`, se valida el `identifier` antes de crear el `cartItem`, y se añadieron logs obligatorios: `[product-detail:add-to-cart:product]`, `[product-detail:add-to-cart:product-keys]`, `[product-detail:add-to-cart:cart-item]` y `[product-detail:cart:before-save]`, además de usar `readCart`/`writeCart` para persistir el carrito (bloquea productos inválidos). 
- En `frontend/js/checkout-form.js` se reemplazó la lectura directa de `localStorage` por `readCart({ migrate: true, onInvalidItems })` tanto para tracking inicial como para el submit, mostrando la alerta solicitada cuando haya ítems inválidos. 
- En `frontend/js/checkout-steps.js` se agregó el log frontend `[checkout:mp-carritoBackend]` justo antes del `fetch` a `/api/mercado-pago/crear-preferencia`. 
- En `backend/server.js` se añadió el log exacto `[checkout:raw-body]` en el endpoint `/api/mercado-pago/crear-preferencia` antes de mapear el carrito. 
- Se aplicó cache-busting en los HTML de entrada para scripts críticos cambiando las referencias a `/js/product.js`, `/js/checkout-steps.js` y `/js/shop.js` por versiones con `?v=__BUILD_ID__`. 
- Archivos modificados: `frontend/js/product.js`, `frontend/js/checkout-form.js`, `frontend/js/checkout-steps.js`, `backend/server.js`, `frontend/product.html`, `frontend/checkout-steps.html`, `frontend/shop.html`.

### Testing
- Ejecuté búsquedas de código para verificar las modificaciones y ausencia de lecturas directas de `nerinCart` en los puntos de checkout, y todas devolvieron los resultados esperados (se reemplazaron `JSON.parse(localStorage.getItem("nerinCart")...)` por llamadas a `readCart`).
- Verifiqué la importación de `getProductIdentifier` y la presencia de los logs en `product.js` mediante `rg`/`grep` (coincidencias presentes).
- Verifiqué que el frontend ahora loguea `[checkout:mp-carritoBackend]` y que el backend imprime `[checkout:raw-body]` en el endpoint de Mercado Pago mediante búsquedas en los archivos.
- Prueba E2E (navegador incógnito + flujo de compra y pago en Mercado Pago) no fue ejecutada en este entorno CLI y queda pendiente de validación manual en staging/Render.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7545a5bf48331ad785114babbe326)