### PR TITLE
Improve automatic product quality detection from supplier CSV

### DIFF
--- a/nerin_final_updated/backend/utils/productAutoContent.js
+++ b/nerin_final_updated/backend/utils/productAutoContent.js
@@ -1,0 +1,313 @@
+function normalizeText(value) {
+  if (value == null) return "";
+  return String(value).replace(/\s+/g, " ").trim();
+}
+
+function cleanSentence(value) {
+  return normalizeText(value).replace(/\s+([.,;:])/g, "$1");
+}
+
+function pickMetadata(product = {}) {
+  return product && typeof product.metadata === "object" && product.metadata !== null
+    ? product.metadata
+    : {};
+}
+
+function pickSupplierImport(product = {}) {
+  const meta = pickMetadata(product);
+  return meta && typeof meta.supplierImport === "object" && meta.supplierImport !== null
+    ? meta.supplierImport
+    : {};
+}
+
+function pickField(product = {}, keys = []) {
+  const meta = pickMetadata(product);
+  const supplierImport = pickSupplierImport(product);
+  for (const key of keys) {
+    if (!key) continue;
+    if (Object.prototype.hasOwnProperty.call(product, key)) {
+      const value = product[key];
+      if (value != null && value !== "") return value;
+    }
+    if (Object.prototype.hasOwnProperty.call(meta, key)) {
+      const value = meta[key];
+      if (value != null && value !== "") return value;
+    }
+    if (Object.prototype.hasOwnProperty.call(supplierImport, key)) {
+      const value = supplierImport[key];
+      if (value != null && value !== "") return value;
+    }
+  }
+  return null;
+}
+
+function normalizeKey(value) {
+  return normalizeText(value).toLowerCase();
+}
+
+function buildSearchText(product = {}) {
+  return [
+    pickField(product, ["description", "Description"]),
+    pickField(product, ["quality", "Quality"]),
+    pickField(product, ["name", "title"]),
+    pickField(product, ["remarks", "Remarks"]),
+  ]
+    .map(normalizeText)
+    .filter(Boolean)
+    .join(" ");
+}
+
+function canonicalQuality(rawQuality) {
+  const quality = normalizeText(rawQuality);
+  const key = quality.toLowerCase();
+  const aliases = new Map([
+    ["original", "Original"],
+    ["compatible", "Compatible"],
+    ["compatible soft", "Compatible Soft"],
+    ["compatible hard", "Compatible Hard"],
+    ["compatible budget", "Compatible Budget"],
+    ["refurbished", "Refurbished"],
+    ["pulled", "Pulled"],
+    ["pulled a", "Pulled A"],
+    ["pulled b", "Pulled B"],
+    ["pulled c", "Pulled C"],
+    ["factory standard", "Factory Standard"],
+    ["in-cell", "In-Cell"],
+    ["incell", "In-Cell"],
+    ["in cell", "In-Cell"],
+    ["in-cell fhd", "In-Cell FHD"],
+    ["incell fhd", "In-Cell FHD"],
+    ["in cell fhd", "In-Cell FHD"],
+    ["best possible", "Best possible"],
+    ["selected by the art of repair", "Selected by The Art Of Repair"],
+    ["while supplies last", "While supplies last"],
+    ["po-a", "PO-A"],
+    ["po-a+", "PO-A+"],
+    ["po-b", "PO-B"],
+    ["po-c", "PO-C"],
+    ["po-c+", "PO-C+"],
+    ["po-swap", "PO-SWAP"],
+  ]);
+  if (aliases.has(key)) return aliases.get(key);
+  if (/^pulled\s+[abc]$/i.test(quality)) return quality.replace(/\bpulled\b/i, "Pulled").toUpperCase().replace("PULLED", "Pulled");
+  if (/^po-[a-z0-9+]+$/i.test(quality)) return quality.toUpperCase();
+  return quality;
+}
+
+function buildQualityResult(commercialQuality, origin, rawQuality, detectedFrom = "quality") {
+  const originLabels = {
+    original_fabricante: "original de fabricante",
+    original_reacondicionado: "original reacondicionado",
+    aftermarket: "aftermarket",
+    aftermarket_economico: "aftermarket economico",
+    estandar_fabrica: "estandar de fabrica",
+    retirado_de_equipo: "retirado de equipo",
+    pre_owned: "pre-owned",
+    unknown: "no especificado",
+  };
+  return {
+    rawQuality: normalizeText(rawQuality),
+    commercialQuality,
+    origin,
+    originLabel: originLabels[origin] || origin,
+    qualityKnown: commercialQuality !== "Calidad no especificada",
+    detectedFrom,
+  };
+}
+
+function detectProductQuality(product = {}) {
+  const raw = pickField(product, ["quality", "Quality"]);
+  const description = normalizeText(pickField(product, ["description", "Description"]));
+  const quality = canonicalQuality(raw);
+
+  if (!quality) {
+    if (/\brefurb(?:ished)?\b/i.test(description)) {
+      return buildQualityResult("Refurbished", "original_reacondicionado", "Refurbished", "description");
+    }
+    return buildQualityResult("Calidad no especificada", "unknown", "", "missing");
+  }
+
+  const key = normalizeKey(quality);
+  if (key === "original") return buildQualityResult("Original", "original_fabricante", quality);
+  if (key === "refurbished") return buildQualityResult("Refurbished", "original_reacondicionado", quality);
+  if (key === "compatible") return buildQualityResult("Compatible", "aftermarket", quality);
+  if (key === "compatible soft") return buildQualityResult("Compatible Soft OLED", "aftermarket", quality);
+  if (key === "compatible hard") return buildQualityResult("Compatible Hard OLED", "aftermarket", quality);
+  if (key === "compatible budget") return buildQualityResult("Compatible Budget", "aftermarket_economico", quality);
+  if (key === "factory standard") return buildQualityResult("Factory Standard", "estandar_fabrica", quality);
+  if (key === "in-cell") return buildQualityResult("Compatible In-Cell", "aftermarket", quality);
+  if (key === "in-cell fhd") return buildQualityResult("Compatible In-Cell FHD", "aftermarket", quality);
+  if (/^pulled\b/i.test(quality)) return buildQualityResult(quality, "retirado_de_equipo", quality);
+  if (/^po-/i.test(quality)) return buildQualityResult(quality, "pre_owned", quality);
+
+  return buildQualityResult(quality, "unknown", quality);
+}
+
+function detectDisplayTechnology(product = {}) {
+  const quality = canonicalQuality(pickField(product, ["quality", "Quality"]));
+  const text = buildSearchText(product);
+  if (quality === "Compatible Soft" || /\bsoft\s+oled\b/i.test(text)) return "Soft OLED";
+  if (quality === "Compatible Hard" || /\bhard\s+oled\b/i.test(text)) return "Hard OLED";
+  if (quality === "In-Cell FHD" || /\bin[\s-]?cell\s+fhd\b/i.test(text)) return "In-Cell FHD";
+  if (quality === "In-Cell" || /\bin[\s-]?cell\b/i.test(text)) return "In-Cell";
+  if (/\bamoled\b/i.test(text)) return "AMOLED";
+  if (/\boled\b/i.test(text)) return "OLED";
+  if (/\blcd\b/i.test(text)) return "LCD";
+  if (/\btft\b/i.test(text)) return "TFT";
+  return null;
+}
+
+function detectAssemblyType(product = {}) {
+  const text = buildSearchText(product);
+  const result = {
+    assemblyType: null,
+    extra: null,
+  };
+  if (/\b(?:incl\.?\s*frame|with\s+frame)\b/i.test(text)) result.assemblyType = "con marco";
+  if (/\b(?:excl\.?\s*frame|without\s+frame)\b/i.test(text)) result.assemblyType = "sin marco";
+  if (/\bfront\s+flex\b/i.test(text)) result.extra = "con flex frontal";
+  return result;
+}
+
+function detectProductCondition(product = {}) {
+  const quality = detectProductQuality(product);
+  const text = buildSearchText(product);
+  if (/\brefurb(?:ished)?\b/i.test(text) || quality.commercialQuality === "Refurbished") return "reacondicionado";
+  if (/\bpulled\b/i.test(text) || quality.origin === "retirado_de_equipo") return "retirado de equipo";
+  if (quality.origin === "pre_owned") return "equipo pre-owned";
+  if (/\bused\b/i.test(text)) return "usado";
+  if (["Original", "Compatible", "Compatible Soft OLED", "Compatible Hard OLED", "Compatible Budget", "Factory Standard", "Compatible In-Cell", "Compatible In-Cell FHD"].includes(quality.commercialQuality)) return "nuevo";
+  return null;
+}
+
+function detectPartType(product = {}) {
+  const text = buildSearchText(product);
+  const category = normalizeText(pickField(product, ["category", "Category"]));
+  if (/\b(display|screen|pantalla|lcd|oled|amoled|tft)\b/i.test(text)) return "Pantalla / display";
+  return category || "Repuesto";
+}
+
+function detectAvailability(product = {}) {
+  const direct = normalizeText(pickField(product, ["availability", "Availability", "availabilityLabel"]));
+  if (direct) return direct;
+  const stock = Number(pickField(product, ["stock", "Stock", "available_stock", "remote_stock"]));
+  if (Number.isFinite(stock) && stock > 0) return "Disponible";
+  const canBeOrdered = pickField(product, ["canBeOrdered", "csvCanBeOrdered"]);
+  const stockMode = normalizeKey(pickField(product, ["stock_mode", "fulfillment_mode"]));
+  const leadDays = Number(pickField(product, ["remote_lead_days", "remote_lead_min_days"]));
+  if (canBeOrdered === true || stockMode === "remote" || (Number.isFinite(leadDays) && leadDays > 0)) return "Disponible a pedido";
+  return "Consultar disponibilidad";
+}
+
+function cleanModelCandidate(value = "") {
+  return normalizeText(value)
+    .replace(/\([^)]*\)/g, " ")
+    .replace(/\bdisplay\b/gi, " ")
+    .replace(/\b(?:incl\.?|excl\.?)\s*frame\b/gi, " ")
+    .replace(/\b(?:with|without)\s+frame\b/gi, " ")
+    .replace(/\b(?:soft|hard)?\s*oled\b/gi, " ")
+    .replace(/\bamoled|lcd|tft|in[\s-]?cell(?:\s+fhd)?\b/gi, " ")
+    .replace(/\bcompatible|original|refurbished|pulled\b/gi, " ")
+    .replace(/[.,;:]+$/g, "")
+    .replace(/\s*&\s*/g, " / ")
+    .replace(/\s*\/\s*/g, " / ")
+    .replace(/\s+-\s*$/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function inferModelFromText(product = {}) {
+  const sources = [pickField(product, ["description", "Description"]), pickField(product, ["name"]), pickField(product, ["title"])].map(normalizeText).filter(Boolean);
+  for (const source of sources) {
+    const forMatch = source.match(/\b(?:for|para)\s+(.+?)(?:\.|$)/i);
+    if (forMatch && forMatch[1]) {
+      const cleaned = cleanModelCandidate(forMatch[1]);
+      if (cleaned) return cleaned;
+    }
+    const dashMatch = source.match(/\s-\s*(.+)$/);
+    if (dashMatch && dashMatch[1]) {
+      const cleaned = cleanModelCandidate(dashMatch[1]);
+      if (cleaned) return cleaned;
+    }
+  }
+  return "";
+}
+
+function buildBrandModel(product = {}) {
+  const brand = normalizeText(pickField(product, ["brand", "Brand", "manufacturerName", "ManufacturerName"]));
+  const model = normalizeText(pickField(product, ["model", "Model"]));
+  const inferredModel = inferModelFromText(product);
+  const modelLabel = model || inferredModel;
+  if (brand && modelLabel && modelLabel.toLowerCase().includes(brand.toLowerCase())) return modelLabel;
+  return [brand, modelLabel].filter(Boolean).join(" ").trim();
+}
+
+function qualityForTitle(commercialQuality) {
+  if (!commercialQuality || commercialQuality === "Calidad no especificada") return "";
+  if (commercialQuality === "Original") return "original";
+  if (commercialQuality === "Refurbished") return "refurbished";
+  if (commercialQuality.startsWith("Compatible ")) return `compatible ${commercialQuality.slice("Compatible ".length)}`;
+  if (commercialQuality === "Compatible") return "compatible";
+  return commercialQuality;
+}
+
+function partTypeForTitle(partType) {
+  if (/pantalla|display/i.test(partType)) return "Pantalla";
+  return partType || "Repuesto";
+}
+
+function buildH1(product, detected) {
+  const chunks = [partTypeForTitle(detected.partType)];
+  const qualityText = qualityForTitle(detected.commercialQuality);
+  if (qualityText) chunks.push(qualityText);
+  if (detected.brandModel) chunks.push(`para ${detected.brandModel}`);
+  if (detected.assemblyType) chunks.push(detected.assemblyType);
+  return cleanSentence(chunks.join(" ")) || normalizeText(product?.name) || "Producto NERIN Parts";
+}
+
+function truncateText(value, limit) {
+  const text = cleanSentence(value);
+  if (!limit || text.length <= limit) return text;
+  const slice = text.slice(0, Math.max(0, limit - 1));
+  const lastSpace = slice.lastIndexOf(" ");
+  const base = lastSpace > 40 ? slice.slice(0, lastSpace) : slice;
+  return `${base.replace(/[\s,.!?;:-]+$/, "")}...`;
+}
+
+function buildProductAutoContent(product = {}) {
+  const quality = detectProductQuality(product);
+  const displayTechnology = detectDisplayTechnology(product);
+  const assembly = detectAssemblyType(product);
+  const condition = detectProductCondition(product);
+  const partType = detectPartType(product);
+  const brand = normalizeText(pickField(product, ["brand", "Brand", "manufacturerName", "ManufacturerName"]));
+  const model = normalizeText(pickField(product, ["model", "Model"]));
+  const brandModel = buildBrandModel(product);
+  const sku = normalizeText(pickField(product, ["sku", "SKU", "supplierPartNumber"]));
+  const partNumber = normalizeText(pickField(product, ["part_number", "partNumber", "PartNumber", "Part Number", "supplierPartNumber"]));
+  const category = normalizeText(pickField(product, ["category", "Category"]));
+  const availability = detectAvailability(product);
+  const detected = { ...quality, displayTechnology, assemblyType: assembly.assemblyType, assemblyExtra: assembly.extra, condition, partType, brand, model, brandModel, sku, partNumber, category, availability };
+  const h1 = buildH1(product, detected);
+  const modelCopy = brandModel || "el modelo indicado por proveedor";
+  const qualityCopy = quality.commercialQuality;
+  const technologyCopy = displayTechnology ? ` con tecnologia ${displayTechnology}` : "";
+  const assemblyCopy = assembly.assemblyType ? `, montaje ${assembly.assemblyType}` : "";
+  const conditionCopy = condition ? ` en condicion ${condition}` : "";
+  const shortDescription = cleanSentence(`${h1}. Repuesto ${qualityCopy}${technologyCopy}${assemblyCopy}${conditionCopy}. ${availability}.`);
+  const supplierDescription = normalizeText(pickField(product, ["description", "Description"]));
+  const longDescription = cleanSentence([
+    `${h1} para ${modelCopy}. La calidad informada por el proveedor es ${qualityCopy} y el origen se clasifica como ${quality.originLabel}.`,
+    displayTechnology ? `La tecnologia de pantalla detectada es ${displayTechnology}; no se agregan tecnologias que no figuren en la descripcion o en Quality.` : "La tecnologia de pantalla no fue especificada por el proveedor, por eso no se asume OLED, AMOLED, LCD ni otra variante.",
+    assembly.assemblyType ? `El tipo de armado detectado es ${assembly.assemblyType}${assembly.extra ? `, ${assembly.extra}` : ""}.` : "El montaje no fue especificado por el proveedor.",
+    supplierDescription ? `Descripcion del proveedor: ${supplierDescription}` : "",
+    "Antes de instalar, comparar modelo, SKU y numero de parte con el equipo a reparar.",
+  ].filter(Boolean).join(" "));
+  const technicalSpecs = { calidad: qualityCopy, tecnologia: displayTechnology || "No especificada por proveedor", tipoRepuesto: partType, marcaModelo: brandModel || "No especificado por proveedor", condicion: condition || "No especificada por proveedor", origen: quality.originLabel, montaje: assembly.assemblyType || "no especificado", extra: assembly.extra || null, sku: sku || null, partNumber: partNumber || null, categoria: category || null, disponibilidad: availability };
+  const compatibilityNotice = cleanSentence(`Verificar compatibilidad con ${modelCopy}${sku ? `, SKU ${sku}` : ""}${partNumber ? ` y numero de parte ${partNumber}` : ""} antes de confirmar la compra o realizar la instalacion.`);
+  const seoTitle = truncateText(`${h1} | NERIN Parts`, 160);
+  const seoDescription = truncateText(`${h1}. Calidad ${qualityCopy}${displayTechnology ? `, tecnologia ${displayTechnology}` : ""}. ${availability}. ${compatibilityNotice}`, 200);
+  return { h1, shortDescription, longDescription, technicalSpecs, compatibilityNotice, seoTitle, seoDescription, detected };
+}
+
+module.exports = { buildProductAutoContent };

--- a/nerin_final_updated/backend/utils/productSeoQuality.js
+++ b/nerin_final_updated/backend/utils/productSeoQuality.js
@@ -1,0 +1,85 @@
+const { buildProductAutoContent } = require("./productAutoContent");
+
+function normalizeText(value) {
+  if (value == null) return "";
+  return String(value).replace(/\s+/g, " ").trim();
+}
+
+function pickMetadata(product = {}) {
+  return product && typeof product.metadata === "object" && product.metadata !== null ? product.metadata : {};
+}
+
+function pickSupplierImport(product = {}) {
+  const meta = pickMetadata(product);
+  return meta && typeof meta.supplierImport === "object" && meta.supplierImport !== null ? meta.supplierImport : {};
+}
+
+function pickField(product = {}, keys = []) {
+  const meta = pickMetadata(product);
+  const supplierImport = pickSupplierImport(product);
+  for (const key of keys) {
+    if (!key) continue;
+    if (Object.prototype.hasOwnProperty.call(product, key)) {
+      const value = product[key];
+      if (value != null && value !== "") return value;
+    }
+    if (Object.prototype.hasOwnProperty.call(meta, key)) {
+      const value = meta[key];
+      if (value != null && value !== "") return value;
+    }
+    if (Object.prototype.hasOwnProperty.call(supplierImport, key)) {
+      const value = supplierImport[key];
+      if (value != null && value !== "") return value;
+    }
+  }
+  return null;
+}
+
+function firstPositiveNumber(values = []) {
+  for (const value of values) {
+    const number = Number(value);
+    if (Number.isFinite(number) && number > 0) return number;
+  }
+  return null;
+}
+
+function evaluateProductSeoQuality(product = {}, autoContent = null) {
+  const content = autoContent || buildProductAutoContent(product);
+  const detected = content.detected || {};
+  const autoText = normalizeText([content.shortDescription, content.longDescription, content.compatibilityNotice].filter(Boolean).join(" "));
+  const supplierText = normalizeText([
+    pickField(product, ["description", "Description"]),
+    pickField(product, ["shortDescription", "short_description"]),
+    pickField(product, ["remarks", "Remarks"]),
+  ].filter(Boolean).join(" "));
+  const price = firstPositiveNumber([pickField(product, ["price_minorista", "precio_minorista", "price", "precio_final", "price_mayorista"])]);
+  const slug = normalizeText(pickField(product, ["slug", "publicSlug", "public_slug"]));
+  const brand = normalizeText(pickField(product, ["brand", "Brand", "manufacturerName"]));
+  const model = normalizeText(pickField(product, ["model", "Model"]));
+  const sku = normalizeText(pickField(product, ["sku", "SKU", "part_number", "partNumber", "PartNumber", "Part Number", "supplierPartNumber"]));
+  const qualityKnown = Boolean(detected.qualityKnown);
+  const hasRichAutomaticDescription = autoText.length >= 250;
+  const hasPoorSupplierDescription = supplierText.length < 80;
+  const hasIdentity = Boolean((brand && model) || sku || detected.brandModel);
+  const hasPrice = price != null;
+  const hasSlug = Boolean(slug);
+  const availability = normalizeText(detected.availability);
+  const availableOnRequest = /pedido/i.test(availability);
+  const signals = { qualityKnown, hasPrice, hasSlug, hasIdentity, hasRichAutomaticDescription, hasPoorSupplierDescription, autoDescriptionLength: autoText.length, supplierDescriptionLength: supplierText.length, availability, availableOnRequest };
+
+  if (!qualityKnown && hasPoorSupplierDescription) {
+    return { indexable: false, noindex: true, robots: "noindex,follow", reason: "unknown_quality_and_poor_description", signals };
+  }
+  if (qualityKnown && hasPrice && hasSlug && hasIdentity && hasRichAutomaticDescription) {
+    return { indexable: true, noindex: false, robots: "index,follow", reason: "indexable_product_content", signals };
+  }
+  const missing = [];
+  if (!qualityKnown) missing.push("quality");
+  if (!hasPrice) missing.push("price");
+  if (!hasSlug) missing.push("slug");
+  if (!hasIdentity) missing.push("identity");
+  if (!hasRichAutomaticDescription) missing.push("rich_description");
+  return { indexable: false, noindex: true, robots: "noindex,follow", reason: `missing_${missing.join("_") || "seo_signals"}`, signals };
+}
+
+module.exports = { evaluateProductSeoQuality };

--- a/nerin_final_updated/package.json
+++ b/nerin_final_updated/package.json
@@ -4,7 +4,7 @@
   "description": "Sistema ERP + E‑commerce para NERIN Repuestos",
   "main": "backend/index.js",
   "scripts": {
-    "start": "node scripts/applyCodexSeoBulkPatch.js && node scripts/applySitemapHotfix.js && node --max-old-space-size=512 -r ./backend/utils/preloadProductAvailability.js backend/server.js",
+    "start": "node scripts/applyCodexSeoBulkPatch.js && node scripts/applyProductAutoContentPatch.js && node scripts/applySitemapHotfix.js && node --max-old-space-size=512 -r ./backend/utils/preloadProductAvailability.js backend/server.js",
     "test": "jest",
     "validate:meta-feed": "node scripts/validate-meta-feed.js",
     "catalog:enrich-csv": "node scripts/enrichCatalogCsv.js",

--- a/nerin_final_updated/scripts/applyProductAutoContentPatch.js
+++ b/nerin_final_updated/scripts/applyProductAutoContentPatch.js
@@ -1,0 +1,126 @@
+const fs = require("fs");
+const path = require("path");
+
+const root = path.resolve(__dirname, "..");
+let changedFiles = 0;
+
+function filePath(rel) { return path.join(root, rel); }
+function read(rel) { return fs.readFileSync(filePath(rel), "utf8"); }
+function write(rel, text) { fs.writeFileSync(filePath(rel), text, "utf8"); }
+function patch(rel, updater) {
+  const before = read(rel);
+  const after = updater(before);
+  if (after !== before) {
+    write(rel, after);
+    changedFiles += 1;
+    console.log("[product-auto-content-patch] updated " + rel);
+  }
+}
+
+patch("backend/utils/productSeo.js", (text) => {
+  let next = text;
+  if (!next.includes('require("./productAutoContent")')) {
+    next = next.replace(/(\nfunction normalizeText\(value\) \{)/, '\nconst { buildProductAutoContent } = require("./productAutoContent");\n$1');
+  }
+  if (!next.includes("const autoContent = buildProductAutoContent(product);")) {
+    next = next.replace(/function generateProductSeo\(product = \{\}\) \{\n/, `function generateProductSeo(product = {}) {
+  const autoContent = buildProductAutoContent(product);
+  if (autoContent && (autoContent.seoTitle || autoContent.seoDescription)) {
+    return {
+      title: truncateText(autoContent.seoTitle || "Repuesto NERIN Parts", 160),
+      description: truncateText(autoContent.seoDescription || autoContent.shortDescription || "", 200),
+      ogTitle: autoContent.h1 || autoContent.seoTitle,
+      ogDescription: autoContent.longDescription || autoContent.seoDescription,
+    };
+  }
+
+`);
+  }
+  return next;
+});
+
+patch("backend/services/catalogCsvImport.js", (text) => {
+  let next = text;
+  if (!next.includes("quality: imported.quality,")) {
+    next = next.replace(/(\s+csvMaximumQuantityInOrder: imported\.maximumQuantityInOrder,\n)/, "$1      quality: imported.quality,\n      remarks: imported.remarks,\n");
+    next = next.replace(/(\s+supplierPartNumber: imported\.supplierPartNumber,\n)/, "$1    quality: imported.quality,\n    remarks: imported.remarks,\n");
+    next = next.replace(/(\s+brand: imported\.manufacturerName,\n)/, "$1    quality: imported.quality,\n    remarks: imported.remarks,\n");
+  }
+  return next;
+});
+
+patch("backend/server.js", (text) => {
+  let next = text;
+  if (!next.includes('require("./utils/productAutoContent")')) {
+    next = next.replace(/(\} = require\("\.\/utils\/productSeo"\);\n)/, '$1const { buildProductAutoContent } = require("./utils/productAutoContent");\nconst { evaluateProductSeoQuality } = require("./utils/productSeoQuality");\n');
+  }
+  if (!next.includes("function isProductIndexable(product)")) {
+    next = next.replace(/(\n  return hasIdentifier;\n\}\n\n)function getProductLastModifiedDate/, `$1function isProductIndexable(product) {
+  if (!isProductPublic(product)) return false;
+  const autoContent = buildProductAutoContent(product || {});
+  return evaluateProductSeoQuality(product || {}, autoContent).indexable;
+}
+
+function getProductLastModifiedDate`);
+  }
+  next = next.replace(/function buildFeaturePhrase\(product\) \{\n(?!\s+const autoContent = buildProductAutoContent)/, `function buildFeaturePhrase(product) {
+  const autoContent = buildProductAutoContent(product || {});
+  if (autoContent.shortDescription) return autoContent.shortDescription;
+`);
+  next = next.replace(/function buildProductSeoTitle\(product\) \{\n(?!\s+const autoContent = buildProductAutoContent)/, `function buildProductSeoTitle(product) {
+  const autoContent = buildProductAutoContent(product || {});
+  if (autoContent.seoTitle) return autoContent.seoTitle;
+`);
+  next = next.replace(/function buildProductHeading\(product\) \{\n(?!\s+const autoContent = buildProductAutoContent)/, `function buildProductHeading(product) {
+  const autoContent = buildProductAutoContent(product || {});
+  if (autoContent.h1) return autoContent.h1;
+`);
+  next = next.replace(/function buildProductMetaDescription\(product\) \{\n(?!\s+const autoContent = buildProductAutoContent)/, `function buildProductMetaDescription(product) {
+  const autoContent = buildProductAutoContent(product || {});
+  if (autoContent.seoDescription) return autoContent.seoDescription;
+`);
+  next = next.replace(/const productEntries = products\.filter\(\(p\)=>isProductPublic\(p\)\)/g, "const productEntries = products.filter((p)=>isProductIndexable(p))");
+  next = next.replace(/\.filter\(\(product\) => isProductPublic\(product\)\)/g, ".filter((product) => isProductIndexable(product))");
+  next = next.replace(/function renderProductInfoSsr\(product, siteBase\) \{\n\s+const heading = buildProductHeading\(product\);\n\s+const description = buildFeaturePhrase\(product\);/, `function renderProductInfoSsr(product, siteBase) {
+  const autoContent = buildProductAutoContent(product || {});
+  const heading = autoContent.h1 || buildProductHeading(product);
+  const description = autoContent.shortDescription || buildFeaturePhrase(product);`);
+  next = next.replace(/(\s+const stockValue = typeof product\?\.stock === "number" \? product\.stock : null;\n)\s+const technology = inferDisplayTechnology\(product\);\n\s+const frame = inferHasFrame\(product\);/, `$1  const specs = autoContent.technicalSpecs || {};
+  const technology = null;
+  const frame = null;`);
+  if (!next.includes("specs.calidad ? `<li><strong>Calidad:")) {
+    next = next.replace(/(\s+const infoItems = \[\n)/, `$1    specs.calidad ? \`<li><strong>Calidad:</strong> \${esc(specs.calidad)}</li>\` : "",
+    specs.tecnologia ? \`<li><strong>Tecnologia:</strong> \${esc(specs.tecnologia)}</li>\` : "",
+    specs.tipoRepuesto ? \`<li><strong>Tipo de repuesto:</strong> \${esc(specs.tipoRepuesto)}</li>\` : "",
+    specs.marcaModelo ? \`<li><strong>Marca/modelo:</strong> \${esc(specs.marcaModelo)}</li>\` : "",
+    specs.condicion ? \`<li><strong>Condicion:</strong> \${esc(specs.condicion)}</li>\` : "",
+    specs.origen ? \`<li><strong>Origen:</strong> \${esc(specs.origen)}</li>\` : "",
+    specs.montaje ? \`<li><strong>Montaje:</strong> \${esc(specs.montaje)}</li>\` : "",
+    specs.disponibilidad ? \`<li><strong>Disponibilidad:</strong> \${esc(specs.disponibilidad)}</li>\` : "",
+`);
+  }
+  next = next.replace(/const compatibility = \[brand, model, sku\]\.filter\(Boolean\)\.join\(" "\);\n\s+const compatibilityHtml = compatibility\n\s+\? `<p class=\\"product-compatibility\\">Compatible con \$\{esc\(compatibility\)\}\.<\/p>`/, `const compatibility = autoContent.compatibilityNotice || [brand, model, sku].filter(Boolean).join(" ");
+  const compatibilityHtml = compatibility
+    ? \`<p class=\\"product-compatibility\\">\${esc(compatibility)}</p>\``);
+  next = next.replace(/(\s+const name = product\.name \|\| "";\n)(?!\s+const autoContent = buildProductAutoContent)/, `$1    const autoContent = buildProductAutoContent(product);
+    const seoQuality = evaluateProductSeoQuality(product, autoContent);
+`);
+  next = next.replace(/const seoTitle = productSeo\.title \|\| buildProductSeoTitle\(product\);/, "const seoTitle = autoContent.seoTitle || productSeo.title || buildProductSeoTitle(product);");
+  next = next.replace(/const description = productSeo\.description \|\| buildProductMetaDescription\(product\);/, "const description = autoContent.seoDescription || productSeo.description || buildProductMetaDescription(product);");
+  next = next.replace(/const h1 = buildProductHeading\(product\);/, "const h1 = autoContent.h1 || buildProductHeading(product);");
+  if (!next.includes("const schemaCondition = /reacondicionado/i.test")) {
+    next = next.replace(/(\s+const formattedPrice = Number\.isFinite\(numericPrice\)\n\s+\? numericPrice\.toFixed\(2\)\n\s+: "0\.00";\n)/, `$1    const schemaCondition = /reacondicionado/i.test(autoContent.detected?.condition || "")
+      ? "https://schema.org/RefurbishedCondition"
+      : /(usado|retirado|pre-owned)/i.test(autoContent.detected?.condition || "")
+        ? "https://schema.org/UsedCondition"
+        : "https://schema.org/NewCondition";
+`);
+  }
+  next = next.replace(/itemCondition: "https:\/\/schema\.org\/NewCondition",/, "itemCondition: schemaCondition,");
+  if (!next.includes('<meta name="robots" content="${esc(seoQuality.robots)}">')) {
+    next = next.replace(/(`\<meta name="description" content="\$\{esc\(metaDescription\)\}"\>`,\n)/, '$1      `<meta name="robots" content="${esc(seoQuality.robots)}">`,\n');
+  }
+  return next;
+});
+
+console.log("[product-auto-content-patch] complete; changedFiles=" + changedFiles);

--- a/nerin_final_updated/scripts/applySitemapHotfix.js
+++ b/nerin_final_updated/scripts/applySitemapHotfix.js
@@ -20,8 +20,8 @@ if (!text.includes(marker)) {
 
 const snippet = String.raw`async function requestHandler(req, res) {
   // [sitemap-hotfix-large-catalog]
-  // Intercepta sitemaps antes del handler histórico para evitar cargar products.json completo en memoria.
-  // El catálogo real puede superar 100 MB, por eso acá se consulta SQLite vía productsSqliteRepo.
+  // Intercepta sitemaps antes del handler historico para evitar cargar products.json completo en memoria.
+  // El catalogo real puede superar 100 MB, por eso aca se consulta SQLite via productsSqliteRepo.
   const __sitemapParsedUrl = url.parse(req.url, true);
   const __sitemapPathname = __sitemapParsedUrl.pathname;
   if (
@@ -45,6 +45,8 @@ const snippet = String.raw`async function requestHandler(req, res) {
       const toProductEntry = (product) => {
         const slug = product?.publicSlug || product?.public_slug || product?.slug;
         if (!slug) return null;
+        const autoContent = buildProductAutoContent(product || {});
+        if (!evaluateProductSeoQuality(product || {}, autoContent).indexable) return null;
         return {
           loc: absoluteUrl("/p/" + encodeURIComponent(String(slug)), base),
           lastmod: generatedAt,


### PR DESCRIPTION
## Summary
- Detecta calidades reales del CSV: Original, Compatible Soft/Hard OLED, In-Cell, Refurbished, Pulled, Factory Standard, etc.
- Separa calidad comercial, tecnologia de pantalla, condicion y tipo de armado.
- Genera fichas SEO automaticas sin inventar datos.
- Mantiene stock 0 vendible como Disponible a pedido.
- No toca precios, pagos, Resend, pedidos ni Andreani.

## Implementation notes
- Agrega `backend/utils/productAutoContent.js` con deteccion de calidad, tecnologia, armado y condicion.
- Agrega `backend/utils/productSeoQuality.js` para decidir index/noindex segun calidad, contenido, precio, slug e identidad del producto.
- Agrega un startup patch idempotente para integrar el contenido automatico en `productSeo`, SSR de producto, importacion CSV y sitemap sin pisar hotfixes vigentes de Render.

## Testing
- `node --check backend/utils/productAutoContent.js`
- `node --check backend/utils/productSeoQuality.js`
- `node --check backend/server.js`
- `node --check scripts/applyProductAutoContentPatch.js`
- `node --check scripts/applySitemapHotfix.js`
- Casos probados: Compatible Soft OLED, Compatible Hard OLED, In-Cell, In-Cell FHD, Original Samsung, Refurbished, Pulled A, Factory Standard.