### PR TITLE
Fix Merchant audit counts, preorder availability and text encoding

### DIFF
--- a/nerin_final_updated/__tests__/backend/merchant-feed.test.js
+++ b/nerin_final_updated/__tests__/backend/merchant-feed.test.js
@@ -1,4 +1,4 @@
-const { buildMerchantFeedAudit } = require('../../backend/utils/merchantFeed');
+const { buildMerchantFeedAudit, safeMerchantText } = require('../../backend/utils/merchantFeed');
 
 function baseRow(overrides = {}, raw = {}) {
   return {
@@ -50,12 +50,35 @@ describe('merchant feed audit', () => {
   test('stock > 0 => in_stock', () => {
     const audit = buildMerchantFeedAudit([baseRow({ stock: 5 })]);
     expect(audit.samplesEligible[0].availability).toBe('in_stock');
+    expect(audit.samplesEligible[0].availability_date).toBeNull();
   });
 
   test('stock 0 vendible a pedido => preorder + availability_date', () => {
-    const audit = buildMerchantFeedAudit([baseRow({ stock: 0, raw_json: JSON.stringify({ allow_backorder: true }) })]);
+    const audit = buildMerchantFeedAudit([baseRow({ stock: 0 })]);
     expect(audit.samplesEligible[0].availability).toBe('preorder');
     expect(audit.samplesEligible[0].availability_date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+  test('contadores reales pueden ser mayores al lote escaneado', () => {
+    const rows = [baseRow({ id: 'a' }), baseRow({ id: 'b', is_public: 0 })];
+    const audit = buildMerchantFeedAudit(rows, { totalCatalogProducts: 52000, publicProductsCount: 12000, limit: 5, offset: 3 });
+    expect(audit.totalCatalogProducts).toBe(52000);
+    expect(audit.publicProductsCount).toBe(12000);
+    expect(audit.scannedRows).toBe(2);
+    expect(audit.limit).toBe(5);
+    expect(audit.offset).toBe(3);
+  });
+
+  test('producto público stock 0 con imagen externa válida no cae en missingAvailability', () => {
+    const audit = buildMerchantFeedAudit([
+      baseRow({ id: 'pre-ext', stock: 0, image: 'https://images.2service.nl/v7/Images/Part/1/img.jpg' }),
+    ]);
+    expect(audit.skipped.missingAvailability).toBe(0);
+    expect(audit.emittedCount).toBe(1);
+    expect(audit.samplesEligible[0].availability).toBe('preorder');
+  });
+
+  test('safeMerchantText corrige mojibake típico', () => {
+    expect(safeMerchantText('MÃ³dulo Pantalla')).toBe('Módulo Pantalla');
   });
 
   test('taxonomía clasifica casos solicitados', () => {

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -12507,6 +12507,7 @@ async function requestHandler(req, res) {
     const stats = { missingImage: 0, missingPrice: 0, missingSlug: 0, privateOrHidden: 0, nonSellable: 0, emitted: 0 };
     const sample = [];
     let totalCatalogProducts = 0;
+    let publicProductsCount = 0;
     let eligibleCount = 0;
     let allRows = [];
     const { GOOGLE_CATEGORY, mapProductTypeToFeed, buildMerchantTitle, computeAvailability, isEligibleState, detectProductType, buildMerchantFeedAudit } = require('./utils/merchantFeed');
@@ -12516,6 +12517,8 @@ async function requestHandler(req, res) {
       dbConn = await openSqliteReadonly(productsSqliteRepo.SQLITE_PATH);
       const totalRows = await sqliteAll(dbConn, 'SELECT COUNT(*) AS c FROM products');
       totalCatalogProducts = Number(totalRows?.[0]?.c || 0);
+      const publicRows = await sqliteAll(dbConn, "SELECT COUNT(*) AS c FROM products WHERE (is_public = 1 OR json_extract(raw_json, '$.is_public') = 1 OR lower(json_extract(raw_json, '$.publicable')) = 'true')");
+      publicProductsCount = Number(publicRows?.[0]?.c || 0);
       const productColumns = await sqliteAll(dbConn, 'PRAGMA table_info(products)');
       const availableColumns = new Set((productColumns || []).map((col) => String(col?.name || '').trim()).filter(Boolean));
       const preferredColumns = [
@@ -12605,6 +12608,8 @@ async function requestHandler(req, res) {
         offset: emittedOffset,
         preorderDays,
         baseUrl,
+        totalCatalogProducts,
+        publicProductsCount,
       });
       return sendJson(res, 200, audit);
     }

--- a/nerin_final_updated/backend/utils/merchantFeed.js
+++ b/nerin_final_updated/backend/utils/merchantFeed.js
@@ -3,9 +3,22 @@ const { detectProductType } = require('./productTaxonomy');
 const GOOGLE_CATEGORY = 'Electrónica > Comunicaciones > Telefonía > Accesorios para móviles';
 const VALID_AVAILABILITY = new Set(['in_stock', 'preorder']);
 
-function cleanText(value, max = 150) {
-  const text = String(value || '').replace(/\s+/g, ' ').trim();
+function safeMerchantText(value, max = 150) {
+  const mojibakeFixes = [
+    ['MÃ³dulo', 'Módulo'],
+    ['BaterÃ­a', 'Batería'],
+    ['CÃ¡mara', 'Cámara'],
+    ['TelÃ©fono', 'Teléfono'],
+  ];
+  let text = String(value || '');
+  for (const [bad, good] of mojibakeFixes) text = text.split(bad).join(good);
+  text = text.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, ' ');
+  text = text.replace(/\s+/g, ' ').trim();
   return text.slice(0, max);
+}
+
+function cleanText(value, max = 150) {
+  return safeMerchantText(value, max);
 }
 
 function toBool(v) { return v === true || v === 1 || String(v).toLowerCase() === 'true'; }
@@ -31,14 +44,12 @@ function mapProductTypeToFeed(label) {
 }
 
 function buildMerchantTitle(row, raw) {
-  return cleanText(row.name || row.title || raw.name || raw.title || raw.description || '');
+  return safeMerchantText(row.name || row.title || raw.name || raw.title || raw.description || '');
 }
 
 function computeAvailability(row, raw, preorderDays = 30) {
   const stockLocal = Number(row.stock ?? raw.stock ?? 0);
-  const sellableRemote = Number(raw.remote_stock ?? raw.stock_remote ?? raw.available_remote ?? 0) > 0 || toBool(raw.allow_backorder) || toBool(raw.sellable_on_demand) || String(raw.availability || '').toLowerCase() === 'preorder';
   if (stockLocal > 0) return { availability: 'in_stock', availabilityDate: '' };
-  if (!sellableRemote) return { availability: null, availabilityDate: '' };
   const existingDate = String(raw.availability_date || raw.preorder_date || '').trim();
   if (existingDate) return { availability: 'preorder', availabilityDate: existingDate };
   const d = new Date(Date.now() + Number(preorderDays) * 86400000).toISOString().slice(0, 10);
@@ -95,7 +106,7 @@ function pushSample(bucket, entry, max = 10) {
   if (bucket.length < max) bucket.push(entry);
 }
 
-function buildMerchantFeedAudit(rows, { limit = 500, offset = 0, preorderDays = 30, baseUrl = 'https://nerinparts.com.ar' } = {}) {
+function buildMerchantFeedAudit(rows, { limit = 500, offset = 0, preorderDays = 30, baseUrl = 'https://nerinparts.com.ar', totalCatalogProducts = null, publicProductsCount = null } = {}) {
   const skipped = getSkipTemplate();
   const samplesEligible = [];
   const samplesSkipped = [];
@@ -104,7 +115,7 @@ function buildMerchantFeedAudit(rows, { limit = 500, offset = 0, preorderDays = 
   const sanitizedLimit = Math.max(1, Number(limit) || 500);
   const sanitizedOffset = Math.max(0, Number(offset) || 0);
 
-  let publicProductsCount = 0;
+  let publicProductsInScan = 0;
   let eligibleCount = 0;
   let emittedCount = 0;
 
@@ -117,7 +128,7 @@ function buildMerchantFeedAudit(rows, { limit = 500, offset = 0, preorderDays = 
       pushSample(samplesSkipped, { id: row.id || row.sku || null, reason: 'notPublic' });
       continue;
     }
-    publicProductsCount += 1;
+    publicProductsInScan += 1;
 
     const flags = [row.status, row.visibility, raw.status, raw.visibility].filter(Boolean).join(' ').toLowerCase();
     if (toBool(raw.private) || toBool(raw.hidden) || /private|hidden/.test(flags)) { skipped.privateOrHidden += 1; pushSample(samplesSkipped, { id: row.id || row.sku || null, reason: 'privateOrHidden' }); continue; }
@@ -134,7 +145,7 @@ function buildMerchantFeedAudit(rows, { limit = 500, offset = 0, preorderDays = 
     const title = buildMerchantTitle(row, raw);
     if (!title) { skipped.missingTitle += 1; pushSample(samplesSkipped, { id: identifier, reason: 'missingTitle' }); continue; }
 
-    const description = cleanText(row.description || raw.description || `${title} disponible en NERIN Parts.`, 5000);
+    const description = safeMerchantText(row.description || raw.description || `${title} disponible en NERIN Parts.`, 5000);
     if (!description) { skipped.missingDescription += 1; pushSample(samplesSkipped, { id: identifier, reason: 'missingDescription' }); continue; }
 
     const slug = String(row.public_slug || row.slug || raw.public_slug || raw.slug || '').trim();
@@ -170,7 +181,23 @@ function buildMerchantFeedAudit(rows, { limit = 500, offset = 0, preorderDays = 
     if (!Number.isFinite(priceNum) || priceNum <= 0) { skipped.invalidPrice += 1; pushSample(samplesSkipped, { id: identifier, reason: 'invalidPrice' }); continue; }
 
     const av = computeAvailability(row, raw, preorderDays);
-    if (!av.availability) { skipped.missingAvailability += 1; pushSample(samplesSkipped, { id: identifier, reason: 'missingAvailability' }); continue; }
+    if (!av.availability) { skipped.missingAvailability += 1; pushSample(samplesSkipped, {
+      id: identifier,
+      title,
+      stock: Number(row.stock ?? raw.stock ?? 0),
+      status: row.status ?? raw.status ?? null,
+      visibility: row.visibility ?? raw.visibility ?? null,
+      enabled: row.enabled ?? raw.enabled ?? null,
+      stock_mode: raw.stock_mode ?? null,
+      fulfillment_mode: raw.fulfillment_mode ?? null,
+      rawAvailabilitySignals: {
+        remote_stock: raw.remote_stock ?? raw.stock_remote ?? raw.available_remote ?? null,
+        sellable_on_demand: raw.sellable_on_demand ?? null,
+        allow_backorder: raw.allow_backorder ?? null,
+        availability: raw.availability ?? null,
+      },
+      reason: 'missingAvailability',
+    }); continue; }
     if (!VALID_AVAILABILITY.has(av.availability)) { skipped.invalidAvailability += 1; pushSample(samplesSkipped, { id: identifier, reason: 'invalidAvailability' }); continue; }
 
     const lowerTitle = title.toLowerCase();
@@ -191,12 +218,12 @@ function buildMerchantFeedAudit(rows, { limit = 500, offset = 0, preorderDays = 
     emittedCount += 1;
     productTypeBreakdown[productType] = (productTypeBreakdown[productType] || 0) + 1;
     availabilityBreakdown[av.availability] = (availabilityBreakdown[av.availability] || 0) + 1;
-    pushSample(samplesEligible, { id: identifier, title, productType, availability: av.availability, availability_date: av.availabilityDate || null, price: `${priceNum.toFixed(2)} ARS`, link, image_link: imageLink });
+    pushSample(samplesEligible, { id: identifier, title, productType, availability: av.availability, availability_date: av.availabilityDate || null, price: `${priceNum.toFixed(2)} ARS`, link, image_link: imageLink, stock: Number(row.stock ?? raw.stock ?? 0) });
   }
 
   return {
-    totalCatalogProducts: rows.length,
-    publicProductsCount,
+    totalCatalogProducts: Number.isFinite(Number(totalCatalogProducts)) ? Number(totalCatalogProducts) : rows.length,
+    publicProductsCount: Number.isFinite(Number(publicProductsCount)) ? Number(publicProductsCount) : publicProductsInScan,
     scannedRows: rows.length,
     eligibleCount,
     emittedCount,
@@ -210,4 +237,4 @@ function buildMerchantFeedAudit(rows, { limit = 500, offset = 0, preorderDays = 
   };
 }
 
-module.exports = { GOOGLE_CATEGORY, mapProductTypeToFeed, buildMerchantTitle, computeAvailability, isEligibleState, cleanText, detectProductType, buildMerchantFeedAudit, normalizeMerchantImageUrl, isValidFeedUrl };
+module.exports = { GOOGLE_CATEGORY, mapProductTypeToFeed, buildMerchantTitle, computeAvailability, isEligibleState, cleanText, safeMerchantText, detectProductType, buildMerchantFeedAudit, normalizeMerchantImageUrl, isValidFeedUrl };


### PR DESCRIPTION
### Motivation

- The merchant audit/debug endpoint was returning counts and samples based only on the scanned batch instead of real SQLite totals and was excluding many public preorder-capable products.  
- Titles/descriptions in the merchant feed showed mojibake and control-character issues that need sanitization for feed consumers.  
- Debug output lacked useful signals for diagnosing why public products were being marked as missing availability.

### Description

- Read real catalog counts in the feed handler and pass them into the auditor so `/merchant-feed-debug.json` reports `totalCatalogProducts` from `SELECT COUNT(*) FROM products` and `publicProductsCount` from a proper `COUNT` of public products (changes in `backend/server.js`).
- Extend `buildMerchantFeedAudit` to accept `totalCatalogProducts` and `publicProductsCount` and keep `scannedRows` tied to the evaluated batch while preserving request `limit` and `offset` (changes in `backend/utils/merchantFeed.js`).
- Introduce `safeMerchantText` and use it for title/description to normalize whitespace, strip control chars, and correct common mojibake sequences such as `MÃ³dulo`→`Módulo` without touching the DB (changes in `backend/utils/merchantFeed.js`).
- Update availability logic so `stock > 0` yields `in_stock` (no date) and `stock == 0` for public/sellable items yields `preorder` with an explicit `availability_date` taken from existing signals or generated using `MERCHANT_PREORDER_DAYS` (default 30), and include stock-mode/remote signals in debug output for troubleshooting (changes in `backend/utils/merchantFeed.js`).
- Improve debug samples: `samplesEligible` now includes `stock`, and `samplesSkipped` entries for missing availability include `id`, `title`, `stock`, `status`, `visibility`, `enabled`, `stock_mode`, `fulfillment_mode` and raw availability signals to aid debugging (changes in `backend/utils/merchantFeed.js`).
- Tests updated/added to validate count semantics, preorder behavior for stock=0, in_stock behavior for stock>0, external-image + preorder eligibility, and `safeMerchantText` mojibake correction (changes in `__tests__/backend/merchant-feed.test.js`).

### Testing

- Ran syntax checks with `node --check backend/server.js` and `node --check backend/utils/merchantFeed.js`, both succeeded.  
- Ran unit tests with `npm test -- merchant-feed.test.js` and all tests passed (`17 passed`).  
- The modified debug endpoint now returns real `totalCatalogProducts` and `publicProductsCount` when the server supplies them, and the new tests exercise the preorder and text-sanitization behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09bd9134408331a0936645c551e14a)