### PR TITLE
Emergency fix product page visible names and remove forced screen-module copy

### DIFF
--- a/nerin_final_updated/__tests__/backend/product-seo-taxonomy.test.js
+++ b/nerin_final_updated/__tests__/backend/product-seo-taxonomy.test.js
@@ -9,14 +9,18 @@ describe("product SEO taxonomy", () => {
     expect(["Repuesto", "Adhesivo / pegamento"]).toContain(productType);
     expect(productType).not.toBe("Pantalla / display");
     expect(seo.title).toBe("RESIN PC | NERIN Parts");
-    expect(seo.description).toBe("RESIN PC disponible en NERIN Parts. Verificá compatibilidad, SKU 0103-009557 y disponibilidad antes de comprar.");
+    expect(seo.description).toContain("RESIN PC disponible en NERIN Parts.");
+    expect(seo.description).toContain("SKU/código de pieza");
+    expect(seo.description).toContain("SKU: 0103-009557.");
     expect(`${seo.title} ${seo.description}`).not.toMatch(/M[oó]dulo Pantalla|Samsung Galaxy|Original Service Pack/i);
   });
 
   test("real display is classified as screen", () => {
     const product = { description: "Display incl. frame Original Samsung Galaxy S25 SM-S931", brand: "Samsung", model: "Galaxy S25 SM-S931", quality: "Original" };
     expect(detectProductType(product)).toBe("Pantalla / display");
-    expect(generateProductSeo(product).title).toMatch(/Pantalla/i);
+    const seo = generateProductSeo(product);
+    expect(seo.title).toContain("Display incl. frame Original Samsung Galaxy S25 SM-S931");
+    expect(`${seo.title} ${seo.description}`).not.toMatch(/M[oó]dulo Pantalla|Pantalla para|Original Service Pack/i);
   });
 
   test("display adhesive is adhesive, not screen", () => {
@@ -46,4 +50,12 @@ describe("product SEO taxonomy", () => {
   test("flex cable is internal flex", () => {
     expect(detectProductType({ name: "Flex cable" })).toBe("Flex / cable interno");
   });
+
+  test("RESIN PC keeps real commercial name in SEO", () => {
+    const product = { name: "RESIN PC" };
+    const seo = generateProductSeo(product);
+    expect(seo.title).toContain("RESIN PC");
+    expect(`${seo.title} ${seo.description}`).not.toMatch(/M[oó]dulo Pantalla|Pantalla para|Samsung Galaxy|Original Service Pack/i);
+  });
+
 });

--- a/nerin_final_updated/backend/utils/productSeo.js
+++ b/nerin_final_updated/backend/utils/productSeo.js
@@ -1,4 +1,3 @@
-const { buildProductAutoContent } = require("./productAutoContent");
 const { detectProductType } = require("./productTaxonomy");
 
 const GENERIC_SEO_TITLES = new Set([
@@ -79,30 +78,16 @@ function buildSafeProductDescription(product = {}, label = "") {
 function generateProductSeo(product = {}) {
   const productType = detectProductType(product);
   const label = buildSafeProductLabel(product);
+  const brand = normalizeText(pickField(product, ["brand", "catalog_brand", "Brand"]));
+  const sku = normalizeText(pickField(product, ["sku", "SKU", "part_number", "partNumber", "PartNumber", "Part Number"]));
 
-  if (productType !== "Pantalla / display") {
-    const description = buildSafeProductDescription(product, label);
-    return {
-      title: truncateText(`${label} | NERIN Parts`, 160),
-      description: truncateText(description, 200),
-      ogTitle: label,
-      ogDescription: description,
-      productType,
-    };
-  }
+  const descriptionParts = [
+    `${label} disponible en NERIN Parts. Verificá compatibilidad, SKU/código de pieza y disponibilidad antes de comprar.`,
+  ];
+  if (brand) descriptionParts.push(`Marca: ${brand}.`);
+  if (sku) descriptionParts.push(`SKU: ${sku}.`);
+  const description = compactText(descriptionParts.join(" "));
 
-  const autoContent = buildProductAutoContent(product);
-  if (autoContent && (autoContent.seoTitle || autoContent.seoDescription)) {
-    return {
-      title: truncateText(autoContent.seoTitle || `${label} | NERIN Parts`, 160),
-      description: truncateText(autoContent.seoDescription || autoContent.shortDescription || buildSafeProductDescription(product, label), 200),
-      ogTitle: autoContent.h1 || autoContent.seoTitle || label,
-      ogDescription: autoContent.longDescription || autoContent.seoDescription || buildSafeProductDescription(product, label),
-      productType,
-    };
-  }
-
-  const description = buildSafeProductDescription(product, label);
   return {
     title: truncateText(`${label} | NERIN Parts`, 160),
     description: truncateText(description, 200),

--- a/nerin_final_updated/frontend/js/product.js
+++ b/nerin_final_updated/frontend/js/product.js
@@ -363,6 +363,17 @@ function getProductSku(product) {
   return normalizeContentId(product.id);
 }
 
+function getVisibleProductName(product) {
+  const raw =
+    product?.name ||
+    product?.title ||
+    product?.description ||
+    product?.sku ||
+    product?.id ||
+    "Producto";
+  return normalizeText(String(raw)) || "Producto";
+}
+
 function resolveSeo(product) {
   const { product: enriched, generated } = applySeoDefaults(product || {});
   return {
@@ -373,14 +384,8 @@ function resolveSeo(product) {
 }
 
 function buildModuleAltLabel(product) {
-  const { title } = resolveSeo(product);
-  const label = stripBrandSuffix(title) || normalizeText(product?.name);
-  if (label) {
-    return label.toLowerCase().startsWith("módulo")
-      ? label
-      : `Módulo ${label} Service Pack original`;
-  }
-  return "Módulo Service Pack original";
+  const label = getVisibleProductName(product);
+  return label || "Producto";
 }
 
 function buildMetaTitle(product) {
@@ -407,7 +412,7 @@ function buildMetaDescription(product) {
   const { description } = resolveSeo(product);
   if (description) return truncateText(description, 180);
   const fallback = getProductDescription(product, { preferMeta: true });
-  return truncateText(fallback || "Repuesto original Service Pack", 180);
+  return truncateText(fallback || "Repuesto", 180);
 }
 
 function setMetaContent(attr, key, value) {
@@ -442,7 +447,7 @@ function setCanonicalUrl(url) {
 function updateBreadcrumbJsonLd(product, productUrl) {
   const script = document.getElementById("product-breadcrumbs");
   if (!script || !product) return;
-  const heading = stripBrandSuffix(resolveSeo(product).title) || product.name || "Producto";
+  const heading = getVisibleProductName(product);
   const breadcrumbs = {
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
@@ -567,7 +572,7 @@ function updateJsonLd(product, images, productUrl) {
   if (!product) return;
   const head = document.head;
   if (!head) return;
-  const heading = stripBrandSuffix(resolveSeo(product).title) || product.name || "Producto";
+  const heading = getVisibleProductName(product);
   const gallery = Array.isArray(images) ? images : [];
   const absoluteImages = gallery
     .filter(Boolean)
@@ -1220,7 +1225,7 @@ function renderProduct(product) {
   summary.className = "product-summary product-buy-header";
 
   const title = document.createElement("h1");
-  title.textContent = stripBrandSuffix(seoTitle) || product.name || "Producto";
+  title.textContent = getVisibleProductName(product);
   summary.appendChild(title);
 
   const meta = document.createElement("div");
@@ -1562,7 +1567,7 @@ function renderProduct(product) {
       ? formatPrice(netUnitPrice)
       : formatPrice(0);
     taxFreeNote.textContent = `Precio sin impuestos: ${netText}`;
-    stickyPrice.textContent = `Precio: ${formatPrice(unitPrice)} · x${qty} u · Service Pack original`;
+    stickyPrice.textContent = `Precio: ${formatPrice(unitPrice)} · x${qty} u`;
     if (productPriceContext.canUseWholesale) {
       const bulkSavings = productPriceContext.discountAmount * qty;
       if (productPriceContext.discountAmount > 0) {
@@ -1582,7 +1587,7 @@ function renderProduct(product) {
 
   const setCtaLabels = () => {
     const isMobile = window.matchMedia("(max-width: 768px)").matches;
-    const label = "COMPRAR MÓDULO AHORA";
+    const label = "COMPRAR AHORA";
     addBtn.textContent = label;
     stickyBtn.textContent = label;
   };

--- a/nerin_final_updated/frontend/js/seo-helpers.js
+++ b/nerin_final_updated/frontend/js/seo-helpers.js
@@ -248,44 +248,24 @@ function inferServicePack(product = {}) {
 }
 
 // Generador centralizado de metadatos SEO para un producto.
-// Usa información del modelo, código GH82, código interno y banderas de Service Pack / marco.
+// Mantiene el nombre comercial real y evita copy inventado.
 export function generateProductSeo(product = {}) {
-  const brand = normalizeText(product.brand || product.catalog_brand) || "Samsung";
-  const line = inferLine(product, brand);
-  const model = extractModelName(product);
-  const modelCode = extractModelCode(product);
-  const ghCode = extractGhCode(product);
-  const brandLine = compactText([brand, line].filter(Boolean).join(" ")) || brand;
-  const modelLabel = compactText(model || modelCode || product?.sku || brandLine);
-  const codeCopy =
-    modelCode && (!modelLabel.toLowerCase().includes(modelCode.toLowerCase()) ? modelCode : "");
-  const ghCopy = ghCode ? ghCode : "";
-
-  const lowerModel = modelLabel.toLowerCase();
-  const lowerLine = line.toLowerCase();
-  let adjustedBrandLine = brandLine;
-  if (line && lowerModel.includes(lowerLine)) {
-    adjustedBrandLine = compactText([brand].filter(Boolean).join(" ")) || brandLine;
-  }
-  let modelSegment = compactText([adjustedBrandLine, modelLabel].filter(Boolean).join(" ")) || adjustedBrandLine;
-  if (adjustedBrandLine && lowerModel.includes(adjustedBrandLine.toLowerCase())) {
-    modelSegment = modelLabel || adjustedBrandLine;
-  }
-
-  const title = compactText(
-    `Módulo Pantalla ${modelSegment}${codeCopy ? ` ${codeCopy}` : ""} Original Service Pack${
-      ghCopy ? ` ${ghCopy}` : ""
-    } | NERIN Parts`,
+  const label = compactText(
+    product?.name || product?.title || product?.description || product?.sku || product?.id || "Repuesto",
   );
+  const brand = normalizeText(product?.brand || product?.catalog_brand);
+  const sku = normalizeText(product?.sku);
 
-  const description = compactText(
-    `Módulo pantalla original ${modelSegment}${codeCopy ? ` ${codeCopy}` : ""}${
-      ghCopy ? ` ${ghCopy}` : ""
-    }. Service Pack listo para montar. Stock en Argentina, envío rápido y garantía para servicio técnico.`,
-  );
+  const extras = [];
+  if (brand) extras.push(`Marca: ${brand}.`);
+  if (sku) extras.push(`SKU: ${sku}.`);
+
+  const baseDescription = `${label} disponible en NERIN Parts. Verificá compatibilidad, SKU/código de pieza y disponibilidad antes de comprar.`;
+  const description = compactText([baseDescription, ...extras].join(" "));
+  const title = compactText(`${label} | NERIN Parts`);
 
   return {
-    title: truncateText(title || "Módulo Pantalla original Service Pack | NERIN Parts", 160),
+    title: truncateText(title, 160),
     description: truncateText(description, 200),
     ogTitle: title,
     ogDescription: description,


### PR DESCRIPTION
### Motivation

- The storefront and product pages were replacing real catalog names with invented SEO copy like "Módulo Pantalla", "Pantalla para...", "Samsung Galaxy" and "Original Service Pack", which changes the commercial product name visible to customers. 
- Fix SEO generation and product rendering so visible product names always come from real catalog fields and SEO only affects meta/title without inventing product types.

### Description

- Replaced the unsafe SEO generator in `frontend/js/seo-helpers.js` so `generateProductSeo(product)` uses a safe label derived from `product.name || product.title || product.description || product.sku || product.id || 'Repuesto'` and builds `seoTitle`/`seoDescription` without injecting "Módulo Pantalla"/"Pantalla para"/"Original Service Pack" etc.; brand and SKU are only appended when present. 
- Mirrored the safe behavior in `backend/utils/productSeo.js` to stop forcing screen/module copy during backend SEO generation. 
- Added `getVisibleProductName(product)` and updated `frontend/js/product.js` so the visible H1, breadcrumb names, JSON-LD `Product.name`, image alt fallbacks and purchase card use the real product label (not enriched `seoTitle`), and removed hardcoded service-pack phrasing from price summaries. 
- Replaced hardcoded CTA labels like "COMPRAR MÓDULO AHORA" with the standardized main CTA "COMPRAR AHORA" and adjusted related UI text accordingly. 
- Updated and added unit tests in `__tests__/backend/product-seo-taxonomy.test.js` to assert that `generateProductSeo` keeps real names and does not contain forced module/screen wording for cases like `RESIN PC` and real displays.

### Testing

- Static checks were run: `node --check frontend/js/seo-helpers.js`, `node --check frontend/js/product.js` and `node --check backend/utils/productSeo.js`, all succeeded. 
- Unit tests were executed with `npm test -- product-seo` and the `product-seo` suite passed. 
- New/modified tests validate that `generateProductSeo(...)` includes the real product label and does not inject "Módulo Pantalla", "Pantalla para", "Samsung Galaxy" or "Original Service Pack". 
- No runtime changes were made to prices, stock, payment, checkout, cart, orders, Resend, Andreani integrations, CSV import or mass publication logic as part of this fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04f5a88c948331ae9675453594eef5)