### PR TITLE
[codex] Fix iPhone search ranking variants

### DIFF
--- a/nerin_final_updated/__tests__/backend/product-search-ranking.test.js
+++ b/nerin_final_updated/__tests__/backend/product-search-ranking.test.js
@@ -1,14 +1,119 @@
 const {
   computeSearchIntent,
+  parseAppleModel,
+  getProductAppleModelInfo,
+  isAppleVariantMismatch,
   scoreProductAgainstIntent,
   rankRowsBySearchIntent,
   queryProducts,
   queryAdminProducts,
+  ensureProductsDbOnce,
 } = require('../../backend/data/productsSqliteRepo');
 
 const score = (query, product) => scoreProductAgainstIntent(product, computeSearchIntent(query));
+const firstTitle = (query, products) => {
+  const ranked = rankRowsBySearchIntent(products, computeSearchIntent(query), { preferPositiveScores: true });
+  return ranked[0]?.row?.name || ranked[0]?.row?.title || "";
+};
+
+beforeAll(async () => {
+  await ensureProductsDbOnce();
+}, 30000);
 
 describe('product search ranking intent', () => {
+  test('detects Apple iPhone model generation and variants', () => {
+    expect(parseAppleModel('iphone 12 display')).toEqual({
+      brand: 'apple',
+      family: 'iphone',
+      generation: '12',
+      variant: 'base',
+      exactModel: 'iphone 12',
+    });
+    expect(parseAppleModel('iphone 12 pro max display')).toMatchObject({
+      generation: '12',
+      variant: 'pro max',
+      exactModel: 'iphone 12 pro max',
+    });
+    expect(getProductAppleModelInfo({ name: 'Display (Original), Apple iPhone 12 mini' }).productAppleModel).toMatchObject({
+      exactModel: 'iphone 12 mini',
+      variant: 'mini',
+    });
+    expect(isAppleVariantMismatch(parseAppleModel('iphone 12 display'), parseAppleModel('iphone 12 mini display'))).toBe(true);
+  });
+
+  test('iphone 12 display ranks base iphone 12 before mini/pro/pro max', () => {
+    const title = firstTitle('iphone 12 display', [
+      { rowid: 1, name: 'Display (Original), Apple iPhone 12 mini', model: 'iPhone 12 mini', brand: 'Apple', category: 'Display' },
+      { rowid: 2, name: 'Display (Original), Apple iPhone 12 Pro Max', model: 'iPhone 12 Pro Max', brand: 'Apple', category: 'Display' },
+      { rowid: 3, name: 'Display (Original), Apple iPhone 12', model: 'iPhone 12', brand: 'Apple', category: 'Display' },
+      { rowid: 4, name: 'Display (Original), Apple iPhone 12 Pro', model: 'iPhone 12 Pro', brand: 'Apple', category: 'Display' },
+    ]);
+    expect(title).toContain('Display (Original), Apple iPhone 12');
+    expect(title.toLowerCase()).not.toContain('mini');
+    expect(title.toLowerCase()).not.toContain('pro max');
+  });
+
+  test('iphone 12 mini display ranks mini first', () => {
+    expect(firstTitle('iphone 12 mini display', [
+      { rowid: 1, name: 'Display (Original), Apple iPhone 12', model: 'iPhone 12', brand: 'Apple', category: 'Display' },
+      { rowid: 2, name: 'Display (Original), Apple iPhone 12 mini', model: 'iPhone 12 mini', brand: 'Apple', category: 'Display' },
+      { rowid: 3, name: 'Display (Original), Apple iPhone 12 Pro Max', model: 'iPhone 12 Pro Max', brand: 'Apple', category: 'Display' },
+    ])).toContain('iPhone 12 mini');
+  });
+
+  test('iphone 12 pro max display ranks pro max first', () => {
+    expect(firstTitle('iphone 12 pro max display', [
+      { rowid: 1, name: 'Display (Original), Apple iPhone 12 Pro', model: 'iPhone 12 Pro', brand: 'Apple', category: 'Display' },
+      { rowid: 2, name: 'Display (Original), Apple iPhone 12 Pro Max', model: 'iPhone 12 Pro Max', brand: 'Apple', category: 'Display' },
+      { rowid: 3, name: 'Display (Original), Apple iPhone 12', model: 'iPhone 12', brand: 'Apple', category: 'Display' },
+    ])).toContain('iPhone 12 Pro Max');
+  });
+
+  test('iphone 12 pro display ranks pro first and does not treat pro max as exact pro', () => {
+    expect(firstTitle('iphone 12 pro display', [
+      { rowid: 1, name: 'Display (Original), Apple iPhone 12 Pro Max', model: 'iPhone 12 Pro Max', brand: 'Apple', category: 'Display' },
+      { rowid: 2, name: 'Display (Original), Apple iPhone 12', model: 'iPhone 12', brand: 'Apple', category: 'Display' },
+      { rowid: 3, name: 'Display (Original), Apple iPhone 12 Pro', model: 'iPhone 12 Pro', brand: 'Apple', category: 'Display' },
+    ])).toContain('iPhone 12 Pro');
+  });
+
+  test('iphone 13 display does not rank iphone 12 above exact iphone 13', () => {
+    expect(firstTitle('iphone 13 display', [
+      { rowid: 1, name: 'Display (Original), Apple iPhone 12', model: 'iPhone 12', brand: 'Apple', category: 'Display' },
+      { rowid: 2, name: 'Display (Original), Apple iPhone 13', model: 'iPhone 13', brand: 'Apple', category: 'Display' },
+    ])).toContain('iPhone 13');
+  });
+
+  test('iphone 12 battery ranks batteries above displays', () => {
+    expect(firstTitle('iphone 12 bateria', [
+      { rowid: 1, name: 'Display (Original), Apple iPhone 12', model: 'iPhone 12', brand: 'Apple', category: 'Display' },
+      { rowid: 2, name: 'Bateria Apple iPhone 12', model: 'iPhone 12', brand: 'Apple', category: 'Bateria' },
+    ])).toContain('Bateria');
+  });
+
+  test('iphone 12 tapa ranks rear covers above displays', () => {
+    expect(firstTitle('iphone 12 tapa', [
+      { rowid: 1, name: 'Display (Original), Apple iPhone 12', model: 'iPhone 12', brand: 'Apple', category: 'Display' },
+      { rowid: 2, name: 'Tapa trasera Apple iPhone 12', model: 'iPhone 12', brand: 'Apple', category: 'Tapa trasera' },
+    ])).toContain('Tapa');
+  });
+
+  test('display iphone 12 keeps the same base model order as iphone 12 display', () => {
+    const products = [
+      { rowid: 1, name: 'Display (Original), Apple iPhone 12 mini', model: 'iPhone 12 mini', brand: 'Apple', category: 'Display' },
+      { rowid: 2, name: 'Display (Original), Apple iPhone 12', model: 'iPhone 12', brand: 'Apple', category: 'Display' },
+      { rowid: 3, name: 'Display (Original), Apple iPhone 12 Pro Max', model: 'iPhone 12 Pro Max', brand: 'Apple', category: 'Display' },
+    ];
+    expect(firstTitle('display iphone 12', products)).toBe(firstTitle('iphone 12 display', products));
+  });
+
+  test('pantalla iphone 12 is understood as display intent', () => {
+    expect(firstTitle('pantalla iphone 12', [
+      { rowid: 1, name: 'Bateria Apple iPhone 12', model: 'iPhone 12', brand: 'Apple', category: 'Bateria' },
+      { rowid: 2, name: 'Display (Original), Apple iPhone 12', model: 'iPhone 12', brand: 'Apple', category: 'Display' },
+    ])).toContain('Display');
+  });
+
   test('iphone 15 pro battery ranks 15 pro over other iphones', () => {
     const exact = score('iphone 15 pro battery', { name: 'Bateria iPhone 15 Pro', model: 'iPhone 15 Pro', brand: 'Apple' });
     const iphone17 = score('iphone 15 pro battery', { name: 'Bateria iPhone 17', model: 'iPhone 17', brand: 'Apple' });

--- a/nerin_final_updated/backend/data/productsSqliteRepo.js
+++ b/nerin_final_updated/backend/data/productsSqliteRepo.js
@@ -136,13 +136,36 @@ function normalizeQueryText(value) {
 
 
 
+const APPLE_IPHONE_GENERATIONS = new Set(["11", "12", "13", "14", "15", "16", "17"]);
+const APPLE_VARIANT_ORDER = ["pro max", "mini", "plus", "pro", "air"];
+const APPLE_VARIANT_PENALTIES = {
+  base: { pro: -350, mini: -600, "pro max": -700, plus: -500, air: -500 },
+  mini: { base: -500, pro: -700, "pro max": -800, plus: -700, air: -700 },
+  pro: { base: -300, "pro max": -500, mini: -800, plus: -700, air: -700 },
+  "pro max": { pro: -500, base: -700, mini: -900, plus: -800, air: -800 },
+  plus: { base: -500, pro: -700, "pro max": -800, mini: -800, air: -700 },
+  air: { base: -500, pro: -700, "pro max": -800, mini: -800, plus: -700 },
+};
+
 const REPLACEMENT_TYPE_SYNONYMS = [
-  { key: "bateria", terms: ["battery", "bateria"] },
-  { key: "pantalla", terms: ["display", "pantalla"] },
-  { key: "placa carga", terms: ["charging board", "charge port", "dock connector", "placa de carga", "pin de carga"] },
-  { key: "adhesivo", terms: ["adhesive", "tape", "glue", "adhesivo"] },
-  { key: "flex", terms: ["flex cable", "flex"] },
+  { key: "bateria", terms: ["battery", "bateria", "baterias", "bater?a", "bater?as"] },
+  { key: "pantalla", terms: ["display", "pantalla", "pantallas", "modulo", "modulo display", "modulo pantalla", "modulo lcd", "m?dulo", "lcd", "screen"] },
+  { key: "tapa", terms: ["tapa", "tapa trasera", "back glass", "rear cover", "back cover", "vidrio trasero", "carcasa trasera"] },
+  { key: "placa carga", terms: ["charging board", "charge port", "dock connector", "placa de carga", "pin de carga", "puerto de carga"] },
+  { key: "adhesivo", terms: ["adhesive", "tape", "glue", "adhesivo", "pegamento"] },
+  { key: "flex", terms: ["flex cable", "flex", "cable flex"] },
+  { key: "camara", terms: ["camera", "camara", "c?mara", "camara frontal", "camara trasera"] },
 ];
+
+const REPLACEMENT_TYPE_SEARCH_EQUIVALENTS = new Map(
+  REPLACEMENT_TYPE_SYNONYMS.flatMap((entry) =>
+    entry.terms.map((term) => [normalizeQueryText(term), entry.terms.map(normalizeQueryText)]),
+  ),
+);
+
+function uniqueValues(values = []) {
+  return Array.from(new Set(values.filter(Boolean)));
+}
 
 function tokenizeSearch(value = "") {
   return normalizeQueryText(value)
@@ -161,7 +184,7 @@ function inferReplacementType(text = "") {
 
 function extractModelPhrase(text = "") {
   const normalized = normalizeQueryText(text);
-  const patterns = [/iphone\s+\d+\s+pro\s+max/, /iphone\s+\d+\s+pro/, /iphone\s+\d+/, /galaxy\s+s\d+\s+ultra/, /galaxy\s+[as]\d+/, /sm-s\d{3,}/];
+  const patterns = [/iphone\s+\d+\s+pro\s+max/, /iphone\s+\d+\s+mini/, /iphone\s+\d+\s+plus/, /iphone\s+\d+\s+air/, /iphone\s+\d+\s+pro/, /iphone\s+\d+/, /galaxy\s+s\d+\s+ultra/, /galaxy\s+[as]\d+/, /sm-s\d{3,}/];
   for (const pattern of patterns) {
     const matched = normalized.match(pattern);
     if (matched) return matched[0];
@@ -171,61 +194,327 @@ function extractModelPhrase(text = "") {
 
 function extractSkuOrMpn(text = "") {
   const normalized = normalizeQueryText(text);
-  const match = normalized.match(/(?:gh\d{2}-\d{4,}[a-z]?|sm-s\d{3,}|[a-z]{2,}\d{2,}-\d{2,}[a-z]?)/i);
+  const match = normalized.match(/\b(?:gh\d{2}-\d{4,}[a-z]?|sm-s\d{3,}|[a-z]{2,}\d{2,}-\d{2,}[a-z]?)\b/i);
   return match ? match[0].toLowerCase() : "";
+}
+
+function normalizeAppleModelText(value = "") {
+  return normalizeQueryText(value)
+    .replace(/\biphone\s*(1[1-7])\s*(promax)\b/g, "iphone $1 pro max")
+    .replace(/\biphone\s*(1[1-7])\s*(pro|max|mini|plus|air)\b/g, "iphone $1 $2")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function toAppleModel(generation, variant = "base") {
+  const safeGeneration = String(generation || "").trim();
+  if (!APPLE_IPHONE_GENERATIONS.has(safeGeneration)) return null;
+  const normalizedVariant = normalizeQueryText(variant || "base").replace(/\s+/g, " ") || "base";
+  const safeVariant = normalizedVariant === "max" ? "pro max" : normalizedVariant;
+  const finalVariant = APPLE_VARIANT_ORDER.includes(safeVariant) ? safeVariant : "base";
+  const exactModel = finalVariant === "base" ? `iphone ${safeGeneration}` : `iphone ${safeGeneration} ${finalVariant}`;
+  return {
+    brand: "apple",
+    family: "iphone",
+    generation: safeGeneration,
+    variant: finalVariant,
+    exactModel,
+  };
+}
+
+function parseAppleModel(text = "") {
+  const models = extractAppleModels(text);
+  return models[0] || null;
+}
+
+function extractAppleModels(text = "") {
+  const normalized = normalizeAppleModelText(text);
+  if (!normalized) return [];
+  const models = [];
+  const regex = /\biphone\s*(11|12|13|14|15|16|17)(?:\s+(pro\s+max|mini|plus|pro|air))?\b/g;
+  let match;
+  while ((match = regex.exec(normalized))) {
+    const model = toAppleModel(match[1], match[2] || "base");
+    if (model && !models.some((entry) => entry.exactModel === model.exactModel)) {
+      models.push(model);
+    }
+  }
+  return models;
+}
+
+function parseRawProductJson(product = {}) {
+  if (!product || typeof product !== "object") return {};
+  if (product.raw_json && typeof product.raw_json === "string") {
+    try {
+      return JSON.parse(product.raw_json || "{}");
+    } catch {
+      return {};
+    }
+  }
+  return {};
+}
+
+function joinProductFields(product = {}, aliases = []) {
+  const raw = parseRawProductJson(product);
+  return aliases
+    .map((alias) => getField(product, [alias]) ?? getField(raw, [alias]))
+    .filter((value) => value !== undefined && value !== null)
+    .join(" ");
+}
+
+function getProductAppleModelInfo(product = {}) {
+  const primaryText = joinProductFields(product, [
+    "name",
+    "title",
+    "product_title",
+    "model",
+    "catalog_model",
+    "mpn",
+    "MPN",
+    "partNumber",
+    "part_number",
+    "sku",
+    "code",
+  ]);
+  const secondaryText = joinProductFields(product, [
+    "description",
+    "shortDescription",
+    "short_description",
+    "compatibility",
+    "compatibleModels",
+    "compatible_models",
+    "search_text",
+  ]);
+  const primaryModels = extractAppleModels(primaryText);
+  const allModels = uniqueValues([...primaryModels, ...extractAppleModels(secondaryText)].map((model) => model.exactModel))
+    .map((exactModel) => [...primaryModels, ...extractAppleModels(secondaryText)].find((model) => model.exactModel === exactModel))
+    .filter(Boolean);
+  return {
+    productAppleModel: primaryModels[0] || allModels[0] || null,
+    compatibleAppleModels: allModels,
+  };
+}
+
+function inferBrand(text = "") {
+  const normalized = normalizeQueryText(text);
+  if (/\b(apple|iphone)\b/.test(normalized)) return "apple";
+  if (/\b(samsung|galaxy|sm-[a-z0-9]+)\b/.test(normalized)) return "samsung";
+  if (/\b(xiaomi|redmi|poco)\b/.test(normalized)) return "xiaomi";
+  if (/\b(huawei)\b/.test(normalized)) return "huawei";
+  if (/\b(honor)\b/.test(normalized)) return "honor";
+  if (/\b(oneplus|one plus)\b/.test(normalized)) return "oneplus";
+  if (/\b(motorola|moto)\b/.test(normalized)) return "motorola";
+  return "";
+}
+
+function isSameAppleModel(a, b) {
+  return Boolean(a && b && a.exactModel === b.exactModel);
+}
+
+function isAppleVariantMismatch(queryModel, productModel) {
+  return Boolean(
+    queryModel &&
+      productModel &&
+      queryModel.family === "iphone" &&
+      productModel.family === "iphone" &&
+      queryModel.generation === productModel.generation &&
+      queryModel.variant !== productModel.variant,
+  );
+}
+
+function getAppleVariantPenalty(queryModel, productModel) {
+  if (!isAppleVariantMismatch(queryModel, productModel)) return 0;
+  return APPLE_VARIANT_PENALTIES[queryModel.variant]?.[productModel.variant] ?? -700;
+}
+
+function hasExactAppleTitlePhrase(queryModel, titleText = "") {
+  if (!queryModel) return false;
+  const normalized = normalizeAppleModelText(titleText);
+  if (!normalized) return false;
+  const prefix = "(?:apple\\s+)?iphone\\s+";
+  const variant = queryModel.variant === "base" ? "" : `\\s+${queryModel.variant.replace(/\s+/g, "\\s+")}`;
+  const blockedNextVariant =
+    queryModel.variant === "base"
+      ? "(?!\\s+(?:mini|plus|pro|air))"
+      : queryModel.variant === "pro"
+        ? "(?!\\s+max)"
+        : "";
+  const pattern = new RegExp(`\\b${prefix}${queryModel.generation}${variant}${blockedNextVariant}\\b`);
+  return pattern.test(normalized);
+}
+
+function addScoreReason(state, label, value) {
+  if (!value) return;
+  state.score += value;
+  if (state.debug) state.reasons.push({ label, score: value });
 }
 
 function computeSearchIntent(query = "") {
   const normalizedQuery = normalizeQueryText(query);
   const tokens = tokenizeSearch(normalizedQuery);
+  const appleModel = parseAppleModel(normalizedQuery);
   return {
     normalizedQuery,
     tokens,
-    brand: tokens.find((token) => ["iphone", "apple", "samsung", "galaxy", "xiaomi", "motorola"].includes(token)) || "",
+    brand: inferBrand(normalizedQuery) || tokens.find((token) => ["iphone", "apple", "samsung", "galaxy", "xiaomi", "huawei", "honor", "oneplus", "motorola"].includes(token)) || "",
     modelPhrase: extractModelPhrase(normalizedQuery),
+    appleModel,
     replacementType: inferReplacementType(normalizedQuery),
     skuOrMpn: extractSkuOrMpn(normalizedQuery),
     importantTokens: tokens.filter((token) => token.length >= 3),
   };
 }
 
-function scoreProductAgainstIntent(product = {}, intent = {}) {
-  if (!intent?.normalizedQuery) return 0;
+function scoreProductAgainstIntent(product = {}, intent = {}, options = {}) {
+  if (!intent?.normalizedQuery) {
+    return options?.debug ? { score: 0, reasons: [] } : 0;
+  }
   const haystack = normalizeQueryText([
     getField(product, ["id", "sku", "code", "partNumber", "mpn", "ean", "gtin", "supplier_code"]),
     getField(product, ["name", "title", "description", "shortDescription", "short_description"]),
     getField(product, ["brand", "marca"]),
     getField(product, ["model", "modelo"]),
     getField(product, ["category", "categoria", "productType"]),
+    getField(product, ["search_text"]),
   ].join(" "));
-  let score = 0;
-  if (intent.skuOrMpn && haystack.includes(intent.skuOrMpn)) score += 1000;
-  if (intent.modelPhrase && haystack.includes(intent.modelPhrase)) score += 700;
-  if (intent.replacementType && inferReplacementType(haystack) === intent.replacementType) score += 400;
-  if (intent.brand && haystack.includes(intent.brand)) score += 150;
+  const state = { score: 0, reasons: [], debug: Boolean(options?.debug) };
+  const raw = parseRawProductJson(product);
+  const titleText = joinProductFields(product, ["name", "title", "product_title"]);
+  const productBrand = inferBrand([
+    haystack,
+    getField(product, ["brand", "marca"]),
+    getField(raw, ["brand", "marca", "manufacturer"]),
+  ].join(" "));
+  const productType = inferReplacementType(haystack);
+  const { productAppleModel, compatibleAppleModels } = getProductAppleModelInfo(product);
+  const hasCompatibleExactAppleModel = Boolean(
+    intent.appleModel &&
+      compatibleAppleModels.some((model) => isSameAppleModel(intent.appleModel, model)) &&
+      !isSameAppleModel(intent.appleModel, productAppleModel),
+  );
+
+  if (intent.skuOrMpn && haystack.includes(intent.skuOrMpn)) addScoreReason(state, "sku/mpn exacto", 1000);
+  if (intent.modelPhrase && haystack.includes(intent.modelPhrase)) addScoreReason(state, "frase de modelo presente", 250);
+  if (intent.replacementType) {
+    if (productType === intent.replacementType) addScoreReason(state, `tipo ${intent.replacementType}`, 800);
+    else if (productType) addScoreReason(state, `tipo incorrecto ${productType} vs ${intent.replacementType}`, -800);
+  }
+  if (intent.brand) {
+    if (intent.brand === "apple" || intent.tokens?.some((token) => token === "iphone" || token === "apple")) {
+      if (productBrand === "apple" || productAppleModel) addScoreReason(state, "marca apple", 500);
+      else addScoreReason(state, "marca no apple", -700);
+    } else if (productBrand === intent.brand || haystack.includes(intent.brand)) {
+      addScoreReason(state, `marca ${intent.brand}`, 250);
+    }
+  }
+  if (intent.appleModel) {
+    if (productAppleModel?.generation === intent.appleModel.generation || hasCompatibleExactAppleModel) {
+      addScoreReason(state, `generacion iphone ${intent.appleModel.generation}`, 900);
+    } else if (productAppleModel?.generation) {
+      addScoreReason(state, `generacion incorrecta iphone ${productAppleModel.generation}`, -900);
+    }
+
+    if (isSameAppleModel(intent.appleModel, productAppleModel)) {
+      addScoreReason(state, `modelo exacto ${intent.appleModel.exactModel}`, 1500);
+    } else if (hasCompatibleExactAppleModel) {
+      addScoreReason(state, `compatibilidad explicita ${intent.appleModel.exactModel}`, 450);
+    } else if (isAppleVariantMismatch(intent.appleModel, productAppleModel)) {
+      addScoreReason(
+        state,
+        `variante distinta ${productAppleModel.variant} vs ${intent.appleModel.variant}`,
+        getAppleVariantPenalty(intent.appleModel, productAppleModel),
+      );
+    }
+
+    if (hasExactAppleTitlePhrase(intent.appleModel, titleText)) {
+      addScoreReason(state, "frase exacta en titulo", 1000);
+    }
+  }
   const allImportantPresent = intent.importantTokens.length > 0 && intent.importantTokens.every((token) => haystack.includes(token));
-  if (allImportantPresent) score += 200;
-  else if (intent.importantTokens.some((token) => haystack.includes(token))) score += 50;
+  if (allImportantPresent) addScoreReason(state, "tokens importantes presentes", 200);
+  else if (intent.importantTokens.some((token) => haystack.includes(token))) addScoreReason(state, "tokens importantes parciales", 50);
   if (intent.modelPhrase.includes("iphone") && !haystack.includes(intent.modelPhrase)) {
     const target = intent.modelPhrase.match(/iphone\s+(\d+)/);
     const candidate = haystack.match(/iphone\s+(\d+)/);
-    if (target && candidate && target[1] !== candidate[1]) score -= 500;
-    if (intent.modelPhrase.includes("pro") && !intent.modelPhrase.includes("pro max") && haystack.includes(`${intent.modelPhrase} max`)) score -= 500;
+    if (target && candidate && target[1] !== candidate[1]) addScoreReason(state, "modelo iphone numericamente distinto", -500);
+    if (intent.modelPhrase.includes("pro") && !intent.modelPhrase.includes("pro max") && haystack.includes(`${intent.modelPhrase} max`)) addScoreReason(state, "pro max no solicitado", -500);
   }
-  return score;
+  if (!options?.debug) return state.score;
+  return {
+    score: state.score,
+    reasons: state.reasons,
+    queryModel: intent.appleModel || null,
+    productModel: productAppleModel || null,
+    productVariant: productAppleModel?.variant || null,
+    compatibleAppleModels,
+    productType,
+    productBrand,
+  };
 }
 
 function rankRowsBySearchIntent(rows = [], intent = {}, { preferPositiveScores = false } = {}) {
   if (!Array.isArray(rows) || rows.length === 0 || !intent?.normalizedQuery) return [];
   const ranked = rows.map((row, index) => {
-    const score = scoreProductAgainstIntent(row, intent);
-    return { row, score, index };
+    const debug = scoreProductAgainstIntent(row, intent, { debug: true });
+    return { row, score: debug.score, index, debug };
   });
   ranked.sort((a, b) => b.score - a.score || Number(a.row.rowid || 0) - Number(b.row.rowid || 0) || a.index - b.index);
   if (!preferPositiveScores) return ranked;
   const positives = ranked.filter((entry) => entry.score > 0);
   const nonPositives = ranked.filter((entry) => entry.score <= 0);
   return positives.concat(nonPositives);
+}
+
+function getSearchDebugForRankedEntries(ranked = [], intent = {}, limit = 24) {
+  return ranked.slice(0, Math.max(1, Math.min(100, Number(limit) || 24))).map((entry, position) => ({
+    position: position + 1,
+    id: entry.row?.id || null,
+    sku: entry.row?.sku || null,
+    code: entry.row?.code || null,
+    title: entry.row?.name || entry.row?.title || null,
+    model: entry.row?.model || null,
+    score: entry.score,
+    queryModel: intent.appleModel || null,
+    productModel: entry.debug?.productModel || null,
+    variant: entry.debug?.productVariant || null,
+    compatibleAppleModels: entry.debug?.compatibleAppleModels || [],
+    reasons: entry.debug?.reasons || [],
+  }));
+}
+
+function expandSearchTokenForSynonyms(token = "") {
+  const normalized = normalizeQueryText(token);
+  return uniqueValues(REPLACEMENT_TYPE_SEARCH_EQUIVALENTS.get(normalized) || [normalized]);
+}
+
+function buildFtsQueryFromSearch(normalizedSearch = "") {
+  const tokens = normalizedSearch
+    .replace(/[^a-z0-9\s-]/gi, " ")
+    .split(/\s+/)
+    .filter(Boolean);
+  return tokens
+    .map((token) => {
+      const equivalents = expandSearchTokenForSynonyms(token)
+        .map((term) => term.replace(/[^a-z0-9\s-]/gi, " ").trim())
+        .filter(Boolean)
+        .flatMap((term) => term.split(/\s+/).filter(Boolean));
+      const unique = uniqueValues(equivalents);
+      if (unique.length <= 1) return `${unique[0] || token}*`;
+      return `(${unique.map((value) => `${value}*`).join(" OR ")})`;
+    })
+    .join(" AND ");
+}
+
+function addLikeSearchConditions(where, params, normalizedSearch = "") {
+  const tokens = normalizedSearch
+    .replace(/[^a-z0-9\s-]/gi, " ")
+    .split(/\s+/)
+    .filter(Boolean);
+  tokens.forEach((token) => {
+    const equivalents = expandSearchTokenForSynonyms(token);
+    where.push(`(${equivalents.map(() => "search_text LIKE ?").join(" OR ")})`);
+    equivalents.forEach((term) => params.push(`%${term}%`));
+  });
 }
 
 function boolToInt(value, fallback = 0) {
@@ -1732,16 +2021,9 @@ function buildWhereClause({
   if (normalizedSearch) {
     if (ftsEnabled) {
       where.push("rowid IN (SELECT rowid FROM products_fts WHERE products_fts MATCH ?)");
-      const tokens = normalizedSearch
-        .replace(/[^a-z0-9\s]/gi, " ")
-        .split(" ")
-        .filter(Boolean)
-        .map((token) => `${token}*`)
-        .join(" AND ");
-      params.push(tokens || normalizedSearch);
+      params.push(buildFtsQueryFromSearch(normalizedSearch) || normalizedSearch);
     } else {
-      where.push("search_text LIKE ?");
-      params.push(`%${normalizedSearch}%`);
+      addLikeSearchConditions(where, params, normalizedSearch);
     }
   }
 
@@ -1798,6 +2080,7 @@ async function queryBase({
   status = "",
   stock = "",
   priceMax = null,
+  debugSearch = false,
 } = {}) {
   await ensureDbReadyForRequest();
   const db = await openDb();
@@ -1840,10 +2123,11 @@ async function queryBase({
 
   const selectStartedAt = Date.now();
   let rows = [];
+  let searchDebug = undefined;
   if (!shouldIntentRank) {
     rows = await all(
       db,
-      `SELECT rowid, id, sku, code, slug, public_slug, image, name, title, brand, model, category, status, visibility, stock, price, price_minorista, price_mayorista, precio_minorista, precio_mayorista, precio_final, precio_sin_impuestos, cost, currency
+      `SELECT rowid, id, sku, code, slug, public_slug, image, name, title, brand, model, category, status, visibility, stock, price, price_minorista, price_mayorista, precio_minorista, precio_mayorista, precio_final, precio_sin_impuestos, cost, currency, part_number, mpn, search_text, raw_json
         FROM products ${whereClause.sql} ORDER BY ${orderBy} LIMIT ? OFFSET ?`,
       [...whereClause.params, safePageSize, offset],
     );
@@ -1851,13 +2135,22 @@ async function queryBase({
     const candidateLimit = Math.max(safePageSize, Math.min(SEARCH_RANK_CANDIDATE_LIMIT, totalItems));
     const candidateRows = await all(
       db,
-      `SELECT rowid, id, sku, code, slug, public_slug, image, name, title, brand, model, category, status, visibility, stock, price, price_minorista, price_mayorista, precio_minorista, precio_mayorista, precio_final, precio_sin_impuestos, cost, currency
+      `SELECT rowid, id, sku, code, slug, public_slug, image, name, title, brand, model, category, status, visibility, stock, price, price_minorista, price_mayorista, precio_minorista, precio_mayorista, precio_final, precio_sin_impuestos, cost, currency, part_number, mpn, search_text, raw_json
         FROM products ${whereClause.sql} ORDER BY ${orderBy} LIMIT ? OFFSET 0`,
       [...whereClause.params, candidateLimit],
     );
     const intent = computeSearchIntent(normalizedSearch);
     const ranked = rankRowsBySearchIntent(candidateRows, intent, { preferPositiveScores: Boolean(intent.modelPhrase || intent.replacementType || intent.skuOrMpn || intent.importantTokens?.length) });
-    rows = ranked.slice(offset, offset + safePageSize).map((entry) => entry.row);
+    const pageEntries = ranked.slice(offset, offset + safePageSize);
+    rows = pageEntries.map((entry) => entry.row);
+    if (debugSearch) {
+      searchDebug = {
+        query: search,
+        normalizedQuery: normalizedSearch,
+        queryModel: intent.appleModel || null,
+        results: getSearchDebugForRankedEntries(pageEntries, intent, safePageSize),
+      };
+    }
   }
   const selectMs = Date.now() - selectStartedAt;
 
@@ -1879,6 +2172,7 @@ async function queryBase({
     hasPrevPage: safePage > 1,
     source: "sqlite",
     search: search || undefined,
+    searchDebug,
     countMs,
     selectMs,
     parseItemsMs,
@@ -2489,12 +2783,14 @@ async function debugCatalogSearch({ search = "", limit = 20 } = {}) {
   const totalRow = await get(db, `SELECT COUNT(*) AS total FROM products ${whereClause.sql}`, whereClause.params);
   const sampleMatches = await all(
     db,
-    `SELECT id, sku, code, name, title, model, public_slug, search_text
+    `SELECT rowid, id, sku, code, name, title, model, brand, category, public_slug, part_number, mpn, search_text, raw_json
      FROM products ${whereClause.sql}
      ORDER BY rowid ASC
      LIMIT ?`,
-    [...whereClause.params, Math.max(1, Math.min(100, Number(limit) || 20))],
+    [...whereClause.params, Math.max(1, Math.min(SEARCH_RANK_CANDIDATE_LIMIT, Number(limit) || 20))],
   );
+  const intent = computeSearchIntent(search);
+  const ranked = rankRowsBySearchIntent(sampleMatches, intent, { preferPositiveScores: true });
   const normalizedSearch = normalizeQueryText(search || "");
   const sqliteMatchesAny = await get(db, `SELECT COUNT(*) AS total FROM products WHERE search_text LIKE ?`, [`%${normalizedSearch}%`]);
   const sqlitePublicMatches = await get(db, `SELECT COUNT(*) AS total FROM products WHERE is_public = 1 AND search_text LIKE ?`, [`%${normalizedSearch}%`]);
@@ -2506,6 +2802,8 @@ async function debugCatalogSearch({ search = "", limit = 20 } = {}) {
     search,
     totalMatches: Number(totalRow?.total || 0),
     diagnosis,
+    queryModel: intent.appleModel || null,
+    rankedResults: getSearchDebugForRankedEntries(ranked, intent, limit),
     sampleMatches: sampleMatches.map((row) => ({
       id: row.id || null,
       sku: row.sku || null,
@@ -2677,6 +2975,10 @@ module.exports = {
   normalizeProductForAdminList,
   normalizeQueryText,
   computeSearchIntent,
+  parseAppleModel,
+  extractAppleModels,
+  getProductAppleModelInfo,
+  isAppleVariantMismatch,
   scoreProductAgainstIntent,
   rankRowsBySearchIntent,
   PRODUCTS_SQLITE_SCHEMA_VERSION,

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -6891,6 +6891,7 @@ async function requestHandler(req, res) {
         stock: queryParams.stock || "",
         priceMax: queryParams.price_max ?? queryParams.priceMax,
         sort: queryParams.sort || "",
+        debugSearch: queryParams.debugSearch === "1" || queryParams.debug === "1",
       });
       const items = withWholesale
         ? sqliteData.items.map((item) => normalizeProductImages(item))

--- a/nerin_final_updated/frontend/js/shop.js
+++ b/nerin_final_updated/frontend/js/shop.js
@@ -113,6 +113,9 @@ const FILTER_DEBOUNCE_MS = 350;
 const SHOP_DEBUG =
   new URLSearchParams(window.location.search).get("shopDebug") === "1" ||
   localStorage.getItem("nerinShopDebug") === "1";
+const SEARCH_DEBUG =
+  new URLSearchParams(window.location.search).get("debugSearch") === "1" ||
+  localStorage.getItem("nerinSearchDebug") === "1";
 
 function shopLog(message, payload = undefined) {
   if (!SHOP_DEBUG) return;
@@ -689,6 +692,7 @@ function syncQueryParams(filters) {
   if (filters.stock) params.set("stock", filters.stock);
   if (filters.priceActive && filters.price) params.set("price_max", String(filters.price));
   if (filters.sort && filters.sort !== "relevance") params.set("sort", filters.sort);
+  if (SEARCH_DEBUG) params.set("debugSearch", "1");
   const query = params.toString();
   history.replaceState({}, "", `${window.location.pathname}${query ? `?${query}` : ""}`);
 }
@@ -863,6 +867,7 @@ async function renderProducts({ page = currentProductsPage, scrollToTop = false 
     price_max: filters.priceActive ? filters.price : "",
     sort: mapSortForBackend(filters.sort),
   };
+  if (SEARCH_DEBUG) requestParams.debugSearch = "1";
   console.info("[shop-products] load", {
     page: currentProductsPage,
     pageSize: productsPageSize,
@@ -896,6 +901,19 @@ async function renderProducts({ page = currentProductsPage, scrollToTop = false 
     usingFallback: Boolean(response?.usingFallback),
     source: response?.source || "unknown",
   });
+  if (SEARCH_DEBUG && response?.searchDebug) {
+    console.groupCollapsed("[shop-search-debug]", filters.search || "");
+    console.info("query model", response.searchDebug.queryModel || null);
+    console.table((response.searchDebug.results || []).map((entry) => ({
+      position: entry.position,
+      score: entry.score,
+      title: entry.title,
+      productModel: entry.productModel?.exactModel || "",
+      variant: entry.variant || "",
+      reasons: (entry.reasons || []).map((reason) => `${reason.label} ${reason.score > 0 ? "+" : ""}${reason.score}`).join("; "),
+    })));
+    console.groupEnd();
+  }
   if (requestId !== latestRequestId) {
     shopLog("response:ignored-stale", { requestId, latestRequestId });
     return;

--- a/nerin_final_updated/scripts/test-search-ranking-cases.js
+++ b/nerin_final_updated/scripts/test-search-ranking-cases.js
@@ -1,0 +1,63 @@
+const {
+  computeSearchIntent,
+  rankRowsBySearchIntent,
+} = require("../backend/data/productsSqliteRepo");
+
+const fixtures = [
+  { rowid: 1, name: "Display (Original), Apple iPhone 12 mini", model: "iPhone 12 mini", brand: "Apple", category: "Display" },
+  { rowid: 2, name: "Display (Original), Apple iPhone 12 Pro Max", model: "iPhone 12 Pro Max", brand: "Apple", category: "Display" },
+  { rowid: 3, name: "Display (Original), Apple iPhone 12", model: "iPhone 12", brand: "Apple", category: "Display" },
+  { rowid: 4, name: "Display (Original), Apple iPhone 12 Pro", model: "iPhone 12 Pro", brand: "Apple", category: "Display" },
+  { rowid: 5, name: "Display (Original), Apple iPhone 13", model: "iPhone 13", brand: "Apple", category: "Display" },
+  { rowid: 6, name: "Bateria Apple iPhone 12", model: "iPhone 12", brand: "Apple", category: "Bateria" },
+  { rowid: 7, name: "Tapa trasera Apple iPhone 12", model: "iPhone 12", brand: "Apple", category: "Tapa trasera" },
+];
+
+function rank(query) {
+  return rankRowsBySearchIntent(fixtures, computeSearchIntent(query), { preferPositiveScores: true });
+}
+
+function topTitle(query) {
+  return rank(query)[0]?.row?.name || "";
+}
+
+function assertTop(query, expected, forbidden = []) {
+  const title = topTitle(query);
+  const lower = title.toLowerCase();
+  if (!title.toLowerCase().includes(expected.toLowerCase())) {
+    throw new Error(`Query "${query}" expected first result containing "${expected}", got "${title}"`);
+  }
+  for (const term of forbidden) {
+    if (lower.includes(term.toLowerCase())) {
+      throw new Error(`Query "${query}" first result must not contain "${term}", got "${title}"`);
+    }
+  }
+  return title;
+}
+
+const checks = [
+  ["iphone 12 display", "Display (Original), Apple iPhone 12", ["mini", "pro max"]],
+  ["iphone 12 mini display", "iPhone 12 mini"],
+  ["iphone 12 pro max display", "iPhone 12 Pro Max"],
+  ["iphone 12 pro display", "iPhone 12 Pro"],
+  ["iphone 13 display", "iPhone 13"],
+  ["iphone 12 bateria", "Bateria Apple iPhone 12"],
+  ["iphone 12 tapa", "Tapa trasera Apple iPhone 12"],
+  ["display iphone 12", "Display (Original), Apple iPhone 12", ["mini", "pro max"]],
+  ["pantalla iphone 12", "Display (Original), Apple iPhone 12", ["mini", "pro max"]],
+];
+
+for (const [query, expected, forbidden = []] of checks) {
+  const title = assertTop(query, expected, forbidden);
+  const ranked = rank(query).slice(0, 4).map((entry, index) => ({
+    position: index + 1,
+    score: entry.score,
+    title: entry.row.name,
+    reasons: entry.debug.reasons.map((reason) => `${reason.label} ${reason.score > 0 ? "+" : ""}${reason.score}`).join("; "),
+  }));
+  console.log(`[search-ranking-test] PASS ${query} -> ${title}`);
+  if (query === "iphone 12 display") {
+    console.log("[search-ranking-test] debug iphone 12 display");
+    console.table(ranked);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds Apple iPhone model parsing for generations 11-17 with exact variant detection (`base`, `mini`, `plus`, `pro`, `pro max`, `air`).
- Updates catalog search scoring so exact model, generation, part type, Apple brand, variant mismatch, and exact title phrase affect ranking correctly.
- Adds `debugSearch=1` support for storefront/API search debugging with per-result score reasons.
- Adds regression coverage for the commercial iPhone 12 display ranking cases, including mini/pro/pro max, battery, tapa, display order, and `pantalla` synonym behavior.

## Root Cause
The previous relevance scoring treated `iPhone 12` mostly as a broad phrase/family match, so nearby variants like `iPhone 12 mini`, `iPhone 12 Pro`, and `iPhone 12 Pro Max` could rank above the exact base model for `iphone 12 display`.

## Validation
- `node -c nerin_final_updated/backend/data/productsSqliteRepo.js`
- `node -c nerin_final_updated/backend/server.js`
- `node -c nerin_final_updated/frontend/js/shop.js`
- `node -c nerin_final_updated/scripts/test-search-ranking-cases.js`
- `node nerin_final_updated/scripts/test-search-ranking-cases.js`
- `node .../jest/bin/jest.js nerin_final_updated/__tests__/backend/product-search-ranking.test.js --runInBand`

Key regression log: `iphone 12 display` now ranks `Display (Original), Apple iPhone 12` first, ahead of `iPhone 12 Pro`, `iPhone 12 mini`, and `iPhone 12 Pro Max`.