### PR TITLE
fix(admin): recover Mayoristas requests list loading and empty/error states

### DIFF
--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -5973,12 +5973,19 @@ async function loadWholesaleRequests(options = {}) {
   wholesaleState.loading = true;
   renderWholesaleTable({ loading: true });
   try {
-    const res = await apiFetch("/api/wholesale/requests");
+    const res = await apiFetch("/api/wholesale/requests", { cache: "no-store" });
+    if (res.status === 401 || res.status === 403) {
+      throw new Error(`AUTH ${res.status}`);
+    }
     if (!res.ok) {
       throw new Error(`HTTP ${res.status}`);
     }
-    const data = await res.json();
-    const rawList = Array.isArray(data.requests)
+    const data = await res.json().catch(() => {
+      throw new Error("INVALID_JSON");
+    });
+    const rawList = Array.isArray(data)
+      ? data
+      : Array.isArray(data.requests)
       ? data.requests
       : Array.isArray(data.wholesaleRequests)
       ? data.wholesaleRequests
@@ -5990,6 +5997,14 @@ async function loadWholesaleRequests(options = {}) {
       return tB - tA;
     });
     wholesaleState.requests = list;
+    if (!list.length) {
+      wholesaleTableBody.innerHTML =
+        '<tr><td colspan="5">No hay solicitudes mayoristas por ahora.</td></tr>';
+      if (!wholesaleState.selectedId) {
+        renderWholesaleDetail(null);
+      }
+      return;
+    }
     renderWholesaleTable();
     if (wholesaleState.selectedId) {
       const match = list.find((item) => item.id === wholesaleState.selectedId);
@@ -6001,7 +6016,7 @@ async function loadWholesaleRequests(options = {}) {
   } catch (err) {
     console.error("wholesale-load", err);
     wholesaleTableBody.innerHTML =
-      '<tr><td colspan="5">No se pudieron cargar las solicitudes.</td></tr>';
+      '<tr><td colspan="5">No se pudieron cargar las solicitudes mayoristas.</td></tr>';
     if (window.showToast) {
       showToast("No se pudieron cargar las solicitudes mayoristas");
     }


### PR DESCRIPTION
### Motivation
- The Mayoristas tab showed a generic load failure message instead of distinguishing a real error from a legitimately empty list, preventing correct display of wholesale requests.
- The loader did not robustly handle auth failures, unexpected JSON formats or payloads returned as a raw array, which increased false-positive error states.

### Description
- Hardened `loadWholesaleRequests` in `frontend/js/admin.js` to explicitly handle `401/403` auth errors, non-OK HTTP responses and JSON parse failures.
- Accepted both array payloads and envelope formats (`{ requests }` or `{ wholesaleRequests }`) and added `cache: "no-store"` to avoid stale admin data.
- Added a clear empty-state message `No hay solicitudes mayoristas por ahora.` and preserved the existing real-error message `No se pudieron cargar las solicitudes mayoristas.` for actual failures.
- Only `nerin_final_updated/frontend/js/admin.js` was modified and all approve/reject, filters and search flows remain unchanged.

### Testing
- Ran `git status --short` to confirm working tree and staging state (succeeded).
- Ran `npm test` inside `nerin_final_updated` which executed the test suite but failed due to preexisting unrelated failures in analytics/SEO/sqlite areas, so automated tests did not fully pass in this environment.
- The change is minimal and manual verification steps are: open `/admin.html` → tab `Mayoristas` and confirm that existing requests list when present, that the empty state shows `No hay solicitudes mayoristas por ahora.`, and that real failures show `No se pudieron cargar las solicitudes mayoristas.`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb87625c148331afa40ce5dad07d45)