### PR TITLE
Preserve cart quantities when updating cart

### DIFF
--- a/nerin_final_updated/frontend/js/cart-utils.js
+++ b/nerin_final_updated/frontend/js/cart-utils.js
@@ -26,7 +26,14 @@ export function getProductIdentifier(product = {}) {
   return "";
 }
 
-export function normalizeCartItem(product = {}, quantity = 1) {
+function normalizeQuantity(product = {}, quantity) {
+  const rawQuantity = quantity ?? product?.quantity ?? product?.qty ?? 1;
+  const parsed = Number(rawQuantity);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 1;
+  return Math.max(1, Math.floor(parsed));
+}
+
+export function normalizeCartItem(product = {}, quantity = undefined) {
   const identifier = getProductIdentifier(product);
   if (!identifier) {
     console.error("[add-to-cart:blocked-invalid-product]", product);
@@ -47,7 +54,7 @@ export function normalizeCartItem(product = {}, quantity = 1) {
     supplierCode: product?.supplierCode ?? product?.supplier_code ?? null,
     productId: product?.productId ?? product?.product_id ?? product?.id ?? null,
     product_id: product?.product_id ?? product?.productId ?? product?.id ?? null,
-    quantity: Number(quantity || product?.quantity || product?.qty || 1),
+    quantity: normalizeQuantity(product, quantity),
   };
 }
 


### PR DESCRIPTION
### Summary
- Fixes a regression where cart item quantities could be reset to 1 whenever `writeCart()` sanitized the cart.
- `normalizeCartItem()` previously defaulted its `quantity` parameter to `1`, so `quantity || product.quantity` always resolved to `1` when callers normalized existing cart items without explicitly passing quantity.
- Added `normalizeQuantity()` and changed the default quantity argument to `undefined`, so existing `product.quantity` / `product.qty` is preserved.

### Impact
- Incrementing quantity in cart should now persist.
- Repeated add-to-cart should be able to increase quantity above 1.
- Invalid cart item protection remains in place.

### Testing
- Not run in browser here. After deploy, test adding the same product twice and using +/- on `/cart.html`; `localStorage.nerinCart[0].quantity` should update and persist above 1.