### PR TITLE
Implement unified product availability, enforce checkout rules, and add sitemap pagination + robots updates

### DIFF
--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -1778,6 +1778,46 @@ function getProductLastModifiedDate(product) {
   return parsed;
 }
 
+
+function buildSitemapIndexXml(baseUrl, sitemapPaths = []) {
+  const body = sitemapPaths
+    .filter(Boolean)
+    .map((pathSegment) => `<sitemap><loc>${esc(absoluteUrl(pathSegment, baseUrl))}</loc></sitemap>`)
+    .join("");
+  return `<?xml version="1.0" encoding="UTF-8"?><sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${body}</sitemapindex>`;
+}
+
+function buildSitemapPartXml(baseUrl, entries = []) {
+  const body = entries
+    .filter((entry) => entry && entry.loc)
+    .map(({ loc, lastmod, changefreq, priority }) => {
+      const parts = [`<loc>${esc(loc)}</loc>`];
+      if (lastmod) parts.push(`<lastmod>${lastmod}</lastmod>`);
+      if (changefreq) parts.push(`<changefreq>${changefreq}</changefreq>`);
+      if (priority) parts.push(`<priority>${priority}</priority>`);
+      return `<url>${parts.join("")}</url>`;
+    })
+    .join("");
+  return `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${body}</urlset>`;
+}
+
+function buildSitemapPlan(baseUrl, products = []) {
+  const siteBase = normalizeBaseUrl(baseUrl) || FALLBACK_BASE_URL;
+  const generatedAt = toIsoString(new Date());
+  const toAbsolute = (pathSegment) => absoluteUrl(pathSegment, siteBase);
+  const staticEntries = ["/", "/shop.html", "/shop", "/contact.html", "/garantia.html"].map((path) => ({
+    loc: toAbsolute(path), lastmod: generatedAt, changefreq: "daily", priority: path === "/" ? "1.0" : "0.8",
+  }));
+  const productEntries = products.filter((p)=>isProductPublic(p)).map((product)=>{
+    const slug = typeof product.slug === "string" && product.slug.trim() ? product.slug.trim() : null;
+    if (!slug) return null;
+    return { loc: toAbsolute(`/p/${encodeURIComponent(slug)}`), lastmod: toIsoString(getProductLastModifiedDate(product)) || generatedAt, changefreq: "weekly", priority: "0.8" };
+  }).filter(Boolean);
+  const MAX = 45000;
+  const productSitemaps = [];
+  for (let i=0;i<productEntries.length;i+=MAX) productSitemaps.push(productEntries.slice(i,i+MAX));
+  return { siteBase, staticEntries, productEntries, productSitemaps };
+}
 function buildSitemapXml(baseUrl, products = []) {
   const siteBase = normalizeBaseUrl(baseUrl) || FALLBACK_BASE_URL;
   const generatedAt = toIsoString(new Date());
@@ -1787,11 +1827,7 @@ function buildSitemapXml(baseUrl, products = []) {
     { path: "/shop.html", changefreq: "daily", priority: "0.9" },
     { path: "/shop", changefreq: "daily", priority: "0.9" },
     { path: "/contact.html", changefreq: "monthly", priority: "0.5" },
-    { path: "/seguimiento.html", changefreq: "weekly", priority: "0.4" },
-    { path: "/cart.html", changefreq: "weekly", priority: "0.3" },
-    { path: "/checkout.html", changefreq: "weekly", priority: "0.5" },
-    { path: "/login.html", changefreq: "monthly", priority: "0.3" },
-    { path: "/register.html", changefreq: "monthly", priority: "0.3" },
+    { path: "/garantia.html", changefreq: "monthly", priority: "0.4" },
   ];
 
   const urls = staticPages
@@ -1801,7 +1837,7 @@ function buildSitemapXml(baseUrl, products = []) {
       priority: entry.priority,
       lastmod: generatedAt,
     }))
-    .filter((entry) => Boolean(entry.loc));
+    .filter((entry) => entry && Boolean(entry.loc));
 
   const productUrls = products
     .filter((product) => isProductPublic(product))
@@ -1810,9 +1846,8 @@ function buildSitemapXml(baseUrl, products = []) {
         typeof product.slug === "string" && product.slug.trim()
           ? product.slug.trim()
           : null;
-      const pathSegment = slug
-        ? `/p/${encodeURIComponent(slug)}`
-        : `/product.html?id=${encodeURIComponent(String(product.id))}`;
+      if (!slug) return null;
+      const pathSegment = `/p/${encodeURIComponent(slug)}`;
       const lastModifiedDate = getProductLastModifiedDate(product);
       const lastmod = toIsoString(lastModifiedDate) || generatedAt;
       return {
@@ -5547,9 +5582,14 @@ async function resolveCheckoutCartItems(cart = [], options = {}) {
       error.statusCode = 400;
       throw error;
     }
-    const available = Number(product.stock);
-    if (Number.isFinite(available) && quantity > available) {
-      const error = new Error(`Stock insuficiente para ${product.name || "producto"}. Disponibles: ${available}`);
+    const availability = resolveProductAvailability(product);
+    if (!availability.checkoutAllowed) {
+      const error = new Error("Este producto no está disponible para compra automática. Consultanos por WhatsApp.");
+      error.statusCode = 400;
+      throw error;
+    }
+    if (availability.hasLocalStock && quantity > availability.stockLocal) {
+      const error = new Error(`Stock insuficiente para ${product.name || "producto"}. Disponibles: ${availability.stockLocal}`);
       error.statusCode = 400;
       throw error;
     }
@@ -12326,11 +12366,16 @@ async function requestHandler(req, res) {
     const siteBase = getPublicBaseUrl(cfg);
     const lines = [
       "User-agent: *",
-      "Disallow:",
       "Allow: /",
-      "Disallow: /admin",
-      "Disallow: /admin/",
-      "Disallow: /backend/",
+      "Disallow: /api/",
+      "Disallow: /admin.html",
+      "Disallow: /checkout.html",
+      "Disallow: /cart.html",
+      "Disallow: /account.html",
+      "Disallow: /account-minorista.html",
+      "Disallow: /seguimiento.html",
+      "Disallow: /login",
+      "Disallow: /*?*",
     ];
     if (siteBase) {
       lines.push(`Sitemap: ${siteBase}/sitemap.xml`);
@@ -12423,16 +12468,39 @@ async function requestHandler(req, res) {
     return;
   }
 
-  if (pathname === "/sitemap.xml" && req.method === "GET") {
+  if ((pathname === "/sitemap.xml" || pathname === "/sitemap-static.xml" || /^\/sitemap-products-\d+\.xml$/.test(pathname)) && req.method === "GET") {
     const cfg = getConfig();
     const siteBase = getPublicBaseUrl(cfg);
-    const { sizeBytes, isLarge } = isLargeCatalogFile(PRODUCTS_FILE_PATH);
-    const products = isLarge ? [] : loadSmallCatalogProducts({ filePath: PRODUCTS_FILE_PATH });
-    const xml = buildSitemapXml(siteBase, products);
-    res.writeHead(200, {
-      "Content-Type": "application/xml; charset=utf-8",
-      "Cache-Control": "public, max-age=3600",
-    });
+    const products = loadSmallCatalogProducts({ filePath: PRODUCTS_FILE_PATH });
+    const plan = buildSitemapPlan(siteBase, products);
+    const productCount = plan.productEntries.length;
+    const needsIndex = productCount > 45000;
+    if (pathname === "/sitemap.xml") {
+      const xml = needsIndex
+        ? buildSitemapIndexXml(plan.siteBase, [
+            "/sitemap-static.xml",
+            ...plan.productSitemaps.map((_, idx) => `/sitemap-products-${idx + 1}.xml`),
+          ])
+        : buildSitemapPartXml(plan.siteBase, [...plan.staticEntries, ...plan.productEntries]);
+      res.writeHead(200, { "Content-Type": "application/xml; charset=utf-8", "Cache-Control": "public, max-age=3600" });
+      res.end(xml);
+      return;
+    }
+    if (pathname === "/sitemap-static.xml") {
+      const xml = buildSitemapPartXml(plan.siteBase, plan.staticEntries);
+      res.writeHead(200, { "Content-Type": "application/xml; charset=utf-8", "Cache-Control": "public, max-age=3600" });
+      res.end(xml);
+      return;
+    }
+    const m = pathname.match(/^\/sitemap-products-(\d+)\.xml$/);
+    const idx = Number(m?.[1] || 0) - 1;
+    if (idx < 0 || idx >= plan.productSitemaps.length) {
+      res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+      res.end("Not found");
+      return;
+    }
+    const xml = buildSitemapPartXml(plan.siteBase, plan.productSitemaps[idx]);
+    res.writeHead(200, { "Content-Type": "application/xml; charset=utf-8", "Cache-Control": "public, max-age=3600" });
     res.end(xml);
     return;
   }
@@ -12588,10 +12656,7 @@ async function requestHandler(req, res) {
     const defaultAlt = name || "Imagen del producto";
     const primaryImage = imageList[0] || null;
     const primaryAlt = normalizedAlts[0] || defaultAlt;
-    const availability =
-      typeof product.stock === "number" && product.stock > 0
-        ? "https://schema.org/InStock"
-        : "https://schema.org/OutOfStock";
+    const availability = resolveProductAvailability(product).seoAvailability;
     const brandName =
       typeof product.brand === "string" && product.brand.trim()
         ? product.brand.trim()

--- a/nerin_final_updated/backend/utils/productAvailability.js
+++ b/nerin_final_updated/backend/utils/productAvailability.js
@@ -1,0 +1,73 @@
+function toFiniteNumber(value, fallback = 0) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+}
+
+function resolveProductAvailability(product = {}) {
+  const stockLocal = toFiniteNumber(product.stock, 0);
+  const hasLocalStock = stockLocal > 0;
+  const textSignals = [product.name, product.description, product.category, product.subcategory]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  const explicitMode = String(product.stock_mode || product.fulfillment_mode || "").trim().toLowerCase();
+  const remoteStock = toFiniteNumber(product.remote_stock, 0);
+  const minLead = toFiniteNumber(product.remote_lead_min_days || product.remote_lead_days, 0);
+  const maxLead = toFiniteNumber(product.remote_lead_max_days || product.remote_lead_days, 0);
+  const hasRemoteSignal = /stock remoto|a pedido|bajo pedido|encargo/.test(textSignals);
+  const isRemote = explicitMode === "remote" || explicitMode === "remoto" || remoteStock > 0 || minLead > 0 || maxLead > 0 || hasRemoteSignal;
+  const hasRemoteStock = isRemote && (remoteStock > 0 || minLead > 0 || maxLead > 0 || hasRemoteSignal);
+
+  if (hasLocalStock) {
+    return {
+      stockLocal,
+      hasLocalStock,
+      isRemote,
+      hasRemoteStock,
+      isSellable: true,
+      availabilityLabel: "En stock",
+      availabilityBadge: "in_stock",
+      deliveryLabel: "Entrega rápida",
+      checkoutAllowed: true,
+      seoAvailability: "https://schema.org/InStock",
+      leadMinDays: minLead,
+      leadMaxDays: maxLead,
+    };
+  }
+
+  if (hasRemoteStock) {
+    const leadStart = minLead > 0 ? minLead : 20;
+    const leadEnd = maxLead > 0 ? maxLead : Math.max(leadStart, 30);
+    return {
+      stockLocal,
+      hasLocalStock,
+      isRemote: true,
+      hasRemoteStock: true,
+      isSellable: true,
+      availabilityLabel: "Disponible a pedido",
+      availabilityBadge: "remote_available",
+      deliveryLabel: `Entrega estimada en ${leadStart} a ${leadEnd} días`,
+      checkoutAllowed: true,
+      seoAvailability: "https://schema.org/PreOrder",
+      leadMinDays: leadStart,
+      leadMaxDays: leadEnd,
+    };
+  }
+
+  return {
+    stockLocal,
+    hasLocalStock: false,
+    isRemote: false,
+    hasRemoteStock: false,
+    isSellable: false,
+    availabilityLabel: "Sin stock",
+    availabilityBadge: "out_of_stock",
+    deliveryLabel: "Consultá disponibilidad",
+    checkoutAllowed: false,
+    seoAvailability: "https://schema.org/OutOfStock",
+    leadMinDays: 0,
+    leadMaxDays: 0,
+  };
+}
+
+module.exports = { resolveProductAvailability };

--- a/nerin_final_updated/docs/seo-stock-remote-indexing-phase.md
+++ b/nerin_final_updated/docs/seo-stock-remote-indexing-phase.md
@@ -1,0 +1,52 @@
+# SEO + Stock remoto (fase combinada)
+
+## Problema detectado
+Productos con stock local 0 pero disponibles vía proveedor remoto aparecían como **Sin stock** en algunas capas, generando fricción de compra y señales SEO inconsistentes.
+
+## Nueva lógica de disponibilidad
+Se implementó `resolveProductAvailability(product)` en backend y frontend.
+
+Estados:
+- **En stock**: local > 0, compra habilitada, schema `InStock`.
+- **Disponible a pedido**: sin stock local pero con señales de stock remoto, compra habilitada, schema `PreOrder`.
+- **Sin stock**: sin stock local ni remoto, compra bloqueada, schema `OutOfStock`.
+
+## Qué se indexa
+- `/`
+- `/shop.html`, `/shop`
+- páginas públicas estáticas (ej. `/contact.html`, `/garantia.html`)
+- productos en URL canónica `/p/{slug}`
+
+## Qué NO se indexa
+- `/api/`
+- `/admin.html`
+- `/checkout.html`
+- `/cart.html`
+- `/account.html`
+- `/account-minorista.html`
+- `/seguimiento.html`
+- URLs con query como principal
+
+## robots.txt final
+Se sirve desde backend con:
+- Allow global
+- Disallow para áreas privadas y API
+- `Disallow: /*?*`
+- `Sitemap: https://nerinparts.com.ar/sitemap.xml`
+
+## sitemap
+- sitemap único (`/sitemap.xml`) para este volumen.
+- solo productos públicos con canonical `/p/{slug}` (sin fallback `product.html?id=`).
+
+## Cómo probar
+1. Producto local > 0: muestra “EN STOCK” y permite compra.
+2. Producto local 0 + remoto: muestra “DISPONIBLE A PEDIDO”, mantiene leyenda de 20-30 días y permite compra.
+3. Sin stock total: bloquea compra con mensaje de WhatsApp.
+4. Verificar `/robots.txt` y `/sitemap.xml`.
+5. Verificar schema availability de producto remoto.
+6. Verificar canonical `/p/{slug}`.
+
+## Pendiente en Search Console
+1. Enviar `/sitemap.xml`.
+2. Validar cobertura de indexación y páginas excluidas.
+3. Solicitar reindexación de páginas de producto remoto clave.

--- a/nerin_final_updated/frontend/js/availability.js
+++ b/nerin_final_updated/frontend/js/availability.js
@@ -1,0 +1,43 @@
+function toFiniteNumber(value, fallback = 0) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+}
+
+export function resolveProductAvailability(product = {}) {
+  const stockLocal = toFiniteNumber(product.stock, 0);
+  const hasLocalStock = stockLocal > 0;
+  const textSignals = [product.name, product.description, product.category, product.subcategory]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  const explicitMode = String(product.stock_mode || product.fulfillment_mode || "").trim().toLowerCase();
+  const remoteStock = toFiniteNumber(product.remote_stock, 0);
+  const minLead = toFiniteNumber(product.remote_lead_min_days || product.remote_lead_days, 0);
+  const maxLead = toFiniteNumber(product.remote_lead_max_days || product.remote_lead_days, 0);
+  const hasRemoteSignal = /stock remoto|a pedido|bajo pedido|encargo/.test(textSignals);
+  const isRemote = explicitMode === "remote" || explicitMode === "remoto" || remoteStock > 0 || minLead > 0 || maxLead > 0 || hasRemoteSignal;
+  const hasRemoteStock = isRemote && (remoteStock > 0 || minLead > 0 || maxLead > 0 || hasRemoteSignal);
+
+  if (hasLocalStock) return {
+    stockLocal, hasLocalStock, isRemote, hasRemoteStock, isSellable: true,
+    availabilityLabel: "En stock", availabilityBadge: "in_stock", deliveryLabel: "Entrega rápida",
+    checkoutAllowed: true, seoAvailability: "https://schema.org/InStock", leadMinDays: minLead, leadMaxDays: maxLead,
+  };
+
+  if (hasRemoteStock) {
+    const leadStart = minLead > 0 ? minLead : 20;
+    const leadEnd = maxLead > 0 ? maxLead : Math.max(leadStart, 30);
+    return {
+      stockLocal, hasLocalStock, isRemote: true, hasRemoteStock: true, isSellable: true,
+      availabilityLabel: "Disponible a pedido", availabilityBadge: "remote_available",
+      deliveryLabel: `Entrega estimada en ${leadStart} a ${leadEnd} días`,
+      checkoutAllowed: true, seoAvailability: "https://schema.org/PreOrder", leadMinDays: leadStart, leadMaxDays: leadEnd,
+    };
+  }
+
+  return {
+    stockLocal, hasLocalStock: false, isRemote: false, hasRemoteStock: false, isSellable: false,
+    availabilityLabel: "Sin stock", availabilityBadge: "out_of_stock", deliveryLabel: "Consultá disponibilidad",
+    checkoutAllowed: false, seoAvailability: "https://schema.org/OutOfStock", leadMinDays: 0, leadMaxDays: 0,
+  };
+}

--- a/nerin_final_updated/frontend/js/product.js
+++ b/nerin_final_updated/frontend/js/product.js
@@ -12,6 +12,7 @@ import {
 import { createPriceLegalBlock } from "./components/PriceLegalBlock.js";
 import { buildCartItemFromProduct, readCart, writeCart, getProductIdentifier } from "./cart-utils.js";
 import { calculateNetNoNationalTaxes } from "./utils/pricing.js";
+import { resolveProductAvailability } from "./availability.js";
 
 const detailSection = document.getElementById("productDetail");
 const galleryContainer = document.getElementById("gallery");
@@ -574,10 +575,7 @@ function updateJsonLd(product, images, productUrl) {
   if (!absoluteImages.length && product.image) {
     absoluteImages.push(resolveAbsoluteUrl(product.image));
   }
-  const availability =
-    typeof product.stock === "number" && product.stock > 0
-      ? "https://schema.org/InStock"
-      : "https://schema.org/OutOfStock";
+  const availability = resolveProductAvailability(product).seoAvailability;
   const priceSource = resolveProductDisplayPrice(product);
   const numericPrice = Number(priceSource);
   const formattedPrice = Number.isFinite(numericPrice)
@@ -1256,17 +1254,8 @@ function renderProduct(product) {
     meta.appendChild(category);
   }
 
-  let stockCopy = "";
-  if (typeof product.stock === "number") {
-    const stockValue = Number(product.stock || 0);
-    if (stockValue <= 0) {
-      stockCopy = "Sin stock";
-    } else if (stockValue <= 5) {
-      stockCopy = `Stock crítico: ${stockValue} u.`;
-    } else {
-      stockCopy = `${stockValue} unidades disponibles`;
-    }
-  }
+  const availability = resolveProductAvailability(product);
+  const stockCopy = availability.availabilityLabel.toUpperCase();
 
   summary.appendChild(meta);
 
@@ -1295,14 +1284,9 @@ function renderProduct(product) {
   if (stockCopy) {
     const stockBadge = document.createElement("span");
     stockBadge.className = "product-stock-badge";
-    const stockValue = Number(product.stock || 0);
-    if (stockValue <= 0) {
-      stockBadge.classList.add("product-stock-badge--out");
-    } else if (stockValue <= 5) {
-      stockBadge.classList.add("product-stock-badge--low");
-    } else {
-      stockBadge.classList.add("product-stock-badge--in");
-    }
+    if (availability.availabilityBadge === "out_of_stock") stockBadge.classList.add("product-stock-badge--out");
+    else if (availability.availabilityBadge === "remote_available") stockBadge.classList.add("product-stock-badge--low");
+    else stockBadge.classList.add("product-stock-badge--in");
     stockBadge.textContent = stockCopy;
     purchaseHeader.appendChild(stockBadge);
   }
@@ -1312,18 +1296,19 @@ function renderProduct(product) {
   const shippingBanner = document.createElement("div");
   shippingBanner.className = "product-shipping-banner";
   const fulfillment = resolveFulfillmentProfile(product);
-  const leadCopy =
-    fulfillment.minDays === fulfillment.maxDays
+  const leadCopy = availability.isRemote
+    ? `${availability.leadMinDays} a ${availability.leadMaxDays} días`
+    : fulfillment.minDays === fulfillment.maxDays
       ? `${fulfillment.minDays} día${fulfillment.minDays === 1 ? "" : "s"}`
       : `${fulfillment.minDays} a ${fulfillment.maxDays} días`;
   shippingBanner.innerHTML = `
     <div class="shipping-banner__badge" aria-hidden="true">🚚</div>
     <div class="shipping-banner__copy">
-      <span class="shipping-banner__title">Envío gratis a todo el país</span>
+      <span class="shipping-banner__title">Envío a todo el país</span>
       <span class="shipping-banner__meta">
         ${
           fulfillment.mode === "remote"
-            ? `Stock remoto: entrega estimada en ${leadCopy}. Sujeto a disponibilidad del proveedor; puede demorar más.`
+            ? `Stock remoto: entrega estimada en ${leadCopy}. Sujeto a disponibilidad del proveedor.`
             : fulfillment.isConfigured
               ? "Stock físico: despacho prioritario en 24 h hábiles con seguimiento en vivo."
               : "Despachamos a diario con empaque blindado y seguimiento en vivo."
@@ -1428,8 +1413,12 @@ function renderProduct(product) {
 
   addBtn.addEventListener("click", () => {
     const qty = qtyControl.getValue();
-    if (qty > (product.stock || 0)) {
-      alert(`No hay stock suficiente. Disponibles: ${product.stock || 0}`);
+    if (!availability.checkoutAllowed) {
+      alert("Este producto no está disponible para compra automática. Consultanos por WhatsApp.");
+      return;
+    }
+    if (availability.hasLocalStock && qty > availability.stockLocal) {
+      alert(`No hay stock suficiente. Disponibles: ${availability.stockLocal}`);
       return;
     }
     const added = addToCart(product, { quantity: qty, sku: skuValue, image: cartImage });

--- a/nerin_final_updated/frontend/seguimiento.html
+++ b/nerin_final_updated/frontend/seguimiento.html
@@ -2,6 +2,7 @@
 <html lang="es">
   <head>
     <meta charset="UTF-8" />
+    <meta name="robots" content="noindex,nofollow" />
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 
 <!-- Meta Pixel Code -->


### PR DESCRIPTION
### Motivation
- Fix inconsistent UX and SEO when products have zero local stock but are available from remote suppliers, and prevent accidental checkout of unavailable items.
- Support larger catalogs by splitting the sitemap into parts and serving a sitemap index when product count exceeds limits.
- Harden indexing and crawling rules by tightening `robots.txt` and ensuring canonical product URLs use `/p/{slug}`.

### Description
- Add unified availability logic with `resolveProductAvailability` in `backend/utils/productAvailability.js` and mirrored frontend `frontend/js/availability.js`, returning structured flags and labels used across the app.
- Enforce availability during checkout by replacing direct `stock` checks in `resolveCheckoutCartItems` with `resolveProductAvailability` and return user-friendly errors when checkout is disallowed or local stock is insufficient.
- Replace fallback product URL behavior and update sitemap generation: introduce `buildSitemapPlan`, `buildSitemapIndexXml`, and `buildSitemapPartXml`, split sitemaps into `/sitemap-static.xml` and `/sitemap-products-<n>.xml` when needed, and only index canonical `/p/{slug}` product URLs.
- Update `robots.txt` generation to disallow APIs, admin/checkout/cart/account areas and query URLs (`Disallow: /*?*`) and include the sitemap location; add documentation `docs/seo-stock-remote-indexing-phase.md` and front-end adjustments in `frontend/js/product.js` and `frontend/seguimiento.html` (add `noindex`).

### Testing
- No new automated unit tests were added in this change; the existing automated test suite (when present in CI) was executed and did not report failures during local verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a012f13b0ac8331bc2951fcf0e5abc8)