### PR TITLE
Improve bulk publish preview diagnostics and disabled classification

### DIFF
--- a/nerin_final_updated/__tests__/backend/bulk-publish-eligibility.test.js
+++ b/nerin_final_updated/__tests__/backend/bulk-publish-eligibility.test.js
@@ -16,11 +16,27 @@ const validProduct = (overrides = {}) => ({
   ...overrides,
 });
 
+const catalogImportMetadata = (overrides = {}) => ({
+  importSource: "catalog_csv",
+  supplierPartNumber: "GH82-12345A",
+  csvStockQuantity: 0,
+  supplierImport: {
+    source: "parts_csv",
+    supplierPartNumber: "GH82-12345A",
+    csvStatus: "Available",
+    csvCanBeOrdered: true,
+    csvStockQuantity: 0,
+    csvMaximumQuantityInOrder: 10,
+    ...overrides.supplierImport,
+  },
+  ...overrides,
+});
+
 describe("bulk publish eligibility", () => {
   test("private and hidden block by default", () => {
-    expect(resolveBulkPublishEligibility(validProduct({ visibility: "private" })).reasons).toContain("private");
-    expect(resolveBulkPublishEligibility(validProduct({ status: "hidden" })).reasons).toContain("hidden");
-    expect(resolveBulkPublishEligibility(validProduct({ hidden: true })).reasons).toContain("hidden");
+    expect(resolveBulkPublishEligibility(validProduct({ visibility: "private" })).reasons).toContain("private_visibility");
+    expect(resolveBulkPublishEligibility(validProduct({ status: "hidden" })).reasons).toContain("hidden_visibility");
+    expect(resolveBulkPublishEligibility(validProduct({ hidden: true })).reasons).toContain("hidden_visibility");
   });
 
   test("private and hidden can be eligible when includePrivateHidden=true", () => {
@@ -34,16 +50,71 @@ describe("bulk publish eligibility", () => {
     ["missing_price", { price: 0, price_minorista: 0, precio_minorista: 0, precio_final: 0 }],
     ["deleted", { deleted: true }],
     ["archived", { archived: true }],
-    ["disabled", { enabled: false }],
-    ["disabled", { enabled: 0 }],
     ["draft", { status: "draft" }],
     ["vip_only", { vip_only: true }],
     ["wholesale_only", { wholesale_only: true }],
-  ])("%s always blocks", (reason, overrides) => {
-    const result = resolveBulkPublishEligibility(validProduct({ visibility: "private", ...overrides }), {
+  ])("%s remains an absolute blocker", (reason, overrides) => {
+    const result = resolveBulkPublishEligibility(validProduct({
+      visibility: "private",
+      metadata: catalogImportMetadata(),
+      enabled: false,
+      ...overrides,
+    }), {
       includePrivateHidden: true,
+      includeDisabledImportCandidates: true,
     });
     expect(result.reasons).toContain(reason);
+    expect(result.eligible).toBe(false);
+  });
+
+  test.each([
+    ["disabled_enabled_false", { enabled: false }],
+    ["disabled_enabled_zero", { enabled: 0 }],
+    ["disabled_field_true", { disabled: true }],
+    ["disabled_status", { status: "disabled" }],
+    ["disabled_visibility", { visibility: "disabled" }],
+    [
+      "disabled_catalog_import_not_orderable",
+      {
+        enabled: false,
+        metadata: catalogImportMetadata({
+          supplierImport: { csvCanBeOrdered: false, csvStockQuantity: 5 },
+          csvStockQuantity: 5,
+        }),
+      },
+    ],
+    [
+      "disabled_stock_import_zero",
+      {
+        enabled: false,
+        stock: 0,
+        metadata: catalogImportMetadata(),
+      },
+    ],
+  ])("classifies %s explicitly", (reason, overrides) => {
+    const result = resolveBulkPublishEligibility(validProduct(overrides));
+    expect(result.diagnostics.disabledReasons).toContain(reason);
+    expect(result.reasons).toContain(reason);
+    expect(result.eligible).toBe(false);
+  });
+
+  test("disabled import and stock candidates require the advanced flag", () => {
+    const product = validProduct({ enabled: false, stock: 0, metadata: catalogImportMetadata() });
+
+    const defaultResult = resolveBulkPublishEligibility(product);
+    expect(defaultResult.reasons).toEqual(expect.arrayContaining(["disabled_enabled_false", "disabled_stock_import_zero"]));
+    expect(defaultResult.eligible).toBe(false);
+
+    const advancedResult = resolveBulkPublishEligibility(product, { includeDisabledImportCandidates: true });
+    expect(advancedResult.reasons).toEqual([]);
+    expect(advancedResult.eligible).toBe(true);
+  });
+
+  test("generic disabled reasons stay hard-blocked even with disabled import flag", () => {
+    const product = validProduct({ disabled: true, stock: 0, metadata: catalogImportMetadata() });
+    const result = resolveBulkPublishEligibility(product, { includeDisabledImportCandidates: true });
+
+    expect(result.reasons).toContain("disabled_field_true");
     expect(result.eligible).toBe(false);
   });
 
@@ -61,23 +132,35 @@ describe("bulk publish eligibility", () => {
     ]));
   });
 
-  test("preview summary separates public candidates from private/hidden candidates", () => {
+  test("preview summary separates strict, private hidden, disabled import and hard-blocked candidates", () => {
     const summary = summarizeBulkPublishProducts(
       [
-        validProduct({ id: "public-candidate" }),
+        validProduct({ id: "public-candidate", image: "battery.jpg" }),
         validProduct({ id: "private-candidate", visibility: "private" }),
+        validProduct({ id: "disabled-import-candidate", enabled: false, stock: 0, metadata: catalogImportMetadata() }),
         validProduct({ id: "blocked-candidate", price: 0 }),
       ],
-      { includePrivateHidden: true, totalCatalogProducts: 3, publicProductsCount: 1 },
+      { includePrivateHidden: true, includeDisabledImportCandidates: true, totalCatalogProducts: 4, publicProductsCount: 1 },
     );
 
-    expect(summary.totalCatalogProducts).toBe(3);
+    expect(summary.totalCatalogProducts).toBe(4);
     expect(summary.publicProductsCount).toBe(1);
-    expect(summary.scannedRows).toBe(3);
-    expect(summary.eligiblePublicCandidates).toBe(1);
+    expect(summary.scannedRows).toBe(4);
+    expect(summary.searchMatchedCount).toBe(4);
+    expect(summary.withNameCount).toBe(4);
+    expect(summary.withIdentifierCount).toBe(4);
+    expect(summary.withPriceCount).toBe(3);
+    expect(summary.withImageCount).toBe(1);
+    expect(summary.strictEligibleCount).toBe(1);
+    expect(summary.eligiblePublicCandidates).toBe(2);
     expect(summary.eligiblePrivateHiddenCandidates).toBe(1);
+    expect(summary.eligibleDisabledImportCandidates).toBe(1);
+    expect(summary.privateHiddenCount).toBe(1);
+    expect(summary.advancedPublishableCount).toBe(2);
+    expect(summary.hardBlockedCount).toBe(1);
     expect(summary.blockedCount).toBe(1);
     expect(summary.reasons.missing_price).toBe(1);
+    expect(summary.disabledBreakdown.disabled_stock_import_zero).toBe(1);
   });
 
   test("publish patch does not change price or stock", () => {

--- a/nerin_final_updated/backend/data/productsSqliteRepo.js
+++ b/nerin_final_updated/backend/data/productsSqliteRepo.js
@@ -615,20 +615,118 @@ function isTruthyFlag(value) {
   return text === "true" || text === "1" || text === "yes" || text === "si";
 }
 
+function isFalsyFlag(value) {
+  if (value === false || value === 0) return true;
+  const text = normalizeQueryText(value);
+  return text === "false" || text === "0" || text === "no";
+}
+
+function getProductMetadata(product = {}) {
+  return product?.metadata && typeof product.metadata === "object" ? product.metadata : {};
+}
+
+function getSupplierImportMetadata(product = {}) {
+  const metadata = getProductMetadata(product);
+  return metadata?.supplierImport && typeof metadata.supplierImport === "object" ? metadata.supplierImport : {};
+}
+
+function getBulkDisabledReasons(product = {}, signals = {}) {
+  const reasons = [];
+  const metadata = getProductMetadata(product);
+  const supplierImport = getSupplierImportMetadata(product);
+  const enabledValue = getField(product, ["enabled"]);
+  const disabledValue = getField(product, ["disabled", "deshabilitado"]);
+
+  if (enabledValue === false || normalizeQueryText(enabledValue) === "false") reasons.push("disabled_enabled_false");
+  if (enabledValue === 0 || enabledValue === "0") reasons.push("disabled_enabled_zero");
+  if (isTruthyFlag(disabledValue)) reasons.push("disabled_field_true");
+  if (signals.status === "disabled") reasons.push("disabled_status");
+  if (signals.visibility === "disabled") reasons.push("disabled_visibility");
+
+  const isCatalogImport =
+    normalizeQueryText(metadata.importSource) === "catalog_csv" ||
+    normalizeQueryText(supplierImport.source) === "parts_csv" ||
+    Boolean(supplierImport.externalId || supplierImport.supplierPartNumber || metadata.supplierPartNumber);
+  const canBeOrdered = supplierImport.csvCanBeOrdered ?? supplierImport.canBeOrdered;
+  const csvStatus = normalizeQueryText(supplierImport.csvStatus || supplierImport.status || "");
+  const maxOrder = firstNumber([supplierImport.csvMaximumQuantityInOrder, supplierImport.maximumQuantityInOrder]);
+  const notOrderable =
+    isCatalogImport &&
+    (isFalsyFlag(canBeOrdered) ||
+      (csvStatus && csvStatus !== "available") ||
+      (Number.isFinite(maxOrder) && maxOrder <= 0));
+  if (notOrderable) reasons.push("disabled_catalog_import_not_orderable");
+
+  const stockSource = normalizeQueryText(product.stockSource || metadata.stockSource || "");
+  const hasStockImport =
+    Boolean(stockSource) ||
+    Boolean(product.stockUpdatedAt || metadata.stockUpdatedAt) ||
+    Object.prototype.hasOwnProperty.call(metadata, "stockQuantity") ||
+    Object.prototype.hasOwnProperty.call(metadata, "csvStockQuantity") ||
+    Object.prototype.hasOwnProperty.call(supplierImport, "csvStockQuantity");
+  const importedStock = firstNumber([
+    product.stockQuantity,
+    metadata.stockQuantity,
+    metadata.csvStockQuantity,
+    supplierImport.csvStockQuantity,
+    product.remote_stock,
+    product.stock,
+  ]);
+  if ((hasStockImport || isCatalogImport) && Number.isFinite(importedStock) && importedStock <= 0) {
+    reasons.push("disabled_stock_import_zero");
+  }
+
+  return Array.from(new Set(reasons));
+}
+
+function getBulkPrivateHiddenReasons(product = {}, signals = {}) {
+  const reasons = [];
+  if (signals.visibility === "hidden" || signals.status === "hidden" || isTruthyFlag(getField(product, ["hidden", "oculto"]))) {
+    reasons.push("hidden_visibility");
+  }
+  if (signals.visibility === "private" || signals.status === "private" || isTruthyFlag(getField(product, ["private", "privado"]))) {
+    reasons.push("private_visibility");
+  }
+  return Array.from(new Set(reasons));
+}
+
+function hasAbsoluteBulkBlocker(reasons = []) {
+  return reasons.some((reason) => [
+    "missing_name",
+    "missing_identifier",
+    "missing_price",
+    "deleted",
+    "archived",
+    "draft",
+    "vip_only",
+    "wholesale_only",
+  ].includes(reason));
+}
+
+function isDisabledImportCandidate(disabledReasons = []) {
+  if (!disabledReasons.length) return false;
+  const importReasons = new Set(["disabled_catalog_import_not_orderable", "disabled_stock_import_zero"]);
+  const hardReasons = new Set(["disabled_field_true", "disabled_status", "disabled_visibility"]);
+  const hasImportReason = disabledReasons.some((reason) => importReasons.has(reason));
+  const hasHardReason = disabledReasons.some((reason) => hardReasons.has(reason));
+  return hasImportReason && !hasHardReason;
+}
+
 function resolveBulkPublishEligibility(product = {}, options = {}) {
   const reasons = [];
   const warnings = [];
   const updates = {};
   const includePrivateHidden = options?.includePrivateHidden === true;
+  const includeDisabledImportCandidates = options?.includeDisabledImportCandidates === true;
   const computed = computeProductPublicState(product);
   const signals = computed?.signals || {};
   const deletedFlag = signals.deleted || isTruthyFlag(getField(product, ["deleted", "eliminado"]));
   const archivedFlag = signals.archived || isTruthyFlag(getField(product, ["archived", "archive", "archivado"]));
-  const disabledFlag = signals.enabledFalse || isTruthyFlag(getField(product, ["disabled", "deshabilitado"])) || getField(product, ["enabled"]) === 0 || getField(product, ["enabled"]) === "0" || normalizeQueryText(getField(product, ["enabled"]) || "") === "false";
   const vipOnlyFlag = signals.vipOnly || isTruthyFlag(getField(product, ["vip_only", "vipOnly", "vip only"]));
   const wholesaleOnlyFlag = signals.wholesaleOnly || isTruthyFlag(getField(product, ["wholesaleOnly", "wholesale_only", "wholesale only"]));
-  const hiddenFlag = signals.visibility === "hidden" || signals.status === "hidden" || isTruthyFlag(getField(product, ["hidden", "oculto"]));
-  const privateFlag = signals.visibility === "private" || signals.status === "private" || isTruthyFlag(getField(product, ["private", "privado"]));
+  const privateHiddenReasons = getBulkPrivateHiddenReasons(product, signals);
+  const disabledReasons = getBulkDisabledReasons(product, signals);
+  const disabledImportCandidate = isDisabledImportCandidate(disabledReasons);
 
   const hasName = !signals.missingName;
   const hasIdentifier = !signals.missingIdentifier;
@@ -636,19 +734,18 @@ function resolveBulkPublishEligibility(product = {}, options = {}) {
     getField(product, ["price", "precio", "price_minorista", "precio_minorista", "precio_final", "finalPrice", "salePrice"]),
   ]);
   const hasValidPrice = Number.isFinite(priceValue) && priceValue > 0;
+  const hasImage = hasBulkImage(product);
 
   if (!hasName) reasons.push("missing_name");
   if (!hasIdentifier) reasons.push("missing_identifier");
   if (!hasValidPrice) reasons.push("missing_price");
   if (deletedFlag) reasons.push("deleted");
   if (archivedFlag) reasons.push("archived");
-  if (disabledFlag) reasons.push("disabled");
   if (vipOnlyFlag) reasons.push("vip_only");
   if (wholesaleOnlyFlag) reasons.push("wholesale_only");
-  if (!includePrivateHidden && hiddenFlag) reasons.push("hidden");
-  if (!includePrivateHidden && privateFlag) reasons.push("private");
+  if (!includePrivateHidden) reasons.push(...privateHiddenReasons);
+  if (!(includeDisabledImportCandidates && disabledImportCandidate)) reasons.push(...disabledReasons);
   if (signals.visibility === "draft" || signals.status === "draft") reasons.push("draft");
-  if (signals.visibility === "disabled" || signals.status === "disabled") reasons.push("disabled");
   if (signals.visibility === "deleted" || signals.status === "deleted") reasons.push("deleted");
   if (signals.visibility === "archived" || signals.status === "archived") reasons.push("archived");
 
@@ -666,7 +763,28 @@ function resolveBulkPublishEligibility(product = {}, options = {}) {
     warnings.push("stock_zero_remote_assumed");
     warnings.push("remote_delivery_estimated");
   }
-  return { eligible: reasons.length === 0, reasons: Array.from(new Set(reasons)), warnings: Array.from(new Set(warnings)), updates };
+  const uniqueReasons = Array.from(new Set(reasons));
+  const hasAbsoluteBlocker = hasAbsoluteBulkBlocker(uniqueReasons);
+  const privateHiddenCandidate = privateHiddenReasons.length > 0;
+  const strictEligible = !hasAbsoluteBlocker && privateHiddenReasons.length === 0 && disabledReasons.length === 0;
+  const advancedPublishable = !hasAbsoluteBlocker && (privateHiddenCandidate || disabledImportCandidate) && !uniqueReasons.some((reason) => ["disabled_field_true", "disabled_status", "disabled_visibility"].includes(reason));
+  return {
+    eligible: uniqueReasons.length === 0,
+    reasons: uniqueReasons,
+    warnings: Array.from(new Set(warnings)),
+    updates,
+    diagnostics: {
+      hasName,
+      hasIdentifier,
+      hasValidPrice,
+      hasImage,
+      privateHiddenReasons,
+      disabledReasons,
+      disabledImportCandidate,
+      strictEligible,
+      advancedPublishable,
+    },
+  };
 }
 
 function parseBulkBooleanFilter(value) {
@@ -765,10 +883,21 @@ function createBulkPublishSummary({ totalCatalogProducts = 0, publicProductsCoun
     publicProductsCount: Number(publicProductsCount || 0),
     scannedRows: 0,
     totalScanned: 0,
+    searchMatchedCount: 0,
+    withNameCount: 0,
+    withIdentifierCount: 0,
+    withPriceCount: 0,
+    withImageCount: 0,
+    strictEligibleCount: 0,
     eligiblePublicCandidates: 0,
     eligiblePrivateHiddenCandidates: 0,
+    eligibleDisabledImportCandidates: 0,
+    hardBlockedCount: 0,
+    privateHiddenCount: 0,
+    advancedPublishableCount: 0,
     eligibleCount: 0,
     blockedCount: 0,
+    disabledBreakdown: {},
     warningCount: 0,
     reasons: {},
     warnings: {},
@@ -780,8 +909,29 @@ function createBulkPublishSummary({ totalCatalogProducts = 0, publicProductsCoun
   };
 }
 
-function recordBulkPublishEvaluation(summary, product, result) {
+function recordBulkPublishEvaluation(summary, product, result, options = {}) {
   const identifier = product.id || product.sku || product.code || product.public_slug || product.slug || `row:${product.rowid}`;
+  const diagnostics = result.diagnostics || {};
+  const privateHiddenCandidate = isPrivateHiddenProduct(product);
+  summary.searchMatchedCount += 1;
+  if (diagnostics.hasName) summary.withNameCount += 1;
+  if (diagnostics.hasIdentifier) summary.withIdentifierCount += 1;
+  if (diagnostics.hasValidPrice) summary.withPriceCount += 1;
+  if (diagnostics.hasImage) summary.withImageCount += 1;
+  if (diagnostics.strictEligible) summary.strictEligibleCount += 1;
+  if (privateHiddenCandidate) summary.privateHiddenCount += 1;
+  (diagnostics.disabledReasons || []).forEach((reason) => incCounter(summary.disabledBreakdown, reason));
+  const hasAbsoluteBlocker = hasAbsoluteBulkBlocker(result.reasons || []);
+  const hasHardDisabledReason = (diagnostics.disabledReasons || []).some((reason) => ["disabled_field_true", "disabled_status", "disabled_visibility"].includes(reason));
+  const advancedPublishable = diagnostics.advancedPublishable === true || (!hasAbsoluteBlocker && !hasHardDisabledReason && (privateHiddenCandidate || diagnostics.disabledImportCandidate === true));
+  const disabledImportPublishableWithCurrentOptions =
+    diagnostics.disabledImportCandidate === true &&
+    !hasAbsoluteBlocker &&
+    !hasHardDisabledReason &&
+    (!privateHiddenCandidate || options.includePrivateHidden === true);
+  if (disabledImportPublishableWithCurrentOptions) summary.eligibleDisabledImportCandidates += 1;
+  if (advancedPublishable) summary.advancedPublishableCount += 1;
+  if (!result.eligible && !advancedPublishable) summary.hardBlockedCount += 1;
   result.reasons.forEach((reason) => {
     incCounter(summary.reasons, reason);
     incCounter(summary.reasonCounts, reason);
@@ -811,13 +961,13 @@ function recordBulkPublishEvaluation(summary, product, result) {
   }
 }
 
-function summarizeBulkPublishProducts(products = [], { includePrivateHidden = false, totalCatalogProducts = products.length, publicProductsCount = 0 } = {}) {
+function summarizeBulkPublishProducts(products = [], { includePrivateHidden = false, includeDisabledImportCandidates = false, totalCatalogProducts = products.length, publicProductsCount = 0 } = {}) {
   const summary = createBulkPublishSummary({ totalCatalogProducts, publicProductsCount });
   for (const product of products) {
     summary.scannedRows += 1;
     summary.totalScanned = summary.scannedRows;
-    const result = resolveBulkPublishEligibility(product, { includePrivateHidden });
-    recordBulkPublishEvaluation(summary, product, result);
+    const result = resolveBulkPublishEligibility(product, { includePrivateHidden, includeDisabledImportCandidates });
+    recordBulkPublishEvaluation(summary, product, result, { includePrivateHidden });
   }
   return summary;
 }
@@ -2304,7 +2454,7 @@ async function bulkPublication({ action = "publish", scope = "private_products",
   return { ok: true, beforePublicCount, afterPublicCount, updatedRows, skipped, examplesUpdated, dryRun: Boolean(dryRun) };
 }
 
-async function scanBulkPublishCandidates({ filters = {}, limit = 500, includePrivateHidden = false, onEligible = null } = {}) {
+async function scanBulkPublishCandidates({ filters = {}, limit = 500, includePrivateHidden = false, includeDisabledImportCandidates = false, onEligible = null } = {}) {
   await ensureDbReadyForRequest();
   const db = await openDb();
   const safeLimit = Math.max(1, Math.min(50000, Number(limit) || 500));
@@ -2338,8 +2488,8 @@ async function scanBulkPublishCandidates({ filters = {}, limit = 500, includePri
 
       summary.scannedRows += 1;
       summary.totalScanned = summary.scannedRows;
-      const result = resolveBulkPublishEligibility(product, { includePrivateHidden });
-      recordBulkPublishEvaluation(summary, product, result);
+      const result = resolveBulkPublishEligibility(product, { includePrivateHidden, includeDisabledImportCandidates });
+      recordBulkPublishEvaluation(summary, product, result, { includePrivateHidden });
 
       if (result.eligible && typeof onEligible === "function" && summary.eligibleCount <= safeLimit) {
         await onEligible(product, result, summary.eligibleCount);
@@ -2354,19 +2504,42 @@ async function scanBulkPublishCandidates({ filters = {}, limit = 500, includePri
   return summary;
 }
 
-async function previewBulkPublish({ filters = {}, limit = 500, includePrivateHidden = false } = {}) {
-  return scanBulkPublishCandidates({ filters, limit, includePrivateHidden: includePrivateHidden === true });
+async function previewBulkPublish({ filters = {}, limit = 500, includePrivateHidden = false, includeDisabledImportCandidates = false } = {}) {
+  return scanBulkPublishCandidates({
+    filters,
+    limit,
+    includePrivateHidden: includePrivateHidden === true,
+    includeDisabledImportCandidates: includeDisabledImportCandidates === true,
+  });
 }
 
-async function bulkPublishEligible({ dryRun = false, filters = {}, limit = 500, publishMode = "eligible_only", includePrivateHidden = false, confirmPrivateHiddenPublish = false } = {}) {
+async function bulkPublishEligible({
+  dryRun = false,
+  filters = {},
+  limit = 500,
+  publishMode = "eligible_only",
+  includePrivateHidden = false,
+  confirmPrivateHiddenPublish = false,
+  includeDisabledImportCandidates = false,
+  confirmDisabledImportPublish = false,
+} = {}) {
   if (publishMode !== "eligible_only") throw new Error("publishMode must be eligible_only");
   let updatedCount = 0;
 
   if (includePrivateHidden === true && confirmPrivateHiddenPublish !== true && dryRun !== true) {
-    const preview = await previewBulkPublish({ filters, limit, includePrivateHidden: true });
+    const preview = await previewBulkPublish({ filters, limit, includePrivateHidden: true, includeDisabledImportCandidates: includeDisabledImportCandidates === true });
     if (Number(preview.eligiblePrivateHiddenCandidates || 0) > 0) {
       const error = new Error("confirmPrivateHiddenPublish is required when includePrivateHidden=true");
       error.code = "PRIVATE_HIDDEN_CONFIRMATION_REQUIRED";
+      throw error;
+    }
+  }
+
+  if (includeDisabledImportCandidates === true && confirmDisabledImportPublish !== true && dryRun !== true) {
+    const preview = await previewBulkPublish({ filters, limit, includePrivateHidden: includePrivateHidden === true, includeDisabledImportCandidates: true });
+    if (Number(preview.eligibleDisabledImportCandidates || 0) > 0) {
+      const error = new Error("confirmDisabledImportPublish is required when includeDisabledImportCandidates=true");
+      error.code = "DISABLED_IMPORT_CONFIRMATION_REQUIRED";
       throw error;
     }
   }
@@ -2375,6 +2548,7 @@ async function bulkPublishEligible({ dryRun = false, filters = {}, limit = 500, 
     filters,
     limit,
     includePrivateHidden: includePrivateHidden === true,
+    includeDisabledImportCandidates: includeDisabledImportCandidates === true,
     async onEligible(product, result) {
       const identifier = product.id || product.sku || product.code || product.public_slug || product.slug;
       if (!identifier) return;
@@ -2383,7 +2557,15 @@ async function bulkPublishEligible({ dryRun = false, filters = {}, limit = 500, 
       updatedCount += 1;
     },
   });
-  return { ok: true, dryRun: Boolean(dryRun), publishMode, includePrivateHidden: includePrivateHidden === true, ...summary, updatedCount };
+  return {
+    ok: true,
+    dryRun: Boolean(dryRun),
+    publishMode,
+    includePrivateHidden: includePrivateHidden === true,
+    includeDisabledImportCandidates: includeDisabledImportCandidates === true,
+    ...summary,
+    updatedCount,
+  };
 }
 
 async function getCatalogFieldAudit({ sampleSize = 300 } = {}) {

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -6693,6 +6693,7 @@ async function requestHandler(req, res) {
           filters: payload?.filters || {},
           limit: payload?.limit || 500,
           includePrivateHidden: payload?.includePrivateHidden === true,
+          includeDisabledImportCandidates: payload?.includeDisabledImportCandidates === true,
         });
         return sendJson(res, 200, { ok: true, ...result });
       } catch (error) {
@@ -6716,6 +6717,8 @@ async function requestHandler(req, res) {
           publishMode: payload?.publishMode || "eligible_only",
           includePrivateHidden: payload?.includePrivateHidden === true,
           confirmPrivateHiddenPublish: payload?.confirmPrivateHiddenPublish === true,
+          includeDisabledImportCandidates: payload?.includeDisabledImportCandidates === true,
+          confirmDisabledImportPublish: payload?.confirmDisabledImportPublish === true,
         });
         return sendJson(res, 200, result);
       } catch (error) {
@@ -6724,6 +6727,13 @@ async function requestHandler(req, res) {
             ok: false,
             code: "PRIVATE_HIDDEN_CONFIRMATION_REQUIRED",
             error: "Confirmacion requerida para publicar productos ocultos o privados",
+          });
+        }
+        if (error?.code === "DISABLED_IMPORT_CONFIRMATION_REQUIRED") {
+          return sendJson(res, 400, {
+            ok: false,
+            code: "DISABLED_IMPORT_CONFIRMATION_REQUIRED",
+            error: "Confirmacion requerida para publicar productos deshabilitados por importacion o stock",
           });
         }
         return sendJson(res, 500, { ok: false, code: "BULK_PUBLISH_FAILED", error: error?.message || "No se pudo publicar productos aptos" });

--- a/nerin_final_updated/frontend/admin.html
+++ b/nerin_final_updated/frontend/admin.html
@@ -500,6 +500,7 @@
             <div class="bulk-publish-card">
               <h5>Opciones avanzadas</h5>
               <label style="display:flex;align-items:center;gap:8px;"><input type="checkbox" id="bulkPublishIncludePrivateHidden" /> Incluir ocultos/privados como candidatos de publicación</label>
+              <label style="display:flex;align-items:center;gap:8px;"><input type="checkbox" id="bulkPublishIncludeDisabledImport" /> Incluir deshabilitados por importación/stock como candidatos</label>
               <p class="bulk-publish-warning">Usar solo si querés hacer públicos productos que actualmente no aparecen en la tienda.</p>
             </div>
             <div class="bulk-publish-card">

--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -1750,6 +1750,7 @@ const bulkPublishWithImage = document.getElementById("bulkPublishWithImage");
 const bulkPublishWithPrice = document.getElementById("bulkPublishWithPrice");
 const bulkPublishRemoteStock = document.getElementById("bulkPublishRemoteStock");
 const bulkPublishIncludePrivateHidden = document.getElementById("bulkPublishIncludePrivateHidden");
+const bulkPublishIncludeDisabledImport = document.getElementById("bulkPublishIncludeDisabledImport");
 const bulkPublishLimit = document.getElementById("bulkPublishLimit");
 const bulkPublishPreviewBtn = document.getElementById("bulkPublishPreviewBtn");
 const bulkPublishRunBtn = document.getElementById("bulkPublishRunBtn");
@@ -3796,7 +3797,9 @@ function getBulkPublishPayload() {
     filters,
     limit: safeLimit,
     includePrivateHidden: Boolean(bulkPublishIncludePrivateHidden?.checked),
+    includeDisabledImportCandidates: Boolean(bulkPublishIncludeDisabledImport?.checked),
     confirmPrivateHiddenPublish: false,
+    confirmDisabledImportPublish: false,
   };
 }
 
@@ -3825,9 +3828,18 @@ function renderBulkPublishSummary(data = {}, mode = "preview") {
     ["Total catálogo", data.totalCatalogProducts || 0],
     ["Públicos actuales", data.publicProductsCount || 0],
     ["Filas escaneadas", data.scannedRows || data.totalScanned || 0],
+    ["Coincidencias búsqueda", data.searchMatchedCount || data.scannedRows || data.totalScanned || 0],
+    ["Con nombre", data.withNameCount || 0],
+    ["Con SKU/código", data.withIdentifierCount || 0],
+    ["Con precio", data.withPriceCount || 0],
+    ["Con imagen", data.withImageCount || 0],
+    ["Aptos estrictos", data.strictEligibleCount || 0],
     ["Aptos públicos", data.eligiblePublicCandidates || 0],
     ["Aptos ocultos/privados", data.eligiblePrivateHiddenCandidates || 0],
+    ["Deshabilitados import/stock", data.eligibleDisabledImportCandidates || 0],
+    ["Publicables avanzados", data.advancedPublishableCount || 0],
     ["Bloqueados", data.blockedCount || 0],
+    ["Bloqueados duros", data.hardBlockedCount || 0],
     ["Warnings", data.warningCount || 0],
   ];
   bulkPublishSummary.innerHTML = `
@@ -3846,6 +3858,7 @@ function renderBulkPublishSummary(data = {}, mode = "preview") {
   };
   bulkPublishDetails.innerHTML = [
     renderMapList("Reasons / motivos de bloqueo", data.reasons || data.reasonCounts || {}),
+    renderMapList("Disabled breakdown", data.disabledBreakdown || {}),
     renderMapList("Warnings / advertencias", data.warnings || data.warningCounts || {}),
     renderSampleList("Samples aptos", data.eligibleSamples || data.samplesEligible || []),
     renderSampleList("Samples bloqueados", data.blockedSamples || data.samplesBlocked || []),
@@ -3897,10 +3910,18 @@ if (bulkPublishRunBtn) {
       if (!confirmedPrivateHidden) return;
       payload.confirmPrivateHiddenPublish = true;
     }
+    if (payload.includeDisabledImportCandidates && Number(lastValidBulkPreview.eligibleDisabledImportCandidates || 0) > 0) {
+      const confirmedDisabledImport = confirm("Vas a hacer públicos productos deshabilitados por importación o stock. Confirmá que querés continuar.");
+      if (!confirmedDisabledImport) return;
+      payload.confirmDisabledImportPublish = true;
+    }
     try {
       setBulkPublishBusy(true, "Simular publicación");
       setBulkStatus("Publicando productos aptos...");
-      const scope = payload.includePrivateHidden ? "filtrados, incluyendo ocultos/privados aptos" : "filtrados";
+      const advancedScopes = [];
+      if (payload.includePrivateHidden) advancedScopes.push("ocultos/privados aptos");
+      if (payload.includeDisabledImportCandidates) advancedScopes.push("deshabilitados por importación/stock aptos");
+      const scope = advancedScopes.length ? `filtrados, incluyendo ${advancedScopes.join(" y ")}` : "filtrados";
       if (!confirm(`Publicar ${lastValidBulkPreview.eligibleCount || 0} productos ${scope}?`)) return;
       console.log("[bulk-publish] payload", payload);
       const res = await apiFetch("/api/admin/products/bulk-publish", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload) });


### PR DESCRIPTION
## Summary
- Split bulk publish disabled diagnostics into explicit reasons instead of a generic disabled blocker.
- Add preview KPIs for matched rows, name/SKU/price/image coverage, strict eligible, advanced publishable, hard-blocked, private/hidden, and disabled breakdown counts.
- Add an advanced admin option and separate confirmation for products disabled by import/stock before publishing them.

## Safety
- Publication still only updates public visibility/status/enabled/is_public plus existing publication metadata.
- Generic disabled signals such as disabled field, disabled status, and disabled visibility remain hard-blocked.
- Private/hidden products still require their existing explicit confirmation.
- No changes to prices, margin, real stock, checkout, payments, orders, Resend/emails, Andreani, Merchant feed, or destructive CSV/XLSX import.

## Validation
- `node --check backend/data/productsSqliteRepo.js`
- `node --check backend/server.js`
- `node --check frontend/js/admin.js`
- `npm test -- --runTestsByPath __tests__/backend/bulk-publish-eligibility.test.js`