### PR TITLE
Fix normalizedSearch ReferenceError in product catalog query

### DIFF
--- a/nerin_final_updated/__tests__/backend/product-search-ranking.test.js
+++ b/nerin_final_updated/__tests__/backend/product-search-ranking.test.js
@@ -1,4 +1,9 @@
-const { computeSearchIntent, scoreProductAgainstIntent } = require('../../backend/data/productsSqliteRepo');
+const {
+  computeSearchIntent,
+  scoreProductAgainstIntent,
+  queryProducts,
+  queryAdminProducts,
+} = require('../../backend/data/productsSqliteRepo');
 
 const score = (query, product) => scoreProductAgainstIntent(product, computeSearchIntent(query));
 
@@ -33,5 +38,28 @@ describe('product search ranking intent', () => {
     const exactSku = score('gh82-31231a', { sku: 'GH82-31231A', name: 'Battery Samsung' });
     const partial = score('gh82-31231a', { sku: 'GH82-00001A', name: 'Battery Samsung' });
     expect(exactSku).toBeGreaterThan(partial);
+  });
+});
+
+
+describe('query APIs should not throw without normalized search scope errors', () => {
+  const expectNoReferenceError = async (promiseFactory) => {
+    try {
+      await promiseFactory();
+    } catch (error) {
+      expect(String(error && error.message ? error.message : error)).not.toMatch(/normalizedSearch is not defined|ReferenceError/i);
+    }
+  };
+
+  test('queryProducts without search does not crash with ReferenceError', async () => {
+    await expectNoReferenceError(() => queryProducts({ page: 1, pageSize: 1 }));
+  });
+
+  test('queryProducts with iphone 15 pro battery does not throw ReferenceError', async () => {
+    await expectNoReferenceError(() => queryProducts({ page: 1, pageSize: 1, search: 'iphone 15 pro battery' }));
+  });
+
+  test('queryAdminProducts without search does not crash with ReferenceError', async () => {
+    await expectNoReferenceError(() => queryAdminProducts({ page: 1, pageSize: 1 }));
   });
 });

--- a/nerin_final_updated/backend/data/productsSqliteRepo.js
+++ b/nerin_final_updated/backend/data/productsSqliteRepo.js
@@ -1790,6 +1790,7 @@ async function queryBase({
   const safePage = Math.max(1, Number(page) || 1);
   const safePageSize = Math.max(1, Number(pageSize) || 24);
   const offset = (safePage - 1) * safePageSize;
+  const normalizedSearch = normalizeQueryText(search);
   const whereClause = buildWhereClause({
     search,
     isPublicOnly,


### PR DESCRIPTION
### Motivation
- A ReferenceError occurred because `normalizedSearch` was used in `queryBase` but only defined inside `buildWhereClause`, breaking catalog endpoints and APIs that rely on product queries.
- The bug affected public and admin catalog listing and the product search endpoints and needed a scoped fix without changing unrelated systems (pricing, stock, checkout, payments, feeds, bulk publish, etc.).

### Description
- Define `const normalizedSearch = normalizeQueryText(search);` inside `queryBase` before building filters so the variable is available for later logic. 
- Reuse `normalizedSearch` for `computeSearchIntent(normalizedSearch)` and the relevance-ranking condition to avoid `ReferenceError` during sorting.
- Add minimal regression tests to `__tests__/backend/product-search-ranking.test.js` that exercise `queryProducts` (with and without a search string) and `queryAdminProducts` to ensure no `normalizedSearch` ReferenceError is thrown.
- Changes are limited to `backend/data/productsSqliteRepo.js` and the added test in `__tests__/backend/product-search-ranking.test.js` and do not modify pricing/checkout/payment or integration logic.

### Testing
- Ran `node --check nerin_final_updated/backend/data/productsSqliteRepo.js` and `node --check nerin_final_updated/backend/server.js` which succeeded.
- Ran tests with `cd nerin_final_updated && npm test -- product-search-ranking.test.js` and the suite passed (`Test Suites: 1 passed, Tests: 8 passed`).
- The new tests confirm `queryProducts` without `search`, `queryProducts` with `search="iphone 15 pro battery"`, and `queryAdminProducts` without `search` do not throw `ReferenceError`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a076ab96a6c83319c4a3d490f029574)