### PR TITLE
Importar readCart/writeCart en config para restaurar banner "Agregado al carrito"

### DIFF
--- a/nerin_final_updated/frontend/js/config.js
+++ b/nerin_final_updated/frontend/js/config.js
@@ -1,5 +1,6 @@
 import { apiFetch } from "./api.js";
 import { startTracking, trackEvent } from "./tracker.js";
+import { readCart, writeCart } from "./cart-utils.js";
 
 const CONFIG_CACHE_KEY = "nerin:config-cache";
 


### PR DESCRIPTION
### Motivation
- Corrige un `ReferenceError` provocado porque `config.js` invocaba `readCart`/`writeCart` sin importarlos, lo que rompía `showCartIndicator()` y el feedback visual al agregar productos.

### Description
- Agregué `import { readCart, writeCart } from "./cart-utils.js";` en `nerin_final_updated/frontend/js/config.js` y confirmé que las llamadas posteriores en `product.js`, `shop.js` e `index.js` mantienen `writeCart(...)` seguido de `if (window.updateNav) window.updateNav();` y `if (window.showCartIndicator) window.showCartIndicator(...)` sin cambios de diseño.

### Testing
- Ejecuté búsquedas y revisiones de archivo con `rg` y `sed` para validar la inserción del import y la presencia de los call-sites, y realicé `git add` + `git commit` para aplicar el cambio; todos los pasos automatizados finalizaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f76bc9e47083319607533e0e43119a)