### PR TITLE
Fix product detail auto headings for SEO taxonomy

### DIFF
--- a/nerin_final_updated/__tests__/backend/product-seo-taxonomy.test.js
+++ b/nerin_final_updated/__tests__/backend/product-seo-taxonomy.test.js
@@ -1,3 +1,4 @@
+const { buildProductAutoContent } = require("../../backend/utils/productAutoContent");
 const { generateProductSeo } = require("../../backend/utils/productSeo");
 const { detectProductType } = require("../../backend/utils/productTaxonomy");
 
@@ -6,21 +7,51 @@ describe("product SEO taxonomy", () => {
     const product = { name: "RESIN PC", brand: "Samsung", sku: "0103-009557" };
     const productType = detectProductType(product);
     const seo = generateProductSeo(product);
+    const autoContent = buildProductAutoContent(product);
+
     expect(["Repuesto", "Adhesivo / pegamento"]).toContain(productType);
     expect(productType).not.toBe("Pantalla / display");
     expect(seo.title).toBe("RESIN PC | NERIN Parts");
-    expect(seo.description).toBe("RESIN PC disponible en NERIN Parts. Verificá compatibilidad, SKU 0103-009557 y disponibilidad antes de comprar.");
-    expect(`${seo.title} ${seo.description}`).not.toMatch(/M[oó]dulo Pantalla|Samsung Galaxy|Original Service Pack/i);
+    expect(seo.description).toBe(
+      "RESIN PC disponible en NERIN Parts. Verificá compatibilidad, SKU 0103-009557 y disponibilidad antes de comprar.",
+    );
+    expect(autoContent.h1).toBe("RESIN PC");
+    expect(`${seo.title} ${seo.description} ${autoContent.h1}`).not.toMatch(
+      /M[oó]dulo Pantalla|Samsung Galaxy|Original Service Pack/i,
+    );
   });
 
   test("real display is classified as screen", () => {
-    const product = { description: "Display incl. frame Original Samsung Galaxy S25 SM-S931", brand: "Samsung", model: "Galaxy S25 SM-S931", quality: "Original" };
+    const product = {
+      description: "Display incl. frame Original Samsung Galaxy S25 SM-S931",
+      brand: "Samsung",
+      model: "Galaxy S25 SM-S931",
+      quality: "Original",
+    };
     expect(detectProductType(product)).toBe("Pantalla / display");
     expect(generateProductSeo(product).title).toMatch(/Pantalla/i);
+    expect(buildProductAutoContent(product).h1).toBe("Pantalla original Samsung Galaxy S25 SM-S931 con marco");
+  });
+
+  test("original Samsung display without frame keeps model in generated H1", () => {
+    const product = {
+      name: "Display excl. frame (Original), Samsung Galaxy S25; SM-S931",
+      description: "Display excl. frame (Original), Samsung Galaxy S25; SM-S931",
+      brand: "Samsung",
+      sku: "GH82-36327A",
+      quality: "Original",
+    };
+    const autoContent = buildProductAutoContent(product);
+
+    expect(detectProductType(product)).toBe("Pantalla / display");
+    expect(autoContent.h1).toBe("Pantalla original Samsung Galaxy S25 SM-S931 sin marco");
+    expect(autoContent.h1).not.toBe("Pantalla para Samsung sin marco");
   });
 
   test("display adhesive is adhesive, not screen", () => {
-    expect(detectProductType({ name: "Display adhesive Samsung" })).toBe("Adhesivo para pantalla");
+    const product = { name: "Display adhesive Samsung", brand: "Samsung" };
+    expect(detectProductType(product)).toBe("Adhesivo para pantalla");
+    expect(buildProductAutoContent(product).h1).toBe("Display adhesive Samsung");
   });
 
   test("screen protection tempered glass is protector", () => {

--- a/nerin_final_updated/backend/utils/productAutoContent.js
+++ b/nerin_final_updated/backend/utils/productAutoContent.js
@@ -1,3 +1,5 @@
+const { detectProductType } = require("./productTaxonomy");
+
 function normalizeText(value) {
   if (value == null) return "";
   return String(value).replace(/\s+/g, " ").trim();
@@ -8,12 +10,16 @@ function cleanSentence(value) {
 }
 
 function pickMetadata(product = {}) {
-  return product && typeof product.metadata === "object" && product.metadata !== null ? product.metadata : {};
+  return product && typeof product.metadata === "object" && product.metadata !== null
+    ? product.metadata
+    : {};
 }
 
 function pickSupplierImport(product = {}) {
   const meta = pickMetadata(product);
-  return meta && typeof meta.supplierImport === "object" && meta.supplierImport !== null ? meta.supplierImport : {};
+  return meta && typeof meta.supplierImport === "object" && meta.supplierImport !== null
+    ? meta.supplierImport
+    : {};
 }
 
 function pickField(product = {}, keys = []) {
@@ -47,10 +53,10 @@ function buildSearchText(product = {}) {
     pickField(product, ["quality", "Quality"]),
     pickField(product, ["name", "title"]),
     pickField(product, ["remarks", "Remarks"]),
-    pickField(product, ["category", "Category", "mainCategory", "MainCategory"]),
-    pickField(product, ["subcategory", "subCategory", "SubCategory"]),
-    pickField(product, ["productGroup", "ProductGroup"]),
-  ].map(normalizeText).filter(Boolean).join(" ");
+  ]
+    .map(normalizeText)
+    .filter(Boolean)
+    .join(" ");
 }
 
 function canonicalQuality(rawQuality) {
@@ -117,7 +123,9 @@ function detectProductQuality(product = {}) {
   const quality = canonicalQuality(raw);
 
   if (!quality) {
-    if (/\brefurb(?:ished)?\b/i.test(description)) return buildQualityResult("Refurbished", "original_reacondicionado", "Refurbished", "description");
+    if (/\brefurb(?:ished)?\b/i.test(description)) {
+      return buildQualityResult("Refurbished", "original_reacondicionado", "Refurbished", "description");
+    }
     return buildQualityResult("Calidad no especificada", "unknown", "", "missing");
   }
 
@@ -133,61 +141,20 @@ function detectProductQuality(product = {}) {
   if (key === "in-cell fhd") return buildQualityResult("Compatible In-Cell FHD", "aftermarket", quality);
   if (/^pulled\b/i.test(quality)) return buildQualityResult(quality, "retirado_de_equipo", quality);
   if (/^po-/i.test(quality)) return buildQualityResult(quality, "pre_owned", quality);
+
   return buildQualityResult(quality, "unknown", quality);
 }
 
-function textHas(text, regex) {
-  return regex.test(String(text || ""));
-}
-
-function detectAdhesiveTarget(text) {
-  if (textHas(text, /\b(display|screen|pantalla|lcd|oled|amoled|tft)\b/i)) return "pantalla";
-  if (textHas(text, /\b(back\s+cover|rear\s+cover|battery\s+cover|back\s+glass|tapa\s+trasera)\b/i)) return "tapa trasera";
-  if (textHas(text, /\bbattery|bateria\b/i)) return "bateria";
-  if (textHas(text, /\bcamera\s+lens|lente\s+camara\b/i)) return "lente de camara";
-  return null;
-}
-
 function detectPartType(product = {}) {
-  const text = buildSearchText(product);
-  const mainCategory = normalizeText(pickField(product, ["mainCategory", "MainCategory", "category", "Category"]));
-  const subCategory = normalizeText(pickField(product, ["subCategory", "SubCategory", "subcategory"]));
-  const categoryText = [mainCategory, subCategory].filter(Boolean).join(" ");
-
-  // Orden defensivo: consumibles, adhesivos, herramientas y accesorios se detectan antes que display.
-  // Esto evita que "display adhesive" termine clasificado como pantalla.
-  if (textHas(`${categoryText} ${text}`, /\b(adhesive|adhesive\s+tape|glue|tape|sticker|seal|sealant|gasket|bonding|resin|oca|ac[f]?|epoxy|b7000|t7000|e8000|e6000|uv\s+glue|liquid\s+adhesive|double\s+sided|pegamento|adhesivo|cinta)\b/i)) {
-    const target = detectAdhesiveTarget(text);
-    return target ? `Adhesivo para ${target}` : "Adhesivo / pegamento";
-  }
-
-  if (textHas(`${categoryText} ${text}`, /\b(tool|repair\s+tool|screwdriver|tweezer|spudger|opener|suction|clamp|mat|pressing\s+jig|jig|fixture|solder|tip|herramienta|destornillador|pinza)\b/i)) return "Herramienta / accesorio tecnico";
-  if (textHas(`${categoryText} ${text}`, /\b(screen\s+protection|tempered\s+glass|protector|glass\s+tempered|film)\b/i)) return "Protector de pantalla";
-  if (textHas(`${categoryText} ${text}`, /\b(battery|bateria)\b/i)) return "Bateria";
-  if (textHas(`${categoryText} ${text}`, /\b(back\s+cover|rear\s+cover|battery\s+cover|back\s+glass|housing|case|tapa\s+trasera|carcasa)\b/i)) return "Tapa trasera / carcasa";
-  if (textHas(`${categoryText} ${text}`, /\b(charging\s+board|charge\s+port|charging\s+port|dock\s+connector|usb\s+connector|conector\s+de\s+carga|placa\s+de\s+carga)\b/i)) return "Placa / flex de carga";
-  if (textHas(`${categoryText} ${text}`, /\b(flex\s+cable|flex|ribbon\s+cable|flat\s+cable)\b/i)) return "Flex / cable interno";
-  if (textHas(`${categoryText} ${text}`, /\b(camera\s+lens|lens\s+cover|lente\s+camara)\b/i)) return "Lente / vidrio de camara";
-  if (textHas(`${categoryText} ${text}`, /\b(camera|camara)\b/i)) return "Camara";
-  if (textHas(`${categoryText} ${text}`, /\b(speaker|earpiece|buzzer|loudspeaker|altavoz|auricular)\b/i)) return "Audio / parlante";
-  if (textHas(`${categoryText} ${text}`, /\b(microphone|mic\b|microfono)\b/i)) return "Microfono";
-  if (textHas(`${categoryText} ${text}`, /\b(vibrator|vibration|taptic|vibrador)\b/i)) return "Vibrador / taptic";
-  if (textHas(`${categoryText} ${text}`, /\b(button|keypad|power\s+key|volume\s+key|boton|tecla)\b/i)) return "Boton / tecla";
-  if (textHas(`${categoryText} ${text}`, /\b(sim\s+tray|sim\s+holder|card\s+tray|bandeja\s+sim)\b/i)) return "Bandeja SIM";
-  if (textHas(`${categoryText} ${text}`, /\b(antenna|antena)\b/i)) return "Antena";
-  if (textHas(`${categoryText} ${text}`, /\b(ic|chip|board\s+component|component)\b/i)) return "Componente electronico";
-
-  if (textHas(`${categoryText} ${text}`, /\b(display|screen|pantalla|lcd|oled|amoled|tft)\b/i)) return "Pantalla / display";
-  return mainCategory || subCategory || "Repuesto";
+  return detectProductType(product);
 }
 
 function isDisplayPartType(partType) {
-  return /pantalla|display/i.test(partType || "");
+  return partType === "Pantalla / display";
 }
 
-function detectDisplayTechnology(product = {}, partType = null) {
-  const resolvedPartType = partType || detectPartType(product);
-  if (!isDisplayPartType(resolvedPartType)) return null;
+function detectDisplayTechnology(product = {}) {
+  if (!isDisplayPartType(detectProductType(product))) return null;
   const quality = canonicalQuality(pickField(product, ["quality", "Quality"]));
   const text = buildSearchText(product);
   if (quality === "Compatible Soft" || /\bsoft\s+oled\b/i.test(text)) return "Soft OLED";
@@ -201,11 +168,12 @@ function detectDisplayTechnology(product = {}, partType = null) {
   return null;
 }
 
-function detectAssemblyType(product = {}, partType = null) {
-  const resolvedPartType = partType || detectPartType(product);
+function detectAssemblyType(product = {}) {
+  if (!isDisplayPartType(detectProductType(product))) {
+    return { assemblyType: null, extra: null };
+  }
   const text = buildSearchText(product);
   const result = { assemblyType: null, extra: null };
-  if (!isDisplayPartType(resolvedPartType)) return result;
   if (/\b(?:incl\.?\s*frame|with\s+frame)\b/i.test(text)) result.assemblyType = "con marco";
   if (/\b(?:excl\.?\s*frame|without\s+frame)\b/i.test(text)) result.assemblyType = "sin marco";
   if (/\bfront\s+flex\b/i.test(text)) result.extra = "con flex frontal";
@@ -219,7 +187,9 @@ function detectProductCondition(product = {}) {
   if (/\bpulled\b/i.test(text) || quality.origin === "retirado_de_equipo") return "retirado de equipo";
   if (quality.origin === "pre_owned") return "equipo pre-owned";
   if (/\bused\b/i.test(text)) return "usado";
-  if (["Original", "Compatible", "Compatible Soft OLED", "Compatible Hard OLED", "Compatible Budget", "Factory Standard", "Compatible In-Cell", "Compatible In-Cell FHD"].includes(quality.commercialQuality)) return "nuevo";
+  if (["Original", "Compatible", "Compatible Soft OLED", "Compatible Hard OLED", "Compatible Budget", "Factory Standard", "Compatible In-Cell", "Compatible In-Cell FHD"].includes(quality.commercialQuality)) {
+    return "nuevo";
+  }
   return null;
 }
 
@@ -231,29 +201,44 @@ function detectAvailability(product = {}) {
   const canBeOrdered = pickField(product, ["canBeOrdered", "csvCanBeOrdered"]);
   const stockMode = normalizeKey(pickField(product, ["stock_mode", "fulfillment_mode"]));
   const leadDays = Number(pickField(product, ["remote_lead_days", "remote_lead_min_days"]));
-  if (canBeOrdered === true || stockMode === "remote" || (Number.isFinite(leadDays) && leadDays > 0)) return "Disponible a pedido";
+  if (canBeOrdered === true || stockMode === "remote" || (Number.isFinite(leadDays) && leadDays > 0)) {
+    return "Disponible a pedido";
+  }
   return "Consultar disponibilidad";
 }
 
 function cleanModelCandidate(value = "") {
   return normalizeText(value)
     .replace(/\([^)]*\)/g, " ")
-    .replace(/\b(display|screen|pantalla|adhesive|glue|tape|sticker|protector|battery|rear\s+cover|back\s+cover|charging\s+board|charge\s+port|camera|speaker|microphone|flex)\b/gi, " ")
+    .replace(/\bdisplay\b/gi, " ")
+    .replace(/\bscreen\b/gi, " ")
+    .replace(/\bpantalla\b/gi, " ")
     .replace(/\b(?:incl\.?|excl\.?)\s*frame\b/gi, " ")
     .replace(/\b(?:with|without)\s+frame\b/gi, " ")
     .replace(/\b(?:soft|hard)?\s*oled\b/gi, " ")
     .replace(/\bamoled|lcd|tft|in[\s-]?cell(?:\s+fhd)?\b/gi, " ")
-    .replace(/\bcompatible|original|refurbished|pulled\b/gi, " ")
+    .replace(/\bcompatible|original|refurbished|pulled|service\s+pack\b/gi, " ")
+    .replace(/\b(?:incl\.?|excl\.?)\b/gi, " ")
+    .replace(/\bframe\b/gi, " ")
     .replace(/[.,;:]+$/g, "")
+    .replace(/^[\s,.;:-]+/g, "")
     .replace(/\s*&\s*/g, " / ")
     .replace(/\s*\/\s*/g, " / ")
+    .replace(/\s*[;,]\s*/g, " ")
     .replace(/\s+-\s*$/g, "")
     .replace(/\s+/g, " ")
     .trim();
 }
 
 function inferModelFromText(product = {}) {
-  const sources = [pickField(product, ["description", "Description"]), pickField(product, ["name"]), pickField(product, ["title"])].map(normalizeText).filter(Boolean);
+  const sources = [
+    pickField(product, ["description", "Description"]),
+    pickField(product, ["name"]),
+    pickField(product, ["title"]),
+  ]
+    .map(normalizeText)
+    .filter(Boolean);
+
   for (const source of sources) {
     const forMatch = source.match(/\b(?:for|para)\s+(.+?)(?:\.|$)/i);
     if (forMatch && forMatch[1]) {
@@ -263,6 +248,21 @@ function inferModelFromText(product = {}) {
     const dashMatch = source.match(/\s-\s*(.+)$/);
     if (dashMatch && dashMatch[1]) {
       const cleaned = cleanModelCandidate(dashMatch[1]);
+      if (cleaned) return cleaned;
+    }
+    const commaModelMatch = source.match(/\b(?:display|screen|pantalla)\b.*?,\s*(.+)$/i);
+    if (commaModelMatch && commaModelMatch[1]) {
+      const cleaned = cleanModelCandidate(commaModelMatch[1]);
+      if (cleaned) return cleaned;
+    }
+    const samsungModelMatch = source.match(/\b(samsung\s+galaxy\s+[a-z0-9][a-z0-9\s+.-]*(?:sm-[a-z0-9]+)?)/i);
+    if (samsungModelMatch && samsungModelMatch[1]) {
+      const cleaned = cleanModelCandidate(samsungModelMatch[1]);
+      if (cleaned) return cleaned;
+    }
+    const iphoneModelMatch = source.match(/\b(iphone\s+[a-z0-9][a-z0-9\s+./&-]*(?:pro|max|plus|mini)?)\b/i);
+    if (iphoneModelMatch && iphoneModelMatch[1]) {
+      const cleaned = cleanModelCandidate(iphoneModelMatch[1]);
       if (cleaned) return cleaned;
     }
   }
@@ -282,26 +282,42 @@ function qualityForTitle(commercialQuality) {
   if (!commercialQuality || commercialQuality === "Calidad no especificada") return "";
   if (commercialQuality === "Original") return "original";
   if (commercialQuality === "Refurbished") return "refurbished";
-  if (commercialQuality.startsWith("Compatible ")) return `compatible ${commercialQuality.slice("Compatible ".length)}`;
+  if (commercialQuality.startsWith("Compatible ")) {
+    return `compatible ${commercialQuality.slice("Compatible ".length)}`;
+  }
   if (commercialQuality === "Compatible") return "compatible";
   return commercialQuality;
 }
 
 function partTypeForTitle(partType) {
-  const type = normalizeText(partType);
-  if (/adhesivo/i.test(type)) return type;
-  if (/pantalla|display/i.test(type)) return "Pantalla";
-  if (/bateria/i.test(type)) return "Bateria";
-  return type || "Repuesto";
+  if (/pantalla|display/i.test(partType)) return "Pantalla";
+  return partType || "Repuesto";
+}
+
+function buildSafeProductLabel(product = {}, detected = {}) {
+  return (
+    normalizeText(product?.name) ||
+    normalizeText(product?.title) ||
+    normalizeText(pickField(product, ["description", "Description"])) ||
+    normalizeText(detected.sku) ||
+    normalizeText(detected.partNumber) ||
+    "Producto NERIN Parts"
+  );
 }
 
 function buildH1(product, detected) {
-  const chunks = [partTypeForTitle(detected.partType)];
+  if (detected.partType !== "Pantalla / display") {
+    return buildSafeProductLabel(product, detected);
+  }
+  const partType = partTypeForTitle(detected.partType);
   const qualityText = qualityForTitle(detected.commercialQuality);
+  const brandModel = detected.brandModel;
+  const assembly = detected.assemblyType;
+  const chunks = [partType];
   if (qualityText) chunks.push(qualityText);
-  if (detected.brandModel) chunks.push(`para ${detected.brandModel}`);
-  if (detected.assemblyType) chunks.push(detected.assemblyType);
-  return cleanSentence(chunks.join(" ")) || normalizeText(product?.name) || "Producto NERIN Parts";
+  if (brandModel) chunks.push(brandModel);
+  if (assembly) chunks.push(assembly);
+  return cleanSentence(chunks.join(" ")) || buildSafeProductLabel(product, detected);
 }
 
 function truncateText(value, limit) {
@@ -315,59 +331,128 @@ function truncateText(value, limit) {
 
 function buildProductAutoContent(product = {}) {
   const quality = detectProductQuality(product);
-  const partType = detectPartType(product);
-  const displayTechnology = detectDisplayTechnology(product, partType);
-  const assembly = detectAssemblyType(product, partType);
+  const displayTechnology = detectDisplayTechnology(product);
+  const assembly = detectAssemblyType(product);
   const condition = detectProductCondition(product);
+  const partType = detectPartType(product);
   const brand = normalizeText(pickField(product, ["brand", "Brand", "manufacturerName", "ManufacturerName"]));
   const model = normalizeText(pickField(product, ["model", "Model"]));
   const brandModel = buildBrandModel(product);
   const sku = normalizeText(pickField(product, ["sku", "SKU", "supplierPartNumber"]));
   const partNumber = normalizeText(pickField(product, ["part_number", "partNumber", "PartNumber", "Part Number", "supplierPartNumber"]));
-  const category = normalizeText(pickField(product, ["category", "Category", "mainCategory", "MainCategory"]));
-  const subCategory = normalizeText(pickField(product, ["subcategory", "subCategory", "SubCategory"]));
+  const category = normalizeText(pickField(product, ["category", "Category"]));
   const availability = detectAvailability(product);
-  const detected = { ...quality, displayTechnology, assemblyType: assembly.assemblyType, assemblyExtra: assembly.extra, condition, partType, brand, model, brandModel, sku, partNumber, category, subCategory, availability };
+  const detected = {
+    ...quality,
+    displayTechnology,
+    assemblyType: assembly.assemblyType,
+    assemblyExtra: assembly.extra,
+    condition,
+    partType,
+    brand,
+    model,
+    brandModel,
+    sku,
+    partNumber,
+    category,
+    availability,
+  };
   const h1 = buildH1(product, detected);
+  if (partType !== "Pantalla / display") {
+    const typeCopy = partType || "Repuesto";
+    const skuCopy = sku ? `, SKU ${sku}` : "";
+    const shortDescription = cleanSentence(`${h1} disponible en NERIN Parts. Verifica compatibilidad${skuCopy} y disponibilidad antes de comprar.`);
+    const longDescription = cleanSentence(
+      `${h1} es un ${typeCopy.toLowerCase()} disponible en NERIN Parts. Verifica compatibilidad${skuCopy} y disponibilidad antes de comprar.`,
+    );
+    const compatibilityNotice = cleanSentence(
+      `Verificar compatibilidad${sku ? ` con SKU ${sku}` : ""}${partNumber ? ` y numero de parte ${partNumber}` : ""} antes de confirmar la compra.`,
+    );
+    return {
+      h1,
+      shortDescription,
+      longDescription,
+      technicalSpecs: {
+        calidad: quality.commercialQuality,
+        tecnologia: "No especificada por proveedor",
+        tipoRepuesto: typeCopy,
+        marcaModelo: brandModel || "No especificado por proveedor",
+        condicion: condition || "No especificada por proveedor",
+        origen: quality.originLabel,
+        montaje: "no especificado",
+        extra: null,
+        sku: sku || null,
+        partNumber: partNumber || null,
+        categoria: category || null,
+        disponibilidad: availability,
+      },
+      compatibilityNotice,
+      seoTitle: truncateText(`${h1} | NERIN Parts`, 160),
+      seoDescription: truncateText(shortDescription, 200),
+      detected,
+    };
+  }
   const modelCopy = brandModel || "el modelo indicado por proveedor";
   const qualityCopy = quality.commercialQuality;
   const technologyCopy = displayTechnology ? ` con tecnologia ${displayTechnology}` : "";
   const assemblyCopy = assembly.assemblyType ? `, montaje ${assembly.assemblyType}` : "";
   const conditionCopy = condition ? ` en condicion ${condition}` : "";
-  const shortDescription = cleanSentence(`${h1}. Repuesto ${qualityCopy}${technologyCopy}${assemblyCopy}${conditionCopy}. ${availability}.`);
+  const shortDescription = cleanSentence(
+    `${h1}. Repuesto ${qualityCopy}${technologyCopy}${assemblyCopy}${conditionCopy}. ${availability}.`,
+  );
   const supplierDescription = normalizeText(pickField(product, ["description", "Description"]));
-  const displayParagraph = isDisplayPartType(partType)
-    ? (displayTechnology ? `La tecnologia de pantalla detectada es ${displayTechnology}; no se agregan tecnologias que no figuren en la descripcion o en Quality.` : "La tecnologia de pantalla no fue especificada por el proveedor, por eso no se asume OLED, AMOLED, LCD ni otra variante.")
-    : `Este producto fue clasificado como ${partType}; no se lo trata como pantalla ni se le asigna tecnologia OLED/LCD/AMOLED salvo que sea realmente un display.`;
-  const assemblyParagraph = isDisplayPartType(partType)
-    ? (assembly.assemblyType ? `El tipo de armado detectado es ${assembly.assemblyType}${assembly.extra ? `, ${assembly.extra}` : ""}.` : "El montaje no fue especificado por el proveedor.")
-    : "El tipo de armado con/sin marco no aplica para este tipo de repuesto.";
-  const longDescription = cleanSentence([
-    `${h1} para ${modelCopy}. La calidad informada por el proveedor es ${qualityCopy} y el origen se clasifica como ${quality.originLabel}.`,
-    displayParagraph,
-    assemblyParagraph,
-    supplierDescription ? `Descripcion del proveedor: ${supplierDescription}` : "",
-    "Antes de instalar, comparar modelo, SKU y numero de parte con el equipo a reparar.",
-  ].filter(Boolean).join(" "));
+  const longDescription = cleanSentence(
+    [
+      `${h1} para ${modelCopy}. La calidad informada por el proveedor es ${qualityCopy} y el origen se clasifica como ${quality.originLabel}.`,
+      displayTechnology
+        ? `La tecnologia de pantalla detectada es ${displayTechnology}; no se agregan tecnologias que no figuren en la descripcion o en Quality.`
+        : "La tecnologia de pantalla no fue especificada por el proveedor, por eso no se asume OLED, AMOLED, LCD ni otra variante.",
+      assembly.assemblyType
+        ? `El tipo de armado detectado es ${assembly.assemblyType}${assembly.extra ? `, ${assembly.extra}` : ""}.`
+        : "El montaje no fue especificado por el proveedor.",
+      supplierDescription ? `Descripcion del proveedor: ${supplierDescription}` : "",
+      "Antes de instalar, comparar modelo, SKU y numero de parte con el equipo a reparar.",
+    ]
+      .filter(Boolean)
+      .join(" "),
+  );
   const technicalSpecs = {
     calidad: qualityCopy,
-    tecnologia: isDisplayPartType(partType) ? (displayTechnology || "No especificada por proveedor") : "No aplica",
+    tecnologia: displayTechnology || "No especificada por proveedor",
     tipoRepuesto: partType,
     marcaModelo: brandModel || "No especificado por proveedor",
     condicion: condition || "No especificada por proveedor",
     origen: quality.originLabel,
-    montaje: isDisplayPartType(partType) ? (assembly.assemblyType || "no especificado") : "no aplica",
+    montaje: assembly.assemblyType || "no especificado",
     extra: assembly.extra || null,
     sku: sku || null,
     partNumber: partNumber || null,
     categoria: category || null,
-    subcategoria: subCategory || null,
     disponibilidad: availability,
   };
-  const compatibilityNotice = cleanSentence(`Verificar compatibilidad con ${modelCopy}${sku ? `, SKU ${sku}` : ""}${partNumber ? ` y numero de parte ${partNumber}` : ""} antes de confirmar la compra o realizar la instalacion.`);
+  const compatibilityNotice = cleanSentence(
+    `Verificar compatibilidad con ${modelCopy}${sku ? `, SKU ${sku}` : ""}${
+      partNumber ? ` y numero de parte ${partNumber}` : ""
+    } antes de confirmar la compra o realizar la instalacion.`,
+  );
   const seoTitle = truncateText(`${h1} | NERIN Parts`, 160);
-  const seoDescription = truncateText(`${h1}. Calidad ${qualityCopy}${displayTechnology ? `, tecnologia ${displayTechnology}` : ""}. ${availability}. ${compatibilityNotice}`, 200);
-  return { h1, shortDescription, longDescription, technicalSpecs, compatibilityNotice, seoTitle, seoDescription, detected };
+  const seoDescription = truncateText(
+    `${h1}. Calidad ${qualityCopy}${displayTechnology ? `, tecnologia ${displayTechnology}` : ""}. ${availability}. ${compatibilityNotice}`,
+    200,
+  );
+
+  return {
+    h1,
+    shortDescription,
+    longDescription,
+    technicalSpecs,
+    compatibilityNotice,
+    seoTitle,
+    seoDescription,
+    detected,
+  };
 }
 
-module.exports = { buildProductAutoContent };
+module.exports = {
+  buildProductAutoContent,
+};


### PR DESCRIPTION
## Summary
- Corrige el camino real que usa la ficha `/p/...`: `buildProductAutoContent` ya no genera H1 de pantalla para productos no pantalla.
- Conserva el nombre real en RESIN PC y adhesivos/display adhesive.
- Para pantallas reales, preserva modelo y part number visibles del proveedor, por ejemplo `Samsung Galaxy S25 SM-S931`.
- Agrega cobertura de tests para H1/auto content, no solo meta SEO.
- No toca precios, pagos, checkout, pedidos, Resend, Andreani ni stock.

## Testing
- node --check backend/utils/productAutoContent.js
- node --check backend/utils/productSeo.js
- node --check backend/utils/productTaxonomy.js
- node --check backend/server.js
- node --check scripts/auditBadScreenSeoTitles.js
- node --check scripts/fixBadScreenSeoTitles.js
- npm test -- product-seo-taxonomy.test.js
- Remote branch smoke test for RESIN PC, Samsung S25 screen, and Adhesive Tape Display