### PR TITLE
Arreglo de emergencia: detalle de producto móvil — desactivar carrusel y fallback funcional

### DIFF
--- a/nerin_final_updated/frontend/js/product.js
+++ b/nerin_final_updated/frontend/js/product.js
@@ -1091,6 +1091,61 @@ function createQuantityControl(product) {
 }
 
 
+
+function renderSimpleGallery(product) {
+  if (!galleryContainer) return;
+
+  const images = Array.isArray(product.images) && product.images.length
+    ? product.images
+    : [product.image || product.thumbnail].filter(Boolean);
+
+  const firstImage = images[0] || "";
+
+  galleryContainer.innerHTML = `
+    <div class="product-gallery product-gallery--simple">
+      ${firstImage ? `<img class="product-gallery__image product-hero-img" src="${firstImage}" alt="${product.name || product.title || "Producto"}" />` : ""}
+    </div>
+  `;
+}
+
+function renderProductInfoFallback(product) {
+  if (!infoContainer || !product) return;
+
+  const price = Number(
+    product.price ||
+    product.price_minorista ||
+    product.precio_minorista ||
+    product.precio_final ||
+    0
+  );
+
+  const sku = product.sku || product.code || product.id || "";
+  const stock = product.stock ?? "Consultar";
+  const title = product.name || product.title || "Producto";
+
+  infoContainer.innerHTML = `
+    <article class="product-detail-card product-detail-card--fallback">
+      ${sku ? `<p class="eyebrow">${sku}</p>` : ""}
+      <h1>${title}</h1>
+      <p class="product-detail-price">$${price.toLocaleString("es-AR")}</p>
+      <p class="product-detail-stock">Stock: ${stock}</p>
+      <div class="product-detail-actions">
+        <button type="button" class="button primary" id="productFallbackAddToCart">
+          Agregar al carrito
+        </button>
+        <a class="button secondary" href="/cart.html">Ir al carrito</a>
+        <a class="button secondary" href="https://wa.me/5491130341550" target="_blank" rel="noopener">
+          Consultar por WhatsApp
+        </a>
+      </div>
+    </article>
+  `;
+
+  document
+    .getElementById("productFallbackAddToCart")
+    ?.addEventListener("click", () => addToCart(product));
+}
+
 function addToCart(product, { quantity = 1, sku = "", image = "" } = {}) {
   console.log("[product-detail:add-to-cart:product]", product);
   console.log("[product-detail:add-to-cart:product-keys]", product ? Object.keys(product) : null);
@@ -1115,6 +1170,14 @@ function addToCart(product, { quantity = 1, sku = "", image = "" } = {}) {
   } else {
     cart.push({
       ...cartItem,
+      identifier,
+      id: product.id || cartItem.id || null,
+      productId: product.productId || product.product_id || product.id || null,
+      product_id: product.product_id || product.productId || product.id || null,
+      sku: product.sku || cartItem.sku || null,
+      slug: product.slug || cartItem.slug || null,
+      publicSlug: product.publicSlug || product.public_slug || cartItem.publicSlug || null,
+      public_slug: product.public_slug || product.publicSlug || cartItem.publicSlug || null,
       name: product.name || product.title || "",
       price: Number(product.price || product.price_minorista || product.precio_final || 0),
       image: image || product.image || product.thumbnail || "",
@@ -1157,6 +1220,9 @@ function renderProduct(product) {
   product.images = [...images];
   product.image = primaryImage || cartImage;
   buildGallery(galleryContainer, images, alts);
+  if (galleryContainer && galleryContainer.querySelectorAll(".product-gallery__image").length > 1) {
+    renderSimpleGallery(product);
+  }
   updateHeadImages(images, alts);
   const metaInfo = updateProductMeta(product, images);
   syncBrowserUrl(metaInfo.relativeUrl);
@@ -1604,23 +1670,11 @@ function renderProduct(product) {
   console.log("[product-detail:info-children]", infoContainer?.children?.length || 0);
   if (infoContainer && !infoContainer.children.length) {
     console.warn("[product-detail:info-empty-fallback]", product);
-    infoContainer.innerHTML = `
-    <article class="product-detail-card product-detail-card--fallback">
-      <p class="eyebrow">${product.sku || product.code || ""}</p>
-      <h1>${product.name || product.title || "Producto"}</h1>
-      <p class="product-detail-price">$${Number(product.price || product.price_minorista || product.precio_final || 0).toLocaleString("es-AR")}</p>
-      <p>Stock: ${product.stock ?? "Consultar"}</p>
-      <button type="button" class="button primary" id="fallbackAddToCart">Agregar al carrito</button>
-      <a class="button secondary" href="/cart.html">Ir al carrito</a>
-    </article>
-  `;
-    document.getElementById("fallbackAddToCart")?.addEventListener("click", () => addToCart(product));
+    renderProductInfoFallback(product);
   }
   } catch (error) {
     console.error("[product-detail:render-error]", error);
-    if (infoContainer) {
-      infoContainer.innerHTML = "<p>Error al renderizar el producto.</p>";
-    }
+    renderProductInfoFallback(product);
   }
 }
 

--- a/nerin_final_updated/frontend/product.html
+++ b/nerin_final_updated/frontend/product.html
@@ -79,7 +79,7 @@
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css"
     />
-    <link rel="stylesheet" href="/style.css?v=product-fix-20260503" />
+    <link rel="stylesheet" href="/style.css?v=product-detail-fix-20260503" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r2" />
     <script src="/components/np-footer.js?v=np-r2" defer></script>
     <script
@@ -155,7 +155,7 @@
         <img src="/assets/whatsapp.svg" alt="WhatsApp" />
       </a>
     </div>
-    <script type="module" src="/js/product.js?v=product-fix-20260503"></script>
+    <script type="module" src="/js/product.js?v=product-detail-fix-20260503"></script>
     <!-- Configuración y analíticas globales -->
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
     <script type="module" src="/js/config.js"></script>

--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -9826,3 +9826,126 @@ html, body{ max-width:100%; overflow-x:hidden; }
     min-height: 44px;
   }
 }
+
+/* Emergency product detail fix 2026-05-03 */
+.product-page {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.product-page__layout {
+  display: grid !important;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 0.9fr) !important;
+  gap: 1.5rem !important;
+  align-items: start !important;
+}
+
+.product-page__gallery,
+.product-page__info {
+  min-width: 0 !important;
+  max-width: 100% !important;
+}
+
+.product-gallery,
+.product-gallery__viewport,
+.product-image-wrapper,
+.product-hero-frame {
+  width: 100% !important;
+  max-width: 100% !important;
+  overflow: hidden !important;
+}
+
+.product-gallery__track {
+  display: block !important;
+  width: 100% !important;
+  transform: none !important;
+}
+
+.product-gallery__slide {
+  display: none !important;
+  width: 100% !important;
+  max-width: 100% !important;
+}
+
+.product-gallery__slide:first-child,
+.product-gallery__slide[aria-hidden="false"] {
+  display: block !important;
+}
+
+.product-gallery__image,
+.product-hero-img,
+.product-page__gallery img {
+  display: block !important;
+  width: 100% !important;
+  max-width: 100% !important;
+  height: auto !important;
+  max-height: 520px !important;
+  object-fit: contain !important;
+  margin: 0 auto !important;
+}
+
+.product-page__info {
+  display: grid !important;
+  gap: 0.85rem !important;
+}
+
+.product-page__info h1 {
+  font-size: clamp(1.45rem, 4vw, 2.2rem) !important;
+  line-height: 1.15 !important;
+  margin: 0 !important;
+}
+
+.product-detail-price,
+.product-page__price {
+  font-size: 1.45rem !important;
+  font-weight: 800 !important;
+}
+
+.product-detail-actions,
+.product-page__actions,
+.product-purchase-actions,
+.product-actions {
+  display: grid !important;
+  grid-template-columns: 1fr !important;
+  gap: 0.65rem !important;
+  width: 100% !important;
+}
+
+.product-page__info .button,
+.product-detail-actions .button,
+.product-page__actions .button,
+.product-purchase-actions .button,
+.product-actions .button {
+  width: 100% !important;
+  min-height: 46px !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+}
+
+@media (max-width: 768px) {
+  .product-page {
+    padding: 0.75rem !important;
+  }
+
+  .product-page__layout {
+    grid-template-columns: 1fr !important;
+    gap: 1rem !important;
+  }
+
+  .product-gallery__image,
+  .product-hero-img,
+  .product-page__gallery img {
+    max-height: 430px !important;
+  }
+
+  .product-gallery__slide {
+    display: none !important;
+  }
+
+  .product-gallery__slide:first-child,
+  .product-gallery__slide[aria-hidden="false"] {
+    display: block !important;
+  }
+}


### PR DESCRIPTION
### Motivation

- La página de detalle de producto en mobile mostraba el header seguido de imágenes gigantes apiladas y la ficha de compra quedaba oculta, dejando la vista inutilizable; se necesitaba un arreglo práctico y rápido sin tocar backend ni BD.

### Description

- Se añadió un bloque CSS de emergencia al final de `nerin_final_updated/frontend/style.css` que neutraliza el carrusel y fuerza una sola imagen visible y un layout estable en mobile.
- En `nerin_final_updated/frontend/js/product.js` se añadieron `renderProductInfoFallback(product)` y `renderSimpleGallery(product)` y se integraron como fallback cuando el render normal falla o deja `productInfo` vacío, además de envoltorio `try/catch` para invocar el fallback ante errores de render.
- Se endureció la lógica de `addToCart` para preservar `identifier`, `id`, `productId/product_id`, `sku`, `slug/publicSlug`, `name`, `price` y `quantity` al serializar el carrito y evitar entradas inválidas.
- Se actualizó `nerin_final_updated/frontend/product.html` para forzar cache-busting en CSS y JS con `?v=product-detail-fix-20260503` y así evitar que clientes móviles carguen versiones antiguas.

### Testing

- Se ejecutó `node --check nerin_final_updated/frontend/js/product.js` y la verificación de sintaxis JS pasó correctamente.
- Se verificó con búsquedas de texto (`rg`) que el bloque CSS de emergencia, las funciones de fallback y los nuevos query params están presentes en los archivos modificados, y la verificación fue satisfactoria.
- No se ejecutaron tests automáticos de navegador/viewport en este entorno (no se realizó una prueba visual 390px ni interacción real con `localStorage` desde un navegador automatizado aquí).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f75eab4ce88331a12eb75600a92a57)