### PR TITLE
Fix Merchant image URL validation for supplier CDN links

### DIFF
--- a/nerin_final_updated/__tests__/backend/merchant-feed.test.js
+++ b/nerin_final_updated/__tests__/backend/merchant-feed.test.js
@@ -107,4 +107,47 @@ describe('merchant feed audit', () => {
     expect(Array.isArray(audit.samplesEligible)).toBe(true);
     expect(Array.isArray(audit.samplesSkipped)).toBe(true);
   });
+
+  test('acepta URL externa de proveedor con query params', () => {
+    const image = 'https://images.2service.nl/v7/Images/Part/1337/1336958/C1GH82-36387A.jpg?p=p1000x1000&ci_eqs=x&ci_seal=y';
+    const audit = buildMerchantFeedAudit([baseRow({ id: 'gh82', stock: 1, image })]);
+    expect(audit.emittedCount).toBe(1);
+    expect(audit.samplesEligible[0].image_link).toBe(image);
+  });
+
+  test('normaliza URL externa con caracteres especiales', () => {
+    const rawImage = 'https://images.2service.nl/v7/Images/Part/1337/1336958/]C1GH82-36387A.jpg?p=p1000x1000&ci_eqs=x&ci_seal=y';
+    const audit = buildMerchantFeedAudit([baseRow({ id: 'gh82b', image: rawImage })]);
+    expect(audit.emittedCount).toBe(1);
+    expect(audit.samplesEligible[0].image_link).toContain('https://images.2service.nl/');
+  });
+
+  test('convierte ruta relativa propia a dominio público', () => {
+    const audit = buildMerchantFeedAudit([baseRow({ id: 'rel-1', image: '/assets/uploads/products/x.webp' })]);
+    expect(audit.emittedCount).toBe(1);
+    expect(audit.samplesEligible[0].image_link).toBe('https://nerinparts.com.ar/assets/uploads/products/x.webp');
+  });
+
+  test('rechaza data:image, blob y placeholder vacío', () => {
+    const rows = [
+      baseRow({ id: 'bad-data', image: 'data:image/png;base64,aaaa' }),
+      baseRow({ id: 'bad-blob', image: 'blob:https://nerinparts.com.ar/something' }),
+      baseRow({ id: 'bad-empty', image: '   ' }),
+    ];
+    const audit = buildMerchantFeedAudit(rows);
+    expect(audit.skipped.invalidImageUrl).toBe(3);
+    expect(audit.samplesSkipped.some((item) => item.id === 'bad-data' && item.reason.includes('dataImage'))).toBe(true);
+    expect(audit.samplesSkipped.some((item) => item.id === 'bad-blob' && item.reason.includes('blobUrl'))).toBe(true);
+    expect(audit.samplesSkipped.some((item) => item.id === 'bad-empty' && item.reason.includes('empty'))).toBe(true);
+  });
+
+  test('producto público con imagen externa válida y stock/preorder válido aparece en samplesEligible', () => {
+    const audit = buildMerchantFeedAudit([
+      baseRow({ id: 'ok-ext', image: 'https://images.2service.nl/v7/Images/Part/1/img.jpg', stock: 0, raw_json: JSON.stringify({ allow_backorder: true }) }),
+    ]);
+    expect(audit.emittedCount).toBe(1);
+    expect(audit.samplesEligible[0].id).toBe('ok-ext');
+    expect(audit.samplesEligible[0].image_link).toBe('https://images.2service.nl/v7/Images/Part/1/img.jpg');
+    expect(['in_stock', 'preorder']).toContain(audit.samplesEligible[0].availability);
+  });
 });

--- a/nerin_final_updated/backend/utils/merchantFeed.js
+++ b/nerin_final_updated/backend/utils/merchantFeed.js
@@ -57,6 +57,32 @@ function isValidFeedUrl(v) {
   return /^https?:\/\//i.test(v);
 }
 
+function normalizeMerchantImageUrl(value, baseUrl = 'https://nerinparts.com.ar') {
+  const raw = String(value || '').trim();
+  if (!raw) return { valid: false, reason: 'empty', normalized: '' };
+  if (/^data:image/i.test(raw)) return { valid: false, reason: 'dataImage', normalized: '' };
+  if (/^blob:/i.test(raw)) return { valid: false, reason: 'blobUrl', normalized: '' };
+  if (/^javascript:/i.test(raw)) return { valid: false, reason: 'javascriptUrl', normalized: '' };
+  if (/^base64[,;]/i.test(raw)) return { valid: false, reason: 'base64Placeholder', normalized: '' };
+
+  const candidate = /^https?:\/\//i.test(raw)
+    ? raw
+    : `${String(baseUrl || 'https://nerinparts.com.ar').replace(/\/+$/, '')}/${raw.replace(/^\/+/, '')}`;
+
+  const attempts = [candidate, encodeURI(candidate)];
+  for (const attempt of attempts) {
+    try {
+      const parsed = new URL(attempt);
+      if (!/^https?:$/i.test(parsed.protocol)) continue;
+      if (!parsed.hostname || !parsed.hostname.includes('.')) continue;
+      return { valid: true, reason: null, normalized: parsed.toString() };
+    } catch {
+      // keep trying
+    }
+  }
+  return { valid: false, reason: 'invalidUrl', normalized: attempts[1] || candidate };
+}
+
 function getSkipTemplate() {
   return {
     notPublic: 0, privateOrHidden: 0, disabled: 0, deleted: 0, archived: 0, draft: 0, vipOnly: 0, wholesaleOnly: 0,
@@ -115,10 +141,29 @@ function buildMerchantFeedAudit(rows, { limit = 500, offset = 0, preorderDays = 
     const link = slug ? `${baseUrl}/p/${encodeURIComponent(slug)}` : '';
     if (!link) { skipped.missingLink += 1; pushSample(samplesSkipped, { id: identifier, reason: 'missingLink' }); continue; }
 
-    const imageCandidates = [row.image, raw.image, ...(Array.isArray(raw.images) ? raw.images : [])].filter(Boolean);
+    const imageCandidates = [
+      row.image,
+      row.image_url,
+      raw.image,
+      raw.image_url,
+      ...(Array.isArray(raw.images) ? raw.images : []),
+    ].filter(Boolean);
     if (!imageCandidates.length) { skipped.missingImage += 1; pushSample(samplesSkipped, { id: identifier, reason: 'missingImage' }); continue; }
-    const imageLink = String(imageCandidates[0]);
-    if (!isValidFeedUrl(imageLink)) { skipped.invalidImageUrl += 1; pushSample(samplesSkipped, { id: identifier, reason: 'invalidImageUrl' }); continue; }
+    const rawImage = String(imageCandidates[0]);
+    const normalizedImage = normalizeMerchantImageUrl(rawImage, baseUrl);
+    if (!normalizedImage.valid) {
+      skipped.invalidImageUrl += 1;
+      pushSample(samplesSkipped, {
+        id: row.id || identifier,
+        sku: row.sku || raw.sku || null,
+        title,
+        rawImage,
+        normalizedImageAttempt: normalizedImage.normalized,
+        reason: `invalidImageUrl:${normalizedImage.reason}`,
+      });
+      continue;
+    }
+    const imageLink = normalizedImage.normalized;
 
     const priceNum = Number(row.precio_final ?? row.price_minorista ?? row.precio_minorista ?? row.price ?? raw.precio_final ?? raw.price_minorista ?? raw.price);
     if ((row.price == null && raw.price == null && row.precio_final == null && raw.precio_final == null)) { skipped.missingPrice += 1; pushSample(samplesSkipped, { id: identifier, reason: 'missingPrice' }); continue; }
@@ -165,4 +210,4 @@ function buildMerchantFeedAudit(rows, { limit = 500, offset = 0, preorderDays = 
   };
 }
 
-module.exports = { GOOGLE_CATEGORY, mapProductTypeToFeed, buildMerchantTitle, computeAvailability, isEligibleState, cleanText, detectProductType, buildMerchantFeedAudit };
+module.exports = { GOOGLE_CATEGORY, mapProductTypeToFeed, buildMerchantTitle, computeAvailability, isEligibleState, cleanText, detectProductType, buildMerchantFeedAudit, normalizeMerchantImageUrl, isValidFeedUrl };


### PR DESCRIPTION
### Motivation
- Merchant feed was rejecting many valid supplier CDN image URLs and URLs with query params or special characters, causing valid products to be marked `invalidImageUrl`.
- The intent is to accept absolute `http/https` supplier links, convert internal relative paths to the public domain, and normalize uncommon characters without breaking query params.

### Description
- Added `normalizeMerchantImageUrl(value, baseUrl)` to safely accept/normalize absolute `http/https` URLs and convert relative paths to the configured `baseUrl`, with an `encodeURI` fallback and strict `new URL()` validation for protocol/hostname.
- Expanded image candidate detection to include `image_url` fields from both row and raw payloads and use the normalized URL as the feed `image_link`.
- Reject only the specified cases (`empty`, `data:image`, `blob:`, `javascript:`, base64 placeholder, or unparseable/invalid host) and surface a specific reason as `invalidImageUrl:<reason>`.
- Enhanced debug samples for skipped images to include `id`, `sku`, `title`, `rawImage`, `normalizedImageAttempt`, and `reason`, while keeping `samplesEligible` containing the final emitted `image_link`.
- Exported `normalizeMerchantImageUrl` and `isValidFeedUrl` from the module and added unit tests covering external supplier URLs with query params, URLs with special characters, relative path conversion, rejections for `data:`/`blob:`/empty, and a public product with an external image plus stock/preorder eligibility.

### Testing
- Ran `node --check nerin_final_updated/backend/utils/merchantFeed.js` and it completed without errors.
- Ran `node --check backend/server.js` and it completed without errors.
- Ran `cd nerin_final_updated && npm test -- merchant-feed.test.js` and the test suite passed: `Test Suites: 1 passed, 1 total`, `Tests: 14 passed, 14 total`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a096e44e938833180faf331b06299d5)