### PR TITLE
Improve bulk publish audit and safe public catalog rollout

### DIFF
--- a/nerin_final_updated/__tests__/backend/bulk-publish-eligibility.test.js
+++ b/nerin_final_updated/__tests__/backend/bulk-publish-eligibility.test.js
@@ -1,0 +1,96 @@
+const {
+  resolveBulkPublishEligibility,
+  summarizeBulkPublishProducts,
+  buildBulkPublishPatch,
+} = require("../../backend/data/productsSqliteRepo");
+
+const validProduct = (overrides = {}) => ({
+  id: "prod-1",
+  sku: "SKU-1",
+  name: "iPhone 15 Pro Battery",
+  price: 1000,
+  visibility: "catalog",
+  status: "active",
+  enabled: true,
+  stock: 0,
+  ...overrides,
+});
+
+describe("bulk publish eligibility", () => {
+  test("private and hidden block by default", () => {
+    expect(resolveBulkPublishEligibility(validProduct({ visibility: "private" })).reasons).toContain("private");
+    expect(resolveBulkPublishEligibility(validProduct({ status: "hidden" })).reasons).toContain("hidden");
+    expect(resolveBulkPublishEligibility(validProduct({ hidden: true })).reasons).toContain("hidden");
+  });
+
+  test("private and hidden can be eligible when includePrivateHidden=true", () => {
+    expect(resolveBulkPublishEligibility(validProduct({ visibility: "private" }), { includePrivateHidden: true }).eligible).toBe(true);
+    expect(resolveBulkPublishEligibility(validProduct({ status: "hidden" }), { includePrivateHidden: true }).eligible).toBe(true);
+  });
+
+  test.each([
+    ["missing_name", { name: "", title: "" }],
+    ["missing_identifier", { id: "", sku: "", code: "" }],
+    ["missing_price", { price: 0, price_minorista: 0, precio_minorista: 0, precio_final: 0 }],
+    ["deleted", { deleted: true }],
+    ["archived", { archived: true }],
+    ["disabled", { enabled: false }],
+    ["disabled", { enabled: 0 }],
+    ["draft", { status: "draft" }],
+    ["vip_only", { vip_only: true }],
+    ["wholesale_only", { wholesale_only: true }],
+  ])("%s always blocks", (reason, overrides) => {
+    const result = resolveBulkPublishEligibility(validProduct({ visibility: "private", ...overrides }), {
+      includePrivateHidden: true,
+    });
+    expect(result.reasons).toContain(reason);
+    expect(result.eligible).toBe(false);
+  });
+
+  test("stock zero, missing image, missing description and generated slug are warnings only", () => {
+    const result = resolveBulkPublishEligibility(validProduct({ image: "", description: "", slug: "", public_slug: "" }));
+
+    expect(result.eligible).toBe(true);
+    expect(result.reasons).toEqual([]);
+    expect(result.warnings).toEqual(expect.arrayContaining([
+      "stock_zero_remote_assumed",
+      "remote_delivery_estimated",
+      "missing_image",
+      "missing_description",
+      "generated_slug",
+    ]));
+  });
+
+  test("preview summary separates public candidates from private/hidden candidates", () => {
+    const summary = summarizeBulkPublishProducts(
+      [
+        validProduct({ id: "public-candidate" }),
+        validProduct({ id: "private-candidate", visibility: "private" }),
+        validProduct({ id: "blocked-candidate", price: 0 }),
+      ],
+      { includePrivateHidden: true, totalCatalogProducts: 3, publicProductsCount: 1 },
+    );
+
+    expect(summary.totalCatalogProducts).toBe(3);
+    expect(summary.publicProductsCount).toBe(1);
+    expect(summary.scannedRows).toBe(3);
+    expect(summary.eligiblePublicCandidates).toBe(1);
+    expect(summary.eligiblePrivateHiddenCandidates).toBe(1);
+    expect(summary.blockedCount).toBe(1);
+    expect(summary.reasons.missing_price).toBe(1);
+  });
+
+  test("publish patch does not change price or stock", () => {
+    const product = validProduct({ price: 1234, stock: 7, public_slug: "iphone-15-pro-battery" });
+    const patch = buildBulkPublishPatch(product, resolveBulkPublishEligibility(product));
+
+    expect(patch).toMatchObject({
+      visibility: "public",
+      status: "active",
+      enabled: true,
+      is_public: true,
+    });
+    expect(patch).not.toHaveProperty("price");
+    expect(patch).not.toHaveProperty("stock");
+  });
+});

--- a/nerin_final_updated/backend/data/productsSqliteRepo.js
+++ b/nerin_final_updated/backend/data/productsSqliteRepo.js
@@ -12,6 +12,7 @@ const OVERRIDES_PATH = dataPath("products.overrides.json");
 const COUNT_CACHE_TTL_MS = 60_000;
 const PRODUCTS_SQLITE_SCHEMA_VERSION = 5;
 const CATALOG_MAPPING_VERSION = 2;
+const BULK_PUBLISH_CHUNK_SIZE = 1000;
 
 const REJECTED_STATE_VALUES = new Set([
   "hidden",
@@ -513,16 +514,30 @@ function isProductPublic(product) {
   return computeProductPublicState(product).isPublic;
 }
 
-function resolveBulkPublishEligibility(product = {}) {
+function isTruthyFlag(value) {
+  if (value === true || value === 1) return true;
+  const text = normalizeQueryText(value);
+  return text === "true" || text === "1" || text === "yes" || text === "si";
+}
+
+function resolveBulkPublishEligibility(product = {}, options = {}) {
   const reasons = [];
   const warnings = [];
   const updates = {};
+  const includePrivateHidden = options?.includePrivateHidden === true;
   const computed = computeProductPublicState(product);
   const signals = computed?.signals || {};
+  const deletedFlag = signals.deleted || isTruthyFlag(getField(product, ["deleted", "eliminado"]));
+  const archivedFlag = signals.archived || isTruthyFlag(getField(product, ["archived", "archive", "archivado"]));
+  const disabledFlag = signals.enabledFalse || isTruthyFlag(getField(product, ["disabled", "deshabilitado"])) || getField(product, ["enabled"]) === 0 || getField(product, ["enabled"]) === "0" || normalizeQueryText(getField(product, ["enabled"]) || "") === "false";
+  const vipOnlyFlag = signals.vipOnly || isTruthyFlag(getField(product, ["vip_only", "vipOnly", "vip only"]));
+  const wholesaleOnlyFlag = signals.wholesaleOnly || isTruthyFlag(getField(product, ["wholesaleOnly", "wholesale_only", "wholesale only"]));
+  const hiddenFlag = signals.visibility === "hidden" || signals.status === "hidden" || isTruthyFlag(getField(product, ["hidden", "oculto"]));
+  const privateFlag = signals.visibility === "private" || signals.status === "private" || isTruthyFlag(getField(product, ["private", "privado"]));
 
   const hasName = !signals.missingName;
   const hasIdentifier = !signals.missingIdentifier;
-  const priceValue = firstFiniteNumber([
+  const priceValue = firstNumber([
     getField(product, ["price", "precio", "price_minorista", "precio_minorista", "precio_final", "finalPrice", "salePrice"]),
   ]);
   const hasValidPrice = Number.isFinite(priceValue) && priceValue > 0;
@@ -530,13 +545,13 @@ function resolveBulkPublishEligibility(product = {}) {
   if (!hasName) reasons.push("missing_name");
   if (!hasIdentifier) reasons.push("missing_identifier");
   if (!hasValidPrice) reasons.push("missing_price");
-  if (signals.deleted) reasons.push("deleted");
-  if (signals.archived) reasons.push("archived");
-  if (signals.enabledFalse) reasons.push("disabled");
-  if (signals.vipOnly) reasons.push("vip_only");
-  if (signals.wholesaleOnly) reasons.push("wholesale_only");
-  if (signals.visibility === "hidden" || signals.status === "hidden") reasons.push("hidden");
-  if (signals.visibility === "private" || signals.status === "private") reasons.push("private");
+  if (deletedFlag) reasons.push("deleted");
+  if (archivedFlag) reasons.push("archived");
+  if (disabledFlag) reasons.push("disabled");
+  if (vipOnlyFlag) reasons.push("vip_only");
+  if (wholesaleOnlyFlag) reasons.push("wholesale_only");
+  if (!includePrivateHidden && hiddenFlag) reasons.push("hidden");
+  if (!includePrivateHidden && privateFlag) reasons.push("private");
   if (signals.visibility === "draft" || signals.status === "draft") reasons.push("draft");
   if (signals.visibility === "disabled" || signals.status === "disabled") reasons.push("disabled");
   if (signals.visibility === "deleted" || signals.status === "deleted") reasons.push("deleted");
@@ -551,12 +566,184 @@ function resolveBulkPublishEligibility(product = {}) {
   if (!imageValue) warnings.push("missing_image");
   const description = toNullableText(getField(product, ["description", "descripcion", "shortDescription", "short_description"]));
   if (!description) warnings.push("missing_description");
-  const stock = Number(firstFiniteNumber([getField(product, ["stock", "stock_local"])]) || 0);
+  const stock = Number(firstNumber([getField(product, ["stock", "stock_local"])]) || 0);
   if (stock <= 0) {
     warnings.push("stock_zero_remote_assumed");
     warnings.push("remote_delivery_estimated");
   }
   return { eligible: reasons.length === 0, reasons: Array.from(new Set(reasons)), warnings: Array.from(new Set(warnings)), updates };
+}
+
+function parseBulkBooleanFilter(value) {
+  if (value === true || value === "true" || value === "1" || value === 1 || value === "yes") return true;
+  if (value === false || value === "false" || value === "0" || value === 0 || value === "no") return false;
+  return null;
+}
+
+function hasBulkImage(product = {}) {
+  return Boolean(toNullableText(getField(product, ["image", "imagen", "imageUrl", "image_url", "thumbnail", "photo", "foto"])));
+}
+
+function getBulkPrice(product = {}) {
+  return firstNumber([
+    getField(product, ["price", "precio", "price_minorista", "precio_minorista", "precio_final", "finalPrice", "salePrice"]),
+  ]);
+}
+
+function isBulkRemoteStockCandidate(product = {}) {
+  const stock = Number(firstNumber([getField(product, ["stock", "stock_local"])]) || 0);
+  const stockMode = normalizeQueryText(getField(product, ["stock_mode", "stockMode", "fulfillment_mode", "fulfillmentMode"]) || "");
+  const availability = normalizeQueryText(getField(product, ["availability", "disponibilidad"]) || "");
+  return stock <= 0 || /remote|pedido|a pedido|consultar|supplier|proveedor/.test(`${stockMode} ${availability}`);
+}
+
+function isPrivateHiddenProduct(product = {}) {
+  const visibility = normalizeQueryText(getField(product, ["visibility", "visibilidad"]) || "");
+  const status = normalizeQueryText(getField(product, ["status", "estado"]) || "");
+  return visibility === "private" || status === "private" || visibility === "hidden" || status === "hidden" || isTruthyFlag(getField(product, ["private", "privado", "hidden", "oculto"]));
+}
+
+function hydrateBulkPublishProduct(row = {}) {
+  let raw = {};
+  try {
+    raw = JSON.parse(row.raw_json || "{}");
+  } catch {
+    raw = {};
+  }
+  return {
+    ...raw,
+    rowid: row.rowid,
+    id: raw.id ?? row.id,
+    sku: raw.sku ?? row.sku,
+    code: raw.code ?? row.code,
+    slug: raw.slug ?? row.slug,
+    public_slug: raw.public_slug ?? raw.publicSlug ?? row.public_slug,
+    image: raw.image ?? row.image,
+    name: raw.name ?? row.name,
+    title: raw.title ?? row.title,
+    brand: raw.brand ?? row.brand,
+    model: raw.model ?? row.model,
+    category: raw.category ?? row.category,
+    status: raw.status ?? row.status,
+    visibility: raw.visibility ?? row.visibility,
+    stock: raw.stock ?? row.stock,
+    price: raw.price ?? row.price,
+    price_minorista: raw.price_minorista ?? row.price_minorista,
+    precio_minorista: raw.precio_minorista ?? row.precio_minorista,
+    precio_final: raw.precio_final ?? row.precio_final,
+    is_public: raw.is_public ?? row.is_public,
+  };
+}
+
+function matchesBulkPublishFilters(product = {}, filters = {}) {
+  const search = normalizeQueryText(filters?.search || "");
+  const brand = normalizeQueryText(filters?.brand || "");
+  const model = normalizeQueryText(filters?.model || "");
+  const productType = normalizeQueryText(filters?.productType || filters?.category || "");
+  const withImage = parseBulkBooleanFilter(filters?.withImage);
+  const withPrice = parseBulkBooleanFilter(filters?.withPrice);
+  const remoteStock = parseBulkBooleanFilter(filters?.remoteStock);
+
+  if (brand && !normalizeQueryText(getField(product, ["brand", "marca", "Brand"]) || "").includes(brand)) return false;
+  if (model && !normalizeQueryText(getField(product, ["model", "modelo", "Model"]) || "").includes(model)) return false;
+  if (productType && !normalizeQueryText(getField(product, ["category", "categoria", "Category", "productType", "tipo"]) || "").includes(productType)) return false;
+  if (withImage !== null && hasBulkImage(product) !== withImage) return false;
+  if (withPrice !== null) {
+    const price = getBulkPrice(product);
+    const hasPrice = Number.isFinite(price) && price > 0;
+    if (hasPrice !== withPrice) return false;
+  }
+  if (remoteStock !== null && isBulkRemoteStockCandidate(product) !== remoteStock) return false;
+  if (!search) return true;
+
+  const haystack = [
+    getField(product, ["id", "sku", "code", "partNumber", "mpn", "ean", "gtin"]),
+    getField(product, ["name", "title", "description", "shortDescription", "short_description"]),
+    getField(product, ["brand", "marca"]),
+    getField(product, ["model", "modelo"]),
+    getField(product, ["category", "categoria", "productType"]),
+  ].map((value) => normalizeQueryText(value || "")).join(" ");
+  return haystack.includes(search);
+}
+
+function incCounter(counter, key) {
+  if (!key) return;
+  counter[key] = Number(counter[key] || 0) + 1;
+}
+
+function createBulkPublishSummary({ totalCatalogProducts = 0, publicProductsCount = 0 } = {}) {
+  return {
+    totalCatalogProducts: Number(totalCatalogProducts || 0),
+    publicProductsCount: Number(publicProductsCount || 0),
+    scannedRows: 0,
+    totalScanned: 0,
+    eligiblePublicCandidates: 0,
+    eligiblePrivateHiddenCandidates: 0,
+    eligibleCount: 0,
+    blockedCount: 0,
+    warningCount: 0,
+    reasons: {},
+    warnings: {},
+    reasonCounts: {},
+    warningCounts: {},
+    samplesEligible: [],
+    samplesBlocked: [],
+    privateHiddenEligibleIdentifiers: [],
+  };
+}
+
+function recordBulkPublishEvaluation(summary, product, result) {
+  const identifier = product.id || product.sku || product.code || product.public_slug || product.slug || `row:${product.rowid}`;
+  result.reasons.forEach((reason) => {
+    incCounter(summary.reasons, reason);
+    incCounter(summary.reasonCounts, reason);
+  });
+  result.warnings.forEach((warning) => {
+    incCounter(summary.warnings, warning);
+    incCounter(summary.warningCounts, warning);
+  });
+  summary.warningCount += result.warnings.length;
+
+  if (result.eligible) {
+    summary.eligibleCount += 1;
+    if (isPrivateHiddenProduct(product)) {
+      summary.eligiblePrivateHiddenCandidates += 1;
+      if (summary.privateHiddenEligibleIdentifiers.length < 25) summary.privateHiddenEligibleIdentifiers.push(identifier);
+    } else {
+      summary.eligiblePublicCandidates += 1;
+    }
+    if (summary.samplesEligible.length < 10) {
+      summary.samplesEligible.push({ identifier, name: product.name || product.title || null, warnings: result.warnings, updates: result.updates });
+    }
+  } else {
+    summary.blockedCount += 1;
+    if (summary.samplesBlocked.length < 10) {
+      summary.samplesBlocked.push({ identifier, name: product.name || product.title || null, reasons: result.reasons });
+    }
+  }
+}
+
+function summarizeBulkPublishProducts(products = [], { includePrivateHidden = false, totalCatalogProducts = products.length, publicProductsCount = 0 } = {}) {
+  const summary = createBulkPublishSummary({ totalCatalogProducts, publicProductsCount });
+  for (const product of products) {
+    summary.scannedRows += 1;
+    summary.totalScanned = summary.scannedRows;
+    const result = resolveBulkPublishEligibility(product, { includePrivateHidden });
+    recordBulkPublishEvaluation(summary, product, result);
+  }
+  return summary;
+}
+
+function buildBulkPublishPatch(product = {}, result = resolveBulkPublishEligibility(product, { includePrivateHidden: true })) {
+  const patch = { visibility: "public", status: "active", enabled: true, is_public: true };
+  if (result.updates?.public_slug) patch.public_slug = result.updates.public_slug;
+  if (Number(product.stock || 0) <= 0) {
+    patch.stock_mode = "remote";
+    patch.fulfillment_mode = "remote";
+    patch.remote_lead_min_days = Number(product.remote_lead_min_days || 20);
+    patch.remote_lead_max_days = Number(product.remote_lead_max_days || 30);
+  }
+  return patch;
 }
 
 function buildSearchText(product = {}) {
@@ -2013,64 +2200,86 @@ async function bulkPublication({ action = "publish", scope = "private_products",
   return { ok: true, beforePublicCount, afterPublicCount, updatedRows, skipped, examplesUpdated, dryRun: Boolean(dryRun) };
 }
 
-async function previewBulkPublish({ filters = {}, limit = 500 } = {}) {
+async function scanBulkPublishCandidates({ filters = {}, limit = 500, includePrivateHidden = false, onEligible = null } = {}) {
   await ensureDbReadyForRequest();
   const db = await openDb();
   const safeLimit = Math.max(1, Math.min(50000, Number(limit) || 500));
-  const query = await queryAdminProducts({
-    page: 1,
-    pageSize: safeLimit,
-    search: filters?.search || "",
-    brand: filters?.brand || "",
-    category: filters?.category || "",
-    visibility: filters?.visibility || "",
-    status: filters?.status || "",
+  const totals = await get(
+    db,
+    "SELECT COUNT(*) AS totalCatalogProducts, SUM(CASE WHEN COALESCE(is_public, 0) = 1 THEN 1 ELSE 0 END) AS publicProductsCount FROM products",
+  );
+  const summary = createBulkPublishSummary({
+    totalCatalogProducts: Number(totals?.totalCatalogProducts || 0),
+    publicProductsCount: Number(totals?.publicProductsCount || 0),
   });
-  const rows = query.items || [];
-  const reasonCounts = {};
-  const warningCounts = {};
-  const samplesEligible = [];
-  const samplesBlocked = [];
-  let eligibleCount = 0;
-  rows.forEach((item) => {
-    const result = resolveBulkPublishEligibility(item);
-    result.reasons.forEach((reason) => { reasonCounts[reason] = (reasonCounts[reason] || 0) + 1; });
-    result.warnings.forEach((warning) => { warningCounts[warning] = (warningCounts[warning] || 0) + 1; });
-    if (result.eligible) {
-      eligibleCount += 1;
-      if (samplesEligible.length < 10) samplesEligible.push({ identifier: item.id || item.sku || item.code, name: item.name || item.title || null, warnings: result.warnings, updates: result.updates });
-    } else if (samplesBlocked.length < 10) {
-      samplesBlocked.push({ identifier: item.id || item.sku || item.code, name: item.name || item.title || null, reasons: result.reasons });
+
+  let lastRowid = 0;
+  let reachedLimit = false;
+  while (true) {
+    const rows = await all(
+      db,
+      `SELECT rowid, id, sku, code, slug, public_slug, image, name, title, brand, model, category,
+              status, visibility, stock, price, price_minorista, precio_minorista, precio_final, raw_json, is_public
+       FROM products
+       WHERE rowid > ? AND COALESCE(is_public, 0) != 1
+       ORDER BY rowid ASC
+       LIMIT ?`,
+      [lastRowid, BULK_PUBLISH_CHUNK_SIZE],
+    );
+    if (!rows.length) break;
+    for (const row of rows) {
+      lastRowid = Math.max(lastRowid, Number(row.rowid || 0));
+      const product = hydrateBulkPublishProduct(row);
+      if (!matchesBulkPublishFilters(product, filters)) continue;
+
+      summary.scannedRows += 1;
+      summary.totalScanned = summary.scannedRows;
+      const result = resolveBulkPublishEligibility(product, { includePrivateHidden });
+      recordBulkPublishEvaluation(summary, product, result);
+
+      if (result.eligible && typeof onEligible === "function" && summary.eligibleCount <= safeLimit) {
+        await onEligible(product, result, summary.eligibleCount);
+      }
+      if (result.eligible && summary.eligibleCount >= safeLimit) {
+        reachedLimit = true;
+        break;
+      }
     }
-  });
-  return { totalScanned: rows.length, eligibleCount, blockedCount: rows.length - eligibleCount, warningCount: Object.values(warningCounts).reduce((a, b) => a + b, 0), samplesEligible, samplesBlocked, reasonCounts, warningCounts };
+    if (reachedLimit) break;
+  }
+  return summary;
 }
 
-async function bulkPublishEligible({ dryRun = false, filters = {}, limit = 500, publishMode = "eligible_only" } = {}) {
+async function previewBulkPublish({ filters = {}, limit = 500, includePrivateHidden = false } = {}) {
+  return scanBulkPublishCandidates({ filters, limit, includePrivateHidden: includePrivateHidden === true });
+}
+
+async function bulkPublishEligible({ dryRun = false, filters = {}, limit = 500, publishMode = "eligible_only", includePrivateHidden = false, confirmPrivateHiddenPublish = false } = {}) {
   if (publishMode !== "eligible_only") throw new Error("publishMode must be eligible_only");
-  await ensureDbReadyForRequest();
-  const db = await openDb();
-  const preview = await previewBulkPublish({ filters, limit });
-  const query = await queryAdminProducts({ page: 1, pageSize: Math.max(1, Math.min(50000, Number(limit) || 500)), search: filters?.search || "", brand: filters?.brand || "", category: filters?.category || "", visibility: filters?.visibility || "", status: filters?.status || "" });
-  const rows = query.items || [];
   let updatedCount = 0;
-  for (const item of rows) {
-    const result = resolveBulkPublishEligibility(item);
-    if (!result.eligible) continue;
-    const identifier = item.id || item.sku || item.code || item.public_slug || item.slug;
-    if (!identifier) continue;
-    const patch = { visibility: "public", status: "active", enabled: true, is_public: true };
-    if (result.updates.public_slug) patch.public_slug = result.updates.public_slug;
-    if (Number(item.stock || 0) <= 0) {
-      patch.stock_mode = "remote";
-      patch.fulfillment_mode = "remote";
-      patch.remote_lead_min_days = Number(item.remote_lead_min_days || 20);
-      patch.remote_lead_max_days = Number(item.remote_lead_max_days || 30);
+
+  if (includePrivateHidden === true && confirmPrivateHiddenPublish !== true && dryRun !== true) {
+    const preview = await previewBulkPublish({ filters, limit, includePrivateHidden: true });
+    if (Number(preview.eligiblePrivateHiddenCandidates || 0) > 0) {
+      const error = new Error("confirmPrivateHiddenPublish is required when includePrivateHidden=true");
+      error.code = "PRIVATE_HIDDEN_CONFIRMATION_REQUIRED";
+      throw error;
     }
-    if (!dryRun) await updateProductByIdentifier(identifier, patch, { forceEnabledTrue: true });
-    updatedCount += 1;
   }
-  return { ok: true, dryRun: Boolean(dryRun), publishMode, ...preview, updatedCount };
+
+  const summary = await scanBulkPublishCandidates({
+    filters,
+    limit,
+    includePrivateHidden: includePrivateHidden === true,
+    async onEligible(product, result) {
+      const identifier = product.id || product.sku || product.code || product.public_slug || product.slug;
+      if (!identifier) return;
+      const patch = buildBulkPublishPatch(product, result);
+      if (!dryRun) await updateProductByIdentifier(identifier, patch);
+      updatedCount += 1;
+    },
+  });
+  return { ok: true, dryRun: Boolean(dryRun), publishMode, includePrivateHidden: includePrivateHidden === true, ...summary, updatedCount };
 }
 
 async function getCatalogFieldAudit({ sampleSize = 300 } = {}) {
@@ -2354,6 +2563,8 @@ module.exports = {
   repairPublicFlags,
   bulkPublication,
   resolveBulkPublishEligibility,
+  summarizeBulkPublishProducts,
+  buildBulkPublishPatch,
   previewBulkPublish,
   bulkPublishEligible,
   computeProductPublicState,

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -6692,6 +6692,7 @@ async function requestHandler(req, res) {
         const result = await productsSqliteRepo.previewBulkPublish({
           filters: payload?.filters || {},
           limit: payload?.limit || 500,
+          includePrivateHidden: payload?.includePrivateHidden === true,
         });
         return sendJson(res, 200, { ok: true, ...result });
       } catch (error) {
@@ -6713,9 +6714,18 @@ async function requestHandler(req, res) {
           filters: payload?.filters || {},
           limit: payload?.limit || 500,
           publishMode: payload?.publishMode || "eligible_only",
+          includePrivateHidden: payload?.includePrivateHidden === true,
+          confirmPrivateHiddenPublish: payload?.confirmPrivateHiddenPublish === true,
         });
         return sendJson(res, 200, result);
       } catch (error) {
+        if (error?.code === "PRIVATE_HIDDEN_CONFIRMATION_REQUIRED") {
+          return sendJson(res, 400, {
+            ok: false,
+            code: "PRIVATE_HIDDEN_CONFIRMATION_REQUIRED",
+            error: "Confirmacion requerida para publicar productos ocultos o privados",
+          });
+        }
         return sendJson(res, 500, { ok: false, code: "BULK_PUBLISH_FAILED", error: error?.message || "No se pudo publicar productos aptos" });
       }
     });

--- a/nerin_final_updated/frontend/admin.html
+++ b/nerin_final_updated/frontend/admin.html
@@ -446,9 +446,25 @@
             <strong>Publicación masiva</strong>
             <input type="text" id="bulkPublishSearch" placeholder="Buscar" />
             <input type="text" id="bulkPublishBrand" placeholder="Marca" />
-            <input type="text" id="bulkPublishCategory" placeholder="Categoría" />
+            <input type="text" id="bulkPublishCategory" placeholder="Tipo de producto" />
+            <input type="text" id="bulkPublishModel" placeholder="Modelo" />
+            <select id="bulkPublishWithImage">
+              <option value="">Con/sin imagen</option>
+              <option value="true">Solo con imagen</option>
+              <option value="false">Solo sin imagen</option>
+            </select>
+            <select id="bulkPublishWithPrice">
+              <option value="">Con/sin precio</option>
+              <option value="true">Solo con precio</option>
+              <option value="false">Solo sin precio</option>
+            </select>
+            <select id="bulkPublishRemoteStock">
+              <option value="">Stock remoto/a pedido</option>
+              <option value="true">Solo remoto/a pedido</option>
+              <option value="false">Excluir remoto/a pedido</option>
+            </select>
             <label style="display:flex;align-items:center;gap:8px;">
-              <input type="checkbox" id="bulkPublishOnlyHidden" /> Solo ocultos/privados
+              <input type="checkbox" id="bulkPublishIncludePrivateHidden" /> Incluir ocultos/privados como candidatos de publicación
             </label>
             <input type="number" id="bulkPublishLimit" placeholder="Límite" min="1" max="50000" />
             <button id="bulkPublishPreviewBtn" class="button secondary">Simular publicación</button>

--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -1744,8 +1744,12 @@ const bulkValueInput = document.getElementById("bulkValue");
 const applyBulkBtn = document.getElementById("applyBulkBtn");
 const bulkPublishSearch = document.getElementById("bulkPublishSearch");
 const bulkPublishBrand = document.getElementById("bulkPublishBrand");
+const bulkPublishModel = document.getElementById("bulkPublishModel");
 const bulkPublishCategory = document.getElementById("bulkPublishCategory");
-const bulkPublishOnlyHidden = document.getElementById("bulkPublishOnlyHidden");
+const bulkPublishWithImage = document.getElementById("bulkPublishWithImage");
+const bulkPublishWithPrice = document.getElementById("bulkPublishWithPrice");
+const bulkPublishRemoteStock = document.getElementById("bulkPublishRemoteStock");
+const bulkPublishIncludePrivateHidden = document.getElementById("bulkPublishIncludePrivateHidden");
 const bulkPublishLimit = document.getElementById("bulkPublishLimit");
 const bulkPublishPreviewBtn = document.getElementById("bulkPublishPreviewBtn");
 const bulkPublishRunBtn = document.getElementById("bulkPublishRunBtn");
@@ -3777,20 +3781,36 @@ function getBulkPublishPayload() {
   const filters = {
     search: bulkPublishSearch?.value?.trim() || "",
     brand: bulkPublishBrand?.value?.trim() || "",
-    category: bulkPublishCategory?.value?.trim() || "",
+    model: bulkPublishModel?.value?.trim() || "",
+    productType: bulkPublishCategory?.value?.trim() || "",
+    withImage: bulkPublishWithImage?.value || "",
+    withPrice: bulkPublishWithPrice?.value || "",
+    remoteStock: bulkPublishRemoteStock?.value || "",
   };
-  if (bulkPublishOnlyHidden?.checked) filters.visibility = "private";
   return {
     filters,
     limit: Number(bulkPublishLimit?.value || 500),
+    includePrivateHidden: Boolean(bulkPublishIncludePrivateHidden?.checked),
   };
 }
 
 function renderBulkPublishSummary(data = {}, mode = "preview") {
   if (!bulkPublishSummary) return;
-  const reasons = Object.entries(data.reasonCounts || {}).sort((a, b) => b[1] - a[1]).slice(0, 5).map(([k, v]) => `${k}: ${v}`).join(" · ");
-  const warnings = Object.entries(data.warningCounts || {}).sort((a, b) => b[1] - a[1]).slice(0, 5).map(([k, v]) => `${k}: ${v}`).join(" · ");
-  bulkPublishSummary.textContent = `${mode === "publish" ? "Publicación ejecutada" : "Simulación"} · Escaneados: ${data.totalScanned || 0} · Aptos: ${data.eligibleCount || 0} · Bloqueados: ${data.blockedCount || 0} · Warnings: ${data.warningCount || 0}${reasons ? ` · Reasons: ${reasons}` : ""}${warnings ? ` · Warnings: ${warnings}` : ""}`;
+  const reasons = Object.entries(data.reasons || data.reasonCounts || {}).sort((a, b) => b[1] - a[1]).slice(0, 8).map(([k, v]) => `${k}: ${v}`).join(" � ");
+  const warnings = Object.entries(data.warnings || data.warningCounts || {}).sort((a, b) => b[1] - a[1]).slice(0, 8).map(([k, v]) => `${k}: ${v}`).join(" � ");
+  const lines = [
+    mode === "publish" ? "Publicaci\u00f3n ejecutada" : "Simulaci\u00f3n",
+    `Total cat\u00e1logo: ${data.totalCatalogProducts || 0}`,
+    `P\u00fablicos actuales: ${data.publicProductsCount || 0}`,
+    `Filas escaneadas: ${data.scannedRows || data.totalScanned || 0}`,
+    `Aptos p\u00fablicos: ${data.eligiblePublicCandidates || 0}`,
+    `Aptos ocultos/privados: ${data.eligiblePrivateHiddenCandidates || 0}`,
+    `Bloqueados: ${data.blockedCount || 0}`,
+    `Warnings: ${data.warningCount || 0}`,
+  ];
+  if (reasons) lines.push(`Reasons: ${reasons}`);
+  if (warnings) lines.push(`Warnings: ${warnings}`);
+  bulkPublishSummary.textContent = lines.join(" � ");
 }
 
 if (bulkPublishPreviewBtn) {
@@ -3798,7 +3818,7 @@ if (bulkPublishPreviewBtn) {
     const payload = getBulkPublishPayload();
     const res = await apiFetch("/api/admin/products/bulk-publish-preview", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload) });
     const data = await res.json();
-    if (!res.ok) throw new Error(data?.error || "No se pudo simular publicación");
+    if (!res.ok) throw new Error(data?.error || "No se pudo simular publicaci\u00f3n");
     renderBulkPublishSummary(data, "preview");
   });
 }
@@ -3806,6 +3826,17 @@ if (bulkPublishPreviewBtn) {
 if (bulkPublishRunBtn) {
   bulkPublishRunBtn.addEventListener("click", async () => {
     const payload = { ...getBulkPublishPayload(), dryRun: false, publishMode: "eligible_only" };
+    const previewRes = await apiFetch("/api/admin/products/bulk-publish-preview", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload) });
+    const preview = await previewRes.json();
+    if (!previewRes.ok) throw new Error(preview?.error || "No se pudo simular publicaci\u00f3n");
+    renderBulkPublishSummary(preview, "preview");
+    if (payload.includePrivateHidden && Number(preview.eligiblePrivateHiddenCandidates || 0) > 0) {
+      const confirmedPrivateHidden = confirm("Vas a hacer p\u00fablicos productos que actualmente est\u00e1n ocultos o privados. Confirm\u00e1 que quer\u00e9s continuar.");
+      if (!confirmedPrivateHidden) return;
+      payload.confirmPrivateHiddenPublish = true;
+    }
+    const scope = payload.includePrivateHidden ? "filtrados, incluyendo ocultos/privados aptos" : "filtrados";
+    if (!confirm(`Publicar ${preview.eligibleCount || 0} productos ${scope}?`)) return;
     const res = await apiFetch("/api/admin/products/bulk-publish", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload) });
     const data = await res.json();
     if (!res.ok) throw new Error(data?.error || "No se pudo publicar en masa");
@@ -3813,7 +3844,6 @@ if (bulkPublishRunBtn) {
     loadProducts();
   });
 }
-
 async function deleteProduct(id) {
   if (!confirm("¿Estás seguro de eliminar este producto?")) return;
   const resp = await apiFetch(`/api/products/${id}`, { method: "DELETE" });


### PR DESCRIPTION
## Summary
- Improve bulk publish preview/publish to scan SQLite candidates in chunks instead of only the admin page.
- Add safe eligibility handling for private/hidden products behind `includePrivateHidden` plus explicit publish confirmation.
- Add admin filters and preview counters for total catalog, public count, scanned rows, public/private-hidden eligible candidates, blockers, reasons, and warnings.
- Add focused bulk publish eligibility tests.

## Safety
- Does not touch prices, margin logic, Mercado Pago, checkout, cart, orders, Resend, emails, Andreani, real stock, CSV destructive import, Merchant feed, visual filters, or search.
- Publish patches only public flags/publication metadata and generated public slug/remote-mode metadata when stock is zero.

## Validation
- `node --check backend/server.js`
- `node --check backend/data/productsSqliteRepo.js`
- `node --check frontend/js/admin.js`
- `npm test -- --runTestsByPath __tests__/backend/bulk-publish-eligibility.test.js`