### PR TITLE
Add eligible-only bulk publish for NERIN Parts and treat stock=0 as remote/preorder

### DIFF
--- a/nerin_final_updated/backend/data/productsSqliteRepo.js
+++ b/nerin_final_updated/backend/data/productsSqliteRepo.js
@@ -513,6 +513,52 @@ function isProductPublic(product) {
   return computeProductPublicState(product).isPublic;
 }
 
+function resolveBulkPublishEligibility(product = {}) {
+  const reasons = [];
+  const warnings = [];
+  const updates = {};
+  const computed = computeProductPublicState(product);
+  const signals = computed?.signals || {};
+
+  const hasName = !signals.missingName;
+  const hasIdentifier = !signals.missingIdentifier;
+  const priceValue = firstFiniteNumber([
+    getField(product, ["price", "precio", "price_minorista", "precio_minorista", "precio_final", "finalPrice", "salePrice"]),
+  ]);
+  const hasValidPrice = Number.isFinite(priceValue) && priceValue > 0;
+
+  if (!hasName) reasons.push("missing_name");
+  if (!hasIdentifier) reasons.push("missing_identifier");
+  if (!hasValidPrice) reasons.push("missing_price");
+  if (signals.deleted) reasons.push("deleted");
+  if (signals.archived) reasons.push("archived");
+  if (signals.enabledFalse) reasons.push("disabled");
+  if (signals.vipOnly) reasons.push("vip_only");
+  if (signals.wholesaleOnly) reasons.push("wholesale_only");
+  if (signals.visibility === "hidden" || signals.status === "hidden") reasons.push("hidden");
+  if (signals.visibility === "private" || signals.status === "private") reasons.push("private");
+  if (signals.visibility === "draft" || signals.status === "draft") reasons.push("draft");
+  if (signals.visibility === "disabled" || signals.status === "disabled") reasons.push("disabled");
+  if (signals.visibility === "deleted" || signals.status === "deleted") reasons.push("deleted");
+  if (signals.visibility === "archived" || signals.status === "archived") reasons.push("archived");
+
+  const publicSlug = toNullableText(getField(product, ["public_slug", "publicSlug", "slug"]));
+  if (!publicSlug) {
+    updates.public_slug = buildPublicSlug(product, product?.rowid);
+    warnings.push("generated_slug");
+  }
+  const imageValue = toNullableText(getField(product, ["image", "imagen", "imageUrl", "image_url"]));
+  if (!imageValue) warnings.push("missing_image");
+  const description = toNullableText(getField(product, ["description", "descripcion", "shortDescription", "short_description"]));
+  if (!description) warnings.push("missing_description");
+  const stock = Number(firstFiniteNumber([getField(product, ["stock", "stock_local"])]) || 0);
+  if (stock <= 0) {
+    warnings.push("stock_zero_remote_assumed");
+    warnings.push("remote_delivery_estimated");
+  }
+  return { eligible: reasons.length === 0, reasons: Array.from(new Set(reasons)), warnings: Array.from(new Set(warnings)), updates };
+}
+
 function buildSearchText(product = {}) {
   const mappedCore = {
     publicSlug: toNullableText(getField(product, ["publicSlug", "public_slug"])),
@@ -1967,6 +2013,66 @@ async function bulkPublication({ action = "publish", scope = "private_products",
   return { ok: true, beforePublicCount, afterPublicCount, updatedRows, skipped, examplesUpdated, dryRun: Boolean(dryRun) };
 }
 
+async function previewBulkPublish({ filters = {}, limit = 500 } = {}) {
+  await ensureDbReadyForRequest();
+  const db = await openDb();
+  const safeLimit = Math.max(1, Math.min(50000, Number(limit) || 500));
+  const query = await queryAdminProducts({
+    page: 1,
+    pageSize: safeLimit,
+    search: filters?.search || "",
+    brand: filters?.brand || "",
+    category: filters?.category || "",
+    visibility: filters?.visibility || "",
+    status: filters?.status || "",
+  });
+  const rows = query.items || [];
+  const reasonCounts = {};
+  const warningCounts = {};
+  const samplesEligible = [];
+  const samplesBlocked = [];
+  let eligibleCount = 0;
+  rows.forEach((item) => {
+    const result = resolveBulkPublishEligibility(item);
+    result.reasons.forEach((reason) => { reasonCounts[reason] = (reasonCounts[reason] || 0) + 1; });
+    result.warnings.forEach((warning) => { warningCounts[warning] = (warningCounts[warning] || 0) + 1; });
+    if (result.eligible) {
+      eligibleCount += 1;
+      if (samplesEligible.length < 10) samplesEligible.push({ identifier: item.id || item.sku || item.code, name: item.name || item.title || null, warnings: result.warnings, updates: result.updates });
+    } else if (samplesBlocked.length < 10) {
+      samplesBlocked.push({ identifier: item.id || item.sku || item.code, name: item.name || item.title || null, reasons: result.reasons });
+    }
+  });
+  return { totalScanned: rows.length, eligibleCount, blockedCount: rows.length - eligibleCount, warningCount: Object.values(warningCounts).reduce((a, b) => a + b, 0), samplesEligible, samplesBlocked, reasonCounts, warningCounts };
+}
+
+async function bulkPublishEligible({ dryRun = false, filters = {}, limit = 500, publishMode = "eligible_only" } = {}) {
+  if (publishMode !== "eligible_only") throw new Error("publishMode must be eligible_only");
+  await ensureDbReadyForRequest();
+  const db = await openDb();
+  const preview = await previewBulkPublish({ filters, limit });
+  const query = await queryAdminProducts({ page: 1, pageSize: Math.max(1, Math.min(50000, Number(limit) || 500)), search: filters?.search || "", brand: filters?.brand || "", category: filters?.category || "", visibility: filters?.visibility || "", status: filters?.status || "" });
+  const rows = query.items || [];
+  let updatedCount = 0;
+  for (const item of rows) {
+    const result = resolveBulkPublishEligibility(item);
+    if (!result.eligible) continue;
+    const identifier = item.id || item.sku || item.code || item.public_slug || item.slug;
+    if (!identifier) continue;
+    const patch = { visibility: "public", status: "active", enabled: true, is_public: true };
+    if (result.updates.public_slug) patch.public_slug = result.updates.public_slug;
+    if (Number(item.stock || 0) <= 0) {
+      patch.stock_mode = "remote";
+      patch.fulfillment_mode = "remote";
+      patch.remote_lead_min_days = Number(item.remote_lead_min_days || 20);
+      patch.remote_lead_max_days = Number(item.remote_lead_max_days || 30);
+    }
+    if (!dryRun) await updateProductByIdentifier(identifier, patch, { forceEnabledTrue: true });
+    updatedCount += 1;
+  }
+  return { ok: true, dryRun: Boolean(dryRun), publishMode, ...preview, updatedCount };
+}
+
 async function getCatalogFieldAudit({ sampleSize = 300 } = {}) {
   await ensureDbReadyForRequest();
   const db = await openDb();
@@ -2247,6 +2353,9 @@ module.exports = {
   debugPublicationByIdentifier,
   repairPublicFlags,
   bulkPublication,
+  resolveBulkPublishEligibility,
+  previewBulkPublish,
+  bulkPublishEligible,
   computeProductPublicState,
   updateProductByIdentifier,
   normalizeProductForPublic,

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -6641,6 +6641,46 @@ async function requestHandler(req, res) {
     return;
   }
 
+  if (pathname === "/api/admin/products/bulk-publish-preview" && req.method === "POST") {
+    if (!requireAdmin(req, res)) return;
+    let body = "";
+    req.on("data", (chunk) => { body += chunk; });
+    req.on("end", async () => {
+      try {
+        const payload = JSON.parse(body || "{}");
+        const result = await productsSqliteRepo.previewBulkPublish({
+          filters: payload?.filters || {},
+          limit: payload?.limit || 500,
+        });
+        return sendJson(res, 200, { ok: true, ...result });
+      } catch (error) {
+        return sendJson(res, 500, { ok: false, code: "BULK_PUBLISH_PREVIEW_FAILED", error: error?.message || "No se pudo simular publicación masiva" });
+      }
+    });
+    return;
+  }
+
+  if (pathname === "/api/admin/products/bulk-publish" && req.method === "POST") {
+    if (!requireAdmin(req, res)) return;
+    let body = "";
+    req.on("data", (chunk) => { body += chunk; });
+    req.on("end", async () => {
+      try {
+        const payload = JSON.parse(body || "{}");
+        const result = await productsSqliteRepo.bulkPublishEligible({
+          dryRun: Boolean(payload?.dryRun),
+          filters: payload?.filters || {},
+          limit: payload?.limit || 500,
+          publishMode: payload?.publishMode || "eligible_only",
+        });
+        return sendJson(res, 200, result);
+      } catch (error) {
+        return sendJson(res, 500, { ok: false, code: "BULK_PUBLISH_FAILED", error: error?.message || "No se pudo publicar productos aptos" });
+      }
+    });
+    return;
+  }
+
   if (pathname === "/api/catalog/performance-test" && req.method === "GET") {
     try {
       const perfStartedAt = Date.now();

--- a/nerin_final_updated/backend/utils/productAvailability.js
+++ b/nerin_final_updated/backend/utils/productAvailability.js
@@ -54,6 +54,24 @@ function resolveProductAvailability(product = {}) {
     };
   }
 
+  const priceValue = Number(product.price || product.precio || product.price_minorista || product.precio_minorista || product.precio_final || 0);
+  if (Number.isFinite(priceValue) && priceValue > 0) {
+    return {
+      stockLocal,
+      hasLocalStock: false,
+      isRemote: true,
+      hasRemoteStock: true,
+      isSellable: true,
+      availabilityLabel: "Disponible a pedido",
+      availabilityBadge: "remote_available",
+      deliveryLabel: "Entrega estimada en 20 a 30 días",
+      checkoutAllowed: true,
+      seoAvailability: "https://schema.org/PreOrder",
+      leadMinDays: 20,
+      leadMaxDays: 30,
+    };
+  }
+
   return {
     stockLocal,
     hasLocalStock: false,

--- a/nerin_final_updated/docs/bulk-product-publishing-phase.md
+++ b/nerin_final_updated/docs/bulk-product-publishing-phase.md
@@ -1,0 +1,62 @@
+# Publicación masiva de productos (fase NERIN Parts)
+
+## Criterio de elegibilidad corregido
+Se implementó `resolveBulkPublishEligibility(product)` con salida:
+
+```json
+{ "eligible": true|false, "reasons": [], "warnings": [], "updates": {} }
+```
+
+### Bloquea (reasons)
+- `missing_name`
+- `missing_identifier`
+- `missing_price`
+- `deleted`
+- `archived`
+- `disabled`
+- `hidden`
+- `private`
+- `draft`
+- `vip_only`
+- `wholesale_only`
+
+### Solo advierte (warnings)
+- `missing_image`
+- `missing_description`
+- `stock_zero_remote_assumed`
+- `generated_slug`
+- `remote_delivery_estimated`
+
+No se bloquea por `stock 0`, por `missing_image` ni por `missing_slug`.
+
+## Endpoints
+- `POST /api/admin/products/bulk-publish-preview`
+  - Simula publicación y devuelve:
+  - `totalScanned, eligibleCount, blockedCount, warningCount, samplesEligible, samplesBlocked, reasonCounts, warningCounts`.
+
+- `POST /api/admin/products/bulk-publish`
+  - Acepta: `{ dryRun, filters, limit, publishMode: "eligible_only" }`
+  - Publica solo aptos.
+  - Genera `public_slug` cuando falta.
+  - Marca `visibility=status=public/active`, `enabled=true`, `is_public=true`.
+  - Para stock local 0 configura modo remoto para mostrar “Disponible a pedido”.
+
+## Ejemplos
+- Stock local 0 + precio + nombre + sku => `eligible=true`, warning `stock_zero_remote_assumed`, se publica con disponibilidad remota.
+- Sin imagen => `eligible=true`, warning `missing_image`.
+- Sin precio => `eligible=false`, reason `missing_price`.
+
+## UI Admin agregada
+Sección “Publicación masiva” con:
+- Botón **Simular publicación**.
+- Botón **Publicar productos aptos**.
+- Filtros: búsqueda, marca, categoría, solo ocultos/privados y límite.
+- Resumen: escaneados, aptos, bloqueados, warnings, top reasons/warnings.
+
+## Cómo probar
+1. En Admin > Productos, usar sección “Publicación masiva”.
+2. Simular con distintos filtros y validar que `missing_image`/`stock_zero_remote_assumed` aparecen como warning.
+3. Ejecutar publicación con `limit=10`.
+4. Verificar en catálogo público y sitemap rutas `/p/{slug}`.
+5. Verificar que producto con stock 0 muestre “Disponible a pedido”.
+6. Confirmar que no se modificaron precios ni flujos de pagos/logística/emails/pedidos.

--- a/nerin_final_updated/frontend/admin.html
+++ b/nerin_final_updated/frontend/admin.html
@@ -443,6 +443,19 @@
           <div id="stockXlsxImportStatus" role="status" aria-live="polite"></div>
           <progress id="stockXlsxImportProgress" value="0" max="100" style="width:100%;display:none;"></progress>
           <div class="bulk-actions">
+            <strong>Publicación masiva</strong>
+            <input type="text" id="bulkPublishSearch" placeholder="Buscar" />
+            <input type="text" id="bulkPublishBrand" placeholder="Marca" />
+            <input type="text" id="bulkPublishCategory" placeholder="Categoría" />
+            <label style="display:flex;align-items:center;gap:8px;">
+              <input type="checkbox" id="bulkPublishOnlyHidden" /> Solo ocultos/privados
+            </label>
+            <input type="number" id="bulkPublishLimit" placeholder="Límite" min="1" max="50000" />
+            <button id="bulkPublishPreviewBtn" class="button secondary">Simular publicación</button>
+            <button id="bulkPublishRunBtn" class="button">Publicar productos aptos</button>
+          </div>
+          <div id="bulkPublishSummary" role="status" aria-live="polite"></div>
+          <div class="bulk-actions">
             <select id="bulkActionSelect">
               <option value="">Acción masiva…</option>
               <option value="delete">Eliminar</option>

--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -1742,6 +1742,14 @@ const descriptionAssistStatus = document.getElementById("descriptionAssistStatus
 const bulkSelect = document.getElementById("bulkActionSelect");
 const bulkValueInput = document.getElementById("bulkValue");
 const applyBulkBtn = document.getElementById("applyBulkBtn");
+const bulkPublishSearch = document.getElementById("bulkPublishSearch");
+const bulkPublishBrand = document.getElementById("bulkPublishBrand");
+const bulkPublishCategory = document.getElementById("bulkPublishCategory");
+const bulkPublishOnlyHidden = document.getElementById("bulkPublishOnlyHidden");
+const bulkPublishLimit = document.getElementById("bulkPublishLimit");
+const bulkPublishPreviewBtn = document.getElementById("bulkPublishPreviewBtn");
+const bulkPublishRunBtn = document.getElementById("bulkPublishRunBtn");
+const bulkPublishSummary = document.getElementById("bulkPublishSummary");
 const importCatalogCsvBtn = document.getElementById("importCatalogCsvBtn");
 const catalogCsvFileInput = document.getElementById("catalogCsvFile");
 const catalogCsvIncludeOutOfStock = document.getElementById("catalogCsvIncludeOutOfStock");
@@ -3762,6 +3770,47 @@ if (applyBulkBtn && bulkSelect) {
     }
   }
   loadProducts();
+  });
+}
+
+function getBulkPublishPayload() {
+  const filters = {
+    search: bulkPublishSearch?.value?.trim() || "",
+    brand: bulkPublishBrand?.value?.trim() || "",
+    category: bulkPublishCategory?.value?.trim() || "",
+  };
+  if (bulkPublishOnlyHidden?.checked) filters.visibility = "private";
+  return {
+    filters,
+    limit: Number(bulkPublishLimit?.value || 500),
+  };
+}
+
+function renderBulkPublishSummary(data = {}, mode = "preview") {
+  if (!bulkPublishSummary) return;
+  const reasons = Object.entries(data.reasonCounts || {}).sort((a, b) => b[1] - a[1]).slice(0, 5).map(([k, v]) => `${k}: ${v}`).join(" · ");
+  const warnings = Object.entries(data.warningCounts || {}).sort((a, b) => b[1] - a[1]).slice(0, 5).map(([k, v]) => `${k}: ${v}`).join(" · ");
+  bulkPublishSummary.textContent = `${mode === "publish" ? "Publicación ejecutada" : "Simulación"} · Escaneados: ${data.totalScanned || 0} · Aptos: ${data.eligibleCount || 0} · Bloqueados: ${data.blockedCount || 0} · Warnings: ${data.warningCount || 0}${reasons ? ` · Reasons: ${reasons}` : ""}${warnings ? ` · Warnings: ${warnings}` : ""}`;
+}
+
+if (bulkPublishPreviewBtn) {
+  bulkPublishPreviewBtn.addEventListener("click", async () => {
+    const payload = getBulkPublishPayload();
+    const res = await apiFetch("/api/admin/products/bulk-publish-preview", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload) });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data?.error || "No se pudo simular publicación");
+    renderBulkPublishSummary(data, "preview");
+  });
+}
+
+if (bulkPublishRunBtn) {
+  bulkPublishRunBtn.addEventListener("click", async () => {
+    const payload = { ...getBulkPublishPayload(), dryRun: false, publishMode: "eligible_only" };
+    const res = await apiFetch("/api/admin/products/bulk-publish", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload) });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data?.error || "No se pudo publicar en masa");
+    renderBulkPublishSummary(data, "publish");
+    loadProducts();
   });
 }
 

--- a/nerin_final_updated/frontend/js/availability.js
+++ b/nerin_final_updated/frontend/js/availability.js
@@ -35,6 +35,16 @@ export function resolveProductAvailability(product = {}) {
     };
   }
 
+  const priceValue = Number(product.price || product.precio || product.price_minorista || product.precio_minorista || product.precio_final || 0);
+  if (Number.isFinite(priceValue) && priceValue > 0) {
+    return {
+      stockLocal, hasLocalStock: false, isRemote: true, hasRemoteStock: true, isSellable: true,
+      availabilityLabel: "Disponible a pedido", availabilityBadge: "remote_available",
+      deliveryLabel: "Entrega estimada en 20 a 30 días",
+      checkoutAllowed: true, seoAvailability: "https://schema.org/PreOrder", leadMinDays: 20, leadMaxDays: 30,
+    };
+  }
+
   return {
     stockLocal, hasLocalStock: false, isRemote: false, hasRemoteStock: false, isSellable: false,
     availabilityLabel: "Sin stock", availabilityBadge: "out_of_stock", deliveryLabel: "Consultá disponibilidad",


### PR DESCRIPTION
### Motivation
- Allow fast mass-publishing of NERIN Parts even when local stock is 0 or images/slugs are missing, because many items are sold "a pedido" (remote stock) and should not be blocked by local-stock/image/slug gaps. 
- Ensure only explicit non-sellable signals (deleted/archived/disabled/private/draft, missing required identity/price, vip/wholesale only) block publication while missing image/slug/stock become warnings. 
- Provide server-side preview and publish endpoints working against the real SQLite catalog to avoid frontend fan-out and enable safe dry-runs and scoped publishes.

### Description
- Implemented `resolveBulkPublishEligibility(product)` that returns `{ eligible, reasons, warnings, updates }` and blocks only explicit reasons (`missing_name`, `missing_identifier`, `missing_price`, `deleted`, `archived`, `disabled`, `hidden`, `private`, `draft`, `vip_only`, `wholesale_only`), while emitting non-blocking warnings (`missing_image`, `missing_description`, `stock_zero_remote_assumed`, `generated_slug`, `remote_delivery_estimated`), and auto-generates `public_slug` when missing. (file: `backend/data/productsSqliteRepo.js`)
- Added `previewBulkPublish` and `bulkPublishEligible` functions and exported them, and added server endpoints `POST /api/admin/products/bulk-publish-preview` and `POST /api/admin/products/bulk-publish` which use the real SQLite-backed queries and publish only `eligible=true` items with `publishMode: "eligible_only"`. (files: `backend/data/productsSqliteRepo.js`, `backend/server.js`)
- Updated availability logic so products with local stock <= 0 but with a valid price are treated as remote/preorder by default (checkout allowed, schema `PreOrder`, label `Disponible a pedido`) in both backend and frontend availability code. (files: `backend/utils/productAvailability.js`, `frontend/js/availability.js`)
- Added a simple Admin UI block (`frontend/admin.html`, `frontend/js/admin.js`) with filters, a `Simular publicación` button and a `Publicar productos aptos` button, and a summary view; and documented the phase in `docs/bulk-product-publishing-phase.md`.

### Testing
- Ran a basic module import sanity check by executing `node -e "require('./backend/data/productsSqliteRepo'); require('./backend/utils/productAvailability'); console.log('ok')"`, which printed `ok` indicating the updated modules load without immediate runtime errors. (passed)
- No full unit/integration test suite was executed as part of this change; further automated integration tests (preview vs publish, sitemap entries, UI availability labeling, and end-to-end publication flows) are recommended to validate scenarios A–J in the design doc.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01ea1639f083318c7d3544723734d1)