### PR TITLE
Restore dynamic admin-editable footer: persist to DATA_DIR, atomic writes, cache-busting

### DIFF
--- a/nerin_final_updated/backend/__tests__/footer.test.js
+++ b/nerin_final_updated/backend/__tests__/footer.test.js
@@ -1,3 +1,6 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const request = require('supertest');
 
 jest.mock('../emailValidator');
@@ -9,27 +12,81 @@ jest.mock('multer', () => {
   return m;
 }, { virtual: true });
 
-jest.mock('fs', () => {
-  const path = require('path');
-  return {
-    readFileSync: jest.fn(() => { throw new Error('read'); }),
-    writeFileSync: jest.fn(() => { throw new Error('write'); }),
-    existsSync: jest.fn(() => true),
-    mkdirSync: jest.fn(),
-    stat: jest.fn((p, cb) => cb(null, { isDirectory: () => false })),
-  };
-});
+describe('footer api persistence', () => {
+  let tmpDir;
+  let originalDataDir;
+  let createServer;
+  let server;
 
-const { createServer } = require('../server');
-const server = createServer();
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'footer-test-'));
+    originalDataDir = process.env.DATA_DIR;
+    process.env.DATA_DIR = tmpDir;
+    jest.resetModules();
+    ({ createServer } = require('../server'));
+    server = createServer();
+  });
 
-afterAll((done) => {
-  if (server.listening) server.close(done);
-  else done();
-});
+  afterEach((done) => {
+    if (server?.listening) {
+      server.close(() => {
+        if (originalDataDir === undefined) delete process.env.DATA_DIR;
+        else process.env.DATA_DIR = originalDataDir;
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+        done();
+      });
+      return;
+    }
+    if (originalDataDir === undefined) delete process.env.DATA_DIR;
+    else process.env.DATA_DIR = originalDataDir;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    done();
+  });
 
-test('returns default footer when file system is read-only', async () => {
-  const res = await request(server).get('/api/footer');
-  expect(res.status).toBe(200);
-  expect(res.body.brand).toBe('NERIN PARTS');
+  test('GET /api/footer returns default when footer.json does not exist', async () => {
+    const res = await request(server).get('/api/footer');
+    expect(res.status).toBe(200);
+    expect(res.body.brand).toBe('NERIN PARTS');
+    expect(res.headers['cache-control']).toContain('no-store');
+  });
+
+  test('POST /api/footer stores file in DATA_DIR and GET returns it', async () => {
+    const payload = {
+      brand: 'Grupo NERIN',
+      legalDetails: { cuit: '30-99999999-9', iibb: '901-111111-1' },
+      dataFiscal: { mode: 'placeholder', placeholder: 'Fiscal OK' },
+      columns: [{ title: 'Empresa', links: [{ label: 'Contacto', href: '/contact.html' }] }],
+    };
+
+    const post = await request(server)
+      .post('/api/footer')
+      .set('Authorization', `Bearer ${Buffer.from('admin@nerin.com:any').toString('base64')}`)
+      .send(payload);
+
+    expect(post.status).toBe(200);
+    expect(post.body.brand).toBe('Grupo NERIN');
+
+    const savedPath = path.join(tmpDir, 'footer.json');
+    expect(fs.existsSync(savedPath)).toBe(true);
+
+    const get = await request(server).get('/api/footer');
+    expect(get.status).toBe(200);
+    expect(get.body.brand).toBe('Grupo NERIN');
+    expect(get.body.legalDetails.cuit).toBe('30-99999999-9');
+    expect(get.body.dataFiscal.placeholder).toBe('Fiscal OK');
+  });
+
+  test('POST /api/footer returns 500 on write failure (read-only fs simulation)', async () => {
+    const writeSpy = jest.spyOn(fs.promises, 'writeFile').mockRejectedValueOnce(new Error('EROFS'));
+    const payload = { brand: 'No Save' };
+
+    const post = await request(server)
+      .post('/api/footer')
+      .set('Authorization', `Bearer ${Buffer.from('admin@nerin.com:any').toString('base64')}`)
+      .send(payload);
+
+    expect(post.status).toBe(500);
+    expect(post.body.error).toContain('No se pudo guardar footer.json');
+    writeSpy.mockRestore();
+  });
 });

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -1940,7 +1940,7 @@ const fetchFn =
   globalThis.fetch ||
   ((...a) => import("node-fetch").then(({ default: f }) => f(...a)));
 
-const FOOTER_FILE = dataPath("footer.json");
+const FOOTER_FILE_PATH = dataPath("footer.json");
 const DEFAULT_FOOTER = {
   brand: "NERIN PARTS",
   slogan: "Samsung Service Pack Original",
@@ -5608,30 +5608,47 @@ function sendOrderPaidEmail(order) {
   }
 }
 // Leer y guardar configuración de footer
+function buildFooterNoCacheHeaders() {
+  return {
+    "Cache-Control": "no-store, no-cache, must-revalidate, proxy-revalidate",
+    Pragma: "no-cache",
+    Expires: "0",
+  };
+}
+
 function readFooter() {
+  console.log("[footer:get]", {
+    path: FOOTER_FILE_PATH,
+    exists: fs.existsSync(FOOTER_FILE_PATH),
+    dataDir: DATA_DIR,
+    persistent: IS_DATA_DIR_PERSISTENT,
+  });
   try {
-    const txt = fs.readFileSync(FOOTER_FILE, "utf8");
+    const txt = fs.readFileSync(FOOTER_FILE_PATH, "utf8");
     return JSON.parse(txt);
-  } catch {
-    try {
-      fs.writeFileSync(FOOTER_FILE, JSON.stringify(DEFAULT_FOOTER, null, 2));
-    } catch (e) {
-      console.error("Cannot write default footer", e);
-    }
+  } catch (error) {
     return { ...DEFAULT_FOOTER };
   }
 }
 
-function saveFooter(cfg) {
-  try {
-    fs.writeFileSync(FOOTER_FILE, JSON.stringify(cfg, null, 2));
-  } catch (e) {
-    console.error("Cannot save footer", e);
-  }
+async function saveFooter(cfg) {
+  console.log("[footer:post]", {
+    path: FOOTER_FILE_PATH,
+    dataDir: DATA_DIR,
+    persistent: IS_DATA_DIR_PERSISTENT,
+  });
+  await fsp.mkdir(path.dirname(FOOTER_FILE_PATH), { recursive: true });
+  const tmpPath = `${FOOTER_FILE_PATH}.tmp-${Date.now()}-${process.pid}`;
+  const payload = JSON.stringify(cfg, null, 2);
+  await fsp.writeFile(tmpPath, payload, "utf8");
+  await fsp.rename(tmpPath, FOOTER_FILE_PATH);
+  const saved = JSON.parse(await fsp.readFile(FOOTER_FILE_PATH, "utf8"));
+  console.log("[footer:post]", { path: FOOTER_FILE_PATH, saved: true });
+  return saved;
 }
 
 function normalizeFooter(data) {
-  const base = readFooter();
+  const base = DEFAULT_FOOTER;
   const out = { ...base };
   out.brand = typeof data.brand === "string" ? data.brand.trim() : base.brand;
   out.slogan =
@@ -8702,22 +8719,25 @@ async function requestHandler(req, res) {
 
   if (pathname === "/api/footer" && req.method === "GET") {
     const cfg = readFooter();
-    return sendJson(res, 200, cfg);
+    return sendJson(res, 200, cfg, buildFooterNoCacheHeaders());
   }
 
   if (pathname === "/api/footer" && req.method === "POST") {
     if (!requireAdmin(req, res, { allowSeller: false })) return;
     let body = "";
     req.on("data", (c) => (body += c));
-    req.on("end", () => {
+    req.on("end", async () => {
       try {
         const data = JSON.parse(body || "{}");
         const cfg = normalizeFooter(data);
-        saveFooter(cfg);
-        return sendJson(res, 200, { success: true });
+        const savedCfg = await saveFooter(cfg);
+        return sendJson(res, 200, savedCfg, buildFooterNoCacheHeaders());
       } catch (e) {
-        console.error(e);
-        return sendJson(res, 400, { error: "Solicitud inválida" });
+        console.error("footer:post", e);
+        if (e instanceof SyntaxError) {
+          return sendJson(res, 400, { error: "Solicitud inválida" });
+        }
+        return sendJson(res, 500, { error: "No se pudo guardar footer.json en DATA_DIR" });
       }
     });
     return;

--- a/nerin_final_updated/frontend/admin-footer.js
+++ b/nerin_final_updated/frontend/admin-footer.js
@@ -111,6 +111,22 @@ const BADGE_KEYS = ["mercadoPago", "andreani", "efectivo", "transferencia"];
 let badgeUploadsInProgress = 0;
 let dataFiscalUploadInProgress = 0;
 
+function merge(base, incoming) {
+  if (Array.isArray(base) || Array.isArray(incoming)) {
+    return Array.isArray(incoming) ? incoming : Array.isArray(base) ? base : [];
+  }
+  const out = { ...base };
+  for (const key in incoming || {}) {
+    const value = incoming[key];
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      out[key] = merge(base?.[key] ?? {}, value);
+    } else if (value !== undefined) {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
 function isBadgeUploadInProgress() {
   return badgeUploadsInProgress > 0;
 }
@@ -121,9 +137,10 @@ function isDataFiscalUploadInProgress() {
 
 async function loadFooterConfig() {
   try {
-    const res = await fetch('/api/footer');
+    const res = await fetch(`/api/footer?ts=${Date.now()}`, { cache: 'no-store' });
     const data = await res.json();
-    fillForm({ ...defaultConfig, ...data });
+    const cfg = merge(defaultConfig, data);
+    fillForm(cfg);
   } catch (e) {
     fillForm(defaultConfig);
   }
@@ -284,12 +301,21 @@ async function persistFooterConfig({ showSuccessAlert = true } = {}) {
     headers,
     body: JSON.stringify(cfg),
   });
-  if (res.ok) {
-    if (showSuccessAlert) alert('Footer guardado');
-  } else {
-    alert('Error al guardar footer');
+  const postData = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    alert(postData.error || 'Error al guardar footer');
+    return false;
   }
-  return res.ok;
+  const verifyRes = await fetch(`/api/footer?ts=${Date.now()}`, { cache: 'no-store', headers });
+  const verifyData = await verifyRes.json().catch(() => ({}));
+  const expected = JSON.stringify(merge(defaultConfig, cfg));
+  const actual = JSON.stringify(merge(defaultConfig, verifyData));
+  if (!verifyRes.ok || expected !== actual) {
+    alert('El footer se guardó pero la web pública no está leyendo la misma configuración. Revisar Render Disk / DATA_DIR.');
+    return false;
+  }
+  if (showSuccessAlert) alert('Footer guardado');
+  return true;
 }
 
 form.addEventListener('submit', async (e) => {

--- a/nerin_final_updated/frontend/cart.html
+++ b/nerin_final_updated/frontend/cart.html
@@ -47,8 +47,8 @@
       href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css"
     />
       <link rel="stylesheet" href="/style.css?v=cartfix-2" />
-    <link rel="stylesheet" href="/components/np-footer.css?v=np-r2">
-  <script src="/components/np-footer.js?v=np-r2" defer></script>
+    <link rel="stylesheet" href="/components/np-footer.css?v=np-r3">
+  <script src="/components/np-footer.js?v=np-r3" defer></script>
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/checkout.html
+++ b/nerin_final_updated/frontend/checkout.html
@@ -34,8 +34,8 @@ src="https://www.facebook.com/tr?id=2627676134264110&ev=PageView&noscript=1"
   <meta name="robots" content="noindex, nofollow" />
   <link rel="stylesheet" href="/css/style.css?v=cartfix-2" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css" />
-  <link rel="stylesheet" href="/components/np-footer.css?v=np-r2">
-  <script src="/components/np-footer.js?v=np-r2" defer></script>
+  <link rel="stylesheet" href="/components/np-footer.css?v=np-r3">
+  <script src="/components/np-footer.js?v=np-r3" defer></script>
 </head>
 <body>
   <div class="contenedor">

--- a/nerin_final_updated/frontend/components/np-footer.js
+++ b/nerin_final_updated/frontend/components/np-footer.js
@@ -18,7 +18,7 @@
 
   ready(async () => {
     try {
-      const version = "np-r2";
+      const version = "np-r3";
       let tpl = document.getElementById("np-footer-template");
       if (!tpl) {
         try {
@@ -208,10 +208,12 @@
           (window.NERIN_CONFIG && window.NERIN_CONFIG.apiBase) ||
           window.API_BASE_URL ||
           "";
-        const res = await fetch(`${base}/api/footer`, { cache: "no-store" });
+        const res = await fetch(`${base}/api/footer?ts=${Date.now()}`, { cache: "no-store" });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
         remote = await res.json();
-      } catch (e) {
-        console.warn("[NP-FOOTER] /api/footer failed", e);
+        console.info("[NP-FOOTER] remote config loaded", remote);
+      } catch (error) {
+        console.warn("[NP-FOOTER] using defaults because /api/footer failed", error);
       }
       const cfg = merge(defaults, remote);
       const show = cfg.show || {};

--- a/nerin_final_updated/frontend/contact.html
+++ b/nerin_final_updated/frontend/contact.html
@@ -104,8 +104,8 @@
     />
     <link rel="stylesheet" href="/style.css?v=cartfix-2" />
     <link rel="stylesheet" href="/css/contact.css?v=sp-t1" />
-    <link rel="stylesheet" href="/components/np-footer.css?v=np-r2" />
-    <script src="/components/np-footer.js?v=np-r2" defer></script>
+    <link rel="stylesheet" href="/components/np-footer.css?v=np-r3" />
+    <script src="/components/np-footer.js?v=np-r3" defer></script>
     <script
       type="application/ld+json"
       id="contact-schema"

--- a/nerin_final_updated/frontend/index.html
+++ b/nerin_final_updated/frontend/index.html
@@ -115,8 +115,8 @@
       href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css"
     />
     <link rel="stylesheet" href="/style.css?v=cartfix-2" />
-    <link rel="stylesheet" href="/components/np-footer.css?v=np-r2" />
-    <script src="/components/np-footer.js?v=np-r2" defer></script>
+    <link rel="stylesheet" href="/components/np-footer.css?v=np-r3" />
+    <script src="/components/np-footer.js?v=np-r3" defer></script>
     <script
       type="application/ld+json"
       id="org-schema"

--- a/nerin_final_updated/frontend/login.html
+++ b/nerin_final_updated/frontend/login.html
@@ -41,8 +41,8 @@
       href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css"
     />
       <link rel="stylesheet" href="/style.css?v=cartfix-2" />
-    <link rel="stylesheet" href="/components/np-footer.css?v=np-r2">
-  <script src="/components/np-footer.js?v=np-r2" defer></script>
+    <link rel="stylesheet" href="/components/np-footer.css?v=np-r3">
+  <script src="/components/np-footer.js?v=np-r3" defer></script>
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/product.html
+++ b/nerin_final_updated/frontend/product.html
@@ -81,8 +81,8 @@
     />
     <link rel="stylesheet" href="/style.css?v=product-gallery-fix-20260503" />
     <link rel="stylesheet" href="/product-gallery-containment.css?v=product-gallery-containment-real-20260503" />
-    <link rel="stylesheet" href="/components/np-footer.css?v=np-r2" />
-    <script src="/components/np-footer.js?v=np-r2" defer></script>
+    <link rel="stylesheet" href="/components/np-footer.css?v=np-r3" />
+    <script src="/components/np-footer.js?v=np-r3" defer></script>
     <script
       type="application/ld+json"
       id="product-breadcrumbs"

--- a/nerin_final_updated/frontend/register.html
+++ b/nerin_final_updated/frontend/register.html
@@ -41,8 +41,8 @@
       href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css"
     />
       <link rel="stylesheet" href="/style.css?v=cartfix-2" />
-    <link rel="stylesheet" href="/components/np-footer.css?v=np-r2">
-  <script src="/components/np-footer.js?v=np-r2" defer></script>
+    <link rel="stylesheet" href="/components/np-footer.css?v=np-r3">
+  <script src="/components/np-footer.js?v=np-r3" defer></script>
 </head>
   <body>
     <header>

--- a/nerin_final_updated/frontend/shop.html
+++ b/nerin_final_updated/frontend/shop.html
@@ -113,8 +113,8 @@
       href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css"
     />
     <link rel="stylesheet" href="/style.css?v=premium-grid" />
-    <link rel="stylesheet" href="/components/np-footer.css?v=np-r2" />
-    <script src="/components/np-footer.js?v=np-r2" defer></script>
+    <link rel="stylesheet" href="/components/np-footer.css?v=np-r3" />
+    <script src="/components/np-footer.js?v=np-r3" defer></script>
     <script
       type="application/ld+json"
       id="shop-schema"


### PR DESCRIPTION
### Motivation
- The public footer had become static because the API and frontend were falling back to hardcoded defaults or returning cached/stale data instead of the editable `footer.json` on the persistent DATA_DIR/Render Disk. 
- Root cause: the backend sometimes returned success without guaranteeing persistence (silent fallback to repo-local defaults) and the frontend could use cached/default values, so changes from the admin were not visible on the storefront.

### Description
- Backend: switched to a single persistent path `FOOTER_FILE_PATH = dataPath("footer.json")`, added diagnostic logs (`[footer:get]`/`[footer:post]`), added no-cache headers via `buildFooterNoCacheHeaders()`, implemented atomic writes (tmp file + `rename`) and post-write re-read, and return clear HTTP 500 on write failures; key file modified: `backend/server.js` (`readFooter`, `saveFooter`, GET/POST `/api/footer`).
- Frontend (public): `frontend/components/np-footer.js` now fetches `/api/footer?ts=${Date.now()}` with `{ cache: "no-store" }`, logs success (`[NP-FOOTER] remote config loaded`) and only falls back to defaults on real failure, and bumped version to `np-r3` for cache busting.
- Frontend (admin): `frontend/admin-footer.js` uses a deep `merge` when loading remote config, fetches `/api/footer?ts=...` on load, and after `POST /api/footer` it performs a GET verification and surfaces an explicit error if the public API does not reflect the saved config.
- Asset/versioning and pages: updated footer asset references to `?v=np-r3` in storefront pages (index, shop, product, cart, checkout, login, register, contact) and added/updated tests in `backend/__tests__/footer.test.js` to validate persistence and error handling.

### Testing
- Static checks: ran `node --check backend/server.js`, `node --check frontend/components/np-footer.js`, and `node --check frontend/admin-footer.js`, all succeeded. 
- Unit tests: ran `npm test -- footer` and the footer test suite passed (tests cover GET default when missing, POST persistence to `DATA_DIR/footer.json`, GET-after-POST returning saved config, and POST error on write failure). 
- Runtime verification notes: after deploy confirm admin changes (CUIT/IIBB/legalDetails, Data Fiscal, columns/links) are saved and immediately visible on public pages and check backend logs for `[footer:get]` and `[footer:post]` entries showing `path: FOOTER_FILE_PATH` and `saved: true`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b59e85808331b40cbe8d6b3ea468)