### PR TITLE
Polish bulk publish admin UI and safety flow

### DIFF
--- a/nerin_final_updated/frontend/admin.html
+++ b/nerin_final_updated/frontend/admin.html
@@ -138,6 +138,43 @@
         font-weight: 600;
         margin-bottom: 0.35rem;
       }
+      .bulk-publish-panel {
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius);
+        padding: 1rem;
+        display: grid;
+        gap: 1rem;
+        background: var(--color-surface, #fff);
+      }
+      .bulk-publish-header h4 { margin: 0 0 0.35rem; }
+      .bulk-publish-header p { margin: 0; color: var(--color-muted, #555); }
+      .bulk-publish-card {
+        border: 1px solid var(--color-border);
+        border-radius: calc(var(--radius) * 0.8);
+        padding: 0.85rem;
+      }
+      .bulk-publish-card h5 { margin: 0 0 0.65rem; }
+      .bulk-publish-filters-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 0.6rem;
+      }
+      .bulk-publish-field { display: grid; gap: 0.35rem; }
+      .bulk-publish-warning { margin: 0.5rem 0 0; font-size: 0.92rem; color: #7c2d12; }
+      .bulk-publish-actions { display:flex; gap:0.6rem; flex-wrap: wrap; }
+      .bulk-publish-status { font-size: 0.95rem; min-height: 1.2rem; margin-top: 0.65rem; }
+      .bulk-publish-status.is-error { color: #b91c1c; }
+      .bulk-publish-status.is-success { color: #065f46; }
+      .bulk-publish-summary-grid {
+        display:grid; gap:0.6rem; grid-template-columns: repeat(auto-fit, minmax(160px,1fr));
+      }
+      .bulk-kpi { border:1px solid var(--color-border); border-radius:10px; padding:0.65rem; background:#fafafa; }
+      .bulk-kpi-label { display:block; font-size:0.82rem; color:#555; margin-bottom:0.3rem; }
+      .bulk-kpi-value { font-size:1.3rem; font-weight:700; }
+      .bulk-publish-details { display:grid; gap:0.8rem; }
+      .bulk-detail-block h6 { margin:0 0 0.4rem; }
+      .bulk-detail-block ul { margin:0; padding-left:1.1rem; }
+      .bulk-detail-block li { margin:0.2rem 0; }
       .order-detail dd {
         margin: 0;
         color: var(--color-text-muted, #555);
@@ -442,35 +479,40 @@
           </div>
           <div id="stockXlsxImportStatus" role="status" aria-live="polite"></div>
           <progress id="stockXlsxImportProgress" value="0" max="100" style="width:100%;display:none;"></progress>
-          <div class="bulk-actions">
-            <strong>Publicación masiva</strong>
-            <input type="text" id="bulkPublishSearch" placeholder="Buscar" />
-            <input type="text" id="bulkPublishBrand" placeholder="Marca" />
-            <input type="text" id="bulkPublishCategory" placeholder="Tipo de producto" />
-            <input type="text" id="bulkPublishModel" placeholder="Modelo" />
-            <select id="bulkPublishWithImage">
-              <option value="">Con/sin imagen</option>
-              <option value="true">Solo con imagen</option>
-              <option value="false">Solo sin imagen</option>
-            </select>
-            <select id="bulkPublishWithPrice">
-              <option value="">Con/sin precio</option>
-              <option value="true">Solo con precio</option>
-              <option value="false">Solo sin precio</option>
-            </select>
-            <select id="bulkPublishRemoteStock">
-              <option value="">Stock remoto/a pedido</option>
-              <option value="true">Solo remoto/a pedido</option>
-              <option value="false">Excluir remoto/a pedido</option>
-            </select>
-            <label style="display:flex;align-items:center;gap:8px;">
-              <input type="checkbox" id="bulkPublishIncludePrivateHidden" /> Incluir ocultos/privados como candidatos de publicación
-            </label>
-            <input type="number" id="bulkPublishLimit" placeholder="Límite" min="1" max="50000" />
-            <button id="bulkPublishPreviewBtn" class="button secondary">Simular publicación</button>
-            <button id="bulkPublishRunBtn" class="button">Publicar productos aptos</button>
-          </div>
-          <div id="bulkPublishSummary" role="status" aria-live="polite"></div>
+          <section class="bulk-publish-panel" aria-labelledby="bulkPublishTitle">
+            <header class="bulk-publish-header">
+              <h4 id="bulkPublishTitle">Publicación masiva de productos</h4>
+              <p>Publicá productos aptos del catálogo por tandas. La simulación no modifica datos.</p>
+            </header>
+            <div class="bulk-publish-card">
+              <h5>Filtros</h5>
+              <div class="bulk-publish-filters-grid">
+                <label class="bulk-publish-field">Buscar<input type="text" id="bulkPublishSearch" placeholder="Nombre, SKU o texto" /></label>
+                <label class="bulk-publish-field">Marca<input type="text" id="bulkPublishBrand" placeholder="Marca" /></label>
+                <label class="bulk-publish-field">Tipo de producto<input type="text" id="bulkPublishCategory" placeholder="Categoría / tipo" /></label>
+                <label class="bulk-publish-field">Modelo<input type="text" id="bulkPublishModel" placeholder="Modelo" /></label>
+                <label class="bulk-publish-field">Con imagen<select id="bulkPublishWithImage"><option value="">Todos</option><option value="true">Solo con imagen</option><option value="false">Solo sin imagen</option></select></label>
+                <label class="bulk-publish-field">Con precio<select id="bulkPublishWithPrice"><option value="">Todos</option><option value="true">Solo con precio</option><option value="false">Solo sin precio</option></select></label>
+                <label class="bulk-publish-field">Stock remoto/a pedido<select id="bulkPublishRemoteStock"><option value="">Todos</option><option value="true">Solo remoto/a pedido</option><option value="false">Excluir remoto/a pedido</option></select></label>
+                <label class="bulk-publish-field">Límite<input type="number" id="bulkPublishLimit" placeholder="500" min="1" max="50000" value="500" /></label>
+              </div>
+            </div>
+            <div class="bulk-publish-card">
+              <h5>Opciones avanzadas</h5>
+              <label style="display:flex;align-items:center;gap:8px;"><input type="checkbox" id="bulkPublishIncludePrivateHidden" /> Incluir ocultos/privados como candidatos de publicación</label>
+              <p class="bulk-publish-warning">Usar solo si querés hacer públicos productos que actualmente no aparecen en la tienda.</p>
+            </div>
+            <div class="bulk-publish-card">
+              <h5>Acciones</h5>
+              <div class="bulk-publish-actions">
+                <button id="bulkPublishPreviewBtn" class="button secondary">Simular publicación</button>
+                <button id="bulkPublishRunBtn" class="button" disabled>Publicar productos aptos</button>
+              </div>
+              <div id="bulkPublishStatus" class="bulk-publish-status" role="status" aria-live="polite"></div>
+            </div>
+            <div id="bulkPublishSummary" role="status" aria-live="polite"></div>
+            <div id="bulkPublishDetails" class="bulk-publish-details"></div>
+          </section>
           <div class="bulk-actions">
             <select id="bulkActionSelect">
               <option value="">Acción masiva…</option>

--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -1754,6 +1754,8 @@ const bulkPublishLimit = document.getElementById("bulkPublishLimit");
 const bulkPublishPreviewBtn = document.getElementById("bulkPublishPreviewBtn");
 const bulkPublishRunBtn = document.getElementById("bulkPublishRunBtn");
 const bulkPublishSummary = document.getElementById("bulkPublishSummary");
+const bulkPublishDetails = document.getElementById("bulkPublishDetails");
+const bulkPublishStatus = document.getElementById("bulkPublishStatus");
 const importCatalogCsvBtn = document.getElementById("importCatalogCsvBtn");
 const catalogCsvFileInput = document.getElementById("catalogCsvFile");
 const catalogCsvIncludeOutOfStock = document.getElementById("catalogCsvIncludeOutOfStock");
@@ -3778,6 +3780,8 @@ if (applyBulkBtn && bulkSelect) {
 }
 
 function getBulkPublishPayload() {
+  const parsedLimit = Number(bulkPublishLimit?.value || 500);
+  const safeLimit = Number.isFinite(parsedLimit) ? Math.max(1, Math.min(50000, parsedLimit)) : 500;
   const filters = {
     search: bulkPublishSearch?.value?.trim() || "",
     brand: bulkPublishBrand?.value?.trim() || "",
@@ -3789,59 +3793,111 @@ function getBulkPublishPayload() {
   };
   return {
     filters,
-    limit: Number(bulkPublishLimit?.value || 500),
+    limit: safeLimit,
     includePrivateHidden: Boolean(bulkPublishIncludePrivateHidden?.checked),
+    confirmPrivateHiddenPublish: false,
   };
+}
+
+let lastValidBulkPreview = null;
+
+function setBulkPublishBusy(isBusy, previewLabel = "Simular publicación") {
+  if (bulkPublishPreviewBtn) {
+    bulkPublishPreviewBtn.disabled = isBusy;
+    bulkPublishPreviewBtn.textContent = isBusy ? "Simulando..." : previewLabel;
+  }
+  if (bulkPublishRunBtn) {
+    bulkPublishRunBtn.disabled = isBusy || !lastValidBulkPreview;
+  }
+}
+
+function setBulkStatus(message, type = "") {
+  if (!bulkPublishStatus) return;
+  bulkPublishStatus.textContent = message || "";
+  bulkPublishStatus.classList.remove("is-error", "is-success");
+  if (type) bulkPublishStatus.classList.add(type);
 }
 
 function renderBulkPublishSummary(data = {}, mode = "preview") {
   if (!bulkPublishSummary) return;
-  const reasons = Object.entries(data.reasons || data.reasonCounts || {}).sort((a, b) => b[1] - a[1]).slice(0, 8).map(([k, v]) => `${k}: ${v}`).join(" � ");
-  const warnings = Object.entries(data.warnings || data.warningCounts || {}).sort((a, b) => b[1] - a[1]).slice(0, 8).map(([k, v]) => `${k}: ${v}`).join(" � ");
-  const lines = [
-    mode === "publish" ? "Publicaci\u00f3n ejecutada" : "Simulaci\u00f3n",
-    `Total cat\u00e1logo: ${data.totalCatalogProducts || 0}`,
-    `P\u00fablicos actuales: ${data.publicProductsCount || 0}`,
-    `Filas escaneadas: ${data.scannedRows || data.totalScanned || 0}`,
-    `Aptos p\u00fablicos: ${data.eligiblePublicCandidates || 0}`,
-    `Aptos ocultos/privados: ${data.eligiblePrivateHiddenCandidates || 0}`,
-    `Bloqueados: ${data.blockedCount || 0}`,
-    `Warnings: ${data.warningCount || 0}`,
+  const cards = [
+    ["Total catálogo", data.totalCatalogProducts || 0],
+    ["Públicos actuales", data.publicProductsCount || 0],
+    ["Filas escaneadas", data.scannedRows || data.totalScanned || 0],
+    ["Aptos públicos", data.eligiblePublicCandidates || 0],
+    ["Aptos ocultos/privados", data.eligiblePrivateHiddenCandidates || 0],
+    ["Bloqueados", data.blockedCount || 0],
+    ["Warnings", data.warningCount || 0],
   ];
-  if (reasons) lines.push(`Reasons: ${reasons}`);
-  if (warnings) lines.push(`Warnings: ${warnings}`);
-  bulkPublishSummary.textContent = lines.join(" � ");
+  bulkPublishSummary.innerHTML = `
+    <div class="bulk-publish-summary-grid">
+      ${cards.map(([label, value]) => `<article class="bulk-kpi"><span class="bulk-kpi-label">${escapeHtml(String(label))}</span><strong class="bulk-kpi-value">${Number(value) || 0}</strong></article>`).join("")}
+    </div>`;
+  if (!bulkPublishDetails) return;
+  const renderMapList = (title, mapObj = {}) => {
+    const entries = Object.entries(mapObj || {}).filter(([, count]) => Number(count) > 0).sort((a, b) => Number(b[1]) - Number(a[1]));
+    if (!entries.length) return "";
+    return `<section class="bulk-detail-block"><h6>${title}</h6><ul>${entries.map(([key, count]) => `<li><strong>${escapeHtml(String(key))}</strong>: ${Number(count) || 0}</li>`).join("")}</ul></section>`;
+  };
+  const renderSampleList = (title, list = []) => {
+    if (!Array.isArray(list) || !list.length) return "";
+    return `<section class="bulk-detail-block"><h6>${title}</h6><ul>${list.slice(0, 8).map((item) => `<li>${escapeHtml(typeof item === "string" ? item : JSON.stringify(item))}</li>`).join("")}</ul></section>`;
+  };
+  bulkPublishDetails.innerHTML = [
+    renderMapList("Reasons / motivos de bloqueo", data.reasons || data.reasonCounts || {}),
+    renderMapList("Warnings / advertencias", data.warnings || data.warningCounts || {}),
+    renderSampleList("Samples aptos", data.eligibleSamples || data.samplesEligible || []),
+    renderSampleList("Samples bloqueados", data.blockedSamples || data.samplesBlocked || []),
+  ].join("");
 }
 
 if (bulkPublishPreviewBtn) {
   bulkPublishPreviewBtn.addEventListener("click", async () => {
-    const payload = getBulkPublishPayload();
-    const res = await apiFetch("/api/admin/products/bulk-publish-preview", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload) });
-    const data = await res.json();
-    if (!res.ok) throw new Error(data?.error || "No se pudo simular publicaci\u00f3n");
-    renderBulkPublishSummary(data, "preview");
+    try {
+      setBulkPublishBusy(true);
+      setBulkStatus("Simulando...");
+      const payload = getBulkPublishPayload();
+      const res = await apiFetch("/api/admin/products/bulk-publish-preview", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload) });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.error || "No se pudo simular publicación");
+      lastValidBulkPreview = data;
+      renderBulkPublishSummary(data, "preview");
+      setBulkStatus("Simulación lista. No se modificaron productos.", "is-success");
+    } catch (error) {
+      lastValidBulkPreview = null;
+      setBulkStatus(error?.message || "Error al simular la publicación.", "is-error");
+    } finally {
+      setBulkPublishBusy(false);
+    }
   });
 }
 
 if (bulkPublishRunBtn) {
   bulkPublishRunBtn.addEventListener("click", async () => {
+    if (!lastValidBulkPreview) return;
     const payload = { ...getBulkPublishPayload(), dryRun: false, publishMode: "eligible_only" };
-    const previewRes = await apiFetch("/api/admin/products/bulk-publish-preview", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload) });
-    const preview = await previewRes.json();
-    if (!previewRes.ok) throw new Error(preview?.error || "No se pudo simular publicaci\u00f3n");
-    renderBulkPublishSummary(preview, "preview");
-    if (payload.includePrivateHidden && Number(preview.eligiblePrivateHiddenCandidates || 0) > 0) {
-      const confirmedPrivateHidden = confirm("Vas a hacer p\u00fablicos productos que actualmente est\u00e1n ocultos o privados. Confirm\u00e1 que quer\u00e9s continuar.");
+    if (payload.includePrivateHidden && Number(lastValidBulkPreview.eligiblePrivateHiddenCandidates || 0) > 0) {
+      const confirmedPrivateHidden = confirm("Vas a hacer públicos productos que actualmente están ocultos o privados. Confirmá que querés continuar.");
       if (!confirmedPrivateHidden) return;
       payload.confirmPrivateHiddenPublish = true;
     }
-    const scope = payload.includePrivateHidden ? "filtrados, incluyendo ocultos/privados aptos" : "filtrados";
-    if (!confirm(`Publicar ${preview.eligibleCount || 0} productos ${scope}?`)) return;
-    const res = await apiFetch("/api/admin/products/bulk-publish", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload) });
-    const data = await res.json();
-    if (!res.ok) throw new Error(data?.error || "No se pudo publicar en masa");
-    renderBulkPublishSummary(data, "publish");
-    loadProducts();
+    try {
+      setBulkPublishBusy(true, "Simular publicación");
+      setBulkStatus("Publicando productos aptos...");
+      const scope = payload.includePrivateHidden ? "filtrados, incluyendo ocultos/privados aptos" : "filtrados";
+      if (!confirm(`Publicar ${lastValidBulkPreview.eligibleCount || 0} productos ${scope}?`)) return;
+      const res = await apiFetch("/api/admin/products/bulk-publish", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload) });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.error || "No se pudo publicar en masa");
+      renderBulkPublishSummary(data, "publish");
+      const warningsCount = Number(data.warningCount || 0);
+      setBulkStatus(`Publicación completada. updatedCount: ${data.updatedCount || 0}, eligibleCount: ${data.eligibleCount || 0}, blockedCount: ${data.blockedCount || 0}, warnings: ${warningsCount}.`, "is-success");
+      loadProducts();
+    } catch (error) {
+      setBulkStatus(error?.message || "Error al ejecutar la publicación masiva.", "is-error");
+    } finally {
+      setBulkPublishBusy(false, "Simular publicación");
+    }
   });
 }
 async function deleteProduct(id) {


### PR DESCRIPTION
### Motivation
- Mejorar la legibilidad y seguridad de la sección “Publicación masiva” del admin reordenando la UI, corrigiendo textos confusos y evitando caracteres rotos.
- Evitar operaciones peligrosas por defecto añadiendo estados claros, confirmaciones y una simulación que explica el impacto antes de ejecutar la publicación.

### Description
- Reemplacé el layout en `frontend/admin.html` por un bloque visual titulado “Publicación masiva de productos” dividido en tarjetas: **Filtros**, **Opciones avanzadas** y **Acciones**, con subtítulo y texto de advertencia para la opción de incluir privados/ocultos.
- Añadí estilos CSS para panel, cards, grilla de filtros, KPIs y bloques de detalle para presentar resumen y muestras en forma legible (eliminé los separadores “�”).
- Actualicé `frontend/js/admin.js` para sanear el `limit` (`safeLimit` entre 1 y 50000), construir el payload esperado (`filters`, `limit`, `includePrivateHidden`, `confirmPrivateHiddenPublish`), y validar/gestionar el flujo: estados de carga (`Simulando...`), mensajes de éxito/error, deshabilitar el botón de publicar hasta tener una simulación válida, y exigir confirmación adicional cuando `includePrivateHidden=true` y hay candidatos privados/ocultos.
- Reimplementé el render del resumen como tarjetas KPI y añadí secciones de detalle para `Reasons`, `Warnings`, `Samples aptos` y `Samples bloqueados`, manteniendo la lógica backend intacta.

### Testing
- Ejecuté `node --check frontend/js/admin.js` dentro de `nerin_final_updated` y la verificación pasó sin errores.
- No se modificó lógica del backend de bulk publish, por lo que no se ejecutaron pruebas de servidor automáticas para este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07505918548331af5cfdf2a6c13b7b)