### PR TITLE
Fix product availability preload before server start

### DIFF
--- a/nerin_final_updated/backend/utils/preloadProductAvailability.js
+++ b/nerin_final_updated/backend/utils/preloadProductAvailability.js
@@ -1,0 +1,5 @@
+const { resolveProductAvailability } = require("./productAvailability");
+
+globalThis.resolveProductAvailability = resolveProductAvailability;
+
+module.exports = { resolveProductAvailability };

--- a/nerin_final_updated/package.json
+++ b/nerin_final_updated/package.json
@@ -4,7 +4,7 @@
   "description": "Sistema ERP + E‑commerce para NERIN Repuestos",
   "main": "backend/index.js",
   "scripts": {
-    "start": "node --max-old-space-size=512 backend/server.js",
+    "start": "node --max-old-space-size=512 -r ./backend/utils/preloadProductAvailability.js backend/server.js",
     "test": "jest",
     "validate:meta-feed": "node scripts/validate-meta-feed.js",
     "catalog:enrich-csv": "node scripts/enrichCatalogCsv.js",


### PR DESCRIPTION
### Qué corrige

El server estaba crasheando en páginas de producto `/p/...` con:

`ReferenceError: resolveProductAvailability is not defined`

El intento anterior con `node -e` no servía porque podía hacer que `server.js` no arrancara como proceso principal y Render marcara `Application exited early`.

### Solución aplicada

- Agrega `backend/utils/preloadProductAvailability.js`.
- Ese preload carga `resolveProductAvailability` desde `backend/utils/productAvailability.js` y lo expone en `globalThis` antes de que se cargue `backend/server.js`.
- Cambia el start script a usar `node -r`, que precarga el módulo pero mantiene `backend/server.js` como script principal:

`node --max-old-space-size=512 -r ./backend/utils/preloadProductAvailability.js backend/server.js`

### Archivos modificados

- `nerin_final_updated/backend/utils/preloadProductAvailability.js`
- `nerin_final_updated/package.json`

### Alcance

No toca precios, checkout, Mercado Pago, Andreani, Resend, emails, pedidos, publicación masiva ni lógica comercial.

### Prueba esperada

Después de deployar este PR:

1. El server debe quedar corriendo, sin `Application exited early`.
2. Abrir cualquier `/p/{slug}` no debe tirar `ReferenceError`.
3. Las páginas de producto deben seguir renderizando schema availability.