### PR TITLE
Arreglar add-to-cart en catálogo: importar cart-utils y fallback de feedback

### DIFF
--- a/nerin_final_updated/frontend/js/shop.js
+++ b/nerin_final_updated/frontend/js/shop.js
@@ -1,6 +1,7 @@
 import { fetchProductsPage, getUserRole, isWholesale } from "./api.js";
 import { createPriceLegalBlock } from "./components/PriceLegalBlock.js";
 import { calculateNetNoNationalTaxes } from "./utils/pricing.js";
+import { buildCartItemFromProduct, readCart, writeCart } from "./cart-utils.js";
 
 console.info("[shop-products] shop.js loaded", {
   version: "sqlite-public-debug-v3",
@@ -443,9 +444,9 @@ function resetAllFilters() {
 }
 
 function addToCart(product) {
-  console.log("[add-to-cart:received-product]", product);
-  console.log("[add-to-cart:received-product-keys]", product ? Object.keys(product) : null);
+  console.log("[shop:add-to-cart:start]", product);
   const cartItem = buildCartItemFromProduct(product);
+  console.log("[shop:add-to-cart:cart-item]", cartItem);
   if (!cartItem.identifier) {
     alert("No se pudo agregar el producto porque falta identificador.");
     return;
@@ -459,7 +460,7 @@ function addToCart(product) {
     alert("Sin stock disponible");
     return;
   }
-  const cart = readCart();
+  const cart = readCart({ migrate: true });
   const existing = cart.find((item) => item.identifier === cartItem.identifier || item.id === String(product.id || ""));
   const available = typeof product.stock === "number" ? product.stock : Infinity;
   if (existing) {
@@ -475,6 +476,10 @@ function addToCart(product) {
   }
   writeCart(cart);
   if (window.updateNav) window.updateNav();
+  console.log("[shop:add-to-cart:indicator-available]", {
+    showCartIndicator: typeof window.showCartIndicator,
+    showToast: typeof window.showToast,
+  });
   if (window.showCartIndicator) {
     window.showCartIndicator({
       productId: product.id,
@@ -482,6 +487,10 @@ function addToCart(product) {
       productSku: product.sku || product.id,
       source: "shop",
     });
+  } else if (window.showToast) {
+    window.showToast("✅ Producto agregado al carrito");
+  } else {
+    console.warn("[shop:add-to-cart:no-indicator]");
   }
 }
 

--- a/nerin_final_updated/frontend/product.html
+++ b/nerin_final_updated/frontend/product.html
@@ -159,6 +159,6 @@
     <script type="module" src="/js/product.js?v=product-gallery-fix-20260503"></script>
     <!-- Configuración y analíticas globales -->
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
-    <script type="module" src="/js/config.js"></script>
+    <script type="module" src="/js/config.js?v=cart-feedback-catalog-fix-20260503"></script>
   </body>
 </html>

--- a/nerin_final_updated/frontend/shop.html
+++ b/nerin_final_updated/frontend/shop.html
@@ -278,8 +278,8 @@
         <img src="/assets/whatsapp.svg" alt="WhatsApp" />
       </a>
     </div>
-    <script type="module" src="/js/shop.js?v=__BUILD_ID__"></script>
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
-    <script type="module" src="/js/config.js"></script>
+    <script type="module" src="/js/config.js?v=cart-feedback-catalog-fix-20260503"></script>
+    <script type="module" src="/js/shop.js?v=cart-feedback-catalog-fix-20260503"></script>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- Se detectó que desde el catálogo (`/shop.html`) no se podían agregar productos por `ReferenceError` faltando `buildCartItemFromProduct`, `readCart` y `writeCart` en `shop.js`. 
- El banner/popup de “¡Agregado al carrito!” dejó de mostrarse por orden de carga/ausencia de `showCartIndicator` en tiempo de ejecución. 
- El objetivo es restaurar la funcionalidad del carrito en frontend sin tocar backend, Mercado Pago, precios, diseño ni galería.

### Description
- Se agregó el import faltante en `frontend/js/shop.js`: `import { buildCartItemFromProduct, readCart, writeCart } from "./cart-utils.js";`.
- Se modificó `addToCart(product)` en `shop.js` para incluir logs temporales (`[shop:add-to-cart:*]`), usar `readCart({ migrate: true })`, mantener la lógica de agregar/incrementar y persistir con `writeCart(cart)`, llamar `window.updateNav()` y ejecutar el indicador de feedback con fallback a `showToast` o `console.warn` cuando `showCartIndicator` no esté disponible.
- Se actualizó `frontend/shop.html` para cargar `toastify`, luego `config.js?v=cart-feedback-catalog-fix-20260503` y finalmente `shop.js?v=cart-feedback-catalog-fix-20260503` (cache-busting y orden seguro). 
- Se versionó `config.js` en `frontend/product.html` con `?v=cart-feedback-catalog-fix-20260503` para asegurar coherencia del banner desde la página de producto.

### Testing
- Se verificó la presencia de los imports y cambios con búsquedas de código (`rg`/inspección) confirmando `buildCartItemFromProduct`, `readCart`, `writeCart`, logs y fallback en `frontend/js/shop.js`.
- Se inspeccionaron `frontend/shop.html` y `frontend/product.html` para confirmar los `script` actualizados con cache-busting y orden correcto de carga. 
- Se realizó verificación local de estado de workspace y se registraron los cambios en el repositorio de trabajo; no se ejecutaron pruebas E2E en navegador en este entorno. All automated checks above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f770d5275483319593996695cd32f4)