### PR TITLE
Fix public header Admin visibility; enforce role-based nav in `config.js`

### DIFF
--- a/nerin_final_updated/frontend/account-minorista.html
+++ b/nerin_final_updated/frontend/account-minorista.html
@@ -254,6 +254,6 @@
     </main>
     <script type="module" src="/js/account-minorista.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
-    <script type="module" src="/js/config.js"></script>
+    <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>
   </body>
 </html>

--- a/nerin_final_updated/frontend/account.html
+++ b/nerin_final_updated/frontend/account.html
@@ -191,6 +191,6 @@
 
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
     <script type="module" src="/js/account-simple.js"></script>
-    <script type="module" src="/js/config.js"></script>
+    <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>
   </body>
 </html>

--- a/nerin_final_updated/frontend/admin.html
+++ b/nerin_final_updated/frontend/admin.html
@@ -1785,7 +1785,7 @@
         disableAnalytics: true,
       };
     </script>
-    <script type="module" src="/js/config.js"></script>
+    <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>
     <!-- Traducciones -->
     <script type="module" src="/js/lang.js"></script>
   </body>

--- a/nerin_final_updated/frontend/arrepentimiento.html
+++ b/nerin_final_updated/frontend/arrepentimiento.html
@@ -58,6 +58,6 @@
     </main>
 
     <script type="module" src="/js/arrepentimiento.js"></script>
-    <script type="module" src="/js/config.js"></script>
+    <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>
   </body>
 </html>

--- a/nerin_final_updated/frontend/cart.html
+++ b/nerin_final_updated/frontend/cart.html
@@ -120,6 +120,6 @@
     <script type="module" src="/js/cart.js"></script>
     <!-- Configuración y analíticas globales -->
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
-    <script type="module" src="/js/config.js"></script>
+    <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>
   </body>
 </html>

--- a/nerin_final_updated/frontend/checkout-steps.html
+++ b/nerin_final_updated/frontend/checkout-steps.html
@@ -176,6 +176,6 @@
     </div>
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
     <script type="module" src="/js/checkout-steps.js?v=__BUILD_ID__"></script>
-    <script type="module" src="/js/config.js"></script>
+    <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>
   </body>
 </html>

--- a/nerin_final_updated/frontend/checkout/confirmacion-efectivo.html
+++ b/nerin_final_updated/frontend/checkout/confirmacion-efectivo.html
@@ -71,7 +71,7 @@
       </section>
     </main>
     <div id="footer-root"></div>
-    <script type="module" src="/js/config.js"></script>
+    <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>
     <script type="module" src="/js/checkout-confirmation.js"></script>
   </body>
 </html>

--- a/nerin_final_updated/frontend/checkout/confirmacion-transferencia.html
+++ b/nerin_final_updated/frontend/checkout/confirmacion-transferencia.html
@@ -71,7 +71,7 @@
       </section>
     </main>
     <div id="footer-root"></div>
-    <script type="module" src="/js/config.js"></script>
+    <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>
     <script type="module" src="/js/checkout-confirmation.js"></script>
   </body>
 </html>

--- a/nerin_final_updated/frontend/contact.html
+++ b/nerin_final_updated/frontend/contact.html
@@ -514,6 +514,6 @@
     </main>
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
     <script type="module" src="/js/index.js"></script>
-    <script type="module" src="/js/config.js"></script>
+    <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>
   </body>
 </html>

--- a/nerin_final_updated/frontend/failure.html
+++ b/nerin_final_updated/frontend/failure.html
@@ -73,7 +73,7 @@
         </div>
       </article>
     </main>
-    <script type="module" src="/js/config.js"></script>
+    <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>
     <script>
       document.getElementById('fecha').textContent = new Date().toLocaleString('es-AR', {
         day: '2-digit',

--- a/nerin_final_updated/frontend/garantia.html
+++ b/nerin_final_updated/frontend/garantia.html
@@ -238,7 +238,7 @@
       </a>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
-    <script type="module" src="/js/config.js"></script>
+    <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>
     <script type="module" src="/js/legal.js"></script>
   </body>
 </html>

--- a/nerin_final_updated/frontend/index.html
+++ b/nerin_final_updated/frontend/index.html
@@ -175,8 +175,7 @@
             <li><a href="/seguimiento.html">Seguir mi pedido</a></li>
             <li><a href="/contact.html">Contacto</a></li>
             <li><a href="/cart.html">Carrito</a></li>
-            <li><a href="/admin.html">Admin</a></li>
-            <li><a href="/login.html">Acceder</a></li>
+            <li><a href="/login.html">Ingresar</a></li>
           </ul>
         </nav>
               </div>
@@ -301,6 +300,6 @@
     <!-- Configuración y analíticas -->
     <script type="module" src="/js/index.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
-    <script type="module" src="/js/config.js"></script>
+    <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>
   </body>
 </html>

--- a/nerin_final_updated/frontend/invoice.html
+++ b/nerin_final_updated/frontend/invoice.html
@@ -108,6 +108,6 @@
     <script type="module" src="/js/invoice.js"></script>
     <!-- Configuración y analíticas globales para actualizar navegación -->
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
-    <script type="module" src="/js/config.js"></script>
+    <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>
   </body>
 </html>

--- a/nerin_final_updated/frontend/js/config.js
+++ b/nerin_final_updated/frontend/js/config.js
@@ -628,18 +628,18 @@ function updateNav() {
   const config = window.NERIN_CONFIG || {};
   const role = localStorage.getItem("nerinUserRole");
   const token = localStorage.getItem("nerinToken");
-  const loggedIn = Boolean(role && token);
+  const loggedIn = Boolean(token);
+  const isAdminUser = Boolean(token && (role === "admin" || role === "vendedor"));
   const name = localStorage.getItem("nerinUserName");
   const email = localStorage.getItem("nerinUserEmail");
-  // Eliminar botones duplicados de Admin si existieran
+  // Limpiar enlaces Admin hardcodeados para que sólo aparezcan cuando corresponda.
   const adminLinks = navUl.querySelectorAll('a[href="/admin.html"]');
-  if (adminLinks.length > 1) {
-    adminLinks.forEach((link, idx) => {
-      if (idx > 0 && link.parentElement) {
-        link.parentElement.remove();
-      }
-    });
-  }
+  adminLinks.forEach((link, idx) => {
+    const li = link.closest("li");
+    if (!isAdminUser || idx > 0) {
+      li?.remove();
+    }
+  });
   // Calcular cantidad total en el carrito
   let cartCount = 0;
   try {
@@ -686,7 +686,7 @@ function updateNav() {
     if (href && href.includes("/login.html")) {
       if (loggedIn) {
         // Usuario autenticado: cambiar enlace a Admin o Mi cuenta
-        if (role === "admin" || role === "vendedor") {
+        if (isAdminUser) {
           a.textContent = "Admin";
           a.setAttribute("href", "/admin.html");
         } else if (role === "minorista") {
@@ -702,6 +702,26 @@ function updateNav() {
       }
     }
   });
+  if (isAdminUser) {
+    const adminNavLinks = navUl.querySelectorAll('a[href="/admin.html"]');
+    if (adminNavLinks.length === 0) {
+      const adminLi = document.createElement("li");
+      const adminLink = document.createElement("a");
+      adminLink.href = "/admin.html";
+      adminLink.textContent = "Admin";
+      adminLi.appendChild(adminLink);
+      const logoutLi = navUl.querySelector("li.logout-item");
+      if (logoutLi) {
+        navUl.insertBefore(adminLi, logoutLi);
+      } else {
+        navUl.appendChild(adminLi);
+      }
+    } else if (adminNavLinks.length > 1) {
+      adminNavLinks.forEach((link, idx) => {
+        if (idx > 0) link.closest("li")?.remove();
+      });
+    }
+  }
   // Añadir enlace de cierre de sesión si no existe y el usuario está autenticado
   if (loggedIn) {
     let logoutLi = navUl.querySelector("li.logout-item");

--- a/nerin_final_updated/frontend/login.html
+++ b/nerin_final_updated/frontend/login.html
@@ -113,6 +113,6 @@
     <script type="module" src="/js/login.js"></script>
     <!-- Configuración y analíticas globales -->
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
-    <script type="module" src="/js/config.js"></script>
+    <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>
   </body>
 </html>

--- a/nerin_final_updated/frontend/pending.html
+++ b/nerin_final_updated/frontend/pending.html
@@ -74,7 +74,7 @@
         <div class="skeleton block"></div>
       </article>
     </main>
-    <script type="module" src="/js/config.js"></script>
+    <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>
     <script src="/js/order-status.js"></script>
     <script type="module" src="/js/success.js"></script>
     <script>

--- a/nerin_final_updated/frontend/product.html
+++ b/nerin_final_updated/frontend/product.html
@@ -160,6 +160,6 @@
     <script type="module" src="/js/product.js?v=delivery-policy-20260503"></script>
     <!-- Configuración y analíticas globales -->
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
-    <script type="module" src="/js/config.js?v=cart-feedback-catalog-fix-20260503"></script>
+    <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>
   </body>
 </html>

--- a/nerin_final_updated/frontend/register.html
+++ b/nerin_final_updated/frontend/register.html
@@ -482,6 +482,6 @@
     <script type="module" src="/js/register.js"></script>
     <!-- Configuración global -->
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
-    <script type="module" src="/js/config.js"></script>
+    <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>
   </body>
 </html>

--- a/nerin_final_updated/frontend/seguimiento.html
+++ b/nerin_final_updated/frontend/seguimiento.html
@@ -86,6 +86,6 @@
     </main>
 
     <script type="module" src="/js/seguimiento.js?v=20241002-nerin-01"></script>
-    <script type="module" src="/js/config.js"></script>
+    <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>
   </body>
 </html>

--- a/nerin_final_updated/frontend/shop.html
+++ b/nerin_final_updated/frontend/shop.html
@@ -280,7 +280,7 @@
     </div>
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
     <script type="module" src="/js/delivery-policy.js?v=delivery-policy-20260503"></script>
-    <script type="module" src="/js/config.js?v=cart-feedback-catalog-fix-20260503"></script>
+    <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>
     <script type="module" src="/js/shop.js?v=delivery-policy-20260503"></script>
   </body>
 </html>

--- a/nerin_final_updated/frontend/success.html
+++ b/nerin_final_updated/frontend/success.html
@@ -74,7 +74,7 @@
         <div class="skeleton block"></div>
       </article>
     </main>
-    <script type="module" src="/js/config.js"></script>
+    <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>
     <script type="module" src="/js/success.js"></script>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- Evitar que el enlace "Admin" aparezca en el header público para visitantes no autenticados y consolidar la lógica de visibilidad del panel en una sola función del frontend.
- Hacer que sólo usuarios con sesión (`nerinToken`) y rol `admin` o `vendedor` vean el enlace Admin, y que el resto vea los enlaces adecuados (`Ingresar` / `Mi cuenta`).

### Description
- Eliminé el enlace Admin hardcodeado del header público (`nerin_final_updated/frontend/index.html`) y normalicé el texto del enlace de acceso a `Ingresar` cuando corresponde.
- Reforcé `updateNav()` en `nerin_final_updated/frontend/js/config.js` para calcular `isAdminUser` con `token && (role === "admin" || role === "vendedor")`, eliminar cualquier `a[href="/admin.html"]` si no corresponde, evitar duplicados y crear un solo enlace Admin cuando el usuario esté autorizado.
- Mantengo la transformación de `login` a `Admin` o `Mi cuenta` y la inserción de `Cerrar sesión` para sesiones activas, además de posicionar el enlace Admin antes del `logout` cuando procede.
- Añadí cache-busting a las referencias de `config.js` en los HTML del frontend (`?v=nav-admin-fix-20260504`) para evitar que clientes carguen JavaScript obsoleto.

### Testing
- Ejecuté la búsqueda para asegurar que no quedan enlaces Admin hardcodeados con `rg -n "href=\"/admin.html\"|>\s*Admin\s*<" nerin_final_updated/frontend -g '*.html'` y no se encontraron resultados, por lo que no hay Admin público en markup.
- Verifiqué la sintaxis del módulo modificado con `node --check /workspace/ecommerce-3.0/nerin_final_updated/frontend/js/config.js`, que pasó sin errores.
- Comprobé que las protecciones backend siguen vigentes buscando `requireAdmin` / funciones relacionadas en el backend con `rg`, confirmando que los endpoints admin siguen protegidos por validaciones (esta PR es UI-only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f890acea688331bf21616516326ed4)