### PR TITLE
Send payment-approved emails when admin marks transfer orders paid

### DIFF
--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -10132,49 +10132,71 @@ async function requestHandler(req, res) {
 
         if (incomingStatus != null && nextPaymentCode === "approved" && prevPaymentCode !== "approved") {
           const payload = prepareOrderEmailPayload(orders[index]);
-          const orderIdentifier = payload?.order?.id || payload?.order?.order_number || next.id;
+          const orderForEmail = payload?.order || prepareOrderForEmail(orders[index]);
+          const orderIdentifier =
+            orderForEmail?.id || orderForEmail?.order_number || next.id || prev.id || id;
           const paymentMethodRaw = String(
-            payload?.order?.payment_method || next.payment_method || prev.payment_method || ""
+            orderForEmail?.payment_method || next.payment_method || prev.payment_method || ""
           )
             .toLowerCase()
             .trim();
-          const isTransfer = paymentMethodRaw === "transferencia" || paymentMethodRaw === "transfer" || paymentMethodRaw === "bank_transfer";
-          const source = isTransfer ? "admin_manual_transfer_payment" : "admin_manual_payment_update";
-          if (payload) {
-            try {
-              const approvedResult = await sendPaymentApprovedEmailOnce(
-                payload.order,
-                { email: payload.recipient },
-                {
-                  logicalKey: `payment_approved:${orderIdentifier}`,
-                  emailType: "payment_approved",
-                  orderId: orderIdentifier,
-                  metadata: { source },
-                },
-              );
-              emailStatuses.paymentApproved = approvedResult?.status || null;
-              if (approvedResult && approvedResult.ok === false) {
-                emailWarnings.push(
-                  "La operación se realizó correctamente, pero no se pudo enviar el email de pago aprobado.",
-                );
-              }
-            } catch (emailErr) {
-              console.error("order payment approved email failed", emailErr);
+          const isTransfer =
+            paymentMethodRaw === "transferencia" ||
+            paymentMethodRaw === "transfer" ||
+            paymentMethodRaw === "bank_transfer";
+          const metadata = {
+            source: "admin_manual_transfer_payment",
+            paymentMethod: isTransfer
+              ? "Transferencia bancaria"
+              : orderForEmail?.payment_method || next.payment_method || prev.payment_method || null,
+          };
+          console.info("[email-payment-approved-admin] sending", {
+            orderId: orderIdentifier,
+            previousPaymentStatus: prevPaymentCode,
+            nextPaymentStatus: nextPaymentCode,
+          });
+
+          try {
+            const approvedResult = await sendPaymentApprovedEmailOnce(
+              orderForEmail,
+              { email: payload?.recipient || null },
+              {
+                logicalKey: `payment_approved:${orderIdentifier}`,
+                emailType: "payment_approved",
+                orderId: orderIdentifier,
+                metadata,
+              },
+            );
+            emailStatuses.paymentApproved = approvedResult?.status || null;
+            if (approvedResult && approvedResult.ok === false) {
               emailWarnings.push(
                 "La operación se realizó correctamente, pero no se pudo enviar el email de pago aprobado.",
               );
             }
+            console.info("[email-payment-approved-admin] result", {
+              orderId: orderIdentifier,
+              paymentApprovedStatus: approvedResult?.status || null,
+            });
+          } catch (emailErr) {
+            console.error("[email-payment-approved-admin] error", {
+              orderId: orderIdentifier,
+              channel: "payment_approved",
+              message: emailErr?.message || "unknown_error",
+            });
+            emailWarnings.push(
+              "La operación se realizó correctamente, pero no se pudo enviar el email de pago aprobado.",
+            );
           }
 
           try {
-            const adminPaidResult = await sendAdminSalePaidNotificationEmailOnce(next, {
+            const adminPaidResult = await sendAdminSalePaidNotificationEmailOnce(orderForEmail, {
               logicalKey: `admin_sale_paid_notification:${orderIdentifier}`,
               emailType: "admin_sale_paid_notification",
               orderId: orderIdentifier,
               subject: isTransfer
                 ? `Vendiste en NERIN Parts — Pago aprobado por transferencia — Pedido #${orderIdentifier}`
                 : undefined,
-              metadata: { source },
+              metadata,
             });
             emailStatuses.adminSalePaidNotification = adminPaidResult?.status || null;
             if (adminPaidResult && adminPaidResult.ok === false) {
@@ -10182,12 +10204,26 @@ async function requestHandler(req, res) {
                 "La operación se realizó correctamente, pero no se pudo enviar el email interno de pago aprobado.",
               );
             }
+            console.info("[email-payment-approved-admin] result", {
+              orderId: orderIdentifier,
+              adminSalePaidStatus: adminPaidResult?.status || null,
+            });
           } catch (adminEmailErr) {
-            console.error("order admin paid email failed", adminEmailErr);
+            console.error("[email-payment-approved-admin] error", {
+              orderId: orderIdentifier,
+              channel: "admin_sale_paid_notification",
+              message: adminEmailErr?.message || "unknown_error",
+            });
             emailWarnings.push(
               "La operación se realizó correctamente, pero no se pudo enviar el email interno de pago aprobado.",
             );
           }
+        } else if (incomingStatus != null) {
+          console.info("[email-payment-approved-admin] skipped no transition", {
+            orderId: prev.id || prev.order_number || id,
+            previousPaymentStatus: prevPaymentCode,
+            nextPaymentStatus: nextPaymentCode,
+          });
         }
 
         if (

--- a/nerin_final_updated/docs/admin-manual-transfer-payment-emails.md
+++ b/nerin_final_updated/docs/admin-manual-transfer-payment-emails.md
@@ -1,0 +1,76 @@
+# Admin manual transfer payment emails
+
+## Endpoint tocado
+- `PUT/PATCH /api/orders/:id` en `backend/server.js`.
+- Es el endpoint usado por la sección **Actualizar pedido** del admin (`frontend/js/admin.js` hace `fetch` a `/api/orders/{id}` con método `PUT`).
+
+## Qué se corrigió
+Cuando desde admin cambia el estado de pago de un pedido a aprobado/pagado, ahora el backend evalúa transición real y dispara los mismos mails idempotentes que usa Mercado Pago:
+
+- Cliente: `sendPaymentApprovedEmail(order, customer)` con logical key `payment_approved:${orderId}`.
+- Interno admin: `sendAdminSalePaidNotificationEmail(order, options)` con logical key `admin_sale_paid_notification:${orderId}`.
+
+## Detección de transición
+En el update de pedido:
+1. Se toma el estado anterior (`prevPaymentCode`).
+2. Se normaliza el estado nuevo (`nextPaymentCode`).
+3. Solo dispara emails si:
+   - llegó un cambio de estado de pago (`incomingStatus != null`), y
+   - `prevPaymentCode !== "approved"`, y
+   - `nextPaymentCode === "approved"`.
+
+Si no hay transición real, se loguea:
+- `[email-payment-approved-admin] skipped no transition`
+
+## Idempotencia y no duplicados
+Se usan las mismas keys lógicas que MP webhook:
+- `payment_approved:${orderId}`
+- `admin_sale_paid_notification:${orderId}`
+
+Como `emailService.sendTransactionalEmailOnce(...)` consulta `emailLogsRepo` por `logicalKey`, si ya se envió por MP (o por admin), el siguiente intento queda como `skipped_duplicate` y no se reenvía.
+
+## Metadata agregada
+Ambos envíos incluyen metadata:
+
+```json
+{
+  "source": "admin_manual_transfer_payment",
+  "paymentMethod": "Transferencia bancaria" | "<método detectado>" | null
+}
+```
+
+Para transferencia, se fuerza humanización a `Transferencia bancaria`.
+
+## Manejo de fallos sin romper guardado
+- Si falta email cliente: no rompe el update; `sendTransactionalEmailOnce` registra `invalid_recipient` y se devuelve warning controlado.
+- Si falta `ADMIN_SALES_EMAIL`/`ADMIN_SALES_EMAILS`: no rompe; el envío interno devuelve estado no exitoso y se agrega warning.
+- Si falla Resend: no rompe; se captura error y se agrega warning.
+
+## Logs de diagnóstico agregados
+- `[email-payment-approved-admin] sending`
+- `[email-payment-approved-admin] result`
+- `[email-payment-approved-admin] error`
+- `[email-payment-approved-admin] skipped no transition`
+
+Sin secretos ni payload sensible.
+
+## Alcance (qué NO se tocó)
+No se modificó:
+- checkout
+- carrito
+- precios
+- productos
+- Andreani
+- Analytics
+- flujo Mercado Pago ni creación de preferencia MP
+
+## Prueba recomendada (EMAILS_ENABLED=false)
+1. Configurar `EMAILS_ENABLED=false`.
+2. Caso A: pedido transferencia pendiente → admin cambia a pagado → verificar intentos de:
+   - `payment_approved:${orderId}`
+   - `admin_sale_paid_notification:${orderId}`
+3. Caso B: guardar otra vez en pagado → verificar `skipped no transition` o `skipped_duplicate`.
+4. Caso C: pedido ya pagado previo → no disparar.
+5. Caso D: quitar email cliente → no rompe guardado, warning controlado.
+6. Caso E: sin `ADMIN_SALES_EMAIL(S)` → no rompe guardado, warning controlado.
+7. Caso F: webhook MP approved sigue funcionando igual (sin cambios en ruta MP).


### PR DESCRIPTION
### Motivation
- Fix the production issue where marking a bank-transfer order as paid from the admin did not send the customer/internal "Pago aprobado" emails. 
- Ensure the admin/manual flow reuses the same idempotent logic as Mercado Pago so emails are not duplicated across flows. 
- Keep the change narrowly scoped and avoid touching checkout, cart, pricing, products, Andreani, Analytics or Mercado Pago preference creation. 

### Description
- Detect and act on a real payment-status transition in the admin order update endpoint `PUT/PATCH /api/orders/:id` in `nerin_final_updated/backend/server.js`, only when `incomingStatus != null && prevPaymentCode !== "approved" && nextPaymentCode === "approved"`.
- Trigger existing email helpers `sendPaymentApprovedEmailOnce` and `sendAdminSalePaidNotificationEmailOnce` with the same logical keys used by Mercado Pago (`payment_approved:${orderId}` and `admin_sale_paid_notification:${orderId}`) and include `metadata` with `source: "admin_manual_transfer_payment"` and a humanized `paymentMethod` (e.g. `Transferencia bancaria`).
- Add diagnostic logs under `[email-payment-approved-admin]` for `sending`, `result`, `error` and `skipped no transition` and ensure email failures/warnings do not break the order save flow.
- Add documentation `nerin_final_updated/docs/admin-manual-transfer-payment-emails.md` describing the endpoint touched, transition detection, logical keys, metadata, idempotency and a safe testing plan (use `EMAILS_ENABLED=false`).

### Testing
- Automated syntax check `node --check nerin_final_updated/backend/server.js` was run and passed (no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd44cfd1bc8331afc83c5560abdc2e)