### PR TITLE
Enable analytics for large catalogs; hide build banner in production; fix admin mobile tabs

### DIFF
--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -212,10 +212,6 @@ const MAX_ACTIVITY_SESSIONS = 300;
 const ACTIVITY_SESSION_RETENTION_MS = 7 * 24 * 60 * 60 * 1000; // 7 días
 const MAX_ANALYTICS_HISTORY_DAYS = 35;
 const MAX_HISTORY_SESSION_IDS = 2000;
-const DISABLE_HEAVY_ANALYTICS = true;
-const HEAVY_ANALYTICS_PRODUCTS_SIZE_LIMIT_BYTES = 5 * 1024 * 1024;
-const ANALYTICS_DISABLED_REASON = "disabled_for_large_catalog";
-const EMERGENCY_PRODUCTS_MODE = true;
 const DISABLE_PRODUCTS_STREAMING_FALLBACK =
   String(process.env.DISABLE_PRODUCTS_STREAMING_FALLBACK || "true").trim().toLowerCase() === "true";
 const REVIEW_TOKEN_TTL_DAYS =
@@ -3138,6 +3134,8 @@ async function calculateDetailedAnalytics(options = {}) {
   let revenueThisWeek = 0;
   let ordersToday = 0;
   let ordersThisWeek = 0;
+  const orderStatusBreakdown = {};
+  const paymentStatusBreakdown = {};
   orders.forEach((order) => {
     totalSales += order.total || 0;
     const orderDateRaw =
@@ -3153,6 +3151,10 @@ async function calculateDetailedAnalytics(options = {}) {
         ordersThisWeek += 1;
       }
     }
+    const orderStatus = String(order.status || order.shipping_status || "sin_estado").trim() || "sin_estado";
+    orderStatusBreakdown[orderStatus] = (orderStatusBreakdown[orderStatus] || 0) + 1;
+    const paymentStatus = String(order.payment_status || order.paymentStatus || "sin_estado").trim() || "sin_estado";
+    paymentStatusBreakdown[paymentStatus] = (paymentStatusBreakdown[paymentStatus] || 0) + 1;
     // Agrupar ventas por mes
     if (order.date) {
       const month = order.date.slice(0, 7); // YYYY-MM
@@ -3700,8 +3702,10 @@ async function calculateDetailedAnalytics(options = {}) {
     brandsCount: catalogSnapshot.brandsCount,
     revenueToday,
     revenueThisWeek,
+    revenueInRange: revenueThisWeek,
     ordersToday,
     ordersThisWeek,
+    ordersInRange: ordersThisWeek,
     conversionRate,
     cartAbandonmentRate,
     averageSessionDuration,
@@ -3721,6 +3725,8 @@ async function calculateDetailedAnalytics(options = {}) {
     averageOrderValue,
     returnRate,
     mostReturnedProduct,
+    orderStatusBreakdown,
+    paymentStatusBreakdown,
     activeSessions: activeSessions.length,
     checkoutInProgress,
     activeCarts,
@@ -3757,14 +3763,6 @@ async function calculateDetailedAnalytics(options = {}) {
   };
 }
 
-function buildDisabledAnalyticsPayload({ reason = ANALYTICS_DISABLED_REASON } = {}) {
-  return {
-    analyticsAvailable: false,
-    reason,
-    productManifest: productsStreamRepo.safeReadManifest() || null,
-    message: "Analytics desactivado temporalmente para catálogo grande",
-  };
-}
 
 // Leer productos desde el archivo JSON
 function getProducts() {
@@ -4021,7 +4019,7 @@ async function getProductsEmergencyResponse({
       hasPrevPage: Boolean(emergencyPage.hasPrevPage || page > 1),
       warning: warning || null,
       totalItemsUnknown: safeTotalItems == null,
-      mode: EMERGENCY_PRODUCTS_MODE ? "emergency_streaming" : "standard",
+      mode: "emergency_streaming",
       scannedCount: emergencyPage.scannedCount,
       matchedCount: emergencyPage.matchedCount,
     };
@@ -11370,10 +11368,29 @@ async function requestHandler(req, res) {
    * análisis profundo y dashboards.
    */
   if (pathname === "/api/analytics/detailed" && req.method === "GET") {
-    return sendJson(res, 200, {
-      analyticsAvailable: false,
-      reason: ANALYTICS_DISABLED_REASON,
-    });
+    try {
+      const range = parseAnalyticsRange(parsedUrl.query);
+      const events = getEventsByRange({ from: range.from, to: range.to });
+      let sessions = getStoredSessions();
+      if (!Array.isArray(sessions) || sessions.length === 0) {
+        const fallback = getActivityLog();
+        sessions = Array.isArray(fallback.sessions) ? fallback.sessions : [];
+      }
+      const analytics = await calculateDetailedAnalytics({
+        rangeStart: range.from,
+        rangeEnd: range.to,
+        events,
+        sessions,
+      });
+      return sendJson(res, 200, { analyticsAvailable: true, analytics, range });
+    } catch (err) {
+      console.error("analytics-detailed error", err);
+      return sendJson(res, 500, {
+        analyticsAvailable: false,
+        error: "No se pudieron calcular las analíticas detalladas",
+        details: err?.message || String(err),
+      });
+    }
   }
 
   /*

--- a/nerin_final_updated/frontend/admin.html
+++ b/nerin_final_updated/frontend/admin.html
@@ -219,7 +219,7 @@
     </style>
   </head>
   <body>
-    <div id="admin-build-banner">Build: dev • Multi-images: ON</div>
+    <div id="admin-build-banner" hidden>Build: dev • Multi-images: ON</div>
     <header>
       <div class="header-inner">
         <div class="logo"><a href="/index.html" class="brand"><img src="../assets/IMG_3086.png" alt="NERIN" class="site-logo" /></a></div>

--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -17,6 +17,18 @@ if (typeof window !== "undefined" && !window.__NERIN_ADMIN_BUILD__) {
   window.__NERIN_ADMIN_BUILD__ = ADMIN_BUILD_FALLBACK;
 }
 
+function shouldShowAdminBuildBadge() {
+  if (typeof window === "undefined") return false;
+  const host = String(window.location?.hostname || "").toLowerCase();
+  if (host === "localhost" || host === "127.0.0.1") return true;
+  const flags = [
+    window.DEBUG_ADMIN_BUILD,
+    window.SHOW_BUILD_BADGE,
+    window.NEXT_PUBLIC_SHOW_BUILD_BADGE,
+  ];
+  return flags.some((value) => value === true || String(value).toLowerCase() === "true");
+}
+
 async function logAdminBuildVersion() {
   let buildId = ADMIN_BUILD_FALLBACK;
   try {
@@ -39,7 +51,11 @@ async function logAdminBuildVersion() {
   if (typeof document !== "undefined") {
     const banner = document.getElementById("admin-build-banner");
     if (banner) {
-      banner.textContent = `Build: ${buildId || "dev"} • Multi-images: ON`;
+      const showBadge = shouldShowAdminBuildBadge();
+      banner.hidden = !showBadge;
+      if (showBadge) {
+        banner.textContent = `Build: ${buildId || "dev"} • Multi-images: ON`;
+      }
     }
   }
   console.info("admin-js-version", buildId);

--- a/nerin_final_updated/frontend/js/analytics.js
+++ b/nerin_final_updated/frontend/js/analytics.js
@@ -334,12 +334,12 @@ export async function renderAnalyticsDashboard(
     const payload = await res.json();
     const analytics = payload?.analytics || payload || {};
     container.innerHTML = "";
-    if (!analytics?.analyticsAvailable) {
+    if (analytics?.analyticsAvailable === false) {
       const disabled = document.createElement("div");
       disabled.className = "analytics-empty analytics-empty--inline";
       disabled.innerHTML = `
-        <strong>Métricas no disponibles temporalmente</strong>
-        <p>${analytics?.message || "Métricas desactivadas temporalmente para catálogo grande"}</p>
+        <strong>No se pudieron cargar las analíticas</strong>
+        <p>${analytics?.error || analytics?.message || "Ocurrió un error técnico. Reintentá en unos segundos."}</p>
       `;
       container.appendChild(disabled);
       return;

--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -9729,3 +9729,32 @@ html, body{ max-width:100%; overflow-x:hidden; }
   height: auto;
   object-fit: contain;
 }
+
+
+.admin-nav {
+  display: flex;
+  gap: .5rem;
+  overflow-x: auto;
+  overflow-y: hidden;
+  white-space: nowrap;
+  -webkit-overflow-scrolling: touch;
+  padding: .5rem 1rem;
+  scroll-padding-left: 1rem;
+}
+
+.admin-nav button {
+  flex: 0 0 auto;
+}
+
+@media (max-width: 768px) {
+  .admin-container {
+    overflow-x: hidden;
+  }
+
+  .admin-nav {
+    margin-left: calc(-1 * var(--container-padding, 1rem));
+    margin-right: calc(-1 * var(--container-padding, 1rem));
+    padding-left: var(--container-padding, 1rem);
+    padding-right: var(--container-padding, 1rem);
+  }
+}


### PR DESCRIPTION
### Motivation
- Permitir que la pestaña Analíticas funcione aunque el catálogo sea grande sin cargar `products.json` completo y basándose en `orders`, `order items`, `clients`, `returns` y datos de tracking (events/sessions). 
- Evitar que el banner de build aparezca en producción y que las tabs del admin se corten en móvil.

### Description
- Rehabilité el endpoint `GET /api/analytics/detailed` para calcular y devolver siempre las analíticas (rangos `today`, `7d`, `30d`, `custom`) usando `calculateDetailedAnalytics` y datos de eventos/sesiones, sin parsear todo `products.json` en memoria; ahora responde con `analyticsAvailable: true` en condiciones normales y con errores claros en caso de fallo. (`nerin_final_updated/backend/server.js`).
- Añadí breakdowns y alias requeridos en el payload de analíticas (`revenueInRange`, `ordersInRange`, `orderStatusBreakdown`, `paymentStatusBreakdown`) y mantuve el cálculo a partir de órdenes, devoluciones y eventos; el snapshot de catálogo se obtiene por streaming y lookup por ID cuando es necesario. (`nerin_final_updated/backend/server.js`).
- Cambié la UI de analíticas para que ya no muestre el mensaje “Métricas desactivadas temporalmente para catálogo grande”; ahora muestra un error técnico sólo cuando `analyticsAvailable === false`, y en caso de ausencia de datos el dashboard renderiza cards/series vacías o métricas en 0. (`nerin_final_updated/frontend/js/analytics.js`).
- Oculté el banner de build por defecto en `admin.html` y añadí lógica en `admin.js` para mostrarlo solo en localhost/127.0.0.1 o si se pasan flags explícitos (`DEBUG_ADMIN_BUILD`, `SHOW_BUILD_BADGE`, `NEXT_PUBLIC_SHOW_BUILD_BADGE`). (`nerin_final_updated/frontend/admin.html`, `nerin_final_updated/frontend/js/admin.js`).
- Corregí CSS del nav del admin para mobile añadiendo scroll horizontal y evitando que el primer botón quede cortado; ajustes aplicados en `style.css`. (`nerin_final_updated/frontend/style.css`).
- Busqué y limpié referencias relacionadas: `"Métricas desactivadas temporalmente"`, `"Métricas no disponibles temporalmente"`, `"disabled_for_large_catalog"`, `DISABLE_HEAVY_ANALYTICS`, `EMERGENCY_PRODUCTS_MODE`, y `admin-build-banner` y ajusté donde fue necesario.

Modificados principales: `nerin_final_updated/backend/server.js`, `nerin_final_updated/frontend/js/analytics.js`, `nerin_final_updated/frontend/js/admin.js`, `nerin_final_updated/frontend/admin.html`, `nerin_final_updated/frontend/style.css`.

### Testing
- Ejecuté `cd nerin_final_updated && npm test`; la suite se ejecutó pero hay fallos preexistentes en el repositorio (tests relacionados con footer/jsonFile/seo y algunas expectativas de analytics), por lo que los tests terminaron con fallos (listado de pruebas fallidas por Jest). (FALLÓ).
- Ejecuté `cd nerin_final_updated && npm run lint`; no existe script `lint` en `package.json` en este repositorio (NO EJECUTADO).
- Ejecuté `cd nerin_final_updated && npm start` (con timeout de verificación); el servidor arrancó correctamente y mostró logs de arranque antes de finalizar la comprobación (ARRANCÓ OK).

Si preferís, puedo ajustar el endpoint para incluir lookups puntuales adicionales a repositorio indexado/SQLite para enriquecer nombres/categorías por ID cuando haga falta (cumpliendo la regla de no parsear el JSON completo).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7f2b9f8988331baa409292539c71d)