### PR TITLE
Improve admin analytics first render

### DIFF
--- a/nerin_final_updated/frontend/js/analytics.js
+++ b/nerin_final_updated/frontend/js/analytics.js
@@ -1,1264 +1,157 @@
 import { apiFetch } from "./api.js";
 
-const palette = [
-  "#3b82f6",
-  "#8b5cf6",
-  "#10b981",
-  "#f59e0b",
-  "#ef4444",
-  "#6366f1",
-  "#14b8a6",
-  "#f43f5e",
-  "#ec4899",
-  "#a3e635",
-];
+const LIVE_MS = 8000;
+const DETAIL_MS = 120000;
+const state = { range: "7d", from: "", to: "" };
+let liveTimer = null;
+let detailTimer = null;
+let liveBusy = false;
+let detailBusy = false;
+let hasDetail = false;
 
-const activeCharts = [];
-const analyticsRangeState = {
-  range: "7d",
-  from: "",
-  to: "",
-};
+const esc = (v) => String(v ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#039;");
+const num = (v) => (Number(v) || 0).toLocaleString("es-AR");
+const money = (v) => (Number(v) || 0).toLocaleString("es-AR", { style: "currency", currency: "ARS", maximumFractionDigits: 0 });
+const pct = (v) => `${((Number(v) || 0) * 100).toFixed(1)}%`;
+const mins = (v) => { const n = Number(v) || 0; return n >= 120 ? `${(n / 60).toFixed(1)} h` : `${n.toFixed(1)} min`; };
+const clock = (v) => { const d = v ? new Date(v) : new Date(); return Number.isNaN(d.getTime()) ? "sin eventos" : d.toLocaleTimeString("es-AR", { hour: "2-digit", minute: "2-digit", second: "2-digit" }); };
+const setText = (id, value) => { const el = document.getElementById(id); if (el) el.textContent = value; };
 
-const LIVE_REFRESH_MS = 8000;
-let liveRefreshTimer = null;
-let liveRefreshInFlight = false;
-let liveAbortController = null;
-let detailedInFlight = false;
-let detailedAbortController = null;
-
-function updateLiveDom(live = {}) {
-  const setText = (id, value) => {
-    const el = document.getElementById(id);
-    if (el) el.textContent = value;
-  };
-  setText("analytics-live-active-sessions", formatNumber(live.activeSessions || 0));
-  setText("analytics-live-checkout-in-progress", formatNumber(live.checkoutInProgress || 0));
-  const statusEl = document.getElementById("analytics-live-updated-at");
-  if (statusEl) {
-    const stamp = live.updatedAt || new Date().toISOString();
-    statusEl.textContent = `Última actualización ${new Date(stamp).toLocaleTimeString("es-AR")}`;
+function params() {
+  const p = new URLSearchParams();
+  p.set("range", state.range || "7d");
+  if (state.range === "custom") {
+    if (state.from) p.set("from", state.from);
+    if (state.to) p.set("to", state.to);
   }
-  const healthEl = document.getElementById("analytics-live-health");
-  if (healthEl) {
-    healthEl.textContent = `Último evento ${live.lastEventAt ? new Date(live.lastEventAt).toLocaleTimeString("es-AR") : "sin eventos"} · ${formatNumber(live.eventsLastHour || 0)} eventos/h`;
-  }
+  return p;
 }
 
-async function fetchLiveAnalytics() {
-  if (liveRefreshInFlight) return;
-  liveRefreshInFlight = true;
+function card(id, title, subtitle, tone = "default") {
+  return `<article class="analytics-card analytics-card--${tone}"><h4>${esc(title)}</h4><p class="analytics-card__metric" id="${id}">—</p><p class="analytics-card__caption" id="${id}-caption">${esc(subtitle)}</p></article>`;
+}
+
+function shell(container) {
+  if (!container || container.dataset.fastAnalytics === "1") return;
+  container.dataset.fastAnalytics = "1";
+  container.dataset.analyticsReady = "1";
+  container.innerHTML = `
+    <div class="analytics-controls"><div class="analytics-range">
+      <label for="analytics-range-select">Rango de análisis</label>
+      <select id="analytics-range-select"><option value="today">Hoy</option><option value="7d">7 días</option><option value="30d">30 días</option><option value="custom">Personalizado</option></select>
+      <div class="analytics-range__custom" id="analytics-custom-range" style="display:none"><input type="date" id="analytics-from-date"><input type="date" id="analytics-to-date"><button type="button" class="button secondary" id="analytics-apply-range">Aplicar</button></div>
+      <button type="button" class="button secondary" id="analytics-refresh-now">Actualizar ahora</button>
+    </div></div>
+    <div class="analytics-meta" role="status"><span class="analytics-meta__status" id="analytics-live-updated-at">Cargando datos en vivo...</span><span class="analytics-meta__hint">En vivo cada ${Math.round(LIVE_MS / 1000)} s</span><span class="analytics-meta__hint">Detallado cada ${Math.round(DETAIL_MS / 1000)} s</span><span class="analytics-meta__hint" id="analytics-live-health">Último evento: cargando...</span><span class="analytics-meta__hint" id="analytics-detail-status">Métricas detalladas: cargando...</span></div>
+    <div class="analytics-summary-grid">${card("analytics-live-active-sessions", "Sesiones activas", "Personas navegando en tiempo real", "primary")}${card("analytics-live-checkout-in-progress", "Checkout en curso", "Usuarios a punto de comprar", "warning")}${card("analytics-visitors-today", "Visitantes hoy", "Datos detallados")}${card("analytics-revenue-today", "Ingresos hoy", "Datos detallados", "success")}${card("analytics-conversion-rate", "Tasa de conversión", "Datos detallados", "info")}${card("analytics-average-session-duration", "Duración media sesión", "Datos detallados")}</div>
+    <div class="analytics-two-column"><section class="analytics-panel"><h4>Sesiones en vivo</h4><div id="analytics-live-sessions-panel" class="analytics-empty">Cargando sesiones...</div></section><section class="analytics-panel"><h4>Productos más vistos</h4><div id="analytics-hot-products-panel" class="analytics-empty">Cargando productos...</div></section></div>
+    <div class="analytics-two-column analytics-two-column--balanced"><section class="analytics-panel"><h4>Insights automáticos</h4><div id="analytics-insights-panel" class="analytics-empty">Cargando insights...</div></section><section class="analytics-panel"><h4>Calidad de tráfico</h4><div id="analytics-quality-panel" class="analytics-empty">Cargando calidad...</div></section></div>
+    <div class="analytics-charts" id="analytics-charts-panel"><div class="analytics-empty analytics-empty--inline">Los gráficos se actualizan en segundo plano.</div></div>`;
+
+  const range = document.getElementById("analytics-range-select");
+  const custom = document.getElementById("analytics-custom-range");
+  const from = document.getElementById("analytics-from-date");
+  const to = document.getElementById("analytics-to-date");
+  range.value = state.range;
+  range.addEventListener("change", () => {
+    state.range = range.value;
+    custom.style.display = state.range === "custom" ? "flex" : "none";
+    if (state.range !== "custom") { state.from = ""; state.to = ""; fetchDetail(true); }
+  });
+  document.getElementById("analytics-apply-range")?.addEventListener("click", () => { state.range = "custom"; state.from = from?.value || ""; state.to = to?.value || ""; fetchDetail(true); });
+  document.getElementById("analytics-refresh-now")?.addEventListener("click", () => { fetchLive(true); fetchDetail(true); });
+}
+
+function renderLiveSessions(sessions = []) {
+  const panel = document.getElementById("analytics-live-sessions-panel");
+  if (!panel) return;
+  const list = Array.isArray(sessions) ? sessions.slice(0, 12) : [];
+  if (!list.length) { panel.className = "analytics-empty"; panel.textContent = "No hay sesiones activas en este momento."; return; }
+  panel.className = "";
+  panel.innerHTML = `<table class="analytics-live-table"><thead><tr><th>Usuario</th><th>Última actividad</th><th>Etapa</th><th>Carrito</th></tr></thead><tbody>${list.map((s) => `<tr><td><strong>${esc(s.userName || s.userEmail || s.id || "Visitante")}</strong></td><td>${esc(clock(s.lastSeenAt || s.updatedAt))}</td><td>${esc(String(s.currentStep || "Explorando").replace(/_/g, " "))}</td><td>${esc(s.cartValue ? money(s.cartValue) : "—")}</td></tr>`).join("")}</tbody></table>`;
+}
+
+function applyLive(data = {}) {
+  setText("analytics-live-active-sessions", num(data.activeSessions));
+  setText("analytics-live-checkout-in-progress", num(data.checkoutInProgress));
+  setText("analytics-live-updated-at", `Última actualización ${clock(data.updatedAt)}`);
+  setText("analytics-live-health", `Último evento ${clock(data.lastEventAt)} · ${num(data.eventsLastHour)} eventos/h`);
+  renderLiveSessions(data.liveSessions);
+}
+
+async function fetchLive(force = false) {
+  if (liveBusy && !force) return;
+  liveBusy = true;
   try {
-    if (liveAbortController) liveAbortController.abort();
-    liveAbortController = new AbortController();
-    const res = await apiFetch('/api/analytics/live', { signal: liveAbortController.signal });
-    const payload = await res.json();
-    updateLiveDom(payload || {});
+    const res = await apiFetch("/api/analytics/live", { cache: "no-store" });
+    if (!res.ok) throw new Error(`live analytics ${res.status}`);
+    applyLive(await res.json());
   } catch (err) {
-    if (err?.name !== 'AbortError') console.warn('analytics-live-refresh-error', err);
-  } finally {
-    liveRefreshInFlight = false;
-  }
+    console.warn("analytics-live-refresh-error", err);
+    setText("analytics-live-updated-at", "No se pudieron actualizar los datos en vivo");
+  } finally { liveBusy = false; }
 }
 
-function ensureLiveRefresh() {
-  if (liveRefreshTimer) return;
-  liveRefreshTimer = window.setInterval(fetchLiveAnalytics, LIVE_REFRESH_MS);
+function renderListPanel(id, items, emptyText) {
+  const panel = document.getElementById(id);
+  if (!panel) return;
+  if (!items.length) { panel.className = "analytics-empty"; panel.textContent = emptyText; return; }
+  panel.className = "analytics-hot-products";
+  panel.innerHTML = `<ol class="analytics-hot-products__list">${items.map((i) => `<li><span>${esc(i.name || i.path || i.message || "Item")}</span><strong>${i.count != null ? num(i.count) : ""}</strong></li>`).join("")}</ol>`;
 }
 
-function buildRangeParams(state) {
-  const params = new URLSearchParams();
-  const range = state?.range || "7d";
-  params.set("range", range);
-  if (range === "custom") {
-    if (state.from) params.set("from", state.from);
-    if (state.to) params.set("to", state.to);
-  }
-  return params;
+function applyDetail(a = {}) {
+  setText("analytics-visitors-today", num(a.visitorsToday));
+  setText("analytics-revenue-today", money(a.revenueToday));
+  setText("analytics-revenue-today-caption", `${num(a.ordersToday)} órdenes confirmadas`);
+  setText("analytics-conversion-rate", pct(a.conversionRate));
+  setText("analytics-conversion-rate-caption", `Abandono ${pct(a.cartAbandonmentRate)}`);
+  setText("analytics-average-session-duration", mins(a.averageSessionDuration));
+  setText("analytics-average-session-duration-caption", `Mediana ${mins(a.medianSessionDuration)}`);
+  const products = (Array.isArray(a.productViewsToday) ? a.productViewsToday : []).concat(Array.isArray(a.productViewsWeek) ? a.productViewsWeek : []).sort((x, y) => Number(y.count || 0) - Number(x.count || 0)).slice(0, 8);
+  renderListPanel("analytics-hot-products-panel", products, "Sin datos de productos vistos todavía.");
+  renderListPanel("analytics-insights-panel", Array.isArray(a.insights) ? a.insights.slice(0, 6) : [], "Sin insights por ahora.");
+  const quality = [{ name: "Tasa de rebote", count: pct(a.bounceRate) }, { name: "Sesiones comprometidas", count: pct(a.engagedSessionsRate) }, { name: "Clientes recurrentes", count: pct(a.repeatCustomerRate) }];
+  renderListPanel("analytics-quality-panel", quality, "Sin datos de calidad todavía.");
+  const charts = document.getElementById("analytics-charts-panel");
+  if (charts) charts.innerHTML = `<div class="analytics-empty analytics-empty--inline">Métricas detalladas actualizadas. Gráficos completos se mantienen desactivados para priorizar carga rápida.</div>`;
 }
 
-function toDateInputValue(value) {
-  if (!value) return "";
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return "";
-  return date.toISOString().slice(0, 10);
-}
-
-function formatCurrency(value) {
-  const num = Number(value) || 0;
-  return num.toLocaleString("es-AR", {
-    style: "currency",
-    currency: "ARS",
-    maximumFractionDigits: 0,
-  });
-}
-
-function formatNumber(value) {
-  const num = Number(value) || 0;
-  return num.toLocaleString("es-AR");
-}
-
-function formatPercent(value, digits = 1) {
-  const num = Number(value) || 0;
-  return `${(num * 100).toFixed(digits)}%`;
-}
-
-function formatDurationMinutes(value) {
-  const num = Number(value) || 0;
-  if (num >= 120) {
-    return `${(num / 60).toFixed(1)} h`;
-  }
-  return `${num.toFixed(1)} min`;
-}
-
-function clampPercent(value) {
-  const num = Number(value);
-  if (!Number.isFinite(num)) return 0;
-  return Math.min(100, Math.max(0, num));
-}
-
-const insightIcons = {
-  positive: "⬆️",
-  alert: "⚠️",
-  neutral: "•",
-  info: "ℹ️",
-  default: "•",
-};
-
-function hexToRgba(hex, alpha = 1) {
-  if (!hex || typeof hex !== "string") {
-    return `rgba(59, 130, 246, ${alpha})`;
-  }
-  let normalized = hex.replace("#", "").trim();
-  if (normalized.length === 3) {
-    normalized = normalized
-      .split("")
-      .map((char) => char + char)
-      .join("");
-  }
-  if (normalized.length !== 6) {
-    return `rgba(59, 130, 246, ${alpha})`;
-  }
-  const intVal = parseInt(normalized, 16);
-  const r = (intVal >> 16) & 255;
-  const g = (intVal >> 8) & 255;
-  const b = intVal & 255;
-  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
-}
-
-function createStatCard({ title, value, subtitle, tone = "default" }) {
-  const card = document.createElement("article");
-  card.className = `analytics-card analytics-card--${tone}`;
-  const h4 = document.createElement("h4");
-  h4.textContent = title;
-  const metric = document.createElement("p");
-  metric.className = "analytics-card__metric";
-  metric.textContent = value;
-  const caption = document.createElement("p");
-  caption.className = "analytics-card__caption";
-  caption.textContent = subtitle;
-  card.appendChild(h4);
-  card.appendChild(metric);
-  card.appendChild(caption);
-  return card;
-}
-
-function createEmptyState(message) {
-  const div = document.createElement("div");
-  div.className = "analytics-empty";
-  div.textContent = message;
-  return div;
-}
-
-function createProgressRow({ label, value, percent, tone = "default", hint }) {
-  const row = document.createElement("div");
-  row.className = `analytics-progress analytics-progress--${tone}`;
-  const header = document.createElement("div");
-  header.className = "analytics-progress__header";
-  const labelEl = document.createElement("span");
-  labelEl.textContent = label;
-  const valueEl = document.createElement("strong");
-  valueEl.textContent = value;
-  header.appendChild(labelEl);
-  header.appendChild(valueEl);
-  const bar = document.createElement("div");
-  bar.className = "analytics-progress__bar";
-  const fill = document.createElement("span");
-  fill.style.width = `${clampPercent(percent)}%`;
-  bar.appendChild(fill);
-  row.appendChild(header);
-  row.appendChild(bar);
-  if (hint) {
-    const hintEl = document.createElement("p");
-    hintEl.className = "analytics-progress__hint";
-    hintEl.textContent = hint;
-    row.appendChild(hintEl);
-  }
-  return row;
-}
-
-function createInsightItem({ level = "info", message }) {
-  const li = document.createElement("li");
-  li.className = `analytics-insights__item analytics-insights__item--${level}`;
-  const icon = document.createElement("span");
-  icon.className = "analytics-insights__icon";
-  icon.textContent = insightIcons[level] || insightIcons.default;
-  const text = document.createElement("p");
-  text.textContent = message;
-  li.appendChild(icon);
-  li.appendChild(text);
-  return li;
-}
-
-function createChart(
-  container,
-  title,
-  type,
-  labels = [],
-  data = [],
-  { valueType = "currency", fill, color, indexAxis = "x", tension } = {},
-) {
-  if (!labels || labels.length === 0 || !data || data.every((val) => !Number(val))) {
-    const empty = createEmptyState(`Sin datos disponibles para ${title.toLowerCase()}`);
-    empty.classList.add("analytics-empty--inline");
-    const wrapper = document.createElement("div");
-    wrapper.className = "chart-wrapper";
-    const h4 = document.createElement("h4");
-    h4.textContent = title;
-    wrapper.appendChild(h4);
-    wrapper.appendChild(empty);
-    container.appendChild(wrapper);
-    return null;
-  }
-  const wrapper = document.createElement("div");
-  wrapper.className = "chart-wrapper";
-  const h4 = document.createElement("h4");
-  h4.textContent = title;
-  wrapper.appendChild(h4);
-  const canvas = document.createElement("canvas");
-  wrapper.appendChild(canvas);
-  const ctx = canvas.getContext("2d");
-  const colors = labels.map((_, i) => palette[i % palette.length]);
-  const baseColor = color || palette[0];
-  const datasetColors = labels.map((_, i) => palette[i % palette.length]);
-  const dataset = {
-    label: title,
-    data,
-    backgroundColor:
-      type === "line"
-        ? fill === false
-          ? baseColor
-          : hexToRgba(baseColor, 0.2)
-        : datasetColors,
-    borderColor: type === "line" ? baseColor : datasetColors,
-    borderWidth: type === "line" ? 3 : 0,
-    fill: typeof fill === "boolean" ? fill : type === "line",
-    tension: typeof tension === "number" ? tension : type === "line" ? 0.35 : 0,
-    pointRadius: type === "line" ? 3 : 0,
-    pointBackgroundColor: baseColor,
-    pointBorderWidth: 0,
-  };
-  if (type === "line" && dataset.fill) {
-    dataset.backgroundColor = hexToRgba(baseColor, 0.2);
-  }
-  const chart = new Chart(ctx, {
-    type,
-    data: {
-      labels,
-      datasets: [dataset],
-    },
-    options: {
-      responsive: true,
-      maintainAspectRatio: false,
-      indexAxis,
-      plugins: {
-        legend: { display: type === "pie" },
-        tooltip: {
-          callbacks: {
-            label: (ctx) => {
-              const val = type === "pie" ? ctx.parsed : ctx.parsed.y;
-              if (valueType === "units") {
-                return `${val} u.`;
-              }
-              if (valueType === "percent") {
-                return `${val}%`;
-              }
-              if (valueType === "minutes") {
-                return `${val} min`;
-              }
-              return formatCurrency(val);
-            },
-          },
-        },
-      },
-      scales:
-        type === "pie"
-          ? {}
-          : {
-              y: {
-                beginAtZero: true,
-                ticks: {
-                  callback: (tickValue) => {
-                    const numeric = Number(tickValue) || 0;
-                    if (valueType === "percent") {
-                      return `${numeric}%`;
-                    }
-                    if (valueType === "units") {
-                      return formatNumber(numeric);
-                    }
-                    if (valueType === "minutes") {
-                      return `${numeric}m`;
-                    }
-                    return formatCurrency(numeric);
-                  },
-                },
-              },
-            },
-    },
-  });
-
-  const btnContainer = document.createElement("div");
-  btnContainer.className = "chart-buttons";
-  const imgBtn = document.createElement("button");
-  imgBtn.className = "button secondary";
-  imgBtn.textContent = "Descargar PNG";
-  imgBtn.addEventListener("click", () => {
-    const a = document.createElement("a");
-    a.href = chart.toBase64Image();
-    a.download = `${title}.png`;
-    a.click();
-  });
-  const csvBtn = document.createElement("button");
-  csvBtn.className = "button secondary";
-  csvBtn.textContent = "Exportar datos";
-  csvBtn.addEventListener("click", () => {
-    let csv = "Etiqueta,Valor\n";
-    labels.forEach((lab, i) => {
-      csv += `${lab},${data[i]}\n`;
-    });
-    const blob = new Blob([csv], { type: "text/csv" });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = `${title}.csv`;
-    link.click();
-    URL.revokeObjectURL(url);
-  });
-  btnContainer.appendChild(imgBtn);
-  btnContainer.appendChild(csvBtn);
-  wrapper.appendChild(btnContainer);
-  container.appendChild(wrapper);
-  activeCharts.push(chart);
-  return chart;
-}
-
-export async function renderAnalyticsDashboard(
-  containerId = "analytics-dashboard",
-  options = {},
-) {
-  const { autoRefreshMs = null, range, from, to, isAutoRefresh = false } = options || {};
-  const container =
-    typeof containerId === "string"
-      ? document.getElementById(containerId)
-      : containerId;
-  if (!container) return;
-  if (detailedInFlight) return;
-  detailedInFlight = true;
-  if (activeCharts.length) {
-    activeCharts.forEach((chart) => {
-      if (chart && typeof chart.destroy === "function") {
-        chart.destroy();
-      }
-    });
-    activeCharts.splice(0, activeCharts.length);
-  }
-  if (!isAutoRefresh || !container.dataset.analyticsReady) {
-    container.innerHTML = "<p>Cargando...</p>";
-  }
-  if (range) analyticsRangeState.range = range;
-  if (from !== undefined) analyticsRangeState.from = from || "";
-  if (to !== undefined) analyticsRangeState.to = to || "";
-  const rangeParams = buildRangeParams(analyticsRangeState);
+async function fetchDetail(force = false) {
+  if (detailBusy && !force) return;
+  detailBusy = true;
+  setText("analytics-detail-status", "Métricas detalladas: actualizando...");
   try {
-    const res = await apiFetch(`/api/analytics/detailed?${rangeParams.toString()}`);
+    const p = params();
+    if (force) p.set("force", "1");
+    const res = await apiFetch(`/api/analytics/detailed?${p.toString()}`, { cache: "no-store" });
+    if (!res.ok) throw new Error(`detailed analytics ${res.status}`);
     const payload = await res.json();
     const analytics = payload?.analytics || payload || {};
-    container.innerHTML = "";
-    container.dataset.analyticsReady = "1";
-    if (analytics?.analyticsAvailable === false) {
-      const disabled = document.createElement("div");
-      disabled.className = "analytics-empty analytics-empty--inline";
-      disabled.innerHTML = `
-        <strong>No se pudieron cargar las analíticas</strong>
-        <p>${analytics?.error || analytics?.message || "Ocurrió un error técnico. Reintentá en unos segundos."}</p>
-      `;
-      container.appendChild(disabled);
-      return;
-    }
-    const fetchedAt = new Date();
-    const rangeLabelMap = {
-      today: "Hoy",
-      "7d": "Últimos 7 días",
-      "30d": "Últimos 30 días",
-      custom: "Rango personalizado",
-    };
-    const rangeLabel = analyticsRangeState.range === "custom"
-      ? `${analyticsRangeState.from || "inicio"} → ${analyticsRangeState.to || "hoy"}`
-      : rangeLabelMap[analyticsRangeState.range] || analyticsRangeState.range;
-
-    const controls = document.createElement("div");
-    controls.className = "analytics-controls";
-    const rangeGroup = document.createElement("div");
-    rangeGroup.className = "analytics-range";
-    const rangeLabelEl = document.createElement("label");
-    rangeLabelEl.textContent = "Rango de análisis";
-    const rangeSelect = document.createElement("select");
-    [
-      { value: "today", label: "Hoy" },
-      { value: "7d", label: "7 días" },
-      { value: "30d", label: "30 días" },
-      { value: "custom", label: "Personalizado" },
-    ].forEach((opt) => {
-      const option = document.createElement("option");
-      option.value = opt.value;
-      option.textContent = opt.label;
-      if (analyticsRangeState.range === opt.value) {
-        option.selected = true;
-      }
-      rangeSelect.appendChild(option);
-    });
-    const customFields = document.createElement("div");
-    customFields.className = "analytics-range__custom";
-    const fromInput = document.createElement("input");
-    fromInput.type = "date";
-    fromInput.value = analyticsRangeState.from || toDateInputValue(analytics?.range?.from);
-    const toInput = document.createElement("input");
-    toInput.type = "date";
-    toInput.value = analyticsRangeState.to || toDateInputValue(analytics?.range?.to);
-    const applyBtn = document.createElement("button");
-    applyBtn.type = "button";
-    applyBtn.className = "button secondary";
-    applyBtn.textContent = "Aplicar";
-    customFields.append(fromInput, toInput, applyBtn);
-    const toggleCustomFields = () => {
-      customFields.style.display =
-        analyticsRangeState.range === "custom" ? "flex" : "none";
-    };
-    toggleCustomFields();
-    rangeSelect.addEventListener("change", () => {
-      analyticsRangeState.range = rangeSelect.value;
-      if (analyticsRangeState.range !== "custom") {
-        analyticsRangeState.from = "";
-        analyticsRangeState.to = "";
-        renderAnalyticsDashboard(containerId, { autoRefreshMs, range: rangeSelect.value });
-      } else {
-        toggleCustomFields();
-      }
-    });
-    applyBtn.addEventListener("click", () => {
-      analyticsRangeState.range = "custom";
-      analyticsRangeState.from = fromInput.value;
-      analyticsRangeState.to = toInput.value;
-      renderAnalyticsDashboard(containerId, {
-        autoRefreshMs,
-        range: "custom",
-        from: fromInput.value,
-        to: toInput.value,
-      });
-    });
-    rangeGroup.append(rangeLabelEl, rangeSelect, customFields);
-    controls.appendChild(rangeGroup);
-    container.appendChild(controls);
-
-    const meta = document.createElement("div");
-    meta.className = "analytics-meta";
-    meta.setAttribute("role", "status");
-    const status = document.createElement("span");
-    status.className = "analytics-meta__status";
-    status.id = "analytics-live-updated-at";
-    status.textContent = `Última actualización ${fetchedAt.toLocaleTimeString("es-AR", {
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-    })}`;
-    meta.appendChild(status);
-    if (autoRefreshMs) {
-      const intervalSeconds = Math.max(1, Math.round(autoRefreshMs / 1000));
-      const hint = document.createElement("span");
-      hint.className = "analytics-meta__hint";
-      hint.textContent = `Actualización detallada cada ${intervalSeconds} s · actualización en vivo cada ${Math.round(LIVE_REFRESH_MS/1000)} s`;
-      meta.appendChild(hint);
-    }
-    if (analytics?.trackingHealth) {
-      const health = document.createElement("span");
-      health.className = "analytics-meta__hint";
-      health.id = "analytics-live-health";
-      const lastEventText = analytics.trackingHealth.lastEventAt
-        ? new Date(analytics.trackingHealth.lastEventAt).toLocaleTimeString("es-AR", {
-            hour: "2-digit",
-            minute: "2-digit",
-          })
-        : "sin eventos";
-      health.textContent = `Último evento ${lastEventText} · ${formatNumber(
-        analytics.trackingHealth.eventsLastHour || 0,
-      )} eventos/h`;
-      meta.appendChild(health);
-      if (!analytics.trackingHealth.isPersistentDataDir) {
-        const warning = document.createElement("span");
-        warning.className = "analytics-meta__hint analytics-meta__hint--warning";
-        warning.textContent = "⚠️ DATA_DIR no persistente: los datos pueden perderse.";
-        meta.appendChild(warning);
-      }
-    }
-    container.appendChild(meta);
-
-    const summaryGrid = document.createElement("div");
-    summaryGrid.className = "analytics-summary-grid";
-    const summaryCards = [
-      {
-        title: "Sesiones activas",
-        value: formatNumber(analytics.activeSessions || 0),
-        id: "analytics-live-active-sessions",
-        subtitle: "Personas navegando en tiempo real",
-        tone: "primary",
-      },
-      {
-        title: "Checkout en curso",
-        value: formatNumber(analytics.checkoutInProgress || 0),
-        id: "analytics-live-checkout-in-progress",
-        subtitle: "Usuarios a punto de comprar",
-        tone: "warning",
-      },
-      {
-        title: "Visitantes hoy",
-        value: formatNumber(analytics.visitorsToday || 0),
-        subtitle: "Sesiones únicas del día",
-      },
-      {
-        title: `Visitantes ${rangeLabel}`,
-        value: formatNumber(analytics.visitorsThisWeek || 0),
-        subtitle: "Sesiones únicas en el rango",
-      },
-      {
-        title: "Ingresos hoy",
-        value: formatCurrency(analytics.revenueToday || 0),
-        subtitle: `${formatNumber(analytics.ordersToday || 0)} órdenes confirmadas`,
-        tone: "success",
-      },
-      {
-        title: `Ingresos ${rangeLabel}`,
-        value: formatCurrency(analytics.revenueThisWeek || 0),
-        subtitle: `${formatNumber(analytics.ordersThisWeek || 0)} órdenes en el rango`,
-        tone: "primary",
-      },
-      {
-        title: "Tasa de conversión",
-        value: formatPercent(analytics.conversionRate || 0),
-        subtitle: `Abandono ${formatPercent(analytics.cartAbandonmentRate || 0)}`,
-        tone: "info",
-      },
-      {
-        title: "Duración media sesión",
-        value: formatDurationMinutes(analytics.averageSessionDuration || 0),
-        subtitle: `Mediana ${formatDurationMinutes(analytics.medianSessionDuration || 0)}`,
-      },
-    ];
-    summaryCards.forEach((card) => {
-      const cardEl = createStatCard(card);
-      if (card.id) {
-        const metric = cardEl.querySelector(".analytics-card__metric");
-        if (metric) metric.id = card.id;
-      }
-      summaryGrid.appendChild(cardEl);
-    });
-    container.appendChild(summaryGrid);
-
-    const definitions = document.createElement("section");
-    definitions.className = "analytics-panel analytics-definitions";
-    const definitionsTitle = document.createElement("h4");
-    definitionsTitle.textContent = "Definiciones rápidas";
-    const definitionsList = document.createElement("ul");
-    definitionsList.innerHTML = `
-      <li><strong>Sesiones activas:</strong> visitantes con actividad en los últimos 5 minutos.</li>
-      <li><strong>Checkout en curso:</strong> usuarios en carrito o checkout.</li>
-      <li><strong>Carritos activos:</strong> sesiones con importe en carrito en 24 h.</li>
-      <li><strong>Conversión:</strong> compras / vistas de producto.</li>
-    `;
-    definitions.append(definitionsTitle, definitionsList);
-    container.appendChild(definitions);
-
-    const topRow = document.createElement("div");
-    topRow.className = "analytics-two-column";
-
-    const liveBlock = document.createElement("section");
-    liveBlock.className = "analytics-panel";
-    const liveTitle = document.createElement("h4");
-    liveTitle.textContent = "Sesiones en vivo";
-    liveBlock.appendChild(liveTitle);
-    if (analytics.liveSessions && analytics.liveSessions.length > 0) {
-      const table = document.createElement("table");
-      table.className = "analytics-live-table";
-      table.innerHTML = `
-        <thead>
-          <tr>
-            <th>Usuario</th>
-            <th>Última actividad</th>
-            <th>Etapa</th>
-            <th>Carrito</th>
-          </tr>
-        </thead>
-        <tbody></tbody>
-      `;
-      const tbody = table.querySelector("tbody");
-      analytics.liveSessions.forEach((session) => {
-        const tr = document.createElement("tr");
-        const name = session.userName || session.userEmail || session.id;
-        const lastSeen = session.lastSeenAt
-          ? new Date(session.lastSeenAt).toLocaleTimeString("es-AR", {
-              hour: "2-digit",
-              minute: "2-digit",
-            })
-          : "—";
-        const step = session.currentStep
-          ? session.currentStep
-              .replace(/_/g, " ")
-              .replace(/\b\w/g, (c) => c.toUpperCase())
-          : "Explorando";
-        const cartValue = session.cartValue
-          ? formatCurrency(session.cartValue)
-          : "—";
-        tr.innerHTML = `
-          <td>
-            <div class="analytics-user">
-              <strong>${name}</strong>
-              ${session.location ? `<span>${session.location}</span>` : ""}
-            </div>
-          </td>
-          <td>${lastSeen}</td>
-          <td>${step}</td>
-          <td>${cartValue}</td>
-        `;
-        tbody.appendChild(tr);
-      });
-      liveBlock.appendChild(table);
-    } else {
-      liveBlock.appendChild(
-        createEmptyState("No hay sesiones activas en este momento."),
-      );
-    }
-
-    const highlightBlock = document.createElement("section");
-    highlightBlock.className = "analytics-panel";
-    const highlightTitle = document.createElement("h4");
-    highlightTitle.textContent = "Productos más vistos";
-    highlightBlock.appendChild(highlightTitle);
-
-    const hotProducts = document.createElement("div");
-    hotProducts.className = "analytics-hot-products";
-    if (analytics.mostViewedToday) {
-      const badge = document.createElement("div");
-      badge.className = "analytics-hot-products__leader";
-      badge.innerHTML = `
-        <p>Hoy</p>
-        <strong>${analytics.mostViewedToday.name}</strong>
-        <span>${formatNumber(analytics.mostViewedToday.count)} vistas</span>
-      `;
-      hotProducts.appendChild(badge);
-    }
-    if (analytics.mostViewedWeek) {
-      const badge = document.createElement("div");
-      badge.className = "analytics-hot-products__leader analytics-hot-products__leader--muted";
-      badge.innerHTML = `
-        <p>Semana</p>
-        <strong>${analytics.mostViewedWeek.name}</strong>
-        <span>${formatNumber(analytics.mostViewedWeek.count)} vistas</span>
-      `;
-      hotProducts.appendChild(badge);
-    }
-    const listsWrapper = document.createElement("div");
-    listsWrapper.className = "analytics-hot-products__lists";
-
-    const todayColumn = document.createElement("div");
-    todayColumn.className = "analytics-hot-products__column";
-    const todayTitle = document.createElement("span");
-    todayTitle.className = "analytics-hot-products__subtitle";
-    todayTitle.textContent = "Detalle del día";
-    todayColumn.appendChild(todayTitle);
-    const todayList = document.createElement("ol");
-    todayList.className = "analytics-hot-products__list";
-    (analytics.productViewsToday || [])
-      .sort((a, b) => b.count - a.count)
-      .slice(0, 5)
-      .forEach((item) => {
-        const li = document.createElement("li");
-        li.innerHTML = `
-          <span>${item.name}</span>
-          <strong>${formatNumber(item.count)}</strong>
-        `;
-        todayList.appendChild(li);
-      });
-    if (!todayList.children.length) {
-      const li = document.createElement("li");
-      li.textContent = "Sin datos de vistas de producto hoy.";
-      todayList.appendChild(li);
-    }
-    todayColumn.appendChild(todayList);
-    listsWrapper.appendChild(todayColumn);
-
-    const weekColumn = document.createElement("div");
-    weekColumn.className = "analytics-hot-products__column";
-    const weekTitle = document.createElement("span");
-    weekTitle.className = "analytics-hot-products__subtitle";
-    weekTitle.textContent = rangeLabel;
-    weekColumn.appendChild(weekTitle);
-    const weekList = document.createElement("ol");
-    weekList.className = "analytics-hot-products__list analytics-hot-products__list--muted";
-    (analytics.productViewsWeek || [])
-      .sort((a, b) => b.count - a.count)
-      .slice(0, 5)
-      .forEach((item) => {
-        const li = document.createElement("li");
-        li.innerHTML = `
-          <span>${item.name}</span>
-          <strong>${formatNumber(item.count)}</strong>
-        `;
-        weekList.appendChild(li);
-      });
-    if (!weekList.children.length) {
-      const li = document.createElement("li");
-      li.textContent = `Sin datos en ${rangeLabel.toLowerCase()}.`;
-      weekList.appendChild(li);
-    }
-    weekColumn.appendChild(weekList);
-    listsWrapper.appendChild(weekColumn);
-
-    hotProducts.appendChild(listsWrapper);
-    highlightBlock.appendChild(hotProducts);
-
-    topRow.appendChild(liveBlock);
-    topRow.appendChild(highlightBlock);
-    container.appendChild(topRow);
-
-    const insightsRow = document.createElement("div");
-    insightsRow.className = "analytics-two-column analytics-two-column--balanced";
-
-    const insightsPanel = document.createElement("section");
-    insightsPanel.className = "analytics-panel analytics-insights";
-    const insightsTitle = document.createElement("h4");
-    insightsTitle.textContent = "Insights automáticos";
-    insightsPanel.appendChild(insightsTitle);
-    if (Array.isArray(analytics.insights) && analytics.insights.length > 0) {
-      const list = document.createElement("ul");
-      list.className = "analytics-insights__list";
-      analytics.insights.forEach((insight) => {
-        list.appendChild(createInsightItem(insight));
-      });
-      insightsPanel.appendChild(list);
-    } else {
-      insightsPanel.appendChild(createEmptyState("Sin insights por ahora."));
-    }
-
-    const qualityPanel = document.createElement("section");
-    qualityPanel.className = "analytics-panel analytics-quality";
-    const qualityTitle = document.createElement("h4");
-    qualityTitle.textContent = "Calidad de tráfico";
-    qualityPanel.appendChild(qualityTitle);
-    const progressGroup = document.createElement("div");
-    progressGroup.className = "analytics-progress-group";
-    const bounceRate = Number(analytics.bounceRate || 0);
-    progressGroup.appendChild(
-      createProgressRow({
-        label: "Tasa de rebote",
-        value: formatPercent(bounceRate),
-        percent: bounceRate * 100,
-        tone: bounceRate > 0.4 ? "danger" : "success",
-        hint:
-          analytics.topLandingPages && analytics.topLandingPages.length > 0
-            ? `Entrada principal: ${analytics.topLandingPages[0].path}`
-            : undefined,
-      }),
-    );
-    const engagedRate = Number(analytics.engagedSessionsRate || 0);
-    progressGroup.appendChild(
-      createProgressRow({
-        label: "Sesiones comprometidas",
-        value: formatPercent(engagedRate),
-        percent: engagedRate * 100,
-        tone: engagedRate >= 0.3 ? "success" : "info",
-        hint: "Objetivo recomendado: 30%",
-      }),
-    );
-    const repeatRate = Number(analytics.repeatCustomerRate || 0);
-    progressGroup.appendChild(
-      createProgressRow({
-        label: "Clientes recurrentes",
-        value: formatPercent(repeatRate),
-        percent: repeatRate * 100,
-        tone: repeatRate >= 0.25 ? "success" : "info",
-        hint: `${formatNumber(analytics.ordersThisWeek || 0)} órdenes en la semana`,
-      }),
-    );
-    qualityPanel.appendChild(progressGroup);
-    if (analytics.peakTrafficHour && analytics.peakTrafficHour.count > 0) {
-      const signal = document.createElement("div");
-      signal.className = "analytics-signal";
-      const icon = document.createElement("span");
-      icon.textContent = "⏰";
-      const text = document.createElement("p");
-      text.textContent = `Hora pico ${analytics.peakTrafficHour.label} · ${formatNumber(
-        analytics.peakTrafficHour.count,
-      )} eventos`;
-      signal.appendChild(icon);
-      signal.appendChild(text);
-      qualityPanel.appendChild(signal);
-    }
-
-    insightsRow.appendChild(insightsPanel);
-    insightsRow.appendChild(qualityPanel);
-    container.appendChild(insightsRow);
-
-    const chartsContainer = document.createElement("div");
-    chartsContainer.className = "analytics-charts";
-
-    createChart(
-      chartsContainer,
-      `Visitantes ${rangeLabel}`,
-      "line",
-      (analytics.visitTrend || []).map((item) => item.date),
-      (analytics.visitTrend || []).map((item) => item.visitors),
-      { valueType: "units" },
-    );
-
-    const hasHourlyTraffic =
-      Array.isArray(analytics.trafficByHour) &&
-      analytics.trafficByHour.some((item) => Number(item.count || 0) > 0);
-    if (hasHourlyTraffic) {
-      createChart(
-        chartsContainer,
-        `Tráfico por hora (${rangeLabel})`,
-        "line",
-        analytics.trafficByHour.map((item) => item.label),
-        analytics.trafficByHour.map((item) => item.count),
-        { valueType: "units", fill: true, tension: 0.4 },
-      );
-    }
-
-    if (Array.isArray(analytics.topLandingPages) && analytics.topLandingPages.length > 0) {
-      createChart(
-        chartsContainer,
-        "Páginas de entrada principales",
-        "bar",
-        analytics.topLandingPages.map((item) => item.path),
-        analytics.topLandingPages.map((item) => item.count),
-        { valueType: "units" },
-      );
-    }
-
-    if (analytics.funnel) {
-      const funnelLabels = [
-        "Vistas de producto",
-        "Añadidos al carrito",
-        "Checkout iniciado",
-        "Pago en proceso",
-        "Compras",
-      ];
-      const funnelData = [
-        analytics.funnel.product_view || 0,
-        analytics.funnel.add_to_cart || 0,
-        analytics.funnel.checkout_start || 0,
-        analytics.funnel.checkout_payment || 0,
-        analytics.funnel.purchase || 0,
-      ];
-      createChart(
-        chartsContainer,
-        "Embudo de conversión",
-        "bar",
-        funnelLabels,
-        funnelData,
-        { valueType: "units" },
-      );
-    }
-
-    createChart(
-      chartsContainer,
-      "Ventas por categoría",
-      "pie",
-      Object.keys(analytics.salesByCategory || {}),
-      Object.values(analytics.salesByCategory || {}),
-    );
-
-    createChart(
-      chartsContainer,
-      "Unidades vendidas por producto",
-      "bar",
-      Object.keys(analytics.salesByProduct || {}),
-      Object.values(analytics.salesByProduct || {}),
-      { valueType: "units" },
-    );
-
-    createChart(
-      chartsContainer,
-      "Devoluciones por producto",
-      "bar",
-      Object.keys(analytics.returnsByProduct || {}),
-      Object.values(analytics.returnsByProduct || {}),
-      { valueType: "units" },
-    );
-
-    const clientLabels = (analytics.topCustomers || []).map((c) => c.email);
-    const clientData = (analytics.topCustomers || []).map((c) => c.total);
-    createChart(
-      chartsContainer,
-      "Clientes con mayor facturación",
-      "bar",
-      clientLabels,
-      clientData,
-      { indexAxis: "y" },
-    );
-
-    createChart(
-      chartsContainer,
-      "Ventas por mes",
-      "line",
-      Object.keys(analytics.monthlySales || {}),
-      Object.values(analytics.monthlySales || {}),
-    );
-
-    container.appendChild(chartsContainer);
-
-    const stats = document.createElement("section");
-    stats.className = "analytics-stats";
-    const statsTitle = document.createElement("h4");
-    statsTitle.textContent = "Resumen operacional";
-    stats.appendChild(statsTitle);
-    const statsGrid = document.createElement("div");
-    statsGrid.className = "analytics-stats__grid";
-    const statItems = [
-      {
-        label: "Valor medio de pedido",
-        value: formatCurrency(analytics.averageOrderValue || 0),
-        hint: `${formatNumber(analytics.ordersThisWeek || 0)} órdenes esta semana`,
-      },
-      {
-        label: "Tasa de devoluciones",
-        value: formatPercent(analytics.returnRate || 0, 2),
-        hint: analytics.mostReturnedProduct
-          ? `Más devuelto: ${analytics.mostReturnedProduct}`
-          : "Sin devoluciones destacadas",
-      },
-      {
-        label: "Carritos activos 24 h",
-        value: formatNumber(analytics.activeCarts || 0),
-        hint: "Con importe mayor a 0",
-      },
-      {
-        label: "Duración mediana",
-        value: formatDurationMinutes(analytics.medianSessionDuration || 0),
-        hint: `Promedio ${formatDurationMinutes(analytics.averageSessionDuration || 0)}`,
-      },
-    ];
-    statItems.forEach((item) => {
-      const card = document.createElement("div");
-      card.className = "analytics-stats__item";
-      const label = document.createElement("span");
-      label.className = "analytics-stats__label";
-      label.textContent = item.label;
-      const value = document.createElement("strong");
-      value.className = "analytics-stats__value";
-      value.textContent = item.value;
-      card.appendChild(label);
-      card.appendChild(value);
-      if (item.hint) {
-        const hint = document.createElement("p");
-        hint.className = "analytics-stats__hint";
-        hint.textContent = item.hint;
-        card.appendChild(hint);
-      }
-      statsGrid.appendChild(card);
-    });
-    stats.appendChild(statsGrid);
-    container.appendChild(stats);
-
-    const stories = document.createElement("section");
-    stories.className = "analytics-panel analytics-stories";
-    const storiesTitle = document.createElement("h4");
-    storiesTitle.textContent = "Seguimiento por visitante";
-    stories.appendChild(storiesTitle);
-    if (Array.isArray(analytics.sessionStories) && analytics.sessionStories.length > 0) {
-      const list = document.createElement("ul");
-      list.className = "analytics-stories__list";
-      analytics.sessionStories.forEach((story) => {
-        const item = document.createElement("li");
-        item.className = "analytics-stories__item";
-        const header = document.createElement("div");
-        header.className = "analytics-stories__header";
-        const name = document.createElement("span");
-        name.className = "analytics-stories__name";
-        name.textContent = story.person || story.sessionId || "Visitante";
-        header.appendChild(name);
-        const status = document.createElement("span");
-        status.className = `analytics-stories__status${
-          story.status === "active" ? " analytics-stories__status--active" : ""
-        }`;
-        status.textContent = story.statusText || (story.status === "active" ? "Activo" : "Inactivo");
-        header.appendChild(status);
-        item.appendChild(header);
-        if (story.journeyLabel) {
-          const journey = document.createElement("p");
-          journey.className = "analytics-stories__journey";
-          journey.textContent = `Recorrido: ${story.journeyLabel}`;
-          item.appendChild(journey);
-        }
-        if (story.summary) {
-          const summary = document.createElement("p");
-          summary.className = "analytics-stories__summary";
-          summary.textContent = story.summary;
-          item.appendChild(summary);
-        }
-        list.appendChild(item);
-      });
-      stories.appendChild(list);
-    } else {
-      const empty = createEmptyState("Todavía no hay recorridos recientes.");
-      empty.classList.add("analytics-empty--inline");
-      stories.appendChild(empty);
-    }
-    container.appendChild(stories);
-
-    const sessionsPanel = document.createElement("section");
-    sessionsPanel.className = "analytics-panel analytics-sessions";
-    const sessionsHeader = document.createElement("div");
-    sessionsHeader.className = "analytics-sessions__header";
-    const sessionsTitle = document.createElement("h4");
-    sessionsTitle.textContent = "Explorador de sesiones";
-    const sessionsFilters = document.createElement("div");
-    sessionsFilters.className = "analytics-sessions__filters";
-    const searchInput = document.createElement("input");
-    searchInput.type = "search";
-    searchInput.placeholder = "Buscar por email, nombre o ID";
-    const statusSelect = document.createElement("select");
-    [
-      { value: "", label: "Estado: todos" },
-      { value: "active", label: "Activos" },
-      { value: "idle", label: "Inactivos" },
-      { value: "ended", label: "Finalizados" },
-    ].forEach((opt) => {
-      const option = document.createElement("option");
-      option.value = opt.value;
-      option.textContent = opt.label;
-      statusSelect.appendChild(option);
-    });
-    const refreshBtn = document.createElement("button");
-    refreshBtn.type = "button";
-    refreshBtn.className = "button secondary";
-    refreshBtn.textContent = "Actualizar";
-    sessionsFilters.append(searchInput, statusSelect, refreshBtn);
-    sessionsHeader.append(sessionsTitle, sessionsFilters);
-    sessionsPanel.appendChild(sessionsHeader);
-
-    const sessionsTable = document.createElement("table");
-    sessionsTable.className = "analytics-live-table analytics-sessions__table";
-    sessionsTable.innerHTML = `
-      <thead>
-        <tr>
-          <th>Sesión</th>
-          <th>Última actividad</th>
-          <th>Etapa</th>
-          <th>Carrito</th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody></tbody>
-    `;
-    const sessionsTbody = sessionsTable.querySelector("tbody");
-    const timelinePanel = document.createElement("div");
-    timelinePanel.className = "analytics-session-timeline";
-    timelinePanel.innerHTML = "<p>Seleccioná una sesión para ver su timeline.</p>";
-
-    const describeTimelineEvent = (evt) => {
-      const type = String(evt.type || "").toLowerCase();
-      const product = evt.productName || evt.productId || evt.product?.name;
-      if (type === "page_view") {
-        return `Visitó ${evt.path || evt.url || "una página"}.`;
-      }
-      if (type === "product_view") {
-        return `Vio ${product || "un producto"}.`;
-      }
-      if (type === "add_to_cart") {
-        return `Agregó ${product || "un producto"} al carrito.`;
-      }
-      if (type === "checkout_start") {
-        return "Inició el checkout.";
-      }
-      if (type === "checkout_payment") {
-        return "Seleccionó un método de pago.";
-      }
-      if (type === "purchase") {
-        return `Confirmó compra ${evt.orderId ? `#${evt.orderId}` : ""}.`;
-      }
-      return evt.step
-        ? `Pasó por ${evt.step}.`
-        : `Evento ${type || "interacción"}.`;
-    };
-
-    const renderSessionTimeline = (session, timeline) => {
-      timelinePanel.innerHTML = "";
-      const header = document.createElement("div");
-      header.className = "analytics-session-timeline__header";
-      const title = document.createElement("h5");
-      title.textContent = session?.userName || session?.userEmail || session?.id || "Sesión";
-      const meta = document.createElement("span");
-      meta.textContent = session?.lastSeenAt
-        ? `Última actividad ${new Date(session.lastSeenAt).toLocaleString("es-AR", {
-            hour: "2-digit",
-            minute: "2-digit",
-          })}`
-        : "";
-      header.append(title, meta);
-      timelinePanel.appendChild(header);
-      if (!timeline.length) {
-        timelinePanel.appendChild(createEmptyState("Sin eventos en el rango seleccionado."));
-        return;
-      }
-      const list = document.createElement("ul");
-      list.className = "analytics-timeline__list";
-      timeline
-        .slice()
-        .sort((a, b) => Date.parse(a.timestamp || 0) - Date.parse(b.timestamp || 0))
-        .forEach((event) => {
-          const li = document.createElement("li");
-          const time = document.createElement("span");
-          time.className = "analytics-timeline__time";
-          time.textContent = event.timestamp
-            ? new Date(event.timestamp).toLocaleTimeString("es-AR", {
-                hour: "2-digit",
-                minute: "2-digit",
-              })
-            : "—";
-          const desc = document.createElement("span");
-          desc.className = "analytics-timeline__desc";
-          desc.textContent = describeTimelineEvent(event);
-          li.append(time, desc);
-          list.appendChild(li);
-        });
-      timelinePanel.appendChild(list);
-    };
-
-    const loadSessionTimeline = async (session) => {
-      const params = buildRangeParams(analyticsRangeState);
-      const res = await apiFetch(
-        `/api/analytics/sessions/${encodeURIComponent(session.id)}?${params.toString()}`,
-      );
-      const payload = await res.json();
-      renderSessionTimeline(payload.session || session, payload.timeline || []);
-    };
-
-    const renderSessions = (sessionsList) => {
-      sessionsTbody.innerHTML = "";
-      if (!sessionsList.length) {
-        const row = document.createElement("tr");
-        const cell = document.createElement("td");
-        cell.colSpan = 5;
-        cell.textContent = "No hay sesiones para este rango.";
-        row.appendChild(cell);
-        sessionsTbody.appendChild(row);
-        return;
-      }
-      sessionsList.forEach((session) => {
-        const row = document.createElement("tr");
-        const name = session.userName || session.userEmail || session.id;
-        const lastSeen = session.lastSeenAt
-          ? new Date(session.lastSeenAt).toLocaleTimeString("es-AR", {
-              hour: "2-digit",
-              minute: "2-digit",
-            })
-          : "—";
-        const step = session.currentStep
-          ? String(session.currentStep)
-              .replace(/_/g, " ")
-              .replace(/\b\w/g, (c) => c.toUpperCase())
-          : "Explorando";
-        const cartValue = session.cartValue
-          ? formatCurrency(session.cartValue)
-          : "—";
-        row.innerHTML = `
-          <td>${name}</td>
-          <td>${lastSeen}</td>
-          <td>${step}</td>
-          <td>${cartValue}</td>
-        `;
-        const actionCell = document.createElement("td");
-        const btn = document.createElement("button");
-        btn.type = "button";
-        btn.className = "button secondary";
-        btn.textContent = "Ver timeline";
-        btn.addEventListener("click", () => loadSessionTimeline(session));
-        actionCell.appendChild(btn);
-        row.appendChild(actionCell);
-        sessionsTbody.appendChild(row);
-      });
-    };
-
-    const loadSessions = async () => {
-      const params = buildRangeParams(analyticsRangeState);
-      const searchValue = searchInput.value.trim();
-      const statusValue = statusSelect.value;
-      if (searchValue) params.set("search", searchValue);
-      if (statusValue) params.set("status", statusValue);
-      const res = await apiFetch(`/api/analytics/sessions?${params.toString()}`);
-      const payload = await res.json();
-      renderSessions(payload.sessions || []);
-    };
-
-    refreshBtn.addEventListener("click", loadSessions);
-    searchInput.addEventListener("keydown", (event) => {
-      if (event.key === "Enter") {
-        loadSessions();
-      }
-    });
-    statusSelect.addEventListener("change", loadSessions);
-    loadSessions();
-
-    sessionsPanel.append(sessionsTable, timelinePanel);
-    container.appendChild(sessionsPanel);
-
-    const timeline = document.createElement("section");
-    timeline.className = "analytics-panel analytics-timeline";
-    const timelineTitle = document.createElement("h4");
-    timelineTitle.textContent = "Actividad reciente";
-    timeline.appendChild(timelineTitle);
-    if (analytics.recentEvents && analytics.recentEvents.length > 0) {
-      const list = document.createElement("ul");
-      analytics.recentEvents.forEach((event) => {
-        const li = document.createElement("li");
-        const timeSpan = document.createElement("span");
-        timeSpan.className = "analytics-timeline__time";
-        timeSpan.textContent = event.timestamp
-          ? new Date(event.timestamp).toLocaleTimeString("es-AR", {
-              hour: "2-digit",
-              minute: "2-digit",
-            })
-          : "";
-        const descSpan = document.createElement("span");
-        descSpan.className = "analytics-timeline__desc";
-        descSpan.textContent = event.description || "";
-        li.appendChild(timeSpan);
-        li.appendChild(descSpan);
-        list.appendChild(li);
-      });
-      timeline.appendChild(list);
-    } else {
-      timeline.appendChild(createEmptyState("Todavía no hay eventos registrados."));
-    }
-    container.appendChild(timeline);
-    ensureLiveRefresh();
-    fetchLiveAnalytics();
+    if (analytics.analyticsAvailable === false) { setText("analytics-detail-status", analytics.error || analytics.message || "No se pudieron cargar las métricas detalladas."); return; }
+    hasDetail = true;
+    applyDetail(analytics);
+    setText("analytics-detail-status", `Métricas detalladas actualizadas ${clock(new Date().toISOString())}`);
   } catch (err) {
-    console.error(err);
-    if (!container.dataset.analyticsReady) {
-      container.innerHTML = "<p>No se pudieron cargar las analíticas</p>";
-    }
-  } finally {
-    detailedInFlight = false;
-  }
+    console.error("analytics-detailed-refresh-error", err);
+    setText("analytics-detail-status", "No se pudieron actualizar las métricas detalladas.");
+  } finally { detailBusy = false; }
+}
+
+function timers() {
+  if (!liveTimer) liveTimer = window.setInterval(() => fetchLive(), LIVE_MS);
+  if (!detailTimer) detailTimer = window.setInterval(() => fetchDetail(), DETAIL_MS);
+}
+
+export async function renderAnalyticsDashboard(containerId = "analytics-dashboard", options = {}) {
+  const { range, from, to, isAutoRefresh = false, forceDetailed = false } = options || {};
+  const container = typeof containerId === "string" ? document.getElementById(containerId) : containerId;
+  if (!container) return;
+  if (range) state.range = range;
+  if (from !== undefined) state.from = from || "";
+  if (to !== undefined) state.to = to || "";
+  shell(container);
+  timers();
+  fetchLive(true);
+  if (!isAutoRefresh || forceDetailed || !hasDetail) fetchDetail(Boolean(forceDetailed));
 }


### PR DESCRIPTION
Fast-first-render update for the internal admin analytics panel.

Changes:
- Replaces frontend/js/analytics.js with a lightweight shell-first renderer.
- Shows analytics cards/placeholders immediately.
- Loads /api/analytics/live first.
- Loads /api/analytics/detailed in the background.
- Avoids full DOM reset on auto refresh.

Scope: no checkout, prices, products, Mercado Pago, Andreani, Resend, emails, or order logic changes.

Testing: node --check was run locally on the replacement analytics file.