### PR TITLE
Sanitize Resend tags and normalize base URL to prevent 422 errors

### DIFF
--- a/nerin_final_updated/backend/services/emailService.js
+++ b/nerin_final_updated/backend/services/emailService.js
@@ -110,12 +110,41 @@ function formatOrderNumber(value) {
 }
 
 function resolveBaseUrl() {
-  return (
+  const raw = (
     normalizeString(process.env.APP_BASE_URL) ||
     normalizeString(process.env.PUBLIC_BASE_URL) ||
     normalizeString(process.env.FRONTEND_BASE_URL) ||
+    normalizeString(process.env.PUBLIC_URL) ||
     ''
-  ).replace(/\/+$/, '');
+  );
+  if (!raw) return '';
+  let normalized = raw.trim();
+  if (/^\/\//.test(normalized)) normalized = `https:${normalized}`;
+  else if (!/^https?:\/\//i.test(normalized)) normalized = `https://${normalized}`;
+  return normalized.replace(/\/+$/, '');
+}
+
+function sanitizeResendTagValue(value, maxLength = 128) {
+  const asString = normalizeString(value);
+  if (!asString) return null;
+  const sanitized = asString
+    .replace(/[^A-Za-z0-9_-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^[-_]+|[-_]+$/g, '')
+    .slice(0, maxLength);
+  return sanitized || null;
+}
+
+function buildSafeResendTags(metadata) {
+  if (!metadata || typeof metadata !== 'object') return undefined;
+  const tags = Object.entries(metadata)
+    .slice(0, 5)
+    .map(([name, value]) => ({
+      name: sanitizeResendTagValue(name, 64),
+      value: sanitizeResendTagValue(value, 128),
+    }))
+    .filter((tag) => tag.name && tag.value);
+  return tags.length ? tags : undefined;
 }
 
 function resolveTrackingUrl(order = {}, customer = {}) {
@@ -481,12 +510,7 @@ async function sendTransactionalEmail({ to, subject, html, text, replyTo, metada
       text: safeText || undefined,
       reply_to: normalizeString(replyTo) || cfg.replyTo || undefined,
       headers: runtimeTestMode ? { 'X-NERIN-Email-Test-Mode': 'true' } : undefined,
-      tags: metadata && typeof metadata === 'object'
-        ? Object.entries(metadata)
-            .filter(([, value]) => value != null)
-            .slice(0, 5)
-            .map(([name, value]) => ({ name: normalizeString(name), value: normalizeString(value) }))
-        : undefined,
+      tags: buildSafeResendTags(metadata),
     });
     return {
       ok: true,
@@ -592,6 +616,15 @@ async function sendTransactionalEmailOnce(options = {}) {
   const status = result?.error === null && result?.skipped && result?.dryRun
     ? 'disabled'
     : extractStatusFromSendResult(result);
+
+  if (!result?.ok) {
+    console.error('[email-send-error]', {
+      emailType: options.emailType || 'generic',
+      logicalKey: explicitLogicalKey,
+      status,
+      error: result?.error || 'send-failed',
+    });
+  }
 
   emailLogsRepo.updateEmailLog(pending.id, {
     status,
@@ -710,4 +743,8 @@ module.exports = {
   sendAdminSalePaidNotificationEmail,
   buildEmailLogicalKey: emailLogsRepo.buildEmailLogicalKey,
   normalizeEmailRecipient: emailLogsRepo.normalizeEmailRecipient,
+  sanitizeResendTagValue,
+  buildSafeResendTags,
+  resolveBaseUrl,
+  resolveTrackingUrl,
 };

--- a/nerin_final_updated/docs/email-resend-tags-fix.md
+++ b/nerin_final_updated/docs/email-resend-tags-fix.md
@@ -1,0 +1,59 @@
+# Fix: Resend HTTP 422 por tags inválidos
+
+## Causa real del error
+Resend rechazaba algunos envíos con HTTP `422` porque los `tags` incluían caracteres no permitidos (por ejemplo `:`).
+
+Ejemplos reales que rompían:
+- `logicalKey: "order_preparing:NRN-080526-2796"`
+- `idempotencyKey: "email:order_preparing:NRN-080526-2796"`
+
+## Formato permitido por Resend
+Para `tags.name` y `tags.value` solo se permiten caracteres ASCII:
+- letras `A-Z` / `a-z`
+- números `0-9`
+- guion bajo `_`
+- guion medio `-`
+
+## Cómo se corrige
+En `backend/services/emailService.js` se agregaron helpers:
+- `sanitizeResendTagValue(value, maxLength)`
+- `buildSafeResendTags(metadata)`
+
+Reglas de sanitización:
+1. Convierte a string con trim.
+2. Reemplaza caracteres no permitidos por `-`.
+3. Compacta guiones repetidos.
+4. Recorta largo máximo (`name` 64, `value` 128).
+5. Si queda vacío, devuelve `null`.
+6. Se excluyen tags inválidos/vacíos antes de llamar a Resend.
+
+## Ejemplo antes/después
+- Antes: `order_preparing:NRN-080526-2796`
+- Después: `order_preparing-NRN-080526-2796`
+
+- Antes: `email:order_preparing:NRN-080526-2796`
+- Después: `email-order_preparing-NRN-080526-2796`
+
+## Idempotencia y logs internos
+- `logicalKey` e `idempotencyKey` internos se mantienen en logs/repositorio sin alterar su semántica.
+- Solo su representación en `tags` enviados a Resend se sanitiza.
+- Se añadió log seguro para errores de envío:
+
+```txt
+[email-send-error] { emailType, logicalKey, status, error }
+```
+
+Sin exponer `RESEND_API_KEY`, tokens ni secretos.
+
+## Normalización de base URL
+Se actualizó `resolveBaseUrl()` para tomar fallbacks:
+- `APP_BASE_URL`
+- `PUBLIC_BASE_URL`
+- `FRONTEND_BASE_URL`
+- `PUBLIC_URL`
+
+Y normaliza casos como:
+- `nerinparts.com.ar` → `https://nerinparts.com.ar`
+- `//nerinparts.com.ar` → `https://nerinparts.com.ar`
+
+Con esto, el enlace de seguimiento queda como `https://nerinparts.com.ar/seguimiento.html`.


### PR DESCRIPTION
### Motivation
- Resend was rejecting email requests with HTTP 422 because `tags` contained characters not allowed by Resend (for example `:` in `logicalKey` or `idempotencyKey`).
- Tracking links could be generated from base URL values like `//nerinparts.com.ar` or `nerinparts.com.ar`, producing incorrect `//...` links instead of `https://...`.

### Description
- Added `sanitizeResendTagValue(value, maxLength)` to convert values to strings, replace forbidden characters with `-`, compact repeated dashes, trim edges, enforce max length and return `null` when empty. 
- Added `buildSafeResendTags(metadata)` to sanitize up to 5 metadata entries and return only valid `{ name, value }` tags or `undefined` when none valid, and replaced the previous unsafe `tags` construction with `tags: buildSafeResendTags(metadata)`. 
- Normalized base URL resolution in `resolveBaseUrl()` to use fallbacks `APP_BASE_URL`, `PUBLIC_BASE_URL`, `FRONTEND_BASE_URL`, `PUBLIC_URL` and to normalize values like `//domain` or bare `domain` into `https://domain` (trimming trailing slashes). 
- Added a safe error log on send failures with the shape `[email-send-error] { emailType, logicalKey, status, error }` and exported the new helpers plus `resolveBaseUrl`/`resolveTrackingUrl` for testing and reuse; added documentation in `docs/email-resend-tags-fix.md` describing the cause, allowed characters, sanitization rules and examples. 

### Testing
- Ran syntax checks with `node -c nerin_final_updated/backend/services/emailService.js` and `node -c nerin_final_updated/backend/server.js` which both succeeded. 
- Executed a runtime check that builds safe tags: `buildSafeResendTags({ logicalKey: 'order_preparing:NRN-080526-2796', idempotencyKey: 'email:order_preparing:NRN-080526-2796', ok_tag: 'abc_123' })` and confirmed output contains no invalid characters and produces sanitized tags as expected. 
- Verified tracking URL normalization by setting `process.env.APP_BASE_URL='//nerinparts.com.ar'` and confirming `resolveTrackingUrl(...)` returns a URL starting with `https://nerinparts.com.ar/seguimiento.html`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe46a2ab908331be732a59cb359dac)