### PR TITLE
Rediseño visual y mejoras UX para la página "Seguimiento de pedido"

### DIFF
--- a/nerin_final_updated/frontend/js/seguimiento.js
+++ b/nerin_final_updated/frontend/js/seguimiento.js
@@ -9,6 +9,7 @@ const summaryEl = document.getElementById('orderSummary');
 const progressContainer = document.getElementById('orderProgress');
 const alertEl = document.getElementById('orderAlert');
 const contactBtn = document.getElementById('contactWhatsApp');
+const submitBtn = document.getElementById('trackSubmit');
 
 let invoiceInfo = null;
 let pollTimer = null;
@@ -304,10 +305,18 @@ function hideAlert() {
   alertEl.textContent = '';
 }
 
-function showAlert(message) {
+function showAlert(message, variant = 'error') {
   if (!alertEl) return;
+  alertEl.className = `order-alert is-${variant}`;
   alertEl.textContent = message;
   alertEl.style.display = 'block';
+}
+
+function setLoading(isLoading) {
+  if (!submitBtn) return;
+  submitBtn.disabled = !!isLoading;
+  submitBtn.classList.toggle('is-loading', !!isLoading);
+  submitBtn.textContent = isLoading ? 'Consultando…' : 'Consultar pedido';
 }
 
 function renderOrderProgress(order = {}) {
@@ -359,7 +368,7 @@ function renderOrderProgress(order = {}) {
       ? `${alertMessage} / Pago revertido`
       : 'Pago revertido';
   }
-  if (alertMessage) showAlert(alertMessage);
+  if (alertMessage) showAlert(alertMessage, 'warning');
   else hideAlert();
 }
 
@@ -413,21 +422,27 @@ function renderOrder(order = {}) {
   }
 
   summaryEl.innerHTML = `
-    <p><strong>Número de pedido:</strong> ${orderId}</p>
-    <p><strong>Estado del pago:</strong> ${paymentLabel}</p>
-    <p><strong>Estado del envío:</strong> ${shippingLabel}</p>
-    <p><strong>Fecha:</strong> ${formattedDate}</p>
-    ${itemsHtml ? `<ul>${itemsHtml}</ul>` : ''}
-    <p><strong>Total:</strong> ${totalLabel}</p>
-    ${paymentMethod ? `<p><strong>Método de pago:</strong> ${paymentMethod}</p>` : ''}
-    ${destination ? `<p><strong>Envío a:</strong> ${destination}</p>` : '<p><em>Coordinación de envío por WhatsApp</em></p>'}
-    ${province ? `<p><strong>Provincia de envío:</strong> ${province}</p>` : ''}
-    ${shippingCostLabel ? `<p><strong>Costo de envío:</strong> ${shippingCostLabel}</p>` : ''}
-    ${customerEmail ? `<p><strong>Email:</strong> ${customerEmail}</p>` : ''}
-    ${trackingCode ? `<p><strong>Nº de seguimiento:</strong> ${trackingCode}${carrier ? ` (${carrier})` : ''}</p>` : ''}
-    ${invoiceToShow && invoiceToShow.url
-      ? `<p><a href="${invoiceToShow.url}" target="_blank" rel="noopener">Ver/Descargar factura</a></p>`
-      : '<p><em>Factura pendiente</em></p>'}
+    <div class="order-card__header">
+      <h2>Pedido #${orderId || '-'}</h2>
+      <span class="status-chip status-chip--neutral">Última actualización: ${formattedDate}</span>
+    </div>
+    <div class="order-card__grid">
+      <div class="order-data"><span>Estado general</span><strong>${shippingLabel}</strong></div>
+      <div class="order-data"><span>Estado del pago</span><strong>${paymentLabel}</strong></div>
+      <div class="order-data"><span>Método de pago</span><strong>${paymentMethod || 'No informado'}</strong></div>
+      <div class="order-data"><span>Total</span><strong>${totalLabel}</strong></div>
+      <div class="order-data"><span>Empresa de envío</span><strong>${carrier || 'A confirmar'}</strong></div>
+      <div class="order-data"><span>Tracking</span><strong>${trackingCode || 'Pendiente'}</strong></div>
+      <div class="order-data"><span>Destino</span><strong>${destination || 'Coordinación por WhatsApp'}${province ? ` (${province})` : ''}</strong></div>
+      <div class="order-data"><span>Contacto</span><strong>${customerEmail || 'No informado'}</strong></div>
+    </div>
+    ${itemsHtml ? `<div class="order-items"><h3>Productos</h3><ul>${itemsHtml}</ul></div>` : ''}
+    <div class="order-card__footer">
+      ${shippingCostLabel ? `<span class="status-chip">Envío: ${shippingCostLabel}</span>` : ''}
+      ${invoiceToShow && invoiceToShow.url
+      ? `<a class="status-chip status-chip--link" href="${invoiceToShow.url}" target="_blank" rel="noopener">Ver/Descargar factura</a>`
+      : '<span class="status-chip status-chip--neutral">Factura pendiente</span>'}
+    </div>
   `;
   summaryEl.style.display = 'block';
   renderOrderProgress(order);
@@ -487,7 +502,8 @@ function startPolling() {
 async function fetchOrder(email, id) {
   resetView();
   if (!email || !id) return;
-  summaryEl.textContent = 'Buscando...';
+  summaryEl.innerHTML = '<p class="summary-loading">Estamos buscando tu pedido…</p>';
+  setLoading(true);
   summaryEl.style.display = 'block';
   stopPolling();
   currentOrderId = null;
@@ -499,7 +515,9 @@ async function fetchOrder(email, id) {
       body: JSON.stringify({ email, id }),
     });
     if (!res.ok) {
-      summaryEl.textContent = 'No encontramos un pedido con esos datos.';
+      showAlert('No encontramos un pedido con esos datos. Revisá el email y número de pedido.', 'error');
+      summaryEl.innerHTML = '<p class="summary-empty">No se encontró información para esta búsqueda.</p>' ;
+      setLoading(false);
       return;
     }
     const data = await res.json();
@@ -510,9 +528,13 @@ async function fetchOrder(email, id) {
     lastEtag = null;
     await pollOrder();
     startPolling();
+    showAlert('Consulta realizada con éxito.', 'success');
+    setLoading(false);
   } catch (e) {
     console.error(e);
-    summaryEl.textContent = 'Error al buscar el pedido.';
+    showAlert('Tuvimos un inconveniente al consultar el pedido. Intentá nuevamente.', 'error');
+    summaryEl.innerHTML = '<p class="summary-empty">No pudimos completar la consulta.</p>' ;
+    setLoading(false);
   }
 }
 

--- a/nerin_final_updated/frontend/seguimiento.html
+++ b/nerin_final_updated/frontend/seguimiento.html
@@ -35,10 +35,10 @@
       content="width=device-width, initial-scale=1, viewport-fit=cover, shrink-to-fit=no"
     />
     <title>Seguimiento de tu pedido – NERIN</title>
-          <link rel="stylesheet" href="/style.css?v=cartfix-2" />
+    <link rel="stylesheet" href="/style.css?v=cartfix-2" />
     <link rel="stylesheet" href="/components/np-footer.css?v=np-r2">
-  <script src="/components/np-footer.js?v=np-r2" defer></script>
-</head>
+    <script src="/components/np-footer.js?v=np-r2" defer></script>
+  </head>
   <body>
     <header>
       <div class="header-inner">
@@ -54,38 +54,45 @@
         </nav>
       </div>
     </header>
-    <main class="container tracking-container">
-      <h1>Seguimiento de tu pedido</h1>
-      <p>
-        Acá podés ver en qué estado está tu compra. Ante cualquier duda,
-        escribinos por WhatsApp.
-      </p>
+    <main class="container tracking-page">
+      <section class="tracking-hero">
+        <span class="tracking-kicker">Centro de soporte</span>
+        <h1>Seguimiento de tu pedido</h1>
+        <p class="tracking-subtitle">Consultá en segundos el estado de tu compra, envío y factura con tu email y número de pedido.</p>
+      </section>
 
-      <form id="trackForm" class="login-container">
-        <input type="email" id="email" placeholder="Tu email" required />
-        <input type="text" id="orderId" placeholder="Número de pedido" required />
-        <button type="submit">Ver estado</button>
-      </form>
-
-      <div id="orderSummary" class="order-card" style="display:none"></div>
+      <section class="tracking-panel" aria-label="Formulario de seguimiento">
+        <form id="trackForm" class="tracking-form" novalidate>
+          <div class="tracking-field">
+            <label for="email">Email de compra</label>
+            <input type="email" id="email" placeholder="ejemplo@correo.com" autocomplete="email" required />
+          </div>
+          <div class="tracking-field">
+            <label for="orderId">Número de pedido</label>
+            <input type="text" id="orderId" placeholder="Ej: 10542" autocomplete="off" required />
+          </div>
+          <button id="trackSubmit" type="submit">Consultar pedido</button>
+        </form>
+        <p class="tracking-help">Usá los mismos datos que recibiste en el email de confirmación.</p>
+      </section>
 
       <div id="orderAlert" class="order-alert" role="alert" style="display:none"></div>
-
+      <div id="orderSummary" class="order-card" style="display:none"></div>
       <div id="orderProgress" class="order-progress-container" style="display:none"></div>
 
-      <div class="contact-section">
-        <p>Si tenés alguna duda, escribinos con tu número de pedido.</p>
-        <a id="contactWhatsApp" class="button primary" target="_blank">
-          <img src="/assets/whatsapp.svg" alt="WhatsApp" /> WhatsApp
-        </a>
-      </div>
+      <section class="tracking-actions">
+        <div class="contact-section">
+          <p>¿Necesitás ayuda adicional? Te respondemos por WhatsApp con tu número de pedido.</p>
+          <a id="contactWhatsApp" class="button primary" target="_blank" rel="noopener">
+            <img src="/assets/whatsapp.svg" alt="WhatsApp" /> Contactar por WhatsApp
+          </a>
+        </div>
 
-      <div style="margin-top:2rem;text-align:center">
-        <a href="/index.html" class="button secondary">Volver al inicio</a>
-      </div>
+        <a href="/index.html" class="button secondary tracking-back">Volver al inicio</a>
+      </section>
     </main>
 
-    <script type="module" src="/js/seguimiento.js?v=20241002-nerin-01"></script>
+    <script type="module" src="/js/seguimiento.js?v=20260506-tracking-ui-01"></script>
     <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>
   </body>
 </html>

--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -9758,3 +9758,44 @@ html, body{ max-width:100%; overflow-x:hidden; }
     padding-right: var(--container-padding, 1rem);
   }
 }
+
+/* ==== Seguimiento de pedidos (refresh 2026) ==== */
+.tracking-page { max-width: 980px; padding-bottom: 3rem; }
+.tracking-hero { text-align: center; margin: clamp(1.5rem,4vw,3rem) auto 1.2rem; }
+.tracking-kicker { display:inline-block; padding:.35rem .7rem; border:1px solid #dbe6ff; background:#f4f8ff; color:#2854c5; border-radius:999px; font-size:.8rem; font-weight:700; }
+.tracking-subtitle { max-width: 760px; margin: .75rem auto 0; color:#4b5563; }
+.tracking-panel { background:#fff; border:1px solid #e5e7eb; border-radius:20px; padding:clamp(1rem,2vw,1.75rem); box-shadow:0 12px 36px rgba(17,24,39,.08); }
+.tracking-form { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:1rem; align-items:end; }
+.tracking-field { display:flex; flex-direction:column; gap:.45rem; }
+.tracking-field label { font-weight:600; font-size:.92rem; color:#334155; }
+.tracking-field input { height:48px; border-radius:12px; border:1px solid #cbd5e1; padding:0 .85rem; font-size:1rem; background:#fff; }
+.tracking-field input:hover { border-color:#93c5fd; }
+.tracking-field input:focus { outline:none; border-color:#3b82f6; box-shadow:0 0 0 4px rgba(59,130,246,.18); }
+#trackSubmit { height:48px; border-radius:12px; background:linear-gradient(135deg,#2563eb,#1d4ed8); color:#fff; border:none; font-weight:700; }
+#trackSubmit.is-loading { opacity:.8; cursor:wait; }
+#trackSubmit:disabled { opacity:.7; }
+.tracking-help { margin:.8rem 0 0; color:#64748b; font-size:.9rem; }
+.order-alert { border-radius:12px; margin-top:1rem; }
+.order-alert.is-success { background:#ecfdf3; border-color:#86efac; color:#14532d; }
+.order-alert.is-warning { background:#fff7ed; border-color:#fdba74; color:#9a3412; }
+.order-alert.is-error { background:#fef2f2; border-color:#fca5a5; color:#991b1b; }
+.order-card { margin-top:1rem; padding:1.2rem; border-radius:20px; background:#fff; border:1px solid #e5e7eb; box-shadow:0 8px 30px rgba(15,23,42,.06); }
+.order-card__header { display:flex; justify-content:space-between; gap:.8rem; align-items:flex-start; flex-wrap:wrap; margin-bottom:.9rem; }
+.status-chip { display:inline-flex; padding:.3rem .7rem; border-radius:999px; background:#e0edff; color:#1d4ed8; font-weight:600; font-size:.83rem; }
+.status-chip--neutral { background:#f1f5f9; color:#475569; }
+.status-chip--link { text-decoration:none; }
+.order-card__grid { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:.75rem; }
+.order-data { border:1px solid #e2e8f0; background:#f8fafc; border-radius:12px; padding:.75rem; }
+.order-data span { display:block; color:#64748b; font-size:.78rem; margin-bottom:.2rem; }
+.order-items { margin-top:1rem; }
+.order-items ul { margin:.5rem 0 0; padding-left:1.1rem; }
+.order-card__footer { display:flex; gap:.6rem; flex-wrap:wrap; margin-top:1rem; }
+.tracking-actions { margin:1.8rem 0 0; text-align:center; }
+.tracking-back { margin-top:1rem; display:inline-flex; }
+.summary-loading,.summary-empty{ margin:0; color:#475569; }
+
+@media (max-width: 760px){
+  .tracking-form { grid-template-columns:1fr; }
+  .order-card__grid { grid-template-columns:1fr; }
+  .tracking-page { padding-inline: .9rem; }
+}


### PR DESCRIPTION
### Motivation

- Modernizar y profesionalizar la página "Seguimiento de tu pedido" para mejorar claridad, jerarquía visual y confianza sin tocar la lógica de negocio existente.  
- Enfocar los cambios en la experiencia visual y de uso del formulario, la presentación del resultado y los estados (incluyendo mobile).  

### Description

- Rediseñé la estructura HTML de la página de seguimiento en `nerin_final_updated/frontend/seguimiento.html`, añadiendo un hero, subtítulo, panel de formulario más claro, CTA principal y sección de acciones (WhatsApp y volver al inicio).  
- Reescribí la renderización de resultados en `nerin_final_updated/frontend/js/seguimiento.js` para mostrar un `order-card` estructurado (pedido, fecha, estado pago/envío, transportista, tracking, destino, contacto, productos y factura) y reutilicé el stepper/timeline existente para indicar progreso.  
- Añadí mejoras UX en `seguimiento.js`: estado de carga en el botón (`setLoading`), alertas con variantes `is-success|is-warning|is-error`, mensajes claros para "no encontrado"/error/éxito y bloqueo temporal del botón durante la consulta; estas son correcciones UI seguras que mantienen el polling y la lógica actual.  
- Incluí una capa de estilos en `nerin_final_updated/frontend/style.css` con componentes premium (cards, chips `status-chip`, inputs con focus/hover, botonera y responsive) para mejorar jerarquía y experiencia móvil.  

### Testing

- Ejecuté `git status --short` y los archivos modificados aparecen listados: `frontend/seguimiento.html`, `frontend/js/seguimiento.js`, `frontend/style.css`.  
- Corrí `node --check nerin_final_updated/frontend/js/seguimiento.js` para validar la sintaxis del módulo JS y pasó sin errores.  
- Lancé `npm test` en `nerin_final_updated` (Jest); los tests se ejecutaron pero hay fallos preexistentes del repositorio no relacionados con estos cambios de UI (bindings nativos de `sqlite3` ausentes y suites backend con expectativas de datos), resultado: `Test Suites: 4 failed, 13 passed, 17 total` y `Tests: 5 failed, 55 passed, 60 total`.  
- Recomiendo probar manualmente la experiencia nueva abriendo `/seguimiento.html` y verificar: formulario (validaciones/focus/placeholder), estado de loading del botón, resultado en tarjeta y chips, timeline de progreso, mensajes de error/no-encontrado y responsive en mobile.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb265ac27483319c6a21b85f42540a)