### PR TITLE
Ensure availability_date for preorder/backorder in Merchant feed

### DIFF
--- a/nerin_final_updated/__tests__/backend/merchant-feed.test.js
+++ b/nerin_final_updated/__tests__/backend/merchant-feed.test.js
@@ -56,7 +56,7 @@ describe('merchant feed audit', () => {
   test('stock 0 vendible a pedido => preorder + availability_date', () => {
     const audit = buildMerchantFeedAudit([baseRow({ stock: 0 })]);
     expect(audit.samplesEligible[0].availability).toBe('preorder');
-    expect(audit.samplesEligible[0].availability_date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(audit.samplesEligible[0].availability_date).toMatch(/^\d{4}-\d{2}-\d{2}T00:00-0300$/);
   });
   test('contadores reales pueden ser mayores al lote escaneado', () => {
     const rows = [baseRow({ id: 'a' }), baseRow({ id: 'b', is_public: 0 })];
@@ -183,7 +183,7 @@ describe('merchant feed audit', () => {
     expect(audit.emittedCount).toBe(1);
     expect(audit.samplesEligible[0].id).toBe('ok-ext');
     expect(audit.samplesEligible[0].image_link).toBe('https://images.2service.nl/v7/Images/Part/1/img.jpg');
-    expect(['in_stock', 'preorder']).toContain(audit.samplesEligible[0].availability);
+    expect(['in_stock', 'preorder', 'backorder']).toContain(audit.samplesEligible[0].availability);
   });
 });
 
@@ -215,13 +215,15 @@ describe('merchant feed tsv payload', () => {
   });
 
   test('preorder e in_stock availability_date correcto y headers esperados', () => {
-    const rows = [baseRow({ id: 'stk', stock: 3 }), baseRow({ id: 'pre', stock: 0 })];
+    const rows = [baseRow({ id: 'stk', stock: 3 }), baseRow({ id: 'pre', stock: 0 }), baseRow({ id: 'back', stock: 0, raw_json: JSON.stringify({ availability: 'backorder' }) })];
     const { entries } = buildMerchantFeedEntries(rows);
     const byId = Object.fromEntries(entries.map((e) => [e.id, e]));
     expect(byId.stk.availability).toBe('in_stock');
     expect(byId.stk.availability_date).toBe('');
     expect(byId.pre.availability).toBe('preorder');
-    expect(byId.pre.availability_date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(byId.pre.availability_date).toMatch(/^\d{4}-\d{2}-\d{2}T00:00-0300$/);
+    expect(byId.back.availability).toBe('backorder');
+    expect(byId.back.availability_date).toMatch(/^\d{4}-\d{2}-\d{2}T00:00-0300$/);
     expect(Object.keys(entries[0])).toEqual(['id','title','description','link','image_link','additional_image_link','availability','availability_date','price','condition','brand','mpn','identifier_exists','google_product_category','product_type']);
   });
 

--- a/nerin_final_updated/backend/utils/merchantFeed.js
+++ b/nerin_final_updated/backend/utils/merchantFeed.js
@@ -1,7 +1,7 @@
 const { detectProductType } = require('./productTaxonomy');
 
 const GOOGLE_CATEGORY = 'Electrónica > Comunicaciones > Telefonía > Accesorios para móviles';
-const VALID_AVAILABILITY = new Set(['in_stock', 'preorder']);
+const VALID_AVAILABILITY = new Set(['in_stock', 'preorder', 'backorder']);
 
 function safeMerchantText(value, max = 150) {
   const mojibakeFixes = [
@@ -53,13 +53,42 @@ function buildMerchantTitle(row, raw) {
   return safeMerchantText(row.name || row.title || raw.name || raw.title || raw.description || '');
 }
 
+function formatMerchantAvailabilityDate(value) {
+  const formatted = String(value || '').trim();
+  if (!formatted) return '';
+  if (/^\d{4}-\d{2}-\d{2}T00:00-0300$/.test(formatted)) return formatted;
+  const onlyDateMatch = formatted.match(/^(\d{4}-\d{2}-\d{2})(?:[T\s].*)?$/);
+  if (onlyDateMatch) return `${onlyDateMatch[1]}T00:00-0300`;
+  const parsed = new Date(formatted);
+  if (Number.isNaN(parsed.getTime())) return '';
+  const y = parsed.getUTCFullYear();
+  const m = String(parsed.getUTCMonth() + 1).padStart(2, '0');
+  const d = String(parsed.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${d}T00:00-0300`;
+}
+
+function estimateMerchantAvailabilityDate(preorderDays = 30) {
+  const days = Math.max(1, Number(preorderDays) || 30);
+  const future = new Date(Date.now() + days * 86400000);
+  const y = future.getUTCFullYear();
+  const m = String(future.getUTCMonth() + 1).padStart(2, '0');
+  const d = String(future.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${d}T00:00-0300`;
+}
+
 function computeAvailability(row, raw, preorderDays = 30) {
   const stockLocal = Number(row.stock ?? raw.stock ?? 0);
-  if (stockLocal > 0) return { availability: 'in_stock', availabilityDate: '' };
-  const existingDate = String(raw.availability_date || raw.preorder_date || '').trim();
-  if (existingDate) return { availability: 'preorder', availabilityDate: existingDate };
-  const d = new Date(Date.now() + Number(preorderDays) * 86400000).toISOString().slice(0, 10);
-  return { availability: 'preorder', availabilityDate: d };
+  const normalizedAvailability = String(row.availability || raw.availability || '').trim().toLowerCase();
+  const forcedBackorder = normalizedAvailability === 'backorder';
+  const forcedPreorder = normalizedAvailability === 'preorder';
+
+  if (stockLocal > 0 && !forcedPreorder && !forcedBackorder) return { availability: 'in_stock', availabilityDate: '' };
+
+  const existingDateRaw = row.availability_date || raw.availability_date || row.preorder_date || raw.preorder_date || '';
+  const existingDate = formatMerchantAvailabilityDate(existingDateRaw);
+
+  if (forcedBackorder) return { availability: 'backorder', availabilityDate: existingDate || estimateMerchantAvailabilityDate(preorderDays) };
+  return { availability: 'preorder', availabilityDate: existingDate || estimateMerchantAvailabilityDate(preorderDays) };
 }
 
 function isEligibleState(row, raw) {
@@ -104,7 +133,7 @@ function getSkipTemplate() {
   return {
     notPublic: 0, privateOrHidden: 0, disabled: 0, deleted: 0, archived: 0, draft: 0, vipOnly: 0, wholesaleOnly: 0,
     missingId: 0, missingTitle: 0, missingDescription: 0, missingLink: 0, missingImage: 0, invalidImageUrl: 0,
-    missingPrice: 0, invalidPrice: 0, missingAvailability: 0, invalidAvailability: 0, taxonomyBlocked: 0, soft404Risk: 0,
+    missingPrice: 0, invalidPrice: 0, missingAvailability: 0, invalidAvailability: 0, preorderWithoutAvailabilityDate: 0, backorderWithoutAvailabilityDate: 0, invalidAvailabilityDate: 0, taxonomyBlocked: 0, soft404Risk: 0,
   };
 }
 
@@ -177,7 +206,7 @@ function buildMerchantFeedEntries(rows, { limit = 500, offset = 0, preorderDays 
     if (!Number.isFinite(priceNum) || priceNum <= 0) continue;
     const av = computeAvailability(row, raw, preorderDays);
     if (!VALID_AVAILABILITY.has(av.availability)) continue;
-    if (av.availability === 'preorder' && !String(av.availabilityDate || '').match(/^\d{4}-\d{2}-\d{2}$/)) continue;
+    if ((av.availability === 'preorder' || av.availability === 'backorder') && !String(av.availabilityDate || '').match(/^\d{4}-\d{2}-\d{2}T00:00-0300$/)) continue;
     const productTypeDetected = detectMerchantProductType(row, raw, title);
     const product_type = safeMerchantText(mapProductTypeToFeed(productTypeDetected));
     if (!product_type) continue;
@@ -189,7 +218,7 @@ function buildMerchantFeedEntries(rows, { limit = 500, offset = 0, preorderDays 
     entries.push({
       id: identifier, title, description, link, image_link,
       additional_image_link: additional.join(','), availability: av.availability,
-      availability_date: av.availability === 'preorder' ? av.availabilityDate : '',
+      availability_date: (av.availability === 'preorder' || av.availability === 'backorder') ? av.availabilityDate : '',
       price: `${priceNum.toFixed(2)} ARS`, condition: 'new', brand, mpn, identifier_exists,
       google_product_category: GOOGLE_CATEGORY, product_type,
     });
@@ -291,6 +320,14 @@ function buildMerchantFeedAudit(rows, { limit = 500, offset = 0, preorderDays = 
     }); continue; }
     if (!VALID_AVAILABILITY.has(av.availability)) { skipped.invalidAvailability += 1; pushSample(samplesSkipped, { id: identifier, reason: 'invalidAvailability' }); continue; }
 
+    if (av.availability === 'preorder' && !av.availabilityDate) { skipped.preorderWithoutAvailabilityDate += 1; pushSample(samplesSkipped, { id: identifier, reason: 'preorderWithoutAvailabilityDate' }); continue; }
+    if (av.availability === 'backorder' && !av.availabilityDate) { skipped.backorderWithoutAvailabilityDate += 1; pushSample(samplesSkipped, { id: identifier, reason: 'backorderWithoutAvailabilityDate' }); continue; }
+    if ((av.availability === 'preorder' || av.availability === 'backorder') && !/^\d{4}-\d{2}-\d{2}T00:00-0300$/.test(String(av.availabilityDate || ''))) {
+      skipped.invalidAvailabilityDate += 1;
+      pushSample(samplesSkipped, { id: identifier, reason: 'invalidAvailabilityDate', availability: av.availability, availability_date: av.availabilityDate || null });
+      continue;
+    }
+
     const productTypeDetected = detectMerchantProductType(row, raw, title);
     const productType = mapProductTypeToFeed(productTypeDetected);
     if (!productType || productType.toLowerCase() === 'pantallas' && /resin\s*pc/i.test(title)) {
@@ -321,6 +358,7 @@ function buildMerchantFeedAudit(rows, { limit = 500, offset = 0, preorderDays = 
     productTypeBreakdown,
     availabilityBreakdown,
     samplesEligible,
+    samplesMissingAvailabilityDate: samplesSkipped.filter((sample) => ['preorderWithoutAvailabilityDate', 'backorderWithoutAvailabilityDate', 'invalidAvailabilityDate'].includes(sample.reason)).slice(0, 10),
     samplesSkipped: samplesSkipped.map((sample) => ({
       ...sample,
       title: sample.title ? safeMerchantText(sample.title) : sample.title,

--- a/nerin_final_updated/frontend/js/product.js
+++ b/nerin_final_updated/frontend/js/product.js
@@ -1313,7 +1313,7 @@ function renderProduct(product) {
       <span class="shipping-banner__meta">
         ${
           fulfillment.mode === "remote"
-            ? `Stock remoto: entrega estimada en ${leadCopy}. Sujeto a disponibilidad del proveedor.`
+            ? `Producto disponible bajo pedido. Fecha estimada de despacho: ${leadCopy}. Sujeto a disponibilidad del proveedor.`
             : fulfillment.isConfigured
               ? "Stock físico: despacho prioritario en 24 h hábiles con seguimiento en vivo."
               : "Despachamos a diario con empaque blindado y seguimiento en vivo."


### PR DESCRIPTION
### Motivation
- Google Merchant Center rejected some products with `availability=preorder`/`backorder` due to missing or invalid `availability_date`, so the feed must always emit a valid date for those states. 
- The requirement is to keep existing feed structure and non-breaking behavior for `in_stock` while normalizing/estimating dates for remote/preorder/backorder products. 
- Provide clear debug counters so missing/invalid availability_date cases are visible in the feed audit. 

### Description
- Extend accepted availability values by adding `backorder` to `VALID_AVAILABILITY` and make `availability_date` mandatory for `preorder` and `backorder`. 
- Add `formatMerchantAvailabilityDate` and `estimateMerchantAvailabilityDate` helpers and update `computeAvailability` to normalize any existing date or fallback to a default of `+30` days, returning `YYYY-MM-DDT00:00-0300`. 
- Enforce emission checks so entries with `preorder`/`backorder` must match `/^\d{4}-\d{2}-\d{2}T00:00-0300$/` and include the formatted `availability_date` in TSV/CSV/XML payloads. 
- Add audit/debug counters and samples: `preorderWithoutAvailabilityDate`, `backorderWithoutAvailabilityDate`, `invalidAvailabilityDate`, and `samplesMissingAvailabilityDate`, and expose them via `buildMerchantFeedAudit`. 
- Update product page copy to display a visible message for remote/preorder products: `"Producto disponible bajo pedido. Fecha estimada de despacho: DD/MM/YYYY."`. 
- Files changed: `backend/utils/merchantFeed.js`, `frontend/js/product.js`, and `__tests__/backend/merchant-feed.test.js`.

### Testing
- Ran unit tests with `npm test -- __tests__/backend/merchant-feed.test.js` and all tests passed (1 suite, 25 tests). 
- Executed a local Node sanity check that called `buildMerchantFeedEntries` / `buildMerchantFeedAudit` for a `preorder` sample and confirmed the emitted entry contains `availability_date` in the expected format (example: `2026-06-17T00:00-0300`) and audit shows zero missing/invalid availability_date in that scenario. 
- Updated tests to assert the new datetime format and `backorder` support; those updated tests passed as part of the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0af6b71ad88331a530d177c3d15c64)