### PR TITLE
Enviar emails 'Pago aprobado' para Transferencia (admin) y Mercado Pago (webhook)

### DIFF
--- a/nerin_final_updated/backend/routes/mercadoPago.js
+++ b/nerin_final_updated/backend/routes/mercadoPago.js
@@ -291,14 +291,21 @@ async function notifyCustomerStatus({
 
   let sendSucceeded = false;
   try {
-    await config.sender(order, { to });
+    await config.sender(order, { email: to }, {
+      logicalKey: status === 'approved' ? `payment_approved:${resolvedOrderId || order?.id || paymentId}` : undefined,
+      emailType: status === 'approved' ? 'payment_approved' : undefined,
+      orderId: resolvedOrderId || order?.id || null,
+      metadata: status === 'approved'
+        ? { source: 'mercado_pago_webhook', paymentId: paymentId || null }
+        : undefined,
+    });
     if (status === 'approved') {
       try {
         await sendAdminSalePaidNotificationEmail(order, {
           logicalKey: `admin_sale_paid_notification:${resolvedOrderId || order?.id || paymentId}`,
           emailType: 'admin_sale_paid_notification',
           orderId: resolvedOrderId || order?.id || null,
-          metadata: { source: 'mp_webhook', paymentId: paymentId || null },
+          metadata: { source: 'mercado_pago_webhook', paymentId: paymentId || null },
         });
       } catch (adminEmailErr) {
         logger.warn('mp-webhook admin paid email failed', {

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -48,6 +48,8 @@ const {
   sendOrderShippedEmail: sendOrderShippedEmailOnce,
   sendInvoiceAvailableEmail: sendInvoiceAvailableEmailOnce,
   sendAdminSaleNotificationEmail: sendAdminSaleNotificationEmailOnce,
+  sendPaymentApprovedEmail: sendPaymentApprovedEmailOnce,
+  sendAdminSalePaidNotificationEmail: sendAdminSalePaidNotificationEmailOnce,
 } = require("./services/emailService");
 const {
   STATUS_ES_TO_CODE,
@@ -10127,6 +10129,67 @@ async function requestHandler(req, res) {
         saveOrders(orders);
         const emailWarnings = [];
         const emailStatuses = {};
+
+        if (incomingStatus != null && nextPaymentCode === "approved" && prevPaymentCode !== "approved") {
+          const payload = prepareOrderEmailPayload(orders[index]);
+          const orderIdentifier = payload?.order?.id || payload?.order?.order_number || next.id;
+          const paymentMethodRaw = String(
+            payload?.order?.payment_method || next.payment_method || prev.payment_method || ""
+          )
+            .toLowerCase()
+            .trim();
+          const isTransfer = paymentMethodRaw === "transferencia" || paymentMethodRaw === "transfer" || paymentMethodRaw === "bank_transfer";
+          const source = isTransfer ? "admin_manual_transfer_payment" : "admin_manual_payment_update";
+          if (payload) {
+            try {
+              const approvedResult = await sendPaymentApprovedEmailOnce(
+                payload.order,
+                { email: payload.recipient },
+                {
+                  logicalKey: `payment_approved:${orderIdentifier}`,
+                  emailType: "payment_approved",
+                  orderId: orderIdentifier,
+                  metadata: { source },
+                },
+              );
+              emailStatuses.paymentApproved = approvedResult?.status || null;
+              if (approvedResult && approvedResult.ok === false) {
+                emailWarnings.push(
+                  "La operación se realizó correctamente, pero no se pudo enviar el email de pago aprobado.",
+                );
+              }
+            } catch (emailErr) {
+              console.error("order payment approved email failed", emailErr);
+              emailWarnings.push(
+                "La operación se realizó correctamente, pero no se pudo enviar el email de pago aprobado.",
+              );
+            }
+          }
+
+          try {
+            const adminPaidResult = await sendAdminSalePaidNotificationEmailOnce(next, {
+              logicalKey: `admin_sale_paid_notification:${orderIdentifier}`,
+              emailType: "admin_sale_paid_notification",
+              orderId: orderIdentifier,
+              subject: isTransfer
+                ? `Vendiste en NERIN Parts — Pago aprobado por transferencia — Pedido #${orderIdentifier}`
+                : undefined,
+              metadata: { source },
+            });
+            emailStatuses.adminSalePaidNotification = adminPaidResult?.status || null;
+            if (adminPaidResult && adminPaidResult.ok === false) {
+              emailWarnings.push(
+                "La operación se realizó correctamente, pero no se pudo enviar el email interno de pago aprobado.",
+              );
+            }
+          } catch (adminEmailErr) {
+            console.error("order admin paid email failed", adminEmailErr);
+            emailWarnings.push(
+              "La operación se realizó correctamente, pero no se pudo enviar el email interno de pago aprobado.",
+            );
+          }
+        }
+
         if (
           incomingStatus != null &&
           nextPaymentCode === "cancelled" &&

--- a/nerin_final_updated/docs/payment-approved-flows-transfer-mp.md
+++ b/nerin_final_updated/docs/payment-approved-flows-transfer-mp.md
@@ -1,0 +1,67 @@
+# Flujos de email “Pago aprobado”: Transferencia + Mercado Pago
+
+## Objetivo
+Unificar el envío de emails de pago aprobado en dos flujos separados, sin duplicar y sin romper webhook/admin update.
+
+## Flujo A — Transferencia bancaria (manual admin)
+- El email de creación por transferencia (`Esperando pago por transferencia`) se mantiene intacto.
+- En `PUT/PATCH /api/orders/:id` (ruta usada por admin “Actualizar pedido”), cuando hay transición de estado de pago **de no pagado a pagado/aprobado**, se dispara:
+  1. Cliente: `sendPaymentApprovedEmail(order, customer)`
+  2. Admin: `sendAdminSalePaidNotificationEmail(order, options)`
+
+### Detección de transición
+- Se compara `prevPaymentCode` vs `nextPaymentCode`.
+- Solo dispara si:
+  - `incomingStatus != null`
+  - `prevPaymentCode !== "approved"`
+  - `nextPaymentCode === "approved"`
+
+Estados origen cubiertos vía normalización existente (`mapPaymentStatusCode`):
+- `pending`, `pendiente`, `unpaid`, `waiting_payment`, `transfer_pending`, `pendiente de comprobante`, `no_pagado` (y equivalentes que normalizan a pendiente/no pago)
+
+Estados destino cubiertos:
+- `paid`, `pagado`, `approved`, `aprobado`, `payment_approved` (equivalentes que normalizan a approved)
+
+## Flujo B — Mercado Pago webhook
+- Se mantiene en `backend/routes/mercadoPago.js`.
+- Solo dispara al confirmarse estado real `approved` en backend/webhook.
+- Envía:
+  1. Cliente: `sendPaymentApprovedEmail(order, customer)`
+  2. Admin: `sendAdminSalePaidNotificationEmail(order, options)`
+
+## Idempotencia / deduplicación
+Se usan las mismas logical keys en ambos flujos:
+- Cliente: `payment_approved:${orderId}`
+- Admin: `admin_sale_paid_notification:${orderId}`
+
+Así, si intenta disparar por más de un flujo, el servicio de emails deduplica por `logicalKey`.
+
+## Metadata `source`
+- Transferencia manual admin: `source: "admin_manual_transfer_payment"`
+- Mercado Pago webhook: `source: "mercado_pago_webhook"`
+
+## Subject/contenido método de pago
+- Se mantiene humanización de método en templates.
+- Para transferencia manual, subject admin puede salir como:
+  - `Vendiste en NERIN Parts — Pago aprobado por transferencia — Pedido #{ORDER_ID}`
+
+## Manejo de fallas
+- Si falta email cliente: no rompe actualización; queda estado email controlado.
+- Si falta `ADMIN_SALES_EMAIL`/`ADMIN_SALES_EMAILS`: no rompe, retorna estado skipped/disabled.
+- Si falla Resend: no rompe webhook ni actualización admin; registra `failed` y devuelve `emailWarning` en flujo admin.
+
+## Testing seguro
+Usar:
+- `EMAILS_ENABLED=false` o
+- `EMAIL_TEST_MODE=true`
+
+Casos:
+A. Transferencia pendiente -> admin marca pagado -> intenta `payment_approved` + `admin_sale_paid_notification`.
+B. Repetir guardado pagado -> no duplica.
+C. Ya pagado -> no dispara.
+D. MP approved -> sigue disparando webhook.
+E. Reintento webhook MP -> no duplica.
+F. Falla Resend -> no rompe admin/webhook.
+
+## Alcance
+No se tocaron checkout, carrito, precios, productos, Andreani ni Analytics.


### PR DESCRIPTION
### Motivation
- Alinear el comportamiento de notificaciones para pagos aprobados para que tanto el flujo de Mercado Pago por webhook como la aprobación manual desde el admin disparen los mismos emails de `payment_approved` y `admin_sale_paid_notification` sin duplicados. 
- Mantener la idempotencia y trazabilidad usando las mismas logical keys y añadiendo `source` en la metadata para distinguir el origen (admin/manual vs webhook). 
- No modificar checkout, carrito, precios, productos, Andreani, ni Analytics, y evitar envíos reales durante testing usando las flags de email existentes. 

### Description
- Añadido trigger en `PUT/PATCH /api/orders/:id` (`backend/server.js`) que detecta transición de pago `no aprobado → approved` comparando `prevPaymentCode` y `nextPaymentCode`, y en ese caso envía al cliente `sendPaymentApprovedEmail` y al admin `sendAdminSalePaidNotificationEmail` con logical keys `payment_approved:${orderId}` y `admin_sale_paid_notification:${orderId}` respectivamente. 
- En el flujo admin se detecta si el método de pago es transferencia (`transferencia|transfer|bank_transfer`) y se añade `metadata.source:

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fca977f57c8331976d5ca0e6b7726f)