### PR TITLE
Clean Merchant debug text and strip generated citation artifacts

### DIFF
--- a/nerin_final_updated/__tests__/backend/merchant-feed.test.js
+++ b/nerin_final_updated/__tests__/backend/merchant-feed.test.js
@@ -77,6 +77,18 @@ describe('merchant feed audit', () => {
     expect(audit.samplesEligible[0].availability).toBe('preorder');
   });
 
+
+  test('debug limpia mojibake en breakdown y samples', () => {
+    const rows = [
+      baseRow({ id: 'dbg-1', name: 'CÃ¡mara MÃ³dulo', raw_json: JSON.stringify({ category: 'Componentes electrÃ³nicos' }) }),
+      baseRow({ id: 'dbg-2', is_public: 0 }),
+    ];
+    const audit = buildMerchantFeedAudit(rows);
+    expect(Object.keys(audit.productTypeBreakdown).join(' ')).not.toMatch(/MÃ|electrÃ/);
+    expect(audit.samplesEligible[0].title).not.toContain('MÃ³dulo');
+    expect(audit.samplesEligible[0].productType).not.toContain('electrÃ³nicos');
+  });
+
   test('safeMerchantText corrige mojibake típico', () => {
     expect(safeMerchantText('MÃ³dulo Pantalla')).toBe('Módulo Pantalla');
   });
@@ -187,6 +199,19 @@ describe('merchant feed tsv payload', () => {
     const tsv = buildMerchantFeedEntries(rows, { limit: 50, offset: 0 });
     expect(tsv.audit.eligibleCount).toBe(audit.eligibleCount);
     expect(tsv.entries.length).toBe(audit.emittedCount);
+  });
+
+
+  test('description limpia artifacts de contentReference/oaicite', () => {
+    const rows = [
+      baseRow({
+        id: 'cite-1',
+        description: 'Texto limpio :contentReference[oaicite:1]{index=1} y oaicite y :contentReference[foo]',
+      }),
+    ];
+    const { entries } = buildMerchantFeedEntries(rows);
+    expect(entries[0].description).not.toContain('contentReference');
+    expect(entries[0].description).not.toContain('oaicite');
   });
 
   test('preorder e in_stock availability_date correcto y headers esperados', () => {

--- a/nerin_final_updated/backend/utils/merchantFeed.js
+++ b/nerin_final_updated/backend/utils/merchantFeed.js
@@ -15,6 +15,9 @@ function safeMerchantText(value, max = 150) {
   ];
   let text = String(value || '');
   for (const [bad, good] of mojibakeFixes) text = text.split(bad).join(good);
+  text = text.replace(/:contentReference\[[^\]]*\]\{[^}]*\}/gi, ' ');
+  text = text.replace(/:contentReference\[[^\]]*\]/gi, ' ');
+  text = text.replace(/\boaicite\b/gi, ' ');
   text = text.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, ' ');
   text = text.replace(/\s+/g, ' ').trim();
   return text.slice(0, max);
@@ -318,7 +321,11 @@ function buildMerchantFeedAudit(rows, { limit = 500, offset = 0, preorderDays = 
     productTypeBreakdown,
     availabilityBreakdown,
     samplesEligible,
-    samplesSkipped,
+    samplesSkipped: samplesSkipped.map((sample) => ({
+      ...sample,
+      title: sample.title ? safeMerchantText(sample.title) : sample.title,
+      reason: sample.reason ? safeMerchantText(sample.reason) : sample.reason,
+    })),
   };
 }
 


### PR DESCRIPTION
### Motivation
- Debug output and TSV descriptions still showed mojibake (e.g. `MÃ³dulo`, `electrÃ³nicos`) and generated citation artifacts like `:contentReference[...]` / `oaicite` that must be removed from merchant-facing exports.

### Description
- Extended `safeMerchantText` in `backend/utils/merchantFeed.js` to strip citation artifacts (`:contentReference[...]`, `:contentReference[...] {..}` variants and `oaicite`) and kept existing mojibake replacements (`MÃ³dulo` → `Módulo`, `BaterÃ­a` → `Batería`, `CÃ¡mara` → `Cámara`, `CÃ¡maras` → `Cámaras`, `electrÃ³nicos` → `electrónicos`, `TelÃ©fono` → `Teléfono`, `ReparaciÃ³n` → `Reparación`).
- Applied `safeMerchantText` to debug output fields by sanitizing `samplesSkipped` textual fields (`title` and `reason`) in the `buildMerchantFeedAudit` return payload so debug and breakdown keys are consistent with TSV output.
- Left business logic unchanged (pricing, stock, payment, checkout, orders, publishing, import, and eligibility logic not modified); only output/text cleaning was adjusted.
- Added unit tests in `__tests__/backend/merchant-feed.test.js` to cover debug breakdown/samples mojibake cleaning and stripping of citation artifacts from feed descriptions.

### Testing
- Ran `node --check backend/utils/merchantFeed.js` which passed.
- Ran `node --check backend/server.js` which passed.
- Ran `npm test -- merchant-feed.test.js` and all tests passed: `1 suite, 25 tests, 25 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09cba93ffc83319676af101a7489e0)