### PR TITLE
Fix product search to rank candidates before pagination

### DIFF
--- a/nerin_final_updated/__tests__/backend/product-search-ranking.test.js
+++ b/nerin_final_updated/__tests__/backend/product-search-ranking.test.js
@@ -1,6 +1,7 @@
 const {
   computeSearchIntent,
   scoreProductAgainstIntent,
+  rankRowsBySearchIntent,
   queryProducts,
   queryAdminProducts,
 } = require('../../backend/data/productsSqliteRepo');
@@ -38,6 +39,21 @@ describe('product search ranking intent', () => {
     const exactSku = score('gh82-31231a', { sku: 'GH82-31231A', name: 'Battery Samsung' });
     const partial = score('gh82-31231a', { sku: 'GH82-00001A', name: 'Battery Samsung' });
     expect(exactSku).toBeGreaterThan(partial);
+  });
+
+  test('iphone 15 pro battery keeps iphone 17 and huawei below exact intent matches', () => {
+    const intent = computeSearchIntent('iphone 15 pro battery');
+    const ranked = rankRowsBySearchIntent([
+      { rowid: 1, name: 'Bateria iPhone 17', model: 'iPhone 17', brand: 'Apple' },
+      { rowid: 2, name: 'Pantalla iPhone 15 Pro', model: 'iPhone 15 Pro', brand: 'Apple' },
+      { rowid: 3, name: 'Bateria iPhone 15 Pro', model: 'iPhone 15 Pro', brand: 'Apple' },
+      { rowid: 4, name: 'Bateria Huawei P60', model: 'Huawei P60', brand: 'Huawei' },
+      { rowid: 5, name: 'Bateria iPhone 14', model: 'iPhone 14', brand: 'Apple' },
+    ], intent, { preferPositiveScores: true });
+    const topTwoNames = ranked.slice(0, 2).map((entry) => entry.row.name);
+    expect(topTwoNames).toContain('Bateria iPhone 15 Pro');
+    expect(topTwoNames).not.toContain('Bateria iPhone 17');
+    expect(topTwoNames).not.toContain('Bateria Huawei P60');
   });
 });
 

--- a/nerin_final_updated/backend/data/productsSqliteRepo.js
+++ b/nerin_final_updated/backend/data/productsSqliteRepo.js
@@ -13,6 +13,7 @@ const COUNT_CACHE_TTL_MS = 60_000;
 const PRODUCTS_SQLITE_SCHEMA_VERSION = 5;
 const CATALOG_MAPPING_VERSION = 2;
 const BULK_PUBLISH_CHUNK_SIZE = 1000;
+const SEARCH_RANK_CANDIDATE_LIMIT = 1200;
 
 const REJECTED_STATE_VALUES = new Set([
   "hidden",
@@ -212,6 +213,19 @@ function scoreProductAgainstIntent(product = {}, intent = {}) {
     if (intent.modelPhrase.includes("pro") && !intent.modelPhrase.includes("pro max") && haystack.includes(`${intent.modelPhrase} max`)) score -= 500;
   }
   return score;
+}
+
+function rankRowsBySearchIntent(rows = [], intent = {}, { preferPositiveScores = false } = {}) {
+  if (!Array.isArray(rows) || rows.length === 0 || !intent?.normalizedQuery) return [];
+  const ranked = rows.map((row, index) => {
+    const score = scoreProductAgainstIntent(row, intent);
+    return { row, score, index };
+  });
+  ranked.sort((a, b) => b.score - a.score || Number(a.row.rowid || 0) - Number(b.row.rowid || 0) || a.index - b.index);
+  if (!preferPositiveScores) return ranked;
+  const positives = ranked.filter((entry) => entry.score > 0);
+  const nonPositives = ranked.filter((entry) => entry.score <= 0);
+  return positives.concat(nonPositives);
 }
 
 function boolToInt(value, fallback = 0) {
@@ -1804,6 +1818,7 @@ async function queryBase({
   });
 
   const orderBy = buildSort(sort);
+  const shouldIntentRank = Boolean(normalizedSearch) && (!sort || String(sort).trim().toLowerCase() === "relevance");
   const totalStartedAt = Date.now();
 
   const countStartedAt = Date.now();
@@ -1824,15 +1839,25 @@ async function queryBase({
   const countMs = Date.now() - countStartedAt;
 
   const selectStartedAt = Date.now();
-  const rows = await all(
-    db,
-    `SELECT rowid, id, sku, code, slug, public_slug, image, name, title, brand, model, category, status, visibility, stock, price, price_minorista, price_mayorista, precio_minorista, precio_mayorista, precio_final, precio_sin_impuestos, cost, currency
-      FROM products ${whereClause.sql} ORDER BY ${orderBy} LIMIT ? OFFSET ?`,
-    [...whereClause.params, safePageSize, offset],
-  );
-  if (normalizedSearch && (!sort || String(sort).trim().toLowerCase() === "relevance")) {
+  let rows = [];
+  if (!shouldIntentRank) {
+    rows = await all(
+      db,
+      `SELECT rowid, id, sku, code, slug, public_slug, image, name, title, brand, model, category, status, visibility, stock, price, price_minorista, price_mayorista, precio_minorista, precio_mayorista, precio_final, precio_sin_impuestos, cost, currency
+        FROM products ${whereClause.sql} ORDER BY ${orderBy} LIMIT ? OFFSET ?`,
+      [...whereClause.params, safePageSize, offset],
+    );
+  } else {
+    const candidateLimit = Math.max(safePageSize, Math.min(SEARCH_RANK_CANDIDATE_LIMIT, totalItems));
+    const candidateRows = await all(
+      db,
+      `SELECT rowid, id, sku, code, slug, public_slug, image, name, title, brand, model, category, status, visibility, stock, price, price_minorista, price_mayorista, precio_minorista, precio_mayorista, precio_final, precio_sin_impuestos, cost, currency
+        FROM products ${whereClause.sql} ORDER BY ${orderBy} LIMIT ? OFFSET 0`,
+      [...whereClause.params, candidateLimit],
+    );
     const intent = computeSearchIntent(normalizedSearch);
-    rows.sort((a, b) => scoreProductAgainstIntent(b, intent) - scoreProductAgainstIntent(a, intent) || Number(a.rowid || 0) - Number(b.rowid || 0));
+    const ranked = rankRowsBySearchIntent(candidateRows, intent, { preferPositiveScores: Boolean(intent.modelPhrase || intent.replacementType || intent.skuOrMpn || intent.importantTokens?.length) });
+    rows = ranked.slice(offset, offset + safePageSize).map((entry) => entry.row);
   }
   const selectMs = Date.now() - selectStartedAt;
 
@@ -2653,6 +2678,7 @@ module.exports = {
   normalizeQueryText,
   computeSearchIntent,
   scoreProductAgainstIntent,
+  rankRowsBySearchIntent,
   PRODUCTS_SQLITE_SCHEMA_VERSION,
   CATALOG_MAPPING_VERSION,
   getField,


### PR DESCRIPTION
### Motivation
- The previous flow ordered SQL results and paginated before applying intent scoring, causing irrelevant items (e.g. iPhone 17, iPhone 14, Huawei) to surface for intent searches like "iphone 15 pro battery". 
- The goal is to compute `intent = computeSearchIntent(search)`, score candidates with `scoreProductAgainstIntent` and then paginate, while keeping behavior unchanged when `search` is empty and avoiding excessive memory use.

### Description
- Added a bounded candidate window constant `SEARCH_RANK_CANDIDATE_LIMIT = 1200` and a helper `rankRowsBySearchIntent(rows, intent, { preferPositiveScores })` to centralize scoring and ordering. 
- Modified `queryBase` to: when `search` is present and `sort` is `relevance` (or unspecified), fetch a larger candidate set from SQLite, compute `computeSearchIntent(normalizedSearch)`, rank with `rankRowsBySearchIntent` (preferring positive scores when intent is clear), then apply pagination on the ranked results; otherwise keep the original SQL `LIMIT/OFFSET` path. 
- Exported `rankRowsBySearchIntent` and updated tests to include an explicit case asserting that `iphone 15 pro battery` ranks true iPhone 15 Pro battery results above iPhone 17 / Huawei noise. 
- No changes made to checkout, payments, prices, stock, admin UI layout, bulk unrelated flows, or to loading `products.json`; SQLite is used and candidate window is bounded to avoid memory spikes.

### Testing
- Ran `node --check backend/data/productsSqliteRepo.js` which succeeded. 
- Ran `node --check backend/server.js` which succeeded. 
- Ran `npm test -- product-search-ranking.test.js`: Jest reported all tests passing (`1` suite, `9` tests passed) but the process exited non-zero because of async logging emitted by the catalog bootstrap/rebuild after tests completed, causing Jest to report "Cannot log after tests are done"; the ranking assertions themselves passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a076ea568b4833183d9c0daf0f49e8d)