### PR TITLE
Fix Merchant feed debug endpoint crash and expose safe diagnostics

### DIFF
--- a/nerin_final_updated/__tests__/backend/merchant-feed.test.js
+++ b/nerin_final_updated/__tests__/backend/merchant-feed.test.js
@@ -75,6 +75,32 @@ describe('merchant feed audit', () => {
     expect(byId.rs).not.toBe('Pantallas');
   });
 
+
+  test('buildMerchantFeedAudit audita filas válidas sin error genérico', () => {
+    const rows = [baseRow({ id: 'ok-1' }), baseRow({ id: 'ok-2', stock: 0, raw_json: JSON.stringify({ allow_backorder: true }) })];
+    const audit = buildMerchantFeedAudit(rows);
+    expect(audit.ok).toBeUndefined();
+    expect(audit.eligibleCount).toBeGreaterThan(0);
+    expect(audit.emittedCount).toBeGreaterThan(0);
+  });
+
+  test('buildMerchantFeedAudit tolera raw_json null, vacío e inválido', () => {
+    const rows = [
+      baseRow({ id: 'n1', raw_json: null }),
+      baseRow({ id: 'n2', raw_json: '' }),
+      baseRow({ id: 'n3', raw_json: '{invalid-json' }),
+    ];
+    expect(() => buildMerchantFeedAudit(rows)).not.toThrow();
+    const audit = buildMerchantFeedAudit(rows);
+    expect(audit.scannedRows).toBe(3);
+  });
+
+  test('buildMerchantFeedAudit tolera campos opcionales ausentes', () => {
+    const rows = [
+      baseRow({ id: 'opt-1', brand: null, mpn: null, part_number: null, description: null }, {}),
+    ];
+    expect(() => buildMerchantFeedAudit(rows)).not.toThrow();
+  });
   test('debug devuelve skipped reasons y samples', () => {
     const audit = buildMerchantFeedAudit([baseRow(), baseRow({ id: 'x', is_public: 0 })]);
     expect(audit).toHaveProperty('skipped');

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -12516,7 +12516,31 @@ async function requestHandler(req, res) {
       dbConn = await openSqliteReadonly(productsSqliteRepo.SQLITE_PATH);
       const totalRows = await sqliteAll(dbConn, 'SELECT COUNT(*) AS c FROM products');
       totalCatalogProducts = Number(totalRows?.[0]?.c || 0);
-      allRows = await sqliteAll(dbConn, 'SELECT rowid,id,sku,slug,public_slug,name,title,description,brand,stock,price,price_minorista,precio_minorista,precio_final,image,raw_json,status,visibility,enabled,deleted,archived,vip_only,wholesale_only,is_public,part_number,mpn,category FROM products ORDER BY rowid ASC LIMIT ? OFFSET ?', [emittedLimit + emittedOffset + 2000, 0]);
+      const productColumns = await sqliteAll(dbConn, 'PRAGMA table_info(products)');
+      const availableColumns = new Set((productColumns || []).map((col) => String(col?.name || '').trim()).filter(Boolean));
+      const preferredColumns = [
+        'id','sku','slug','public_slug','name','title','description','brand','stock','price','price_minorista','precio_minorista','precio_final','image','raw_json','status','visibility','enabled','deleted','archived','vip_only','wholesale_only','is_public','part_number','mpn','category'
+      ];
+      const fallbackExpressions = {
+        public_slug: "json_extract(raw_json, '$.public_slug') AS public_slug",
+        slug: "json_extract(raw_json, '$.slug') AS slug",
+        status: "json_extract(raw_json, '$.status') AS status",
+        visibility: "json_extract(raw_json, '$.visibility') AS visibility",
+        enabled: "json_extract(raw_json, '$.enabled') AS enabled",
+        is_public: "json_extract(raw_json, '$.is_public') AS is_public",
+      };
+      const selectedColumns = ['rowid'];
+      for (const col of preferredColumns) {
+        if (availableColumns.has(col)) {
+          selectedColumns.push(col);
+        } else if (fallbackExpressions[col]) {
+          selectedColumns.push(fallbackExpressions[col]);
+        } else {
+          selectedColumns.push(`NULL AS ${col}`);
+        }
+      }
+      const selectSql = `SELECT ${selectedColumns.join(',')} FROM products ORDER BY rowid ASC LIMIT ? OFFSET ?`;
+      allRows = await sqliteAll(dbConn, selectSql, [emittedLimit + emittedOffset + 2000, 0]);
       for (const row of allRows) {
         let raw = {};
         try { raw = JSON.parse(row.raw_json || '{}'); } catch {}
@@ -12548,6 +12572,22 @@ async function requestHandler(req, res) {
       }
     } catch (error) {
       if (dbConn) { try { dbConn.close(); } catch {} }
+      if (pathname === '/merchant-feed-debug.json') {
+        console.error('[merchant-feed-debug] error', {
+          message: error?.message,
+          code: error?.code,
+          stack: error?.stack,
+        });
+        return sendJson(res, 500, {
+          ok: false,
+          error: 'No se pudo generar merchant feed',
+          debugError: {
+            message: error?.message || null,
+            code: error?.code || null,
+            stackFirstLine: String(error?.stack || '').split('\n')[0] || null,
+          },
+        });
+      }
       console.error('[merchant-feed] error', { message: error?.message, code: error?.code, stack: error?.stack });
       return sendJson(res, 500, { error: 'No se pudo generar merchant feed' });
     }


### PR DESCRIPTION
### Motivation
- Prevent the merchant feed debug endpoint from crashing and provide a safe, limited diagnostic payload when failures occur. 
- Avoid leaking full stacks or sensitive internals for the production TSV feed while still surfacing useful info on the debug endpoint. 
- Make the product SELECT resilient to schema drift by selecting only real columns and deriving missing optional columns from `raw_json`. 

### Description
- Make the products `SELECT` schema-safe by querying `PRAGMA table_info(products)`, building a column list from actual columns, and using `json_extract(raw_json, ...)` fallbacks for missing optional columns like `slug`, `public_slug`, `status`, `visibility`, `enabled`, and `is_public` (in `backend/server.js`).
- Harden the `try/catch` around the merchant feed query to, for `/merchant-feed-debug.json`, log an object with `console.error('[merchant-feed-debug] error', { message, code, stack })` and return the safe debug JSON `{ ok: false, error: 'No se pudo generar merchant feed', debugError: { message, code, stackFirstLine } }` while preserving the generic error response for `/merchant-feed.tsv` (in `backend/server.js`).
- Add tests to `__tests__/backend/merchant-feed.test.js` to assert that `buildMerchantFeedAudit` audits valid rows without producing a generic error, tolerates `raw_json` being null/empty/invalid, and tolerates missing optional fields.

### Testing
- Ran `node --check backend/server.js` and it passed. 
- Ran `node --check backend/utils/merchantFeed.js` and it passed. 
- Ran `npm test -- merchant-feed.test.js` and the test suite passed (`1` test suite, `9` tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a091e3acc408331bb3162753f772b8f)