### PR TITLE
FASE 3H: Mejorar analíticas internas — endpoint live, caché y refresh sin parpadeos

### DIFF
--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -224,6 +224,15 @@ const MAX_ACTIVITY_SESSIONS = 300;
 const ACTIVITY_SESSION_RETENTION_MS = 7 * 24 * 60 * 60 * 1000; // 7 días
 const MAX_ANALYTICS_HISTORY_DAYS = 35;
 const MAX_HISTORY_SESSION_IDS = 2000;
+const analyticsDetailedCache = new Map();
+const analyticsLiveCache = { at: 0, value: null };
+
+function getDetailedAnalyticsTtlMs(range = "7d") {
+  if (range === "today") return 15_000;
+  if (range === "7d") return 30_000;
+  if (range === "30d") return 60_000;
+  return 60_000;
+}
 const DISABLE_PRODUCTS_STREAMING_FALLBACK =
   String(process.env.DISABLE_PRODUCTS_STREAMING_FALLBACK || "true").trim().toLowerCase() === "true";
 const REVIEW_TOKEN_TTL_DAYS =
@@ -11630,6 +11639,38 @@ async function requestHandler(req, res) {
     }
   }
 
+  if (pathname === "/api/analytics/live" && req.method === "GET") {
+    const startedAt = Date.now();
+    try {
+      const now = Date.now();
+      if (analyticsLiveCache.value && now - analyticsLiveCache.at < 4000) {
+        const cached = { ...analyticsLiveCache.value, cacheHit: true };
+        console.log("[analytics:live]", {
+          activeSessions: cached.activeSessions || 0,
+          eventsLastHour: cached.eventsLastHour || 0,
+          durationMs: Date.now() - startedAt,
+          cacheHit: true,
+        });
+        return sendJson(res, 200, cached);
+      }
+      const oneHourAgo = new Date(now - 60 * 60 * 1000);
+      const sessions = getStoredSessions();
+      const liveSessions = Array.isArray(sessions) ? sessions.slice(0, 8).map((s) => ({ id: s.id, userName: s.userName, userEmail: s.userEmail, lastSeenAt: s.lastSeenAt, currentStep: s.currentStep, cartValue: s.cartValue })) : [];
+      const activeSessions = liveSessions.filter((s) => String(s.status || "active") === "active").length || liveSessions.length;
+      const checkoutInProgress = liveSessions.filter((s) => String(s.currentStep || "").toLowerCase().includes("checkout")).length;
+      const eventsLastHour = getEventsByRange({ from: oneHourAgo, to: new Date(now), skipArchive: true }).length;
+      const trackingHealth = getTrackingHealth();
+      const payload = { activeSessions, checkoutInProgress, liveSessions, lastEventAt: trackingHealth?.lastEventAt || null, eventsLastHour, trackingHealth: { isPersistentDataDir: trackingHealth?.isPersistentDataDir !== false }, updatedAt: new Date().toISOString(), cacheHit: false };
+      analyticsLiveCache.at = now;
+      analyticsLiveCache.value = payload;
+      console.log("[analytics:live]", { activeSessions, eventsLastHour, durationMs: Date.now() - startedAt, cacheHit: false });
+      return sendJson(res, 200, payload);
+    } catch (err) {
+      console.error("analytics-live error", err);
+      return sendJson(res, 500, { error: "No se pudieron cargar las métricas live" });
+    }
+  }
+
   /*
    * API: Analíticas avanzadas
    * Devuelve métricas más detalladas: ventas por categoría, volumen por producto,
@@ -11639,6 +11680,14 @@ async function requestHandler(req, res) {
   if (pathname === "/api/analytics/detailed" && req.method === "GET") {
     try {
       const range = parseAnalyticsRange(parsedUrl.query);
+      const cacheKey = JSON.stringify({ range: range.key, from: range.from?.toISOString?.() || null, to: range.to?.toISOString?.() || null });
+      const ttlMs = getDetailedAnalyticsTtlMs(range.key);
+      const cached = analyticsDetailedCache.get(cacheKey);
+      if (cached && Date.now() - cached.at < ttlMs) {
+        console.log("[analytics:detailed]", { range: range.key, durationMs: Date.now() - cached.at, cacheHit: true, eventsCount: cached.eventsCount || 0 });
+        return sendJson(res, 200, { analyticsAvailable: true, analytics: cached.analytics, range });
+      }
+      const startedAt = Date.now();
       const events = getEventsByRange({ from: range.from, to: range.to });
       let sessions = getStoredSessions();
       if (!Array.isArray(sessions) || sessions.length === 0) {
@@ -11651,6 +11700,8 @@ async function requestHandler(req, res) {
         events,
         sessions,
       });
+      analyticsDetailedCache.set(cacheKey, { at: Date.now(), analytics, eventsCount: events.length });
+      console.log("[analytics:detailed]", { range: range.key, durationMs: Date.now() - startedAt, cacheHit: false, eventsCount: events.length });
       return sendJson(res, 200, { analyticsAvailable: true, analytics, range });
     } catch (err) {
       console.error("analytics-detailed error", err);

--- a/nerin_final_updated/backend/utils/analyticsStore.js
+++ b/nerin_final_updated/backend/utils/analyticsStore.js
@@ -190,7 +190,7 @@ function getSessions({ from, to, search, status } = {}) {
     });
 }
 
-function getEventsByRange({ from, to, type } = {}) {
+function getEventsByRange({ from, to, type, skipArchive = false } = {}) {
   const fromMs = from ? new Date(from).getTime() : null;
   const toMs = to ? new Date(to).getTime() : null;
   const typeFilter =
@@ -227,6 +227,13 @@ function getEventsByRange({ from, to, type } = {}) {
         events.push(evt);
       });
   });
+  if (skipArchive) {
+    return events.sort((a, b) => {
+      const aTime = Date.parse(a.timestamp || "") || 0;
+      const bTime = Date.parse(b.timestamp || "") || 0;
+      return aTime - bTime;
+    });
+  }
   const archiveFiles = listArchiveFiles();
   archiveFiles.forEach((archive) => {
     const weekMs = archive.weekDate.getTime();

--- a/nerin_final_updated/docs/admin-analytics-performance-phase3h.md
+++ b/nerin_final_updated/docs/admin-analytics-performance-phase3h.md
@@ -1,0 +1,47 @@
+# FASE 3H — Rendimiento de analíticas internas del admin
+
+## Problema detectado
+El dashboard de `/admin.html` recargaba todo el árbol DOM y destruía/recreaba gráficos en cada refresh, generando parpadeo, sensación de reset y latencia percibida.
+
+## Endpoints modificados/agregados
+- **Nuevo** `GET /api/analytics/live`: respuesta liviana para tiempo real.
+- **Modificado** `GET /api/analytics/detailed`: mantiene datos pesados, ahora con cache en memoria por rango.
+
+## Estrategia live vs detailed
+- **Live (rápido, 8s):** sesiones activas, checkout en curso, sesiones resumidas, `lastEventAt`, `eventsLastHour`, salud básica y `updatedAt`.
+- **Detailed (45s):** gráficos, tendencias, embudos, históricos e ingresos.
+
+## Cache TTL
+- `today`: 15s
+- `7d`: 30s
+- `30d`: 60s
+- `custom`: 60s
+- `live`: 4s
+
+## Cambios frontend
+- Se evita mostrar `Cargando...` en refresh automático si el panel ya está montado.
+- Se actualizan tarjetas live por ID sin reset total.
+- Se agrega actualización en vivo cada 8s y texto de “Última actualización”.
+- Se evita disparar refresh live simultáneos usando flags + AbortController.
+
+## Cambios backend
+- Cache en memoria para `/api/analytics/detailed` con key por `range/from/to`.
+- Endpoint `/api/analytics/live` con cache corta y lectura optimizada.
+- Optimización en `analyticsStore.getEventsByRange` para soportar `skipArchive` y evitar lectura gzip en modo live.
+- Logs de performance:
+  - `[analytics:live]` con `activeSessions`, `eventsLastHour`, `durationMs`, `cacheHit`.
+  - `[analytics:detailed]` con `range`, `durationMs`, `cacheHit`, `eventsCount`.
+
+## Cómo probar
+1. Abrir `/admin.html` y entrar a Analytics.
+2. Verificar carga inicial completa.
+3. Esperar refresh live (8s): confirmar que no se borra el dashboard.
+4. Verificar que gráficos no se redibujan cada refresh live.
+5. Confirmar en logs `cacheHit`/`durationMs`.
+6. Verificar que módulos de checkout/carrito/precios/pedidos no cambian.
+
+## Qué NO se tocó
+No se tocó Google Analytics, GA4, Meta Pixel, checkout, carrito, precios, productos, Mercado Pago, Andreani, Resend, emails ni pedidos.
+
+## Próximo paso recomendado
+Agregar invalidación selectiva de charts (update datasets en lugar de reconstruir) para también optimizar el refresh detallado.

--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -104,7 +104,7 @@ if (currentRole === "vendedor") {
 const navButtons = document.querySelectorAll(".admin-nav button");
 const sections = document.querySelectorAll(".admin-section");
 const analyticsSection = document.getElementById("analyticsSection");
-const ANALYTICS_REFRESH_INTERVAL_MS = 30 * 1000;
+const ANALYTICS_REFRESH_INTERVAL_MS = 45 * 1000;
 let analyticsRefreshTimer = null;
 let analyticsAutoRefreshMs = null;
 let analyticsLoading = false;
@@ -4464,6 +4464,7 @@ async function loadAnalytics(options = {}) {
   try {
     await renderAnalyticsDashboard("analytics-dashboard", {
       autoRefreshMs: analyticsAutoRefreshMs,
+      isAutoRefresh: Boolean(options?.isAutoRefresh),
     });
   } catch (err) {
     console.error("analytics-dashboard-refresh-error", err);
@@ -4494,7 +4495,7 @@ function startAnalyticsAutoRefresh({ immediate = true } = {}) {
       stopAnalyticsAutoRefresh();
       return;
     }
-    loadAnalytics({ skipIfHidden: true });
+    loadAnalytics({ skipIfHidden: true, isAutoRefresh: true });
   }, ANALYTICS_REFRESH_INTERVAL_MS);
 }
 

--- a/nerin_final_updated/frontend/js/analytics.js
+++ b/nerin_final_updated/frontend/js/analytics.js
@@ -20,6 +20,52 @@ const analyticsRangeState = {
   to: "",
 };
 
+const LIVE_REFRESH_MS = 8000;
+let liveRefreshTimer = null;
+let liveRefreshInFlight = false;
+let liveAbortController = null;
+let detailedInFlight = false;
+let detailedAbortController = null;
+
+function updateLiveDom(live = {}) {
+  const setText = (id, value) => {
+    const el = document.getElementById(id);
+    if (el) el.textContent = value;
+  };
+  setText("analytics-live-active-sessions", formatNumber(live.activeSessions || 0));
+  setText("analytics-live-checkout-in-progress", formatNumber(live.checkoutInProgress || 0));
+  const statusEl = document.getElementById("analytics-live-updated-at");
+  if (statusEl) {
+    const stamp = live.updatedAt || new Date().toISOString();
+    statusEl.textContent = `Última actualización ${new Date(stamp).toLocaleTimeString("es-AR")}`;
+  }
+  const healthEl = document.getElementById("analytics-live-health");
+  if (healthEl) {
+    healthEl.textContent = `Último evento ${live.lastEventAt ? new Date(live.lastEventAt).toLocaleTimeString("es-AR") : "sin eventos"} · ${formatNumber(live.eventsLastHour || 0)} eventos/h`;
+  }
+}
+
+async function fetchLiveAnalytics() {
+  if (liveRefreshInFlight) return;
+  liveRefreshInFlight = true;
+  try {
+    if (liveAbortController) liveAbortController.abort();
+    liveAbortController = new AbortController();
+    const res = await apiFetch('/api/analytics/live', { signal: liveAbortController.signal });
+    const payload = await res.json();
+    updateLiveDom(payload || {});
+  } catch (err) {
+    if (err?.name !== 'AbortError') console.warn('analytics-live-refresh-error', err);
+  } finally {
+    liveRefreshInFlight = false;
+  }
+}
+
+function ensureLiveRefresh() {
+  if (liveRefreshTimer) return;
+  liveRefreshTimer = window.setInterval(fetchLiveAnalytics, LIVE_REFRESH_MS);
+}
+
 function buildRangeParams(state) {
   const params = new URLSearchParams();
   const range = state?.range || "7d";
@@ -310,12 +356,14 @@ export async function renderAnalyticsDashboard(
   containerId = "analytics-dashboard",
   options = {},
 ) {
-  const { autoRefreshMs = null, range, from, to } = options || {};
+  const { autoRefreshMs = null, range, from, to, isAutoRefresh = false } = options || {};
   const container =
     typeof containerId === "string"
       ? document.getElementById(containerId)
       : containerId;
   if (!container) return;
+  if (detailedInFlight) return;
+  detailedInFlight = true;
   if (activeCharts.length) {
     activeCharts.forEach((chart) => {
       if (chart && typeof chart.destroy === "function") {
@@ -324,7 +372,9 @@ export async function renderAnalyticsDashboard(
     });
     activeCharts.splice(0, activeCharts.length);
   }
-  container.innerHTML = "<p>Cargando...</p>";
+  if (!isAutoRefresh || !container.dataset.analyticsReady) {
+    container.innerHTML = "<p>Cargando...</p>";
+  }
   if (range) analyticsRangeState.range = range;
   if (from !== undefined) analyticsRangeState.from = from || "";
   if (to !== undefined) analyticsRangeState.to = to || "";
@@ -334,6 +384,7 @@ export async function renderAnalyticsDashboard(
     const payload = await res.json();
     const analytics = payload?.analytics || payload || {};
     container.innerHTML = "";
+    container.dataset.analyticsReady = "1";
     if (analytics?.analyticsAvailable === false) {
       const disabled = document.createElement("div");
       disabled.className = "analytics-empty analytics-empty--inline";
@@ -424,7 +475,8 @@ export async function renderAnalyticsDashboard(
     meta.setAttribute("role", "status");
     const status = document.createElement("span");
     status.className = "analytics-meta__status";
-    status.textContent = `Actualizado ${fetchedAt.toLocaleTimeString("es-AR", {
+    status.id = "analytics-live-updated-at";
+    status.textContent = `Última actualización ${fetchedAt.toLocaleTimeString("es-AR", {
       hour: "2-digit",
       minute: "2-digit",
       second: "2-digit",
@@ -434,12 +486,13 @@ export async function renderAnalyticsDashboard(
       const intervalSeconds = Math.max(1, Math.round(autoRefreshMs / 1000));
       const hint = document.createElement("span");
       hint.className = "analytics-meta__hint";
-      hint.textContent = `Actualización automática cada ${intervalSeconds} s`;
+      hint.textContent = `Actualización detallada cada ${intervalSeconds} s · actualización en vivo cada ${Math.round(LIVE_REFRESH_MS/1000)} s`;
       meta.appendChild(hint);
     }
     if (analytics?.trackingHealth) {
       const health = document.createElement("span");
       health.className = "analytics-meta__hint";
+      health.id = "analytics-live-health";
       const lastEventText = analytics.trackingHealth.lastEventAt
         ? new Date(analytics.trackingHealth.lastEventAt).toLocaleTimeString("es-AR", {
             hour: "2-digit",
@@ -465,12 +518,14 @@ export async function renderAnalyticsDashboard(
       {
         title: "Sesiones activas",
         value: formatNumber(analytics.activeSessions || 0),
+        id: "analytics-live-active-sessions",
         subtitle: "Personas navegando en tiempo real",
         tone: "primary",
       },
       {
         title: "Checkout en curso",
         value: formatNumber(analytics.checkoutInProgress || 0),
+        id: "analytics-live-checkout-in-progress",
         subtitle: "Usuarios a punto de comprar",
         tone: "warning",
       },
@@ -509,7 +564,12 @@ export async function renderAnalyticsDashboard(
       },
     ];
     summaryCards.forEach((card) => {
-      summaryGrid.appendChild(createStatCard(card));
+      const cardEl = createStatCard(card);
+      if (card.id) {
+        const metric = cardEl.querySelector(".analytics-card__metric");
+        if (metric) metric.id = card.id;
+      }
+      summaryGrid.appendChild(cardEl);
     });
     container.appendChild(summaryGrid);
 
@@ -1191,8 +1251,14 @@ export async function renderAnalyticsDashboard(
       timeline.appendChild(createEmptyState("Todavía no hay eventos registrados."));
     }
     container.appendChild(timeline);
+    ensureLiveRefresh();
+    fetchLiveAnalytics();
   } catch (err) {
     console.error(err);
-    container.innerHTML = "<p>No se pudieron cargar las analíticas</p>";
+    if (!container.dataset.analyticsReady) {
+      container.innerHTML = "<p>No se pudieron cargar las analíticas</p>";
+    }
+  } finally {
+    detailedInFlight = false;
   }
 }


### PR DESCRIPTION
### Motivation
- Reducir la latencia y la sensación de "reset" del dashboard de `/admin.html` separando datos live (frecuentes y ligeros) de datos detallados (pesados y menos frecuentes). 
- Evitar lecturas innecesarias de históricos comprimidos y prevenir requests simultáneos que degradan la experiencia en tiempo real. 
- Mantener la compatibilidad con la seguridad y el ámbito actual del admin sin tocar integraciones externas (GA/GA4/Meta Pixel) ni módulos sensibles (checkout, pagos, pedidos, etc.).

### Description
- Backend: se añadió `GET /api/analytics/live` que devuelve solo métricas livianas (activeSessions, checkoutInProgress, liveSessions resumidas, lastEventAt, eventsLastHour, trackingHealth, updatedAt) con cache corta (≈4s) y log seguro `[analytics:live]` con `{ activeSessions, eventsLastHour, durationMs, cacheHit }` (archivo modificado: `backend/server.js`).
- Backend: se introdujo caché en memoria para `GET /api/analytics/detailed` indexada por `range/from/to` con TTL por rango (`today` 15s, `7d` 30s, `30d` 60s, `custom` 60s) y log `[analytics:detailed]` con `{ range, durationMs, cacheHit, eventsCount }` (archivo modificado: `backend/server.js`).
- Store: `analyticsStore.getEventsByRange` acepta ahora `skipArchive` para evitar leer archivos de archivo/gz en consultas live y acelerar cálculos de la última hora (archivo modificado: `backend/utils/analyticsStore.js`).
- Frontend: `frontend/js/analytics.js` separa refresh live (cada 8s) del refresh detallado, evita reescribir todo el DOM en auto-refresh (no `container.innerHTML = "Cargando..."` si ya montado), actualiza solo tarjetas live por ID, muestra “Última actualización” y usa flags + `AbortController` para evitar requests simultáneos; además inicia el live refresh al montar el dashboard.
- Admin: `frontend/js/admin.js` ajusta el intervalo detallado automático a 45s y propaga `isAutoRefresh` para prevenir parpadeos visuales durante recargas automáticas.
- Documentación: nueva guía `docs/admin-analytics-performance-phase3h.md` con estrategia, TTLs, endpoints y pasos de prueba.

### Testing
- Se validó sintaxis/compilación estática con `node -c backend/server.js` y la comprobación fue exitosa. 
- Se validó `node -c backend/utils/analyticsStore.js` y la comprobación fue exitosa. 
- Se validó `node -c frontend/js/analytics.js` y la comprobación fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff578144f88331b859ea2960ef6023)