### PR TITLE
Emergency fix product SEO forcing all products as screen modules

### DIFF
--- a/nerin_final_updated/__tests__/backend/product-seo-taxonomy.test.js
+++ b/nerin_final_updated/__tests__/backend/product-seo-taxonomy.test.js
@@ -1,0 +1,49 @@
+const { generateProductSeo } = require("../../backend/utils/productSeo");
+const { detectProductType } = require("../../backend/utils/productTaxonomy");
+
+describe("product SEO taxonomy", () => {
+  test("RESIN PC is never treated as a screen module", () => {
+    const product = { name: "RESIN PC", brand: "Samsung", sku: "0103-009557" };
+    const productType = detectProductType(product);
+    const seo = generateProductSeo(product);
+    expect(["Repuesto", "Adhesivo / pegamento"]).toContain(productType);
+    expect(productType).not.toBe("Pantalla / display");
+    expect(seo.title).toBe("RESIN PC | NERIN Parts");
+    expect(seo.description).toBe("RESIN PC disponible en NERIN Parts. Verificá compatibilidad, SKU 0103-009557 y disponibilidad antes de comprar.");
+    expect(`${seo.title} ${seo.description}`).not.toMatch(/M[oó]dulo Pantalla|Samsung Galaxy|Original Service Pack/i);
+  });
+
+  test("real display is classified as screen", () => {
+    const product = { description: "Display incl. frame Original Samsung Galaxy S25 SM-S931", brand: "Samsung", model: "Galaxy S25 SM-S931", quality: "Original" };
+    expect(detectProductType(product)).toBe("Pantalla / display");
+    expect(generateProductSeo(product).title).toMatch(/Pantalla/i);
+  });
+
+  test("display adhesive is adhesive, not screen", () => {
+    expect(detectProductType({ name: "Display adhesive Samsung" })).toBe("Adhesivo para pantalla");
+  });
+
+  test("screen protection tempered glass is protector", () => {
+    expect(detectProductType({ name: "Screen protection tempered glass" })).toBe("Protector de pantalla");
+  });
+
+  test("charging board is charge port board", () => {
+    expect(detectProductType({ name: "Charging board Samsung" })).toBe("Placa / pin de carga");
+  });
+
+  test("dock connector is charge port board", () => {
+    expect(detectProductType({ name: "Dock connector iPhone" })).toBe("Placa / pin de carga");
+  });
+
+  test("pressing jig display is repair tool", () => {
+    expect(detectProductType({ name: "Pressing jig display" })).toBe("Herramienta / accesorio tecnico");
+  });
+
+  test("battery is battery", () => {
+    expect(detectProductType({ name: "Battery Samsung" })).toBe("Batería");
+  });
+
+  test("flex cable is internal flex", () => {
+    expect(detectProductType({ name: "Flex cable" })).toBe("Flex / cable interno");
+  });
+});

--- a/nerin_final_updated/backend/utils/productSeo.js
+++ b/nerin_final_updated/backend/utils/productSeo.js
@@ -1,22 +1,24 @@
+const { buildProductAutoContent } = require("./productAutoContent");
+const { detectProductType } = require("./productTaxonomy");
+
 const GENERIC_SEO_TITLES = new Set([
   "repuesto original service pack | nerin parts",
-  "pantallas originales con garantía | nerin",
-  "pantallas originales con garantía | nerin parts",
-  "repuesto original con garantía técnica",
+  "pantallas originales con garantia | nerin",
+  "pantallas originales con garantia | nerin parts",
+  "repuesto original con garantia tecnica",
 ]);
 
 const GENERIC_SEO_DESCRIPTIONS = new Set([
-  "repuestos originales service pack con garantía en nerin parts.",
-  "repuesto original con garantía técnica",
-  "repuestos originales para técnicos y particulares en argentina.",
+  "repuestos originales service pack con garantia en nerin parts.",
+  "repuesto original con garantia tecnica",
+  "repuestos originales para tecnicos y particulares en argentina.",
 ]);
 
 function normalizeText(value) {
   if (value == null) return "";
   try {
-    const text = String(value).replace(/\s+/g, " ").trim();
-    return text;
-  } catch (err) {
+    return String(value).replace(/\s+/g, " ").trim();
+  } catch {
     return "";
   }
 }
@@ -32,274 +34,81 @@ function truncateText(str, limit) {
   const slice = normalized.slice(0, Math.max(0, limit - 1));
   const lastSpace = slice.lastIndexOf(" ");
   const base = lastSpace > 40 ? slice.slice(0, lastSpace) : slice;
-  return `${base.replace(/[\s,.!?;:-]+$/, "")}…`;
-}
-
-function parseNumber(value) {
-  if (value == null) return null;
-  const num = Number(String(value).replace(/,/g, "."));
-  return Number.isFinite(num) ? num : null;
-}
-
-function extractFromText(values = [], pattern) {
-  for (const raw of values) {
-    if (typeof raw !== "string") continue;
-    const match = raw.match(pattern);
-    if (match && match[1]) return match[1];
-  }
-  return null;
-}
-
-function inferDisplayTechnology(product) {
-  const meta = product && typeof product.metadata === "object" ? product.metadata : {};
-  const candidates = [
-    product?.panel_type,
-    product?.display_type,
-    product?.technology,
-    product?.screen_type,
-    meta.panel_type,
-    meta.display_type,
-    meta.technology,
-    meta.screen_type,
-    product?.meta_description,
-    product?.description,
-  ];
-  for (const value of candidates) {
-    if (typeof value !== "string") continue;
-    const text = value.toLowerCase();
-    if (text.includes("super amoled")) return "Super AMOLED";
-    if (text.includes("amoled")) return "AMOLED";
-    if (text.includes("oled")) return "OLED";
-    if (text.includes("lcd")) return "LCD";
-    if (text.includes("tft")) return "TFT";
-  }
-  return null;
-}
-
-function inferScreenSize(product) {
-  const meta = product && typeof product.metadata === "object" ? product.metadata : {};
-  const candidates = [
-    product?.screen_size,
-    product?.display_size,
-    product?.size_inches,
-    product?.inches,
-    meta?.screen_size,
-    meta?.display_size,
-    meta?.size_inches,
-    meta?.inches,
-  ].map(normalizeText);
-  const fromFields = candidates.find((v) => v);
-  if (fromFields) {
-    const numeric = parseNumber(fromFields);
-    if (numeric) return `${numeric.toString().replace(".", ",")}"`;
-    if (/\d/.test(fromFields)) return fromFields;
-  }
-  const textMatch = extractFromText(
-    [product?.description, product?.short_description, product?.meta_description],
-    /(\d{1,2}(?:[.,]\d{1,2})?)\s*(?:\"|pulg|pulgadas)/i,
-  );
-  if (textMatch) return `${textMatch.replace(".", ",")}"`;
-  return null;
-}
-
-function inferResolution(product) {
-  const meta = product && typeof product.metadata === "object" ? product.metadata : {};
-  const candidates = [product?.resolution, meta?.resolution, product?.description, product?.meta_description];
-  const match = extractFromText(
-    candidates,
-    /(\b(?:fhd\+?|hd\+?|qhd\+?|720p|1080p|1440p|2k|4k)[\w+]*)/i,
-  );
-  if (match) return match.toUpperCase();
-  return null;
-}
-
-function inferRefreshRate(product) {
-  const meta = product && typeof product.metadata === "object" ? product.metadata : {};
-  const candidates = [product?.refresh_rate, meta?.refresh_rate, product?.description, product?.meta_description];
-  const match = extractFromText(candidates, /(\d{2,3})\s*hz/i);
-  if (match) return `${match} Hz`;
-  return null;
-}
-
-function buildModelLabel(product) {
-  const brand = normalizeText(product?.brand || product?.catalog_brand);
-  const model = normalizeText(product?.model || product?.catalog_model);
-  const name = normalizeText(product?.name);
-  const label = [brand, model].filter(Boolean).join(" ");
-  if (label) return label;
-  return name || brand || model || "";
+  return `${base.replace(/[\s,.!?;:-]+$/, "")}...`;
 }
 
 function pickMetadata(product = {}) {
-  return product && typeof product.metadata === "object" && product.metadata !== null
-    ? product.metadata
-    : {};
+  return product && typeof product.metadata === "object" && product.metadata !== null ? product.metadata : {};
+}
+
+function pickSupplierImport(product = {}) {
+  const meta = pickMetadata(product);
+  return meta && typeof meta.supplierImport === "object" && meta.supplierImport !== null ? meta.supplierImport : {};
 }
 
 function pickField(product = {}, keys = []) {
   const meta = pickMetadata(product);
+  const supplierImport = pickSupplierImport(product);
   for (const key of keys) {
     if (!key) continue;
-    if (product && Object.prototype.hasOwnProperty.call(product, key)) {
-      const value = product[key];
-      if (value != null && value !== "") return value;
-    }
-    if (meta && Object.prototype.hasOwnProperty.call(meta, key)) {
-      const metaValue = meta[key];
-      if (metaValue != null && metaValue !== "") return metaValue;
-    }
+    if (Object.prototype.hasOwnProperty.call(product, key) && product[key] != null && product[key] !== "") return product[key];
+    if (Object.prototype.hasOwnProperty.call(meta, key) && meta[key] != null && meta[key] !== "") return meta[key];
+    if (Object.prototype.hasOwnProperty.call(supplierImport, key) && supplierImport[key] != null && supplierImport[key] !== "") return supplierImport[key];
   }
   return null;
 }
 
-function normalizeGhCode(value) {
-  if (!value) return "";
-  const text = String(value);
-  const match = text.match(/(gh\s*\d{2}\s*-?\s*\d{4,6}[a-z]?)/i);
-  if (!match || !match[1]) return "";
-  const cleaned = match[1].replace(/\s+/g, "").toUpperCase();
-  if (cleaned.includes("-")) return cleaned;
-  // Insert hyphen after the first 4 characters to standardize GH82-XXXXX
-  const base = cleaned.startsWith("GH") ? cleaned : `GH${cleaned}`;
-  return `${base.slice(0, 4)}-${base.slice(4)}`;
-}
-
-function extractGhCode(product = {}) {
-  const candidates = [
-    pickField(product, ["gh_code", "ghCode", "gh", "gh82", "gh_model", "catalog_gh", "catalog_gh_code"]),
-    product?.sku,
-    product?.name,
-    product?.description,
-    product?.meta_description,
-  ];
-  for (const candidate of candidates) {
-    const normalized = normalizeGhCode(candidate);
-    if (normalized) return normalized;
-  }
-  return "";
-}
-
-function extractModelCode(product = {}) {
-  const direct = pickField(product, [
-    "model_code",
-    "modelCode",
-    "model_code_full",
-    "full_model_code",
-    "fullModelCode",
-    "catalog_model_code",
-    "catalog_model_ref",
-    "catalog_code",
-    "device_code",
-  ]);
-  const normalizedDirect = normalizeText(direct);
-  if (normalizedDirect) return normalizedDirect;
-
-  const textSources = [product?.sku, product?.name, product?.description];
-  for (const value of textSources) {
-    if (typeof value !== "string") continue;
-    const match = value.match(/\b([A-Z]{1,3}\d{2,4}[A-Z]?)\b/gi);
-    if (match && match.length) {
-      const first = match.find((m) => !/^GH\d{2}/i.test(m));
-      if (first) return first.toUpperCase();
-    }
-  }
-  return "";
-}
-
-function extractModelName(product = {}) {
-  const model = normalizeText(
-    pickField(product, [
-      "model",
-      "model_name",
-      "modelName",
-      "catalog_model",
-      "device_model",
-      "catalog_device",
-    ]),
+function buildSafeProductLabel(product = {}) {
+  return compactText(
+    pickField(product, ["name", "Name"]) ||
+      pickField(product, ["title", "Title"]) ||
+      pickField(product, ["description", "Description"]) ||
+      pickField(product, ["sku", "SKU"]) ||
+      pickField(product, ["part_number", "partNumber", "PartNumber", "Part Number"]) ||
+      pickField(product, ["id"]) ||
+      "Repuesto",
   );
-  if (model) return model;
-
-  const name = normalizeText(product?.name);
-  const brand = normalizeText(product?.brand || product?.catalog_brand);
-  if (name && brand) {
-    const withoutBrand = name.replace(new RegExp(`^${brand}\\s*`, "i"), "").trim();
-    if (withoutBrand) return withoutBrand;
-  }
-  return name;
 }
 
-function inferLine(product = {}, brand = "") {
-  const line = normalizeText(
-    pickField(product, ["line", "series", "family", "catalog_line", "catalog_series", "catalog_family"]),
-  );
-  if (line) return line;
-  if (brand && brand.toLowerCase() === "samsung") return "Galaxy";
-  return "";
+function buildSafeProductDescription(product = {}, label = "") {
+  const sku = normalizeText(pickField(product, ["sku", "SKU", "part_number", "partNumber", "PartNumber", "Part Number"]));
+  const skuCopy = sku ? `, SKU ${sku}` : "";
+  return compactText(`${label || "Repuesto"} disponible en NERIN Parts. Verificá compatibilidad${skuCopy} y disponibilidad antes de comprar.`);
 }
 
-function inferWithFrame(product = {}) {
-  const meta = pickMetadata(product);
-  const flag = pickField(product, ["with_frame", "withFrame", "frame", "has_frame", "marco"]);
-  if (typeof flag === "boolean") return flag;
-  if (flag && typeof flag === "string") {
-    return /true|1|si|sí|con/i.test(flag);
-  }
-  const metaFlag = meta && typeof meta.with_frame === "boolean" ? meta.with_frame : null;
-  if (metaFlag != null) return metaFlag;
-  const textFields = [product?.name, product?.description, product?.short_description, product?.meta_description];
-  return textFields.some((value) => typeof value === "string" && /marco/i.test(value));
-}
-
-function inferServicePack(product = {}) {
-  const flag = pickField(product, ["service_pack", "servicePack", "service_pack_original"]);
-  if (typeof flag === "boolean") return flag;
-  if (flag && typeof flag === "string") return /service\s*pack|sp\b/i.test(flag);
-  const textFields = [product?.name, product?.description, product?.short_description];
-  return textFields.some((value) => typeof value === "string" && /service\s*pack/i.test(value)) || true;
-}
-
-// Generador centralizado de metadatos SEO para un producto.
-// Usa información del modelo, código GH82, código interno y banderas de Service Pack / marco.
 function generateProductSeo(product = {}) {
-  const brand = normalizeText(product.brand || product.catalog_brand) || "Samsung";
-  const line = inferLine(product, brand);
-  const model = extractModelName(product);
-  const modelCode = extractModelCode(product);
-  const ghCode = extractGhCode(product);
-  const brandLine = compactText([brand, line].filter(Boolean).join(" ")) || brand;
-  const modelLabel = compactText(model || modelCode || product?.sku || brandLine);
-  const codeCopy =
-    modelCode && (!modelLabel.toLowerCase().includes(modelCode.toLowerCase()) ? modelCode : "");
-  const ghCopy = ghCode ? ghCode : "";
+  const productType = detectProductType(product);
+  const label = buildSafeProductLabel(product);
 
-  const lowerModel = modelLabel.toLowerCase();
-  const lowerLine = line.toLowerCase();
-  let adjustedBrandLine = brandLine;
-  if (line && lowerModel.includes(lowerLine)) {
-    adjustedBrandLine = compactText([brand].filter(Boolean).join(" ")) || brandLine;
-  }
-  let modelSegment = compactText([adjustedBrandLine, modelLabel].filter(Boolean).join(" ")) || adjustedBrandLine;
-  if (adjustedBrandLine && lowerModel.includes(adjustedBrandLine.toLowerCase())) {
-    modelSegment = modelLabel || adjustedBrandLine;
+  if (productType !== "Pantalla / display") {
+    const description = buildSafeProductDescription(product, label);
+    return {
+      title: truncateText(`${label} | NERIN Parts`, 160),
+      description: truncateText(description, 200),
+      ogTitle: label,
+      ogDescription: description,
+      productType,
+    };
   }
 
-  const title = compactText(
-    `Módulo Pantalla ${modelSegment}${codeCopy ? ` ${codeCopy}` : ""} Original Service Pack${
-      ghCopy ? ` ${ghCopy}` : ""
-    } | NERIN Parts`,
-  );
+  const autoContent = buildProductAutoContent(product);
+  if (autoContent && (autoContent.seoTitle || autoContent.seoDescription)) {
+    return {
+      title: truncateText(autoContent.seoTitle || `${label} | NERIN Parts`, 160),
+      description: truncateText(autoContent.seoDescription || autoContent.shortDescription || buildSafeProductDescription(product, label), 200),
+      ogTitle: autoContent.h1 || autoContent.seoTitle || label,
+      ogDescription: autoContent.longDescription || autoContent.seoDescription || buildSafeProductDescription(product, label),
+      productType,
+    };
+  }
 
-  const description = compactText(
-    `Módulo pantalla original ${modelSegment}${codeCopy ? ` ${codeCopy}` : ""}${
-      ghCopy ? ` ${ghCopy}` : ""
-    }. Service Pack listo para montar. Stock en Argentina, envío rápido y garantía para servicio técnico.`,
-  );
-
+  const description = buildSafeProductDescription(product, label);
   return {
-    title: truncateText(title || "Módulo Pantalla original Service Pack | NERIN Parts", 160),
+    title: truncateText(`${label} | NERIN Parts`, 160),
     description: truncateText(description, 200),
-    ogTitle: title,
+    ogTitle: label,
     ogDescription: description,
+    productType,
   };
 }
 
@@ -318,22 +127,6 @@ function shouldReplaceSeo(value, genericSet) {
   return !text || genericSet.has(text);
 }
 
-function isLegacyTitleReplaceable(product = {}) {
-  const legacy = normalizeText(product.meta_title);
-  const name = normalizeText(product.name);
-  if (!legacy) return false;
-  if (shouldReplaceSeo(legacy, GENERIC_SEO_TITLES)) return true;
-  return legacy.toLowerCase() === name.toLowerCase();
-}
-
-function isLegacyDescriptionReplaceable(product = {}) {
-  const legacy = normalizeText(product.meta_description);
-  const desc = normalizeText(product.description);
-  if (!legacy) return false;
-  if (shouldReplaceSeo(legacy, GENERIC_SEO_DESCRIPTIONS)) return true;
-  return legacy.toLowerCase() === desc.toLowerCase();
-}
-
 function applyProductSeo(product = {}) {
   const generated = buildSeoForProduct(product);
   const next = { ...product };
@@ -343,12 +136,12 @@ function applyProductSeo(product = {}) {
 
   const currentTitle = normalizeText(product.seoTitle);
   const legacyTitle = normalizeText(product.meta_title);
-  const looksAutoTitle = /módulo\s+pantalla/i.test(currentTitle);
+  const looksBadScreenTitle = /m[oó]dulo\s+pantalla|original\s+service\s+pack/i.test(currentTitle);
   const shouldUseGeneratedTitle =
     !currentTitle ||
     shouldReplaceSeo(currentTitle, GENERIC_SEO_TITLES) ||
     currentTitle.toLowerCase() === name.toLowerCase() ||
-    (looksAutoTitle && generated.seoTitle && currentTitle !== generated.seoTitle);
+    (looksBadScreenTitle && detectProductType(product) !== "Pantalla / display");
   if (shouldUseGeneratedTitle) {
     if (generated.seoTitle && generated.seoTitle !== currentTitle) updated = true;
     next.seoTitle = generated.seoTitle;
@@ -359,14 +152,14 @@ function applyProductSeo(product = {}) {
 
   const currentDesc = normalizeText(product.seoDescription);
   const legacyDesc = normalizeText(product.meta_description);
-  const looksAutoDescription = /env[ií]os a todo argentina|service pack/i.test(currentDesc);
+  const looksBadScreenDescription = /m[oó]dulo\s+pantalla|service\s+pack|oled|amoled|lcd/i.test(currentDesc);
   const matchesLegacyDesc = currentDesc && legacyDesc && currentDesc.toLowerCase() === legacyDesc.toLowerCase();
   const shouldUseGeneratedDesc =
     !currentDesc ||
     shouldReplaceSeo(currentDesc, GENERIC_SEO_DESCRIPTIONS) ||
     currentDesc.toLowerCase() === descriptionText.toLowerCase() ||
     matchesLegacyDesc ||
-    (looksAutoDescription && generated.seoDescription && currentDesc !== generated.seoDescription);
+    (looksBadScreenDescription && detectProductType(product) !== "Pantalla / display");
   if (shouldUseGeneratedDesc) {
     if (generated.seoDescription && generated.seoDescription !== currentDesc) updated = true;
     next.seoDescription = generated.seoDescription;

--- a/nerin_final_updated/backend/utils/productTaxonomy.js
+++ b/nerin_final_updated/backend/utils/productTaxonomy.js
@@ -1,0 +1,73 @@
+function normalizeText(value) {
+  if (value == null) return "";
+  return String(value).replace(/\s+/g, " ").trim();
+}
+
+function pickMetadata(product = {}) {
+  return product && typeof product.metadata === "object" && product.metadata !== null ? product.metadata : {};
+}
+
+function pickSupplierImport(product = {}) {
+  const meta = pickMetadata(product);
+  return meta && typeof meta.supplierImport === "object" && meta.supplierImport !== null ? meta.supplierImport : {};
+}
+
+function pickField(product = {}, keys = []) {
+  const meta = pickMetadata(product);
+  const supplierImport = pickSupplierImport(product);
+  for (const key of keys) {
+    if (!key) continue;
+    if (Object.prototype.hasOwnProperty.call(product, key) && product[key] != null && product[key] !== "") return product[key];
+    if (Object.prototype.hasOwnProperty.call(meta, key) && meta[key] != null && meta[key] !== "") return meta[key];
+    if (Object.prototype.hasOwnProperty.call(supplierImport, key) && supplierImport[key] != null && supplierImport[key] !== "") return supplierImport[key];
+  }
+  return null;
+}
+
+function buildTaxonomyText(product = {}) {
+  return [
+    pickField(product, ["name", "Name"]),
+    pickField(product, ["title", "Title"]),
+    pickField(product, ["description", "Description"]),
+    pickField(product, ["category", "Category"]),
+    pickField(product, ["subcategory", "SubCategory", "subCategory"]),
+    pickField(product, ["ProductGroup", "productGroup"]),
+    pickField(product, ["quality", "Quality"]),
+    pickField(product, ["remarks", "Remarks"]),
+    pickField(product, ["MainCategory", "mainCategory"]),
+    pickField(product, ["SubCategory", "subCategory"]),
+    pickField(product, ["Description"]),
+  ].map(normalizeText).filter(Boolean).join(" ").toLowerCase();
+}
+
+function has(text, pattern) {
+  return pattern.test(text);
+}
+
+function detectProductType(product = {}) {
+  const text = buildTaxonomyText(product);
+  if (!text) return "Repuesto";
+
+  if (has(text, /\b(screen\s+protection|screen\s+protector|tempered\s+glass|vidrio\s+templado|protector(?:\s+de\s+pantalla)?)\b/i)) return "Protector de pantalla";
+  if (has(text, /\b(pressing\s+jig|repair\s+tool|tool|herramienta|jig|molde|fixture)\b/i)) return "Herramienta / accesorio tecnico";
+  if (has(text, /\b(display|screen|pantalla)\s+(adhesive|tape|sticker|seal|sealant|gasket|bonding|glue|oca)\b/i)) return "Adhesivo para pantalla";
+  if (has(text, /\b(back|rear|battery)\s+(cover\s+)?(adhesive|tape|sticker|seal|gasket)\b/i)) return "Adhesivo para tapa trasera";
+  if (has(text, /\b(resin|adhesive|adhesive\s+tape|glue|tape|sticker|seal|sealant|gasket|bonding|oca|epoxy|pegamento|adhesivo)\b/i)) return "Adhesivo / pegamento";
+  if (has(text, /\b(charging\s+board|charge\s+port|dock\s+connector|pin\s+de\s+carga|puerto\s+de\s+carga|placa\s+de\s+carga)\b/i)) return "Placa / pin de carga";
+  if (has(text, /\b(flex\s+cable|flex|cable\s+interno|flat\s+cable)\b/i)) return "Flex / cable interno";
+  if (has(text, /\b(back\s+cover|rear\s+cover|battery\s+cover|tapa\s+trasera|carcasa)\b/i)) return "Tapa trasera / carcasa";
+  if (has(text, /\b(battery|bateria|bater[ií]a)\b/i)) return "Batería";
+  if (has(text, /\b(camera\s+lens|lens\s+camera|lente\s+de\s+c[aá]mara|cristal\s+c[aá]mara)\b/i)) return "Lente de cámara";
+  if (has(text, /\b(camera|camara|c[aá]mara)\b/i)) return "Cámara";
+  if (has(text, /\b(speaker|parlante|earpiece|buzzer|audio)\b/i)) return "Audio / parlante";
+  if (has(text, /\b(microphone|micr[oó]fono|microfono)\b/i)) return "Micrófono";
+  if (has(text, /\b(sim\s+tray|sim\s+reader|lector\s+sim|bandeja\s+sim)\b/i)) return "Bandeja / lector SIM";
+  if (has(text, /\b(screw|screws|tornillo|tornillos|fixing|fijaci[oó]n|fijaciones)\b/i)) return "Tornillos / fijaciones";
+  if (has(text, /\b(holder|bracket|soporte)\b/i)) return "Soporte / bracket";
+  if (has(text, /\b(antenna|antena|ic|chip|board\s+component|componente\s+electr[oó]nico)\b/i)) return "Componente electrónico";
+  if (has(text, /\b(display|screen|pantalla|lcd|oled|amoled|tft)\b/i)) return "Pantalla / display";
+
+  return "Repuesto";
+}
+
+module.exports = { detectProductType };

--- a/nerin_final_updated/scripts/auditBadScreenSeoTitles.js
+++ b/nerin_final_updated/scripts/auditBadScreenSeoTitles.js
@@ -1,0 +1,63 @@
+const fs = require("fs");
+const path = require("path");
+const sqlite3 = require("sqlite3");
+const productsSqliteRepo = require("../backend/data/productsSqliteRepo");
+const { detectProductType } = require("../backend/utils/productTaxonomy");
+const { generateProductSeo } = require("../backend/utils/productSeo");
+
+const root = path.resolve(__dirname, "..");
+const reportDir = path.join(root, "nerin-data");
+const reportPath = path.join(reportDir, "bad-screen-seo-titles-report.json");
+
+function normalizeText(value) { return value == null ? "" : String(value).replace(/\s+/g, " ").trim(); }
+function hasBadScreenSeoSignal(product = {}) {
+  const haystack = [product.seoTitle, product.seo_title, product.meta_title, product.name, product.title].map(normalizeText).join(" ");
+  return /\b(m[oó]dulo\s+pantalla|modulo\s+pantalla|pantalla|original\s+service\s+pack)\b/i.test(haystack);
+}
+function getRows(dbPath) {
+  return new Promise((resolve, reject) => {
+    const db = new sqlite3.Database(dbPath, sqlite3.OPEN_READONLY, (error) => { if (error) reject(error); });
+    db.all("SELECT rowid, id, sku, name, title, raw_json FROM products ORDER BY rowid ASC", [], (error, rows) => {
+      db.close();
+      if (error) reject(error); else resolve(rows || []);
+    });
+  });
+}
+function buildReportItem(row, product, detectedProductType) {
+  const generated = generateProductSeo(product);
+  return {
+    id: normalizeText(product.id || row.id),
+    sku: normalizeText(product.sku || row.sku),
+    name: normalizeText(product.name || row.name),
+    title: normalizeText(product.title || row.title),
+    seoTitle: normalizeText(product.seoTitle || product.seo_title || product.meta_title),
+    seoDescription: normalizeText(product.seoDescription || product.seo_description || product.meta_description),
+    detectedProductType,
+    suggestedTitle: generated.title,
+    suggestedSeoDescription: generated.description,
+  };
+}
+async function auditBadScreenSeoTitles() {
+  const dbPath = productsSqliteRepo.SQLITE_PATH;
+  const rows = fs.existsSync(dbPath) ? await getRows(dbPath) : [];
+  const findings = [];
+  for (const row of rows) {
+    let product = {};
+    try { product = JSON.parse(row.raw_json || "{}"); } catch {}
+    product = { id: row.id, sku: row.sku, name: row.name, title: row.title, ...product };
+    const detectedProductType = detectProductType(product);
+    if (detectedProductType === "Pantalla / display") continue;
+    if (!hasBadScreenSeoSignal(product)) continue;
+    findings.push(buildReportItem(row, product, detectedProductType));
+  }
+  fs.mkdirSync(reportDir, { recursive: true });
+  fs.writeFileSync(reportPath, JSON.stringify({ generatedAt: new Date().toISOString(), count: findings.length, items: findings }, null, 2), "utf8");
+  return { count: findings.length, reportPath };
+}
+if (require.main === module) {
+  auditBadScreenSeoTitles().then((result) => {
+    console.log(`[bad-screen-seo-audit] findings=${result.count}`);
+    console.log(`[bad-screen-seo-audit] report=${result.reportPath}`);
+  }).catch((error) => { console.error("[bad-screen-seo-audit] failed", error?.message || error); process.exitCode = 1; });
+}
+module.exports = { auditBadScreenSeoTitles, hasBadScreenSeoSignal };

--- a/nerin_final_updated/scripts/fixBadScreenSeoTitles.js
+++ b/nerin_final_updated/scripts/fixBadScreenSeoTitles.js
@@ -1,0 +1,81 @@
+const fs = require("fs");
+const path = require("path");
+const sqlite3 = require("sqlite3");
+const productsSqliteRepo = require("../backend/data/productsSqliteRepo");
+const { detectProductType } = require("../backend/utils/productTaxonomy");
+const { generateProductSeo } = require("../backend/utils/productSeo");
+const { hasBadScreenSeoSignal } = require("./auditBadScreenSeoTitles");
+
+const root = path.resolve(__dirname, "..");
+const reportDir = path.join(root, "nerin-data");
+const reportPath = path.join(reportDir, "bad-screen-seo-titles-report.json");
+function normalizeText(value) { return value == null ? "" : String(value).replace(/\s+/g, " ").trim(); }
+function parseArgs(argv = process.argv.slice(2)) {
+  const args = { dryRun: true, apply: false, limit: 100 };
+  for (const arg of argv) {
+    if (arg === "--dry-run") { args.dryRun = true; args.apply = false; }
+    else if (arg === "--apply") { args.apply = true; args.dryRun = false; }
+    else if (arg.startsWith("--limit=")) {
+      const limit = Number(arg.slice("--limit=".length));
+      if (Number.isFinite(limit) && limit > 0) args.limit = Math.floor(limit);
+    }
+  }
+  return args;
+}
+function openDb(dbPath, mode) { return new Promise((resolve, reject) => { const db = new sqlite3.Database(dbPath, mode, (error) => error ? reject(error) : resolve(db)); }); }
+function all(db, sql, params = []) { return new Promise((resolve, reject) => db.all(sql, params, (error, rows) => error ? reject(error) : resolve(rows || []))); }
+function run(db, sql, params = []) { return new Promise((resolve, reject) => db.run(sql, params, function done(error) { error ? reject(error) : resolve({ changes: this.changes || 0 }); })); }
+function closeDb(db) { return new Promise((resolve) => db.close(() => resolve())); }
+function buildReportItem(row, product, detectedProductType, generated) {
+  return {
+    id: normalizeText(product.id || row.id),
+    sku: normalizeText(product.sku || row.sku),
+    name: normalizeText(product.name || row.name),
+    title: normalizeText(product.title || row.title),
+    seoTitle: normalizeText(product.seoTitle || product.seo_title || product.meta_title),
+    seoDescription: normalizeText(product.seoDescription || product.seo_description || product.meta_description),
+    detectedProductType,
+    suggestedTitle: generated.title,
+    suggestedSeoDescription: generated.description,
+  };
+}
+async function fixBadScreenSeoTitles(options = parseArgs()) {
+  const dbPath = productsSqliteRepo.SQLITE_PATH;
+  if (!fs.existsSync(dbPath)) return { scanned: 0, candidates: 0, updated: 0, reportPath, missingDb: true };
+  const db = await openDb(dbPath, options.apply ? sqlite3.OPEN_READWRITE : sqlite3.OPEN_READONLY);
+  let scanned = 0;
+  let updated = 0;
+  const reportItems = [];
+  try {
+    const rows = await all(db, "SELECT rowid, id, sku, name, title, raw_json FROM products ORDER BY rowid ASC", []);
+    for (const row of rows) {
+      if (reportItems.length >= options.limit) break;
+      scanned += 1;
+      let product = {};
+      try { product = JSON.parse(row.raw_json || "{}"); } catch {}
+      product = { id: row.id, sku: row.sku, name: row.name, title: row.title, ...product };
+      const detectedProductType = detectProductType(product);
+      if (detectedProductType === "Pantalla / display") continue;
+      if (!hasBadScreenSeoSignal(product)) continue;
+      const generated = generateProductSeo(product);
+      reportItems.push(buildReportItem(row, product, detectedProductType, generated));
+      if (options.apply) {
+        const nextProduct = { ...product, seoTitle: generated.title, seoDescription: generated.description };
+        const result = await run(db, "UPDATE products SET raw_json = ? WHERE rowid = ?", [JSON.stringify(nextProduct), row.rowid]);
+        updated += result.changes;
+      }
+    }
+  } finally { await closeDb(db); }
+  fs.mkdirSync(reportDir, { recursive: true });
+  fs.writeFileSync(reportPath, JSON.stringify({ generatedAt: new Date().toISOString(), mode: options.apply ? "apply" : "dry-run", scanned, count: reportItems.length, updated, items: reportItems }, null, 2), "utf8");
+  return { scanned, candidates: reportItems.length, updated, reportPath };
+}
+if (require.main === module) {
+  const options = parseArgs();
+  fixBadScreenSeoTitles(options).then((result) => {
+    console.log(`[bad-screen-seo-fix] mode=${options.apply ? "apply" : "dry-run"}`);
+    console.log(`[bad-screen-seo-fix] scanned=${result.scanned} candidates=${result.candidates} updated=${result.updated}`);
+    console.log(`[bad-screen-seo-fix] report=${result.reportPath}`);
+  }).catch((error) => { console.error("[bad-screen-seo-fix] failed", error?.message || error); process.exitCode = 1; });
+}
+module.exports = { fixBadScreenSeoTitles, parseArgs };


### PR DESCRIPTION
## Summary
- Corrige generateProductSeo para no asumir pantalla/Samsung/Service Pack en todos los productos.
- Agrega taxonomía defensiva para distinguir pantallas de adhesivos, herramientas, resin, pines de carga, flex, protectores, etc.
- Agrega auditoría y reparación dry-run para seoTitle persistidos incorrectos.
- Mantiene sitemap grande seguro.
- No toca precios, pagos, checkout, pedidos, Resend, Andreani ni stock.

## Testing
- node --check backend/utils/productSeo.js
- node --check backend/utils/productTaxonomy.js
- node --check backend/server.js
- node --check scripts/auditBadScreenSeoTitles.js
- node --check scripts/fixBadScreenSeoTitles.js
- npm test -- product-seo-taxonomy.test.js
- Remote branch package check: start does not call applyProductAutoContentPatch.js