### PR TITLE
fix(admin): harden wholesale requests rendering after phase 2 visual badges

### DIFF
--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -4672,9 +4672,17 @@ const OrdersUI = (() => {
 
 
   function renderAdminBadge(status, type, fallbackLabel = "Sin estado") {
+    const safeLabel = fallbackLabel == null || fallbackLabel === "" ? "Sin estado" : String(fallbackLabel);
     const renderer = window?.NERIN_STATUS_BADGES?.renderStatusBadge;
-    if (typeof renderer === "function") return renderer(status, type);
-    return `<span class="order-badge">${escapeHtml(fallbackLabel)}</span>`;
+    if (typeof renderer === "function") {
+      try {
+        const html = renderer(status, type);
+        if (typeof html === "string" && html.trim()) return html;
+      } catch (error) {
+        console.warn("status-badge-render", error);
+      }
+    }
+    return `<span class="order-badge">${escapeHtml(safeLabel)}</span>`;
   }
 
   function mapOrderStatusForBadge(rawStatus) {
@@ -5866,6 +5874,24 @@ function formatWholesaleStatusBadge(status) {
   return renderAdminBadge(mapped, "wholesale", meta.label);
 }
 
+
+function normalizeWholesaleRequest(request = {}) {
+  if (!request || typeof request !== "object") return { id: "", status: "pending_review" };
+  const normalized = { ...request };
+  normalized.id = request.id || request.requestId || request._id || "";
+  normalized.status = String(request.status || request.state || "pending_review").trim() || "pending_review";
+  normalized.legalName = request.legalName || request.legal_name || "";
+  normalized.contactName = request.contactName || request.contact_name || "";
+  normalized.email = request.email || request.contactEmail || request.contact_email || "";
+  normalized.taxId = request.taxId || request.tax_id || request.cuit || "";
+  normalized.companyType = request.companyType || request.company_type || "";
+  normalized.salesChannel = request.salesChannel || request.sales_channel || "";
+  normalized.updatedAt = request.updatedAt || request.updated_at || request.createdAt || request.created_at || null;
+  normalized.submittedAt = request.submittedAt || request.submitted_at || null;
+  normalized.createdAt = request.createdAt || request.created_at || null;
+  return normalized;
+}
+
 function getFilteredWholesaleRequests() {
   const statusValue =
     wholesaleStatusFilter && wholesaleStatusFilter.value
@@ -5952,7 +5978,12 @@ async function loadWholesaleRequests(options = {}) {
       throw new Error(`HTTP ${res.status}`);
     }
     const data = await res.json();
-    const list = Array.isArray(data.requests) ? data.requests.slice() : [];
+    const rawList = Array.isArray(data.requests)
+      ? data.requests
+      : Array.isArray(data.wholesaleRequests)
+      ? data.wholesaleRequests
+      : [];
+    const list = rawList.map((item) => normalizeWholesaleRequest(item));
     list.sort((a, b) => {
       const tA = Date.parse(a.updatedAt || a.createdAt || 0) || 0;
       const tB = Date.parse(b.updatedAt || b.createdAt || 0) || 0;


### PR DESCRIPTION
### Motivation
- Reparar la sección de solicitudes mayoristas del admin que dejó de mostrar cuentas tras la FASE 2 visual sin revertir la FASE 2. 
- Evitar que errores en el renderer de badges o diferencias en la forma del payload corten la ejecución y dejen la tabla vacía. 
- Aplicar una solución mínima y segura que no afecte checkout, pagos, envíos, analytics ni la base de datos. 

### Description
- Añadí protección defensiva en `renderAdminBadge` para llamar a `window.NERIN_STATUS_BADGES.renderStatusBadge` dentro de `try/catch` y devolver un label plano seguro si el renderer falta, lanza o devuelve HTML inválido (archivo `nerin_final_updated/frontend/js/admin.js`).
- Implementé `normalizeWholesaleRequest(request)` que normaliza variantes `camelCase`/`snake_case`, `id` alternativos y fechas para que el UI no dependa de una forma exacta del payload (archivo `nerin_final_updated/frontend/js/admin.js`).
- Hice `loadWholesaleRequests` tolerante a respuestas tanto en `data.requests` como en `data.wholesaleRequests` y siempre mapeo las entradas con el normalizador antes de ordenar/filtrar/renderizar (archivo `nerin_final_updated/frontend/js/admin.js`).
- Archivo modificado: `nerin_final_updated/frontend/js/admin.js` (cambios focalizados en `renderAdminBadge`, nueva `normalizeWholesaleRequest` y `loadWholesaleRequests` handling). 

### Testing
- Ejecuté `git status --short` y confirmé que solo `nerin_final_updated/frontend/js/admin.js` quedó modificado; comprobación OK. 
- Ejecuté `npm run build` en `nerin_final_updated` y falló porque no existe el script `build` en ese `package.json` (fallo esperado, no relacionado con el hotfix). 
- Ejecuté `npm test` en `nerin_final_updated`; la suite se ejecutó pero falló por tests de backend/analytics preexistentes no relacionados con este cambio (falla externa al hotfix).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb29d0c7fc8331b803a9e066fed2ce)