### PR TITLE
Introduce status badge system and integrate into account/admin UIs

### DIFF
--- a/nerin_final_updated/docs/integracion-auditoria-fase1.md
+++ b/nerin_final_updated/docs/integracion-auditoria-fase1.md
@@ -1,0 +1,51 @@
+# Auditoría técnica FASE 1 — NERIN Parts
+
+Fecha: 2026-05-05
+
+## 1) Estructura y stack detectado
+- **Backend principal:** Node.js + Express (CommonJS), con entrypoints en `backend/server.js` y `backend/index.js`.
+- **Frontend principal:** HTML + CSS + JavaScript vanilla en `frontend/` (no Next.js, no React SPA).
+- **Datos:** repositorios en `backend/data/*`, con soporte híbrido JSON y SQL según disponibilidad de `db.getPool()`.
+- **Pagos:** Mercado Pago activo con webhook en `backend/routes/mercadoPago.js`.
+- **Email:** Resend ya está presente en dependencias y en servicios/templates existentes (`src/` y `backend/`).
+
+## 2) Flujo actual de pedidos, checkout y pagos
+- El checkout envía pedidos al backend por rutas `/api/orders` y `/api/checkout` (servidor Express).
+- Las órdenes se persisten y normalizan desde `backend/data/ordersRepo.js`.
+- El webhook de Mercado Pago actualiza estado de pago y aplica lógica de inventario desde `backend/routes/mercadoPago.js`.
+- El panel admin consume `/api/orders` con resumen/filtros básicos ya implementados.
+
+## 3) Ubicación de dominios clave
+- **Pedidos:** `backend/data/ordersRepo.js`.
+- **Facturas:** `backend/data/invoicesRepo.js`.
+- **Clientes/usuarios:** `backend/data/clientsRepo.js` + endpoints auth en backend.
+- **Estados de pago:** utilidades en `backend/utils/paymentStatus.js` + uso en repo/webhook.
+- **Estados de envío:** utilidades en `backend/utils/shippingStatus.js` y consumo en frontend cuenta/admin.
+- **Admin frontend:** `frontend/admin.html` + `frontend/js/admin.js`.
+- **Cuenta / Mis pedidos:** `frontend/js/account.js`, `frontend/js/account-minorista.js`, `frontend/js/order-status.js`.
+
+## 4) Hallazgos importantes para las próximas fases
+1. **No React en frontend principal:** no aplica instalar `lucide-react` directamente sin migración; conviene usar **Lucide vía SVG/JS compatible con vanilla** o crear una capa de componentes UI en el stack actual.
+2. **Webhook MP ya existe y es crítico:** cualquier ajuste debe conservar idempotencia y evitar duplicados de email/evento purchase.
+3. **Resend parcialmente implementado:** se debe unificar en un único servicio backend para trazabilidad (`EmailLog`) y plantillas estandarizadas.
+4. **Shipping Andreani aún no está modularizado:** falta crear servicio dedicado y endpoints internos.
+5. **Analytics ecommerce:** hay tracking actual, pero se requiere estandarización completa GA4/GTM con `dataLayer` y control anti-duplicado en `purchase`.
+
+## 5) Plan de implementación seguro (sin romper checkout actual)
+- **Fase 2 (UI estados):** crear badges reutilizables en vanilla JS/CSS (`OrderStatusBadge`, `PaymentStatusBadge`, `ShipmentStatusBadge`) y usarlos en admin + cuenta.
+- **Fase 3 (Resend):** consolidar `backend/services/emailService.js`, mover templates y registrar logs de envío.
+- **Fase 4 (MP webhook):** reforzar transición a `PAYMENT_APPROVED`, deduplicación por `payment_id/order_id`, y disparo único de email + purchase.
+- **Fase 5 (Andreani):** implementar `backend/services/andreaniService.js` y endpoints quote/create/track.
+- **Fase 6 (GA4/GTM):** definir capa única `dataLayer.push` y eventos ecommerce obligatorios en los puntos reales del funnel.
+- **Fase 7 (Admin):** ampliar tabla, filtros y acciones operativas.
+- **Fase 8 (Seguridad):** validación estricta webhooks, recálculo backend de totales y logging estructurado de errores externos.
+
+## 6) Decisiones de compatibilidad
+- Se prioriza enfoque incremental sobre arquitectura actual para evitar regresiones en:
+  - checkout
+  - carrito
+  - Mercado Pago
+  - login
+  - panel admin
+  - catálogo/productos
+

--- a/nerin_final_updated/frontend/account-minorista.html
+++ b/nerin_final_updated/frontend/account-minorista.html
@@ -42,6 +42,7 @@
     />
     <link rel="stylesheet" href="/style.css?v=cartfix-2" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r2" />
+    <link rel="stylesheet" href="/css/status-badges.css" />
     <script src="/components/np-footer.js?v=np-r2" defer></script>
   </head>
   <body>
@@ -187,14 +188,16 @@
               <tr>
                 <th>Pedido</th>
                 <th>Fecha</th>
-                <th>Estado</th>
+                <th>Estado envío</th>
+                <th>Estado pago</th>
+                <th>Factura</th>
                 <th>Total</th>
                 <th>Acciones</th>
               </tr>
             </thead>
             <tbody>
               <tr>
-                <td colspan="5">Cargando pedidos...</td>
+                <td colspan="7">Cargando pedidos...</td>
               </tr>
             </tbody>
           </table>
@@ -254,6 +257,7 @@
     </main>
     <script type="module" src="/js/account-minorista.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
+    <script src="/js/status-badges.js"></script>
     <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>
   </body>
 </html>

--- a/nerin_final_updated/frontend/account.html
+++ b/nerin_final_updated/frontend/account.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css" />
     <link rel="stylesheet" href="/style.css?v=cartfix-2" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r2" />
+    <link rel="stylesheet" href="/css/status-badges.css" />
     <script src="/components/np-footer.js?v=np-r2" defer></script>
     <style>
       .account-simple { display: grid; gap: 1rem; }
@@ -190,6 +191,7 @@
     </main>
 
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
+    <script src="/js/status-badges.js"></script>
     <script type="module" src="/js/account-simple.js"></script>
     <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>
   </body>

--- a/nerin_final_updated/frontend/admin.html
+++ b/nerin_final_updated/frontend/admin.html
@@ -40,6 +40,7 @@
       href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css"
     />
       <link rel="stylesheet" href="/style.css?v=cartfix-2" />
+    <link rel="stylesheet" href="/css/status-badges.css" />
     <style>
       #admin-build-banner {
         margin: 0 auto 1.25rem;
@@ -845,7 +846,10 @@
                 <th>Ítems</th>
                 <th>Total</th>
                 <th>Método</th>
+                <th>Estado pedido</th>
                 <th>Pago</th>
+                <th>Envío</th>
+                <th>Factura</th>
                 <th>Acciones</th>
               </tr>
             </thead>
@@ -1775,6 +1779,7 @@
     <script>
       window.__NERIN_ADMIN_BUILD__ = "20241002-nerin-01";
     </script>
+    <script src="/js/status-badges.js"></script>
     <script type="module" src="/js/admin.js?v=20260426-catalog-import-01"></script>
     <!-- Configuración y analíticas globales -->
     <script type="module" src="/admin-footer.js"></script>

--- a/nerin_final_updated/frontend/css/status-badges.css
+++ b/nerin_final_updated/frontend/css/status-badges.css
@@ -1,0 +1,65 @@
+:root {
+  --np-status-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Inter, Helvetica, Arial, sans-serif;
+  --np-status-ring: rgba(15, 23, 42, 0.08);
+}
+
+.np-status-badge {
+  --bg: #f5f7fa;
+  --fg: #1f2937;
+  --bd: #d8dee8;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.42rem;
+  padding: 0.34rem 0.58rem;
+  border-radius: 999px;
+  border: 1px solid var(--bd);
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--np-status-font);
+  font-size: 0.78rem;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+  vertical-align: middle;
+  box-shadow: inset 0 0 0 1px var(--np-status-ring);
+}
+
+.np-status-badge__icon {
+  width: 0.95rem;
+  height: 0.95rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.np-status-badge__icon svg {
+  width: 100%;
+  height: 100%;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.np-status-badge__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.np-status-badge[data-tone="neutral"] { --bg: #f3f4f6; --fg: #374151; --bd: #e5e7eb; }
+.np-status-badge[data-tone="info"] { --bg: #eff6ff; --fg: #1d4ed8; --bd: #bfdbfe; }
+.np-status-badge[data-tone="success"] { --bg: #ecfdf5; --fg: #047857; --bd: #a7f3d0; }
+.np-status-badge[data-tone="warning"] { --bg: #fffbeb; --fg: #b45309; --bd: #fde68a; }
+.np-status-badge[data-tone="danger"] { --bg: #fef2f2; --fg: #b91c1c; --bd: #fecaca; }
+.np-status-badge[data-tone="purple"] { --bg: #f5f3ff; --fg: #6d28d9; --bd: #ddd6fe; }
+
+@media (max-width: 640px) {
+  .np-status-badge {
+    font-size: 0.74rem;
+    padding: 0.32rem 0.5rem;
+    gap: 0.36rem;
+  }
+}

--- a/nerin_final_updated/frontend/js/account-minorista.js
+++ b/nerin_final_updated/frontend/js/account-minorista.js
@@ -212,6 +212,44 @@ function addItemsToCart(items) {
   }
 }
 
+
+function getBadgeRenderer() {
+  return window?.NERIN_STATUS_BADGES?.renderStatusBadge || null;
+}
+
+function mapPaymentStatusForBadge(rawStatus) {
+  const code = toStatusCode(rawStatus);
+  if (["approved", "paid", "accredited", "payment_approved", "pagado", "aprobado"].includes(code)) return "approved";
+  if (["rejected", "declined", "failed", "rechazado"].includes(code)) return "rejected";
+  if (["cancelled", "canceled", "cancelado"].includes(code)) return "cancelled";
+  return "pending";
+}
+
+function mapShipmentStatusForBadge(rawStatus) {
+  const code = toStatusCode(rawStatus);
+  if (["delivered", "entregado"].includes(code)) return "delivered";
+  if (["shipped", "in_transit", "en_transito", "enviado", "despachado"].includes(code)) return code === "shipped" ? "in_transit" : "in_transit";
+  if (["created", "label_generated", "etiqueta_generada"].includes(code)) return code;
+  if (["returned", "devuelto"].includes(code)) return "returned";
+  if (["failed", "fallido", "error"].includes(code)) return "failed";
+  if (["ready_to_ship", "listo_para_enviar"].includes(code)) return "created";
+  return "not_created";
+}
+
+function mapInvoiceStatusForBadge(order) {
+  const raw = order?.invoice_status || order?.factura_estado || order?.invoiceStatus;
+  const code = toStatusCode(raw);
+  if (["available", "available_invoice", "generada", "emitida", "disponible"].includes(code)) return "available";
+  return "pending";
+}
+
+function renderBadgeOrFallback(status, type, fallbackLabel) {
+  const renderer = getBadgeRenderer();
+  if (renderer) return renderer(status, type);
+  const label = fallbackLabel || formatStatusLabel(status || "pendiente");
+  return `<span class="status-badge status-${toStatusCode(status || 'pending')}">${label}</span>`;
+}
+
 function determineMinorLoyalty(orderCount, totalSpent) {
   let level = "Nuevo";
   let progress = Math.min(100, (orderCount / 2) * 100);
@@ -244,7 +282,7 @@ async function renderOrders(orders, email) {
   if (!Array.isArray(orders) || !orders.length) {
     const tr = document.createElement("tr");
     tr.innerHTML =
-      '<td colspan="5">Todavía no registramos pedidos. ¡Empezá tu primera compra en la tienda!</td>';
+      '<td colspan="7">Todavía no registramos pedidos. ¡Empezá tu primera compra en la tienda!</td>';
     tbody.appendChild(tr);
     return;
   }
@@ -271,7 +309,9 @@ async function renderOrders(orders, email) {
       tr.innerHTML = `
         <td>${numero || "—"}</td>
         <td>${fecha ? formatDateTime(fecha) : "—"}</td>
-        <td><span class="status-badge status-${statusCode}">${statusLabel}</span></td>
+        <td>${renderBadgeOrFallback(mapShipmentStatusForBadge(statusRaw), "shipment", statusLabel)}</td>
+        <td>${renderBadgeOrFallback(mapPaymentStatusForBadge(getPaymentStatus(raw)), "payment", formatStatusLabel(getPaymentStatus(raw) || "pending"))}</td>
+        <td>${renderBadgeOrFallback(mapInvoiceStatusForBadge(raw), "invoice", mapInvoiceStatusForBadge(raw) === "available" ? "Factura disponible" : "Factura pendiente")}</td>
         <td>${formatCurrency(totalVal)}</td>
         <td class="order-actions">
           <button type="button" class="button outline small" data-action="track">Ver seguimiento</button>
@@ -352,7 +392,7 @@ async function renderOrders(orders, email) {
               if (!tbody.querySelector("tr")) {
                 const emptyRow = document.createElement("tr");
                 emptyRow.innerHTML =
-                  '<td colspan="5">Todavía no registramos pedidos. ¡Empezá tu primera compra en la tienda!</td>';
+                  '<td colspan="7">Todavía no registramos pedidos. ¡Empezá tu primera compra en la tienda!</td>';
                 tbody.appendChild(emptyRow);
               }
               document.dispatchEvent(

--- a/nerin_final_updated/frontend/js/account-simple.js
+++ b/nerin_final_updated/frontend/js/account-simple.js
@@ -64,6 +64,27 @@ function isDelivered(order) {
   return String(getOrderStatus(order)).toLowerCase() === "entregado";
 }
 
+
+function normalizeStatusCode(value) {
+  return String(value || "").trim().toLowerCase().replace(/\s+/g, "_");
+}
+
+function mapShipmentStatus(rawStatus) {
+  const code = normalizeStatusCode(rawStatus);
+  if (["delivered", "entregado"].includes(code)) return "delivered";
+  if (["shipped", "in_transit", "en_transito", "enviado", "despachado"].includes(code)) return "in_transit";
+  if (["preparing", "preparando"].includes(code)) return "created";
+  if (["failed", "fallido", "error"].includes(code)) return "failed";
+  if (["returned", "devuelto"].includes(code)) return "returned";
+  return "not_created";
+}
+
+function renderShipmentBadge(status) {
+  const renderer = window?.NERIN_STATUS_BADGES?.renderStatusBadge;
+  if (typeof renderer === "function") return renderer(mapShipmentStatus(status), "shipment");
+  return `<span class="status-pill">${String(status || "pendiente")}</span>`;
+}
+
 function normalizeOrders(payload) {
   if (Array.isArray(payload?.orders)) return payload.orders;
   if (Array.isArray(payload?.items)) return payload.items;
@@ -85,7 +106,7 @@ function renderOrders(orders) {
     tr.innerHTML = `
       <td>${getOrderId(order) || "—"}</td>
       <td>${formatDate(getOrderDate(order))}</td>
-      <td><span class="status-pill">${getOrderStatus(order)}</span></td>
+      <td>${renderShipmentBadge(getOrderStatus(order))}</td>
       <td>${getCarrier(order)}</td>
       <td>${formatMoney(order?.total_amount || order?.total || order?.amount)}</td>
     `;
@@ -143,7 +164,7 @@ async function loadReturns(email) {
           <td>${item.orderId || "—"}</td>
           <td>${formatDate(item.date)}</td>
           <td>${item.reason || "—"}</td>
-          <td><span class="status-pill">${item.status || "pendiente"}</span></td>
+          <td>${renderShipmentBadge(item.status || "pendiente")}</td>
         `;
         tbody.appendChild(tr);
       });

--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -4670,6 +4670,44 @@ const OrdersUI = (() => {
     return SHIPPING_STATUS_LABELS[code] || (status ? String(status) : "");
   }
 
+
+  function renderAdminBadge(status, type, fallbackLabel = "Sin estado") {
+    const renderer = window?.NERIN_STATUS_BADGES?.renderStatusBadge;
+    if (typeof renderer === "function") return renderer(status, type);
+    return `<span class="order-badge">${escapeHtml(fallbackLabel)}</span>`;
+  }
+
+  function mapOrderStatusForBadge(rawStatus) {
+    const code = String(rawStatus || "").trim().toLowerCase();
+    if (["pending_payment", "pending", "pendiente"].includes(code)) return "pending_payment";
+    if (["payment_approved", "approved", "paid", "pagado", "aprobado"].includes(code)) return "payment_approved";
+    if (["preparing", "preparando"].includes(code)) return "preparing";
+    if (["ready_to_ship", "listo_para_enviar"].includes(code)) return "ready_to_ship";
+    if (["shipped", "enviado", "despachado"].includes(code)) return "shipped";
+    if (["delivered", "entregado"].includes(code)) return "delivered";
+    if (["cancelled", "canceled", "cancelado"].includes(code)) return "cancelled";
+    if (["refunded", "reintegrado"].includes(code)) return "refunded";
+    return "pending_payment";
+  }
+
+  function mapShippingForBadge(rawStatus) {
+    const code = String(rawStatus || "").trim().toLowerCase();
+    if (["delivered", "entregado"].includes(code)) return "delivered";
+    if (["shipped", "in_transit", "en_transito", "enviado", "despachado"].includes(code)) return "in_transit";
+    if (["created"].includes(code)) return "created";
+    if (["label_generated", "etiqueta_generada"].includes(code)) return "label_generated";
+    if (["failed", "fallido", "error"].includes(code)) return "failed";
+    if (["returned", "devuelto"].includes(code)) return "returned";
+    return "not_created";
+  }
+
+  function mapInvoiceForBadge(order = {}) {
+    const raw = order.invoice_status || order.factura_estado || order.invoiceStatus;
+    const code = String(raw || "").trim().toLowerCase();
+    if (["available", "generated", "generada", "emitida", "disponible"].includes(code)) return "available";
+    return "pending";
+  }
+
   function formatInputDate(date) {
     const d = date instanceof Date ? date : new Date(date);
     const year = d.getFullYear();
@@ -4936,7 +4974,7 @@ const OrdersUI = (() => {
     const total = cache.items.length;
     if (total === 0) {
       elements.tableBody.innerHTML =
-        '<tr><td colspan="9">No hay pedidos para la fecha elegida.</td></tr>';
+        '<tr><td colspan="12">No hay pedidos para la fecha elegida.</td></tr>';
       return;
     }
     const pageCount = Math.max(1, Math.ceil(total / pageSize));
@@ -4987,14 +5025,18 @@ const OrdersUI = (() => {
       methodTd.textContent = formatPaymentMethod(
         order.payment_method || order.metodo_pago,
       );
+      const orderStatusTd = document.createElement("td");
+      const orderStatusSource = order.order_status || order.status || order.estado || "";
+      orderStatusTd.innerHTML = renderAdminBadge(mapOrderStatusForBadge(orderStatusSource), "order", orderStatusSource || "Pendiente");
       const paymentTd = document.createElement("td");
-      const paymentLabel = localizePaymentStatus(
-        order.payment_status ||
-          order.payment_status_code ||
-          order.status ||
-          "",
-      );
-      paymentTd.textContent = paymentLabel ? paymentLabel : "—";
+      const paymentSource = order.payment_status || order.payment_status_code || order.estado_pago || order.status || "";
+      paymentTd.innerHTML = renderAdminBadge(mapPaymentStatusCodeForUi(paymentSource), "payment", localizePaymentStatus(paymentSource) || "Pago pendiente");
+      const shippingTd = document.createElement("td");
+      const shippingSource = order.shipping_status || order.estado_envio || order.shippingStatus || order.envio_estado || "";
+      shippingTd.innerHTML = renderAdminBadge(mapShippingForBadge(shippingSource), "shipment", localizeShippingStatus(shippingSource) || "Sin envío");
+      const invoiceTd = document.createElement("td");
+      const invoiceBadge = mapInvoiceForBadge(order);
+      invoiceTd.innerHTML = renderAdminBadge(invoiceBadge, "invoice", invoiceBadge === "available" ? "Factura disponible" : "Factura pendiente");
       const actionsTd = document.createElement("td");
       actionsTd.className = "order-actions";
 
@@ -5031,7 +5073,10 @@ const OrdersUI = (() => {
       tr.appendChild(itemsTd);
       tr.appendChild(totalTd);
       tr.appendChild(methodTd);
+      tr.appendChild(orderStatusTd);
       tr.appendChild(paymentTd);
+      tr.appendChild(shippingTd);
+      tr.appendChild(invoiceTd);
       tr.appendChild(actionsTd);
       elements.tableBody.appendChild(tr);
     });
@@ -5281,7 +5326,7 @@ const OrdersUI = (() => {
         </dl>
         <dl>
           <dt>Pago</dt>
-          <dd>${displayValue(paymentLabel)}</dd>
+          <dd>${renderAdminBadge(mapPaymentStatusCodeForUi(paymentSource), 'payment', paymentLabel || 'Pago pendiente')}</dd>
         </dl>
         <dl>
           <dt>Método de pago</dt>
@@ -5293,7 +5338,7 @@ const OrdersUI = (() => {
         </dl>
         <dl>
           <dt>Envío</dt>
-          <dd>${displayValue(shippingLabel)}</dd>
+          <dd>${renderAdminBadge(mapShippingForBadge(shippingSource), 'shipment', shippingLabel || 'Sin envío')}</dd>
         </dl>
         <dl>
           <dt>Tracking</dt>
@@ -5319,6 +5364,7 @@ const OrdersUI = (() => {
     ${editSection}
     <div class="order-invoices">
       <h5>Facturas</h5>
+      <div class="order-invoice-status">${renderAdminBadge(mapInvoiceForBadge(detail), "invoice", mapInvoiceForBadge(detail) === "available" ? "Factura disponible" : "Factura pendiente")}</div>
       ${invoiceItemsHtml}
       ${invoiceUploadHtml}
     </div>
@@ -5588,7 +5634,7 @@ const OrdersUI = (() => {
     }
     if (elements.tableBody) {
       elements.tableBody.innerHTML =
-        '<tr><td colspan="9">Cargando pedidos…</td></tr>';
+        '<tr><td colspan="12">Cargando pedidos…</td></tr>';
     }
     let res;
     let responseBodyText = "";
@@ -5691,7 +5737,7 @@ const OrdersUI = (() => {
       cache = { items: [], summary: null };
       if (elements.tableBody) {
         elements.tableBody.innerHTML =
-          '<tr><td colspan="9">No se pudieron cargar los pedidos.</td></tr>';
+          '<tr><td colspan="12">No se pudieron cargar los pedidos.</td></tr>';
       }
       if (elements.pagination) elements.pagination.innerHTML = "";
       renderBanner();
@@ -5811,9 +5857,13 @@ function getWholesaleStatusMeta(status) {
 
 function formatWholesaleStatusBadge(status) {
   const meta = getWholesaleStatusMeta(status);
-  return `<span class="wh-status-badge wh-status-badge--${meta.tone}">${escapeHtml(
-    meta.label,
-  )}</span>`;
+  const key = String(status || "").trim().toLowerCase();
+  const mapped = ["approved", "aprobado"].includes(key)
+    ? "approved"
+    : ["rejected", "rechazado"].includes(key)
+    ? "rejected"
+    : "pending";
+  return renderAdminBadge(mapped, "wholesale", meta.label);
 }
 
 function getFilteredWholesaleRequests() {
@@ -6684,7 +6734,7 @@ async function loadReturns() {
         <td>${ret.customerEmail || ""}</td>
         <td>${new Date(ret.date).toLocaleString("es-AR")}</td>
         <td>${ret.reason}</td>
-        <td>${ret.status}</td>
+        <td>${renderAdminBadge((ret.status || "pending").toLowerCase() === "aprobado" ? "approved" : (ret.status || "pending").toLowerCase() === "rechazado" ? "rejected" : "pending", "wholesale", ret.status || "pendiente")}</td>
         <td></td>
       `;
       // Acción de aprobar/rechazar

--- a/nerin_final_updated/frontend/js/status-badges.js
+++ b/nerin_final_updated/frontend/js/status-badges.js
@@ -1,0 +1,100 @@
+(function initStatusBadges(global) {
+  const ICONS = {
+    clock: '<svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"></circle><path d="M12 7v5l3 2"></path></svg>',
+    check: '<svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"></circle><path d="m8.5 12.5 2.5 2.5 4.5-5"></path></svg>',
+    x: '<svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"></circle><path d="m9 9 6 6"></path><path d="m15 9-6 6"></path></svg>',
+    ban: '<svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"></circle><path d="m6.5 17.5 11-11"></path></svg>',
+    truck: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 7h11v8H3z"></path><path d="M14 10h3l3 3v2h-6z"></path><circle cx="7" cy="17" r="1.7"></circle><circle cx="17" cy="17" r="1.7"></circle></svg>',
+    package: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2 4 6v12l8 4 8-4V6z"></path><path d="M4 6l8 4 8-4"></path><path d="M12 10v12"></path></svg>',
+    receipt: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 3h12v18l-2-1.5L14 21l-2-1.5L10 21l-2-1.5L6 21z"></path><path d="M9 8h6"></path><path d="M9 12h6"></path></svg>',
+    userCheck: '<svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="9" cy="8" r="3"></circle><path d="M3.5 18a5.5 5.5 0 0 1 11 0"></path><path d="m15.5 11.5 2 2 3-3"></path></svg>',
+    refresh: '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12a9 9 0 1 1-2.64-6.36"></path><path d="M21 3v6h-6"></path></svg>'
+  };
+
+  const STATUS_MAP = {
+    payment: {
+      pending: { label: 'Pago pendiente', tone: 'warning', icon: 'clock' },
+      approved: { label: 'Pago aprobado', tone: 'success', icon: 'check' },
+      rejected: { label: 'Pago rechazado', tone: 'danger', icon: 'x' },
+      cancelled: { label: 'Pago cancelado', tone: 'neutral', icon: 'ban' }
+    },
+    order: {
+      pending_payment: { label: 'Pendiente de pago', tone: 'warning', icon: 'clock' },
+      payment_approved: { label: 'Pago aprobado', tone: 'info', icon: 'check' },
+      preparing: { label: 'Preparando', tone: 'info', icon: 'package' },
+      ready_to_ship: { label: 'Listo para enviar', tone: 'purple', icon: 'package' },
+      shipped: { label: 'Enviado', tone: 'info', icon: 'truck' },
+      delivered: { label: 'Entregado', tone: 'success', icon: 'check' },
+      cancelled: { label: 'Cancelado', tone: 'neutral', icon: 'ban' },
+      refunded: { label: 'Reintegrado', tone: 'neutral', icon: 'refresh' }
+    },
+    shipment: {
+      not_created: { label: 'Envío no creado', tone: 'warning', icon: 'clock' },
+      created: { label: 'Envío creado', tone: 'info', icon: 'package' },
+      label_generated: { label: 'Etiqueta generada', tone: 'purple', icon: 'receipt' },
+      in_transit: { label: 'En camino', tone: 'info', icon: 'truck' },
+      delivered: { label: 'Entregado', tone: 'success', icon: 'check' },
+      failed: { label: 'Envío fallido', tone: 'danger', icon: 'x' },
+      returned: { label: 'Devuelto', tone: 'neutral', icon: 'refresh' }
+    },
+    invoice: {
+      pending: { label: 'Factura pendiente', tone: 'warning', icon: 'clock' },
+      available: { label: 'Factura disponible', tone: 'success', icon: 'receipt' }
+    },
+    wholesale: {
+      pending: { label: 'Pendiente de aprobación', tone: 'warning', icon: 'clock' },
+      approved: { label: 'Mayorista aprobado', tone: 'success', icon: 'userCheck' },
+      rejected: { label: 'Mayorista rechazado', tone: 'danger', icon: 'x' }
+    }
+  };
+
+  function normalizeKey(value) {
+    return String(value || '').trim().toLowerCase().replace(/\s+/g, '_');
+  }
+
+  function escapeHtml(value) {
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function resolveStatusMeta(status, type) {
+    const kind = normalizeKey(type);
+    const state = normalizeKey(status);
+    const kindMap = STATUS_MAP[kind] || null;
+    if (!kindMap) {
+      return { label: 'Estado desconocido', tone: 'neutral', icon: 'clock', state, kind };
+    }
+    const meta = kindMap[state] || null;
+    if (meta) return { ...meta, state, kind };
+    return {
+      label: state ? state.replace(/_/g, ' ') : 'Estado desconocido',
+      tone: 'neutral',
+      icon: 'clock',
+      state,
+      kind
+    };
+  }
+
+  function renderStatusBadge(status, type) {
+    const meta = resolveStatusMeta(status, type);
+    const iconSvg = ICONS[meta.icon] || ICONS.clock;
+    return (
+      '<span class="np-status-badge"' +
+      ' data-type="' + escapeHtml(meta.kind || '') + '"' +
+      ' data-status="' + escapeHtml(meta.state || '') + '"' +
+      ' data-tone="' + escapeHtml(meta.tone) + '">' +
+      '<span class="np-status-badge__icon">' + iconSvg + '</span>' +
+      '<span class="np-status-badge__label">' + escapeHtml(meta.label) + '</span>' +
+      '</span>'
+    );
+  }
+
+  global.NERIN_STATUS_BADGES = {
+    renderStatusBadge,
+    resolveStatusMeta
+  };
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/nerin_final_updated/frontend/status-badges-demo.html
+++ b/nerin_final_updated/frontend/status-badges-demo.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>NERIN · Demo Status Badges</title>
+    <link rel="stylesheet" href="/css/status-badges.css" />
+    <style>
+      body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; margin: 24px; background:#f8fafc; color:#0f172a; }
+      .grid { display:grid; grid-template-columns: repeat(auto-fit,minmax(230px,1fr)); gap:14px; }
+      .card { background:#fff; border:1px solid #e2e8f0; border-radius:14px; padding:14px; }
+      .card h3 { margin:0 0 10px 0; font-size:0.95rem; }
+    </style>
+  </head>
+  <body>
+    <h1>Demo aislada · Status Badge System</h1>
+    <div id="demo" class="grid"></div>
+
+    <script src="/js/status-badges.js"></script>
+    <script>
+      const examples = [
+        ['payment', 'approved'],
+        ['order', 'preparing'],
+        ['shipment', 'in_transit'],
+        ['invoice', 'available'],
+        ['wholesale', 'pending']
+      ];
+      const root = document.getElementById('demo');
+      root.innerHTML = examples
+        .map(([type, status]) =>
+          `<article class="card"><h3>${type} · ${status}</h3>${window.NERIN_STATUS_BADGES.renderStatusBadge(status, type)}</article>`
+        )
+        .join('');
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a consistent, reusable visual system for order/payment/shipment/invoice/wholesale statuses across the frontend.
- Surface payment, shipping and invoice states in lists and detail views to improve operator and customer visibility without changing backend flows.
- Prepare the frontend for incremental phases (email consolidation, webhook idempotency, shipping service) by centralizing status rendering logic. 

### Description
- Add a standalone status badge component with `frontend/js/status-badges.js` exposing `NERIN_STATUS_BADGES.renderStatusBadge` and `resolveStatusMeta`, and a stylesheet at `frontend/css/status-badges.css` implementing tones/icons. 
- Integrate badges into multiple pages by including the CSS/JS and updating templates: `frontend/account.html`, `frontend/account-minorista.html`, `frontend/admin.html`, and add a demo at `frontend/status-badges-demo.html`.
- Update frontend logic to use the badge system and richer columns: modify `frontend/js/account-minorista.js`, `frontend/js/account-simple.js`, and `frontend/js/admin.js` to map raw status values to normalized badge keys, render badges for payment/shipping/invoice/wholesale, and adjust table headers/`colspan` values to match added columns.
- Add an audit document `docs/integracion-auditoria-fase1.md` summarizing architecture findings and a phased implementation plan. 

### Testing
- No automated tests were added or executed as part of this change; frontend rendering logic currently relies on runtime integration and should be covered by future unit/UI tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9f71314fc83318af7ec247c18e10c)