### PR TITLE
Refactor merchant feed entry generation and add TSV payload tests

### DIFF
--- a/nerin_final_updated/__tests__/backend/merchant-feed.test.js
+++ b/nerin_final_updated/__tests__/backend/merchant-feed.test.js
@@ -1,4 +1,4 @@
-const { buildMerchantFeedAudit, safeMerchantText } = require('../../backend/utils/merchantFeed');
+const { buildMerchantFeedAudit, buildMerchantFeedEntries, safeMerchantText } = require('../../backend/utils/merchantFeed');
 
 function baseRow(overrides = {}, raw = {}) {
   return {
@@ -173,4 +173,86 @@ describe('merchant feed audit', () => {
     expect(audit.samplesEligible[0].image_link).toBe('https://images.2service.nl/v7/Images/Part/1/img.jpg');
     expect(['in_stock', 'preorder']).toContain(audit.samplesEligible[0].availability);
   });
+});
+
+
+describe('merchant feed tsv payload', () => {
+  test('usa misma elegibilidad que debug', () => {
+    const rows = [
+      baseRow({ id: 'ok-1' }),
+      baseRow({ id: 'bad-hidden', raw_json: JSON.stringify({ hidden: true }) }),
+      baseRow({ id: 'bad-no-image', image: null }),
+    ];
+    const audit = buildMerchantFeedAudit(rows, { limit: 50, offset: 0 });
+    const tsv = buildMerchantFeedEntries(rows, { limit: 50, offset: 0 });
+    expect(tsv.audit.eligibleCount).toBe(audit.eligibleCount);
+    expect(tsv.entries.length).toBe(audit.emittedCount);
+  });
+
+  test('preorder e in_stock availability_date correcto y headers esperados', () => {
+    const rows = [baseRow({ id: 'stk', stock: 3 }), baseRow({ id: 'pre', stock: 0 })];
+    const { entries } = buildMerchantFeedEntries(rows);
+    const byId = Object.fromEntries(entries.map((e) => [e.id, e]));
+    expect(byId.stk.availability).toBe('in_stock');
+    expect(byId.stk.availability_date).toBe('');
+    expect(byId.pre.availability).toBe('preorder');
+    expect(byId.pre.availability_date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(Object.keys(entries[0])).toEqual(['id','title','description','link','image_link','additional_image_link','availability','availability_date','price','condition','brand','mpn','identifier_exists','google_product_category','product_type']);
+  });
+
+  test('limpia mojibake y no duplica additional_image_link', () => {
+    const rows = [
+      baseRow({ id: 'moji', name: 'MÃ³dulo CÃ¡maras', image: 'https://a.com/x.jpg', raw_json: JSON.stringify({ images: ['https://a.com/x.jpg', 'https://a.com/y.jpg'] }) }),
+      baseRow({ id: 'comp', name: 'Componente electrÃ³nico IC PMIC' }),
+      baseRow({ id: 'cam', name: 'CÃ¡mara trasera iPhone' }),
+    ];
+    const { entries } = buildMerchantFeedEntries(rows);
+    const byId = Object.fromEntries(entries.map((e) => [e.id, e]));
+    expect(byId.moji.title).toContain('Módulo');
+    expect(byId.moji.title).toContain('Cámaras');
+    expect(byId.moji.additional_image_link).toBe('https://a.com/y.jpg');
+    expect(byId.comp.product_type).toBe('Componentes electrónicos');
+    expect(byId.cam.product_type).toBe('Cámaras y lentes');
+  });
+
+
+  test('additional_image_link excluye principal, deduplica y descarta inválidas', () => {
+    const rows = [baseRow({
+      id: 'img-dedupe',
+      image: 'https://img.cdn.com/a.webp',
+      raw_json: JSON.stringify({
+        image: 'https://img.cdn.com/a.webp',
+        images: [
+          'https://img.cdn.com/a.webp',
+          'https://img.cdn.com/a.webp#fragment',
+          'data:image/png;base64,aaaa',
+          'blob:https://img.cdn.com/abc',
+          '   ',
+          'https://img.cdn.com/b.webp',
+          'https://img.cdn.com/b.webp',
+          'https://img.cdn.com/c.webp'
+        ],
+      }),
+    })];
+    const { entries } = buildMerchantFeedEntries(rows);
+    expect(entries[0].additional_image_link).toBe('https://img.cdn.com/b.webp,https://img.cdn.com/c.webp');
+    expect(entries[0].additional_image_link.includes(entries[0].image_link)).toBe(false);
+  });
+
+  test('additional_image_link vacío si solo existe imagen principal', () => {
+    const { entries } = buildMerchantFeedEntries([baseRow({ id: 'single-img', image: 'https://img.cdn.com/main.webp' })]);
+    expect(entries[0].additional_image_link).toBe('');
+  });
+
+  test('display incl battery prioriza Pantallas; battery puro queda Baterias', () => {
+    const rows = [
+      baseRow({ id: 'disp-batt', name: 'Display incl. battery (Original) - Black, Huawei Y5 (2017)' }),
+      baseRow({ id: 'batt-main', name: 'Battery (Original), Apple iPhone 14' }),
+    ];
+    const { entries } = buildMerchantFeedEntries(rows);
+    const byId = Object.fromEntries(entries.map((e) => [e.id, e.product_type]));
+    expect(byId['disp-batt']).toBe('Pantallas');
+    expect(byId['batt-main']).toBe('Baterias');
+  });
+
 });

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -12510,7 +12510,7 @@ async function requestHandler(req, res) {
     let publicProductsCount = 0;
     let eligibleCount = 0;
     let allRows = [];
-    const { GOOGLE_CATEGORY, mapProductTypeToFeed, buildMerchantTitle, computeAvailability, isEligibleState, detectProductType, buildMerchantFeedAudit } = require('./utils/merchantFeed');
+    const { buildMerchantFeedAudit, buildMerchantFeedEntries } = require('./utils/merchantFeed');
     let dbConn;
     try {
       await productsSqliteRepo.ensureProductsDbOnce();
@@ -12544,35 +12544,28 @@ async function requestHandler(req, res) {
       }
       const selectSql = `SELECT ${selectedColumns.join(',')} FROM products ORDER BY rowid ASC LIMIT ? OFFSET ?`;
       allRows = await sqliteAll(dbConn, selectSql, [emittedLimit + emittedOffset + 2000, 0]);
-      for (const row of allRows) {
-        let raw = {};
-        try { raw = JSON.parse(row.raw_json || '{}'); } catch {}
-        if (!isEligibleState(row, raw)) { stats.privateOrHidden += 1; continue; }
-        const identifier = String(row.sku || row.id || raw.sku || raw.id || '').trim();
-        const title = buildMerchantTitle(row, raw);
-        const priceNum = Number(row.precio_final ?? row.price_minorista ?? row.precio_minorista ?? row.price ?? raw.precio_final ?? raw.price_minorista ?? raw.price);
-        const slug = String(row.public_slug || row.slug || raw.public_slug || raw.slug || '').trim();
-        const link = `${baseUrl}/p/${encodeURIComponent(slug)}`;
-        const images = [row.image, raw.image, ...(Array.isArray(raw.images) ? raw.images : [])].filter(Boolean).map((v) => absoluteUrl(v, baseUrl)).filter((v) => isValidFeedUrl(v));
-        if (!slug || !isValidFeedUrl(link)) { stats.missingSlug += 1; continue; }
-        if (!Number.isFinite(priceNum) || priceNum <= 0) { stats.missingPrice += 1; continue; }
-        if (!allowMissingImages && !images.length) { stats.missingImage += 1; continue; }
-        const av = computeAvailability(row, raw, preorderDays);
-        if (!identifier || !title || !av.availability) { stats.nonSellable += 1; continue; }
-        eligibleCount += 1;
-        if (eligibleCount <= emittedOffset) continue;
-        if (stats.emitted >= emittedLimit) continue;
-        const productTypeDetected = detectProductType({ ...raw, ...row, title, name: title, category: row.category || raw.category || '' });
-        const productType = mapProductTypeToFeed(productTypeDetected);
-        const brand = String(row.brand || raw.brand || '').trim();
-        const mpn = String(row.mpn || row.part_number || raw.mpn || identifier).trim();
-        const hasIdentifier = Boolean((raw.gtin && String(raw.gtin).trim()) || (brand && mpn));
-        const additional = images.slice(1, 11).join(',');
-        const description = `${title} disponible en NERIN Parts. Verificá compatibilidad, código de pieza y disponibilidad antes de comprar.`;
-        rows.push([identifier,title,description,link,images[0] || '',additional,av.availability,av.availabilityDate || '',`${priceNum.toFixed(2)} ARS`,classifyCondition(raw, title),brand,mpn,hasIdentifier ? 'yes' : 'no',GOOGLE_CATEGORY,productType].map(toTsvCell).join('	'));
+      const feedPayload = buildMerchantFeedEntries(allRows, {
+        limit: emittedLimit,
+        offset: emittedOffset,
+        preorderDays,
+        baseUrl,
+      });
+      const entries = feedPayload.entries;
+      eligibleCount = feedPayload.audit.eligibleCount;
+      for (const entry of entries) {
+        rows.push([
+          entry.id, entry.title, entry.description, entry.link, entry.image_link, entry.additional_image_link,
+          entry.availability, entry.availability_date, entry.price, entry.condition, entry.brand, entry.mpn,
+          entry.identifier_exists, entry.google_product_category, entry.product_type,
+        ].map(toTsvCell).join('	'));
         stats.emitted += 1;
-        if (sample.length < 10) sample.push({ id: row.id || null, sku: row.sku || null, title, productType, price: priceNum, availability: av.availability, link });
+        if (sample.length < 10) sample.push({ id: entry.id, title: entry.title, productType: entry.product_type, price: entry.price, availability: entry.availability, link: entry.link });
       }
+      stats.missingImage = feedPayload.audit.skipped.missingImage + feedPayload.audit.skipped.invalidImageUrl;
+      stats.missingPrice = feedPayload.audit.skipped.missingPrice + feedPayload.audit.skipped.invalidPrice;
+      stats.missingSlug = feedPayload.audit.skipped.missingLink;
+      stats.privateOrHidden = feedPayload.audit.skipped.privateOrHidden + feedPayload.audit.skipped.notPublic;
+      stats.nonSellable = feedPayload.audit.skipped.missingId + feedPayload.audit.skipped.missingTitle + feedPayload.audit.skipped.missingDescription + feedPayload.audit.skipped.missingAvailability + feedPayload.audit.skipped.invalidAvailability + feedPayload.audit.skipped.taxonomyBlocked;
     } catch (error) {
       if (dbConn) { try { dbConn.close(); } catch {} }
       if (pathname === '/merchant-feed-debug.json') {

--- a/nerin_final_updated/backend/utils/merchantFeed.js
+++ b/nerin_final_updated/backend/utils/merchantFeed.js
@@ -9,6 +9,9 @@ function safeMerchantText(value, max = 150) {
     ['BaterÃ­a', 'Batería'],
     ['CÃ¡mara', 'Cámara'],
     ['TelÃ©fono', 'Teléfono'],
+    ['CÃ¡maras', 'Cámaras'],
+    ['electrÃ³nicos', 'electrónicos'],
+    ['ReparaciÃ³n', 'Reparación'],
   ];
   let text = String(value || '');
   for (const [bad, good] of mojibakeFixes) text = text.split(bad).join(good);
@@ -106,6 +109,91 @@ function pushSample(bucket, entry, max = 10) {
   if (bucket.length < max) bucket.push(entry);
 }
 
+
+function normalizeComparableUrl(url) {
+  try {
+    const parsed = new URL(String(url || '').trim());
+    parsed.hash = '';
+    return parsed.toString();
+  } catch {
+    return String(url || '').trim();
+  }
+}
+
+function detectMerchantProductType(row, raw, title) {
+  const lowerTitle = String(title || '').toLowerCase();
+  let productTypeDetected = detectProductType({ ...raw, ...row, title, name: title, category: row.category || raw.category || '' });
+  if (/display\s*(incl\.?|with|\+)\s*battery/.test(lowerTitle)) productTypeDetected = 'Pantalla / display';
+  if (/adhesive\s*tape\s*display/.test(lowerTitle)) productTypeDetected = 'Adhesivo para pantalla';
+  if (/charging\s*board|charge\s*port|dock\s*connector/.test(lowerTitle)) productTypeDetected = 'Placa / pin de carga';
+  if (/\bbattery\b/.test(lowerTitle) && !/display\s*(incl\.?|with|\+)\s*battery/.test(lowerTitle)) productTypeDetected = 'Batería';
+  return productTypeDetected;
+}
+
+function extractRaw(row) {
+  let raw = {};
+  try { raw = JSON.parse(row.raw_json || '{}'); } catch {}
+  return raw;
+}
+
+function buildMerchantFeedEntries(rows, { limit = 500, offset = 0, preorderDays = 30, baseUrl = 'https://nerinparts.com.ar' } = {}) {
+  const audit = buildMerchantFeedAudit(rows, { limit, offset, preorderDays, baseUrl });
+  const entries = [];
+  const sanitizedLimit = Math.max(1, Number(limit) || 500);
+  const sanitizedOffset = Math.max(0, Number(offset) || 0);
+  let eligibleCount = 0;
+  for (const row of rows) {
+    const raw = extractRaw(row);
+    if (!isEligibleState(row, raw)) continue;
+    const identifier = String(row.sku || row.id || row.mpn || row.part_number || raw.sku || raw.id || raw.mpn || raw.part_number || '').trim();
+    if (!identifier) continue;
+    const title = safeMerchantText(buildMerchantTitle(row, raw));
+    if (!title) continue;
+    const description = safeMerchantText(row.description || raw.description || `${title} disponible en NERIN Parts.`, 5000);
+    if (!description) continue;
+    const slug = String(row.public_slug || row.slug || raw.public_slug || raw.slug || '').trim();
+    const link = slug ? `${baseUrl}/p/${encodeURIComponent(slug)}` : '';
+    if (!link || !isValidFeedUrl(link)) continue;
+    const imageCandidates = [row.image,row.image_url,raw.image,raw.image_url,...(Array.isArray(raw.images) ? raw.images : [])].filter(Boolean);
+    if (!imageCandidates.length) continue;
+    const primary = normalizeMerchantImageUrl(String(imageCandidates[0]), baseUrl);
+    if (!primary.valid) continue;
+    const image_link = primary.normalized;
+    const additional = [];
+    const seenImages = new Set([normalizeComparableUrl(image_link)]);
+    for (const img of imageCandidates.slice(1)) {
+      const n = normalizeMerchantImageUrl(String(img), baseUrl);
+      if (!n.valid) continue;
+      const key = normalizeComparableUrl(n.normalized);
+      if (seenImages.has(key)) continue;
+      seenImages.add(key);
+      additional.push(n.normalized);
+      if (additional.length >= 10) break;
+    }
+    const priceNum = Number(row.precio_final ?? row.price_minorista ?? row.precio_minorista ?? row.price ?? raw.precio_final ?? raw.price_minorista ?? raw.price);
+    if (!Number.isFinite(priceNum) || priceNum <= 0) continue;
+    const av = computeAvailability(row, raw, preorderDays);
+    if (!VALID_AVAILABILITY.has(av.availability)) continue;
+    if (av.availability === 'preorder' && !String(av.availabilityDate || '').match(/^\d{4}-\d{2}-\d{2}$/)) continue;
+    const productTypeDetected = detectMerchantProductType(row, raw, title);
+    const product_type = safeMerchantText(mapProductTypeToFeed(productTypeDetected));
+    if (!product_type) continue;
+    eligibleCount += 1;
+    if (eligibleCount <= sanitizedOffset || entries.length >= sanitizedLimit) continue;
+    const brand = safeMerchantText(String(row.brand || raw.brand || '').trim(), 70);
+    const mpn = safeMerchantText(String(row.mpn || row.part_number || row.sku || raw.mpn || raw.part_number || raw.sku || '').trim(), 70);
+    const identifier_exists = (brand && mpn) ? 'yes' : 'no';
+    entries.push({
+      id: identifier, title, description, link, image_link,
+      additional_image_link: additional.join(','), availability: av.availability,
+      availability_date: av.availability === 'preorder' ? av.availabilityDate : '',
+      price: `${priceNum.toFixed(2)} ARS`, condition: 'new', brand, mpn, identifier_exists,
+      google_product_category: GOOGLE_CATEGORY, product_type,
+    });
+  }
+  return { entries, audit };
+}
+
 function buildMerchantFeedAudit(rows, { limit = 500, offset = 0, preorderDays = 30, baseUrl = 'https://nerinparts.com.ar', totalCatalogProducts = null, publicProductsCount = null } = {}) {
   const skipped = getSkipTemplate();
   const samplesEligible = [];
@@ -200,11 +288,7 @@ function buildMerchantFeedAudit(rows, { limit = 500, offset = 0, preorderDays = 
     }); continue; }
     if (!VALID_AVAILABILITY.has(av.availability)) { skipped.invalidAvailability += 1; pushSample(samplesSkipped, { id: identifier, reason: 'invalidAvailability' }); continue; }
 
-    const lowerTitle = title.toLowerCase();
-    let productTypeDetected = detectProductType({ ...raw, ...row, title, name: title, category: row.category || raw.category || '' });
-    if (/adhesive\s*tape\s*display/.test(lowerTitle)) productTypeDetected = 'Adhesivo para pantalla';
-    if (/charging\s*board|charge\s*port|dock\s*connector/.test(lowerTitle)) productTypeDetected = 'Placa / pin de carga';
-    if (/\bbattery\b/.test(lowerTitle)) productTypeDetected = 'Batería';
+    const productTypeDetected = detectMerchantProductType(row, raw, title);
     const productType = mapProductTypeToFeed(productTypeDetected);
     if (!productType || productType.toLowerCase() === 'pantallas' && /resin\s*pc/i.test(title)) {
       skipped.taxonomyBlocked += 1;
@@ -216,9 +300,10 @@ function buildMerchantFeedAudit(rows, { limit = 500, offset = 0, preorderDays = 
     if (eligibleCount <= sanitizedOffset || emittedCount >= sanitizedLimit) continue;
 
     emittedCount += 1;
-    productTypeBreakdown[productType] = (productTypeBreakdown[productType] || 0) + 1;
+    const safeProductType = safeMerchantText(productType);
+    productTypeBreakdown[safeProductType] = (productTypeBreakdown[safeProductType] || 0) + 1;
     availabilityBreakdown[av.availability] = (availabilityBreakdown[av.availability] || 0) + 1;
-    pushSample(samplesEligible, { id: identifier, title, productType, availability: av.availability, availability_date: av.availabilityDate || null, price: `${priceNum.toFixed(2)} ARS`, link, image_link: imageLink, stock: Number(row.stock ?? raw.stock ?? 0) });
+    pushSample(samplesEligible, { id: identifier, title: safeMerchantText(title), productType: safeProductType, availability: av.availability, availability_date: av.availabilityDate || null, price: `${priceNum.toFixed(2)} ARS`, link, image_link: imageLink, stock: Number(row.stock ?? raw.stock ?? 0) });
   }
 
   return {
@@ -237,4 +322,4 @@ function buildMerchantFeedAudit(rows, { limit = 500, offset = 0, preorderDays = 
   };
 }
 
-module.exports = { GOOGLE_CATEGORY, mapProductTypeToFeed, buildMerchantTitle, computeAvailability, isEligibleState, cleanText, safeMerchantText, detectProductType, buildMerchantFeedAudit, normalizeMerchantImageUrl, isValidFeedUrl };
+module.exports = { GOOGLE_CATEGORY, mapProductTypeToFeed, buildMerchantTitle, computeAvailability, isEligibleState, cleanText, safeMerchantText, detectProductType, buildMerchantFeedAudit, buildMerchantFeedEntries, normalizeMerchantImageUrl, isValidFeedUrl };


### PR DESCRIPTION
### Motivation
- Separate entry-generation logic from HTTP handler to centralize feed rules and make TSV generation reusable. 
- Improve image normalization, deduplication and product-type detection to produce more consistent feed rows. 
- Make audit counts and emitted stats derive from the same logic used to build feed entries to avoid mismatches.

### Description
- Introduces `buildMerchantFeedEntries(rows, opts)` which encapsulates eligibility, normalization, image dedupe, availability, pricing and product-type mapping, and returns `entries` and `audit` objects. 
- Adds helper functions `normalizeComparableUrl`, `detectMerchantProductType`, and `extractRaw` and expands `safeMerchantText` replacements to fix common mojibake. 
- Refactors `buildMerchantFeedAudit` to reuse `detectMerchantProductType` and to safen product type and title samples via `safeMerchantText`. 
- Updates `backend/server.js` to call `buildMerchantFeedEntries` and stream TSV rows from the produced `entries`, and to map `stats` values from `feedPayload.audit`. 
- Exports `buildMerchantFeedEntries` from `backend/utils/merchantFeed.js` and updates tests to import it. 
- Adds multiple unit tests in `__tests__/backend/merchant-feed.test.js` covering eligibility parity between audit and TSV, availability and headers, mojibake cleaning, `additional_image_link` dedupe and exclusions, single-image behavior, and product-type heuristics for displays/batteries.

### Testing
- Ran unit tests in `__tests__/backend/merchant-feed.test.js` which include the existing audit tests and the new TSV payload tests, and they all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09c5a823548331a5bae42df6c29568)