### PR TITLE
[codex] Fix Merchant availability and technical search

### DIFF
--- a/nerin_final_updated/__tests__/backend/merchant-feed.test.js
+++ b/nerin_final_updated/__tests__/backend/merchant-feed.test.js
@@ -1,4 +1,5 @@
 const { buildMerchantFeedAudit, buildMerchantFeedEntries, safeMerchantText } = require('../../backend/utils/merchantFeed');
+const { resolveProductAvailability } = require('../../backend/utils/productAvailability');
 
 function baseRow(overrides = {}, raw = {}) {
   return {
@@ -57,6 +58,22 @@ describe('merchant feed audit', () => {
     const audit = buildMerchantFeedAudit([baseRow({ stock: 0 })]);
     expect(audit.samplesEligible[0].availability).toBe('preorder');
     expect(audit.samplesEligible[0].availability_date).toMatch(/^\d{4}-\d{2}-\d{2}T00:00-0300$/);
+  });
+
+  test('preorder comparte fecha entre feed, texto visible y JSON-LD', () => {
+    const availability = resolveProductAvailability(baseRow({ stock: 0, availability_date: '2026-06-16' }), { now: new Date('2026-05-19T12:00:00Z') });
+    expect(availability.merchantAvailability).toBe('preorder');
+    expect(availability.availabilityDateFeed).toBe('2026-06-16T00:00-0300');
+    expect(availability.availabilityStarts).toBe('2026-06-16T00:00:00-03:00');
+    expect(availability.visibleAvailabilityText).toContain('16/06/2026');
+    expect(availability.seoAvailability).toBe('https://schema.org/PreOrder');
+  });
+
+  test('availability_date vencido o mayor a un anio se normaliza a ventana valida', () => {
+    const older = resolveProductAvailability(baseRow({ stock: 0, availability_date: '2026-01-01' }), { now: new Date('2026-05-19T12:00:00Z') });
+    const tooFar = resolveProductAvailability(baseRow({ stock: 0, availability_date: '2028-01-01' }), { now: new Date('2026-05-19T12:00:00Z') });
+    expect(older.availabilityDateFeed).toBe('2026-05-20T00:00-0300');
+    expect(tooFar.availabilityDateFeed).toBe('2027-05-19T00:00-0300');
   });
   test('contadores reales pueden ser mayores al lote escaneado', () => {
     const rows = [baseRow({ id: 'a' }), baseRow({ id: 'b', is_public: 0 })];

--- a/nerin_final_updated/__tests__/backend/product-search-ranking.test.js
+++ b/nerin_final_updated/__tests__/backend/product-search-ranking.test.js
@@ -114,6 +114,74 @@ describe('product search ranking intent', () => {
     ])).toContain('Display');
   });
 
+  test('technical Spanish and English synonyms expand without losing iPhone 12 base precision', () => {
+    const products = [
+      { rowid: 1, name: 'Display (Original), Apple iPhone 12 mini', model: 'iPhone 12 mini', brand: 'Apple', category: 'Display' },
+      { rowid: 2, name: 'Display (Original), Apple iPhone 12 Pro Max', model: 'iPhone 12 Pro Max', brand: 'Apple', category: 'Display' },
+      { rowid: 3, name: 'Display (Original), Apple iPhone 12', model: 'iPhone 12', brand: 'Apple', category: 'Display' },
+      { rowid: 4, name: 'Battery, Apple iPhone 12', model: 'iPhone 12', brand: 'Apple', category: 'Battery' },
+    ];
+    expect(firstTitle('pantalla iphone 12', products)).toBe('Display (Original), Apple iPhone 12');
+    expect(firstTitle('display iphone 12', products)).toBe('Display (Original), Apple iPhone 12');
+    expect(firstTitle('modulo iphone 12', products)).toBe('Display (Original), Apple iPhone 12');
+  });
+
+  test('battery intent ranks battery above display in Spanish and English', () => {
+    const products = [
+      { rowid: 1, name: 'Display (Original), Apple iPhone 12', model: 'iPhone 12', brand: 'Apple', category: 'Display' },
+      { rowid: 2, name: 'Battery, Apple iPhone 12', model: 'iPhone 12', brand: 'Apple', category: 'Battery' },
+    ];
+    expect(firstTitle('bateria iphone 12', products)).toBe('Battery, Apple iPhone 12');
+    expect(firstTitle('battery iphone 12', products)).toBe('Battery, Apple iPhone 12');
+  });
+
+  test('charging Spanish queries rank Samsung A54 charging boards first', () => {
+    const products = [
+      { rowid: 1, name: 'Display Samsung Galaxy A54', model: 'Galaxy A54', brand: 'Samsung', category: 'Display' },
+      { rowid: 2, name: 'Charging board / dock connector Samsung Galaxy A54', model: 'Galaxy A54', brand: 'Samsung', category: 'Charging board' },
+      { rowid: 3, name: 'Back cover Samsung Galaxy A54', model: 'Galaxy A54', brand: 'Samsung', category: 'Back cover' },
+    ];
+    expect(firstTitle('pin de carga samsung a54', products)).toContain('Charging board');
+    expect(firstTitle('placa de carga samsung a54', products)).toContain('Charging board');
+  });
+
+  test('technical part intents rank the requested replacement type first', () => {
+    const products = [
+      { rowid: 1, name: 'Display (Original), Apple iPhone 12', model: 'iPhone 12', brand: 'Apple', category: 'Display' },
+      { rowid: 2, name: 'Back glass rear cover Apple iPhone 12', model: 'iPhone 12', brand: 'Apple', category: 'Back cover' },
+      { rowid: 3, name: 'Rear camera Apple iPhone 12', model: 'iPhone 12', brand: 'Apple', category: 'Camera' },
+      { rowid: 4, name: 'Sim tray Apple iPhone 12', model: 'iPhone 12', brand: 'Apple', category: 'Sim tray' },
+      { rowid: 5, name: 'Display adhesive tape Apple iPhone 12', model: 'iPhone 12', brand: 'Apple', category: 'Adhesive' },
+      { rowid: 6, name: 'Loud speaker Apple iPhone 12', model: 'iPhone 12', brand: 'Apple', category: 'Speaker' },
+    ];
+    expect(firstTitle('tapa trasera iphone 12', products)).toContain('Back glass');
+    expect(firstTitle('camara iphone 12', products)).toContain('camera');
+    expect(firstTitle('bandeja sim iphone 12', products)).toContain('Sim tray');
+    expect(firstTitle('adhesivo pantalla iphone 12', products)).toContain('adhesive');
+    expect(firstTitle('parlante iphone 12', products)).toContain('speaker');
+  });
+
+  test('technical synonyms work for Samsung, Xiaomi and Honor models', () => {
+    const products = [
+      { rowid: 1, name: 'Display Samsung Galaxy A54', model: 'Galaxy A54', brand: 'Samsung', category: 'Display' },
+      { rowid: 2, name: 'Battery Xiaomi Redmi Note 14', model: 'Redmi Note 14', brand: 'Xiaomi', category: 'Battery' },
+      { rowid: 3, name: 'Back Glass Rear Cover Honor 200', model: 'Honor 200', brand: 'Honor', category: 'Back cover' },
+      { rowid: 4, name: 'Battery Samsung Galaxy A54', model: 'Galaxy A54', brand: 'Samsung', category: 'Battery' },
+      { rowid: 5, name: 'Display Honor 200', model: 'Honor 200', brand: 'Honor', category: 'Display' },
+    ];
+    expect(firstTitle('pantalla samsung a54', products)).toContain('Display Samsung');
+    expect(firstTitle('bateria xiaomi note 14', products)).toContain('Battery Xiaomi');
+    expect(firstTitle('tapa honor 200', products)).toContain('Back Glass');
+  });
+
+  test('debug intent exposes expanded query, synonyms and part type', () => {
+    const intent = computeSearchIntent('pantalla iphone 12');
+    expect(intent.intentPartType).toBe('display');
+    expect(intent.expandedTerms).toContain('display');
+    expect(intent.expandedTerms).toContain('screen');
+    expect(intent.appliedSynonyms.display).toContain('pantalla');
+  });
+
   test('iphone 15 pro battery ranks 15 pro over other iphones', () => {
     const exact = score('iphone 15 pro battery', { name: 'Bateria iPhone 15 Pro', model: 'iPhone 15 Pro', brand: 'Apple' });
     const iphone17 = score('iphone 15 pro battery', { name: 'Bateria iPhone 17', model: 'iPhone 17', brand: 'Apple' });

--- a/nerin_final_updated/backend/data/productsSqliteRepo.js
+++ b/nerin_final_updated/backend/data/productsSqliteRepo.js
@@ -168,22 +168,6 @@ const APPLE_VARIANT_PENALTIES = {
   air: { base: -500, pro: -700, "pro max": -800, mini: -800, plus: -700 },
 };
 
-const REPLACEMENT_TYPE_SYNONYMS = [
-  { key: "bateria", terms: ["battery", "bateria", "baterias", "bater?a", "bater?as"] },
-  { key: "pantalla", terms: ["display", "pantalla", "pantallas", "modulo", "modulo display", "modulo pantalla", "modulo lcd", "m?dulo", "lcd", "screen"] },
-  { key: "tapa", terms: ["tapa", "tapa trasera", "back glass", "rear cover", "back cover", "vidrio trasero", "carcasa trasera"] },
-  { key: "placa carga", terms: ["charging board", "charge port", "dock connector", "placa de carga", "pin de carga", "puerto de carga"] },
-  { key: "adhesivo", terms: ["adhesive", "tape", "glue", "adhesivo", "pegamento"] },
-  { key: "flex", terms: ["flex cable", "flex", "cable flex"] },
-  { key: "camara", terms: ["camera", "camara", "c?mara", "camara frontal", "camara trasera"] },
-];
-
-const REPLACEMENT_TYPE_SEARCH_EQUIVALENTS = new Map(
-  REPLACEMENT_TYPE_SYNONYMS.flatMap((entry) =>
-    entry.terms.map((term) => [normalizeQueryText(term), entry.terms.map(normalizeQueryText)]),
-  ),
-);
-
 function uniqueValues(values = []) {
   return Array.from(new Set(values.filter(Boolean)));
 }
@@ -196,22 +180,84 @@ function tokenizeSearch(value = "") {
 }
 
 const PRODUCT_TYPE_DICT = {
-  pantalla: ["pantalla","display","modulo","lcd","oled","amoled","screen","touchscreen","tactil"],
-  bateria: ["bateria","battery","pila"],
-  pin_carga: ["pin de carga","puerto de carga","placa de carga","charging board","dock connector","daughterboard","sub board","usb connector","connector usb"],
-  tapa_trasera: ["tapa","tapa trasera","carcasa","back glass","rear cover","battery cover","back cover"],
-  flex: ["flex","flex cable","main flex","cable flex","flex principal"],
-  camara: ["camara","camera","rear camera","front camera","lens","lente"],
-  adhesivo: ["adhesivo","adhesive","tape","sticker","rear cover adhesive","battery adhesive","display adhesive"],
-  bandeja_sim: ["bandeja sim","sim tray","card tray"],
+  display: ["pantalla","pantallas","modulo","modulo pantalla","modulo display","display","screen","lcd","oled","amoled","super amoled","tactil","touch","glass","display incl frame","display excl frame","assembly"],
+  battery: ["bateria","baterias","battery","batteries","pila","accu","acumulador"],
+  charging: ["pin de carga","placa de carga","puerto de carga","centro de carga","conector de carga","charging","charging board","charging connector","charge port","dock connector","usb connector","connector usb","usb board","sub board","daughterboard"],
+  back_cover: ["tapa","tapa trasera","vidrio trasero","carcasa","carcasa trasera","back glass","rear cover","back cover","battery cover","housing"],
+  camera: ["camara","camera","rear camera","front camera","camera lens","lente camara","camara frontal","camara trasera","lens"],
+  flex: ["flex","flex cable","main flex","cable flex","flex principal","interconnection flex"],
+  speaker: ["parlante","speaker","loud speaker","ear speaker","altavoz","auricular interno"],
+  sim_tray: ["bandeja sim","sim tray","charola sim","porta sim","card tray"],
+  adhesive: ["adhesivo","adhesive","adhesive tape","display adhesive","rear cover adhesive","battery adhesive","gasket","seal","pegamento","cinta","cinta adhesiva","sticker","tape"],
+  vibration: ["vibrador","vibration motor","motor vibrador"],
+  sensor: ["sensor","proximity sensor","sensor proximidad","huella","fingerprint"],
+  button: ["boton","power button","volume button","key","slider key"],
+  component: ["ic","chip","componente","componentes electronicos","antenna","antena","board","placa","sub board","daughterboard"],
 };
+
+const PART_INTENT_PRIORITY = [
+  "charging",
+  "adhesive",
+  "battery",
+  "back_cover",
+  "display",
+  "camera",
+  "flex",
+  "speaker",
+  "sim_tray",
+  "vibration",
+  "sensor",
+  "button",
+  "component",
+];
+
+const RELATED_PART_TYPES = {
+  display: new Set(["adhesive"]),
+  adhesive: new Set(["display", "back_cover", "battery"]),
+  charging: new Set(["component", "flex"]),
+  component: new Set(["charging", "sensor", "button"]),
+  speaker: new Set(["flex"]),
+  camera: new Set(["flex"]),
+  back_cover: new Set(["adhesive"]),
+};
+
+const PRODUCT_TYPE_SEARCH_EQUIVALENTS = new Map(
+  Object.values(PRODUCT_TYPE_DICT).flatMap((terms) => {
+    const normalizedTerms = uniqueValues(terms.map(normalizeSearchText));
+    return normalizedTerms.map((term) => [term, normalizedTerms]);
+  }),
+);
+
+const SEARCH_STOPWORDS = new Set(["de", "del", "la", "el", "para", "for", "con", "y"]);
 
 function inferReplacementType(text = "") {
   const normalized = normalizeSearchText(text);
+  const matches = new Set();
   for (const [key, terms] of Object.entries(PRODUCT_TYPE_DICT)) {
-    if (terms.some((term) => normalized.includes(normalizeSearchText(term)))) return key;
+    if (terms.some((term) => normalized.includes(normalizeSearchText(term)))) matches.add(key);
   }
-  return REPLACEMENT_TYPE_SYNONYMS.find((entry) => entry.terms.some((term) => normalized.includes(normalizeSearchText(term))))?.key || "";
+  return PART_INTENT_PRIORITY.find((key) => matches.has(key)) || "";
+}
+
+function getPartTypeSynonyms(partType = "") {
+  return PRODUCT_TYPE_DICT[partType] ? uniqueValues(PRODUCT_TYPE_DICT[partType].map(normalizeSearchText)) : [];
+}
+
+function expandTechnicalQuery(normalizedQuery = "") {
+  const tokens = tokenizeSearch(normalizedQuery);
+  const intentPartType = inferReplacementType(normalizedQuery);
+  const appliedSynonyms = {};
+  const expandedTerms = [...tokens];
+  if (intentPartType) {
+    const synonyms = getPartTypeSynonyms(intentPartType);
+    appliedSynonyms[intentPartType] = synonyms;
+    expandedTerms.push(...synonyms);
+  }
+  return {
+    intentPartType,
+    appliedSynonyms,
+    expandedTerms: uniqueValues(expandedTerms.map(normalizeSearchText).filter(Boolean)),
+  };
 }
 
 function extractModelPhrase(text = "") {
@@ -384,6 +430,7 @@ function addScoreReason(state, label, value) {
 function computeSearchIntent(query = "") {
   const normalizedQuery = normalizeSearchText(query);
   const tokens = tokenizeSearch(normalizedQuery);
+  const technicalExpansion = expandTechnicalQuery(normalizedQuery);
   const appleModel = parseAppleModel(normalizedQuery);
   const exactCodes = tokens.filter((token) => /[a-z]{1,4}\d{2,}(-[a-z0-9]{2,})?/i.test(token));
   const noHyphenCodes = exactCodes.map(tokenWithoutHyphen);
@@ -391,9 +438,13 @@ function computeSearchIntent(query = "") {
   const originalIntent = /\b(original|oem|service pack|genuine)\b/.test(normalizedQuery);
   const compatibleBrandIntentMatch = normalizedQuery.match(/\bfor\s+([a-z0-9]+)\b/);
   const compatibleBrandIntent = compatibleBrandIntentMatch ? compatibleBrandIntentMatch[1] : "";
-  const productTypeIntent = inferReplacementType(normalizedQuery);
+  const productTypeIntent = technicalExpansion.intentPartType;
   return {
+    originalQuery: query,
     normalizedQuery,
+    expandedTerms: technicalExpansion.expandedTerms,
+    appliedSynonyms: technicalExpansion.appliedSynonyms,
+    intentPartType: technicalExpansion.intentPartType,
     tokens,
     exactCodes,
     noHyphenCodes,
@@ -407,7 +458,7 @@ function computeSearchIntent(query = "") {
     productTypeIntent,
     modelPhrase: extractModelPhrase(normalizedQuery),
     appleModel,
-    replacementType: inferReplacementType(normalizedQuery),
+    replacementType: technicalExpansion.intentPartType,
     skuOrMpn: extractSkuOrMpn(normalizedQuery),
     importantTokens: tokens.filter((token) => token.length >= 3),
   };
@@ -452,9 +503,11 @@ function scoreProductAgainstIntent(product = {}, intent = {}, options = {}) {
     if (tokenWithoutHyphen(haystack).includes(code)) addScoreReason(state, `codigo sin guion ${code}`, 800);
   }
   if (intent.modelPhrase && haystack.includes(intent.modelPhrase)) addScoreReason(state, "frase de modelo presente", 250);
-  if (intent.replacementType) {
-    if (productType === intent.replacementType) addScoreReason(state, `tipo ${intent.replacementType}`, 800);
-    else if (productType) addScoreReason(state, `tipo incorrecto ${productType} vs ${intent.replacementType}`, -800);
+  if (intent.intentPartType || intent.replacementType) {
+    const wantedType = intent.intentPartType || intent.replacementType;
+    if (productType === wantedType) addScoreReason(state, `partType ${wantedType}`, 1200);
+    else if (RELATED_PART_TYPES[wantedType]?.has(productType)) addScoreReason(state, `tipo relacionado ${productType} con ${wantedType}`, 300);
+    else if (productType) addScoreReason(state, `tipo incorrecto ${productType} vs ${wantedType}`, -800);
   }
   if (intent.brand) {
     if (intent.brand === "apple" || intent.tokens?.some((token) => token === "iphone" || token === "apple")) {
@@ -504,9 +557,6 @@ function scoreProductAgainstIntent(product = {}, intent = {}, options = {}) {
     if (target && candidate && target[1] !== candidate[1]) addScoreReason(state, "modelo iphone numericamente distinto", -500);
     if (intent.modelPhrase.includes("pro") && !intent.modelPhrase.includes("pro max") && haystack.includes(`${intent.modelPhrase} max`)) addScoreReason(state, "pro max no solicitado", -500);
   }
-  if (intent.productTypeIntent && productType && intent.productTypeIntent !== productType) {
-    addScoreReason(state, `tipo distinto de ${intent.productTypeIntent}`, -700);
-  }
   const stock = Number(getField(product, ["stock"]));
   if (Number.isFinite(stock) && stock > 0) addScoreReason(state, "stock disponible", 120);
   if (!options?.debug) return state.score;
@@ -538,6 +588,12 @@ function rankRowsBySearchIntent(rows = [], intent = {}, { preferPositiveScores =
 function getSearchDebugForRankedEntries(ranked = [], intent = {}, limit = 24) {
   return ranked.slice(0, Math.max(1, Math.min(100, Number(limit) || 24))).map((entry, position) => ({
     position: position + 1,
+    queryOriginal: intent.originalQuery || "",
+    queryNormalized: intent.normalizedQuery || "",
+    queryExpanded: intent.expandedTerms || [],
+    appliedSynonyms: intent.appliedSynonyms || {},
+    intentPartType: intent.intentPartType || "",
+    queryBrand: intent.brand || "",
     id: entry.row?.id || null,
     sku: entry.row?.sku || null,
     code: entry.row?.code || null,
@@ -548,23 +604,42 @@ function getSearchDebugForRankedEntries(ranked = [], intent = {}, limit = 24) {
     productModel: entry.debug?.productModel || null,
     variant: entry.debug?.productVariant || null,
     compatibleAppleModels: entry.debug?.compatibleAppleModels || [],
+    productType: entry.debug?.productType || "",
+    productBrand: entry.debug?.productBrand || "",
     reasons: entry.debug?.reasons || [],
   }));
 }
 
 function expandSearchTokenForSynonyms(token = "") {
   const normalized = normalizeQueryText(token);
-  return uniqueValues(REPLACEMENT_TYPE_SEARCH_EQUIVALENTS.get(normalized) || [normalized]);
+  return uniqueValues(PRODUCT_TYPE_SEARCH_EQUIVALENTS.get(normalized) || [normalized]);
+}
+
+function splitSearchTerms(values = []) {
+  return uniqueValues(values
+    .flatMap((term) => normalizeSearchText(term).split(/\s+/))
+    .map((term) => term.trim())
+    .filter((term) => term && !SEARCH_STOPWORDS.has(term)));
+}
+
+function buildSearchTermGroups(normalizedSearch = "") {
+  const intent = computeSearchIntent(normalizedSearch);
+  const tokens = tokenizeSearch(normalizedSearch).filter((token) => !SEARCH_STOPWORDS.has(token));
+  if (!intent.intentPartType) return tokens.map((token) => expandSearchTokenForSynonyms(token));
+  const synonymTerms = getPartTypeSynonyms(intent.intentPartType);
+  const synonymTokenSet = new Set(splitSearchTerms(synonymTerms));
+  const groups = [splitSearchTerms(synonymTerms)];
+  tokens
+    .filter((token) => !synonymTokenSet.has(token))
+    .forEach((token) => groups.push(expandSearchTokenForSynonyms(token)));
+  return groups.filter((group) => group.length);
 }
 
 function buildFtsQueryFromSearch(normalizedSearch = "") {
-  const tokens = normalizedSearch
-    .replace(/[^a-z0-9\s-]/gi, " ")
-    .split(/\s+/)
-    .filter(Boolean);
-  return tokens
+  const groups = buildSearchTermGroups(normalizedSearch);
+  return groups
     .map((token) => {
-      const equivalents = expandSearchTokenForSynonyms(token)
+      const equivalents = (Array.isArray(token) ? token : expandSearchTokenForSynonyms(token))
         .map((term) => term.replace(/[^a-z0-9\s-]/gi, " ").trim())
         .filter(Boolean)
         .flatMap((term) => term.split(/\s+/).filter(Boolean));
@@ -576,12 +651,9 @@ function buildFtsQueryFromSearch(normalizedSearch = "") {
 }
 
 function addLikeSearchConditions(where, params, normalizedSearch = "") {
-  const tokens = normalizedSearch
-    .replace(/[^a-z0-9\s-]/gi, " ")
-    .split(/\s+/)
-    .filter(Boolean);
-  tokens.forEach((token) => {
-    const equivalents = expandSearchTokenForSynonyms(token);
+  const groups = buildSearchTermGroups(normalizedSearch);
+  groups.forEach((token) => {
+    const equivalents = Array.isArray(token) ? token : expandSearchTokenForSynonyms(token);
     where.push(`(${equivalents.map(() => "search_text LIKE ?").join(" OR ")})`);
     equivalents.forEach((term) => params.push(`%${term}%`));
   });
@@ -2367,6 +2439,10 @@ async function queryBase({
       searchDebug = {
         query: search,
         normalizedQuery: normalizedSearch,
+        expandedQuery: intent.expandedTerms || [],
+        appliedSynonyms: intent.appliedSynonyms || {},
+        intentPartType: intent.intentPartType || "",
+        brand: intent.brand || "",
         queryModel: intent.appleModel || null,
         results: getSearchDebugForRankedEntries(pageEntries, intent, safePageSize),
       };
@@ -3052,6 +3128,11 @@ async function debugCatalogSearch({ search = "", limit = 20 } = {}) {
   else if (Number(totalRow?.total || 0) === 0) diagnosis = "no_matchea_search_text";
   return {
     search,
+    normalizedQuery: intent.normalizedQuery,
+    expandedQuery: intent.expandedTerms || [],
+    appliedSynonyms: intent.appliedSynonyms || {},
+    intentPartType: intent.intentPartType || "",
+    brand: intent.brand || "",
     totalMatches: Number(totalRow?.total || 0),
     diagnosis,
     queryModel: intent.appleModel || null,

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -77,6 +77,10 @@ const {
 const { importStockXlsxFile } = require("./services/stockXlsxImport");
 const productsStreamRepo = require("./data/productsStreamRepo");
 const productsSqliteRepo = require("./data/productsSqliteRepo");
+const {
+  resolveProductAvailability,
+  getPublicPriceValue,
+} = require("./utils/productAvailability");
 const { readJsonFile } = require("./utils/jsonFile");
 const {
   appendEvent,
@@ -1369,8 +1373,8 @@ function buildProductMetaDescription(product) {
 
 function formatArs(value) {
   const amount = Number(value);
-  if (Number.isFinite(amount)) return `$${amount.toLocaleString("es-AR", { maximumFractionDigits: 0 })}`;
-  return "$0";
+  if (Number.isFinite(amount)) return `$${amount.toLocaleString("es-AR", { maximumFractionDigits: 0 })} ARS`;
+  return "$0 ARS";
 }
 
 
@@ -1419,12 +1423,7 @@ function getProductFeedDescription(product) {
 }
 
 function getProductFeedPrice(product) {
-  const priceSource =
-    product?.price_minorista ??
-    product?.price ??
-    product?.price_mayorista ??
-    0;
-  const numeric = Number(priceSource);
+  const numeric = getPublicPriceValue(product);
   const formatted = Number.isFinite(numeric) ? numeric.toFixed(2) : "0.00";
   return `${formatted} ARS`;
 }
@@ -1585,6 +1584,7 @@ function renderProductGallerySsr(product, siteBase) {
 function renderProductInfoSsr(product, siteBase) {
   const heading = buildProductHeading(product);
   const description = buildFeaturePhrase(product);
+  const availabilityInfo = resolveProductAvailability(product);
   const brand = normalizeTextInput(product?.brand);
   const model = normalizeTextInput(product?.model);
   const sku = normalizeTextInput(product?.sku);
@@ -1593,8 +1593,8 @@ function renderProductInfoSsr(product, siteBase) {
   const technology = inferDisplayTechnology(product);
   const frame = inferHasFrame(product);
   const color = inferColor(product);
-  let stockCopy = "";
-  if (stockValue != null) {
+  let stockCopy = availabilityInfo.visibleAvailabilityText || availabilityInfo.availabilityLabel || "";
+  if (!stockCopy && stockValue != null) {
     if (stockValue <= 0) stockCopy = "Sin stock disponible";
     else if (product?.min_stock != null && stockValue < product.min_stock) {
       stockCopy = `Poco stock • ${stockValue} u.`;
@@ -1617,7 +1617,7 @@ function renderProductInfoSsr(product, siteBase) {
   const compatibilityHtml = compatibility
     ? `<p class=\"product-compatibility\">Compatible con ${esc(compatibility)}.</p>`
     : "";
-  const retailPrice = Number(product?.price_minorista);
+  const retailPrice = getPublicPriceValue(product);
   const canAccessWholesalePricing =
     product?.viewerRole === "admin" ||
     product?.viewerRole === "wholesale" ||
@@ -1674,6 +1674,33 @@ function renderProductInfoSsr(product, siteBase) {
       </aside>
     </div>
   `;
+}
+
+function renderMerchantDebugSsr(product, { canonical = "", imageLink = "" } = {}) {
+  const availabilityInfo = resolveProductAvailability(product);
+  const priceValue = getPublicPriceValue(product);
+  const jsonLdAvailability = availabilityInfo.seoAvailability;
+  const payload = {
+    productId: product?.id || product?.sku || null,
+    title: product?.name || product?.title || null,
+    feedAvailability: availabilityInfo.merchantAvailability || null,
+    feedAvailabilityDate: availabilityInfo.availabilityDateFeed || "",
+    visibleAvailabilityText: availabilityInfo.visibleAvailabilityText || availabilityInfo.availabilityLabel || "",
+    jsonLdAvailability,
+    jsonLdAvailabilityStarts: availabilityInfo.availabilityStarts || "",
+    priceFeed: `${Number(priceValue || 0).toFixed(2)} ARS`,
+    priceVisible: `${Number(priceValue || 0).toFixed(2)} ARS`,
+    imageLink: imageLink || null,
+    canonicalUrl: canonical || null,
+    mismatches: {
+      preorderMissingFeedDate: ["preorder", "backorder"].includes(availabilityInfo.merchantAvailability) && !availabilityInfo.availabilityDateFeed,
+      preorderMissingVisibleDate: ["preorder", "backorder"].includes(availabilityInfo.merchantAvailability) && !availabilityInfo.availabilityDateDisplay,
+      preorderMissingJsonLdAvailabilityStarts: jsonLdAvailability === "https://schema.org/PreOrder" && !availabilityInfo.availabilityStarts,
+      priceMismatch: false,
+      currencyMismatch: false,
+    },
+  };
+  return `<section class="merchant-debug" data-debug-merchant="1"><h2>Merchant debug</h2><pre>${esc(JSON.stringify(payload, null, 2))}</pre></section>`;
 }
 
 function injectProductContent(body, galleryHtml, infoHtml) {
@@ -12569,7 +12596,7 @@ async function requestHandler(req, res) {
       const productColumns = await sqliteAll(dbConn, 'PRAGMA table_info(products)');
       const availableColumns = new Set((productColumns || []).map((col) => String(col?.name || '').trim()).filter(Boolean));
       const preferredColumns = [
-        'id','sku','slug','public_slug','name','title','description','brand','stock','price','price_minorista','precio_minorista','precio_final','image','raw_json','status','visibility','enabled','deleted','archived','vip_only','wholesale_only','is_public','part_number','mpn','category'
+        'id','sku','slug','public_slug','name','title','description','brand','stock','remote_stock','stock_remote','available_remote','remote_lead_days','remote_lead_min_days','remote_lead_max_days','stock_mode','fulfillment_mode','availability','availability_date','preorder_date','price','price_minorista','price_mayorista','precio_minorista','precio_mayorista','precio_final','image','image_url','raw_json','status','visibility','enabled','deleted','archived','vip_only','wholesale_only','is_public','part_number','mpn','category'
       ];
       const fallbackExpressions = {
         public_slug: "json_extract(raw_json, '$.public_slug') AS public_slug",
@@ -12926,7 +12953,8 @@ async function requestHandler(req, res) {
     const defaultAlt = name || "Imagen del producto";
     const primaryImage = imageList[0] || null;
     const primaryAlt = normalizedAlts[0] || defaultAlt;
-    const availability = resolveProductAvailability(product).seoAvailability;
+    const availabilityInfo = resolveProductAvailability(product);
+    const availability = availabilityInfo.seoAvailability;
     const brandName =
       typeof product.brand === "string" && product.brand.trim()
         ? product.brand.trim()
@@ -12939,12 +12967,7 @@ async function requestHandler(req, res) {
           : null;
     const descriptionValue =
       typeof desc === "string" && desc.trim() ? desc.trim() : null;
-    const priceSource =
-      product.price_minorista ??
-      product.price ??
-      product.price_mayorista ??
-      0;
-    const numericPrice = Number(priceSource);
+    const numericPrice = getPublicPriceValue(product);
     const formattedPrice = Number.isFinite(numericPrice)
       ? numericPrice.toFixed(2)
       : "0.00";
@@ -12967,6 +12990,7 @@ async function requestHandler(req, res) {
         priceCurrency: "ARS",
         price: formattedPrice,
         availability,
+        ...(availabilityInfo.availabilityStarts ? { availabilityStarts: availabilityInfo.availabilityStarts } : {}),
         itemCondition: "https://schema.org/NewCondition",
       },
     };
@@ -13055,7 +13079,8 @@ async function requestHandler(req, res) {
       .filter(Boolean)
       .join("");
     const galleryHtml = renderProductGallerySsr(product, siteBase);
-    const infoHtml = renderProductInfoSsr(product, siteBase);
+    const debugMerchant = parsedUrl.query?.debugMerchant === "1";
+    const infoHtml = renderProductInfoSsr(product, siteBase) + (debugMerchant ? renderMerchantDebugSsr(product, { canonical, imageLink: primaryImage || "" }) : "");
     const hydratedBody = injectProductContent(templateBody, galleryHtml, infoHtml);
     const html = `<!DOCTYPE html><html lang="es-AR"><head>${head}</head>${hydratedBody}</html>`;
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });

--- a/nerin_final_updated/backend/utils/merchantFeed.js
+++ b/nerin_final_updated/backend/utils/merchantFeed.js
@@ -1,4 +1,9 @@
 const { detectProductType } = require('./productTaxonomy');
+const {
+  resolveProductAvailability,
+  formatMerchantAvailabilityDate,
+  getPublicPriceValue,
+} = require('./productAvailability');
 
 const GOOGLE_CATEGORY = 'Electrónica > Comunicaciones > Telefonía > Accesorios para móviles';
 const VALID_AVAILABILITY = new Set(['in_stock', 'preorder', 'backorder']);
@@ -53,42 +58,24 @@ function buildMerchantTitle(row, raw) {
   return safeMerchantText(row.name || row.title || raw.name || raw.title || raw.description || '');
 }
 
-function formatMerchantAvailabilityDate(value) {
-  const formatted = String(value || '').trim();
-  if (!formatted) return '';
-  if (/^\d{4}-\d{2}-\d{2}T00:00-0300$/.test(formatted)) return formatted;
-  const onlyDateMatch = formatted.match(/^(\d{4}-\d{2}-\d{2})(?:[T\s].*)?$/);
-  if (onlyDateMatch) return `${onlyDateMatch[1]}T00:00-0300`;
-  const parsed = new Date(formatted);
-  if (Number.isNaN(parsed.getTime())) return '';
-  const y = parsed.getUTCFullYear();
-  const m = String(parsed.getUTCMonth() + 1).padStart(2, '0');
-  const d = String(parsed.getUTCDate()).padStart(2, '0');
-  return `${y}-${m}-${d}T00:00-0300`;
-}
-
-function estimateMerchantAvailabilityDate(preorderDays = 30) {
-  const days = Math.max(1, Number(preorderDays) || 30);
-  const future = new Date(Date.now() + days * 86400000);
-  const y = future.getUTCFullYear();
-  const m = String(future.getUTCMonth() + 1).padStart(2, '0');
-  const d = String(future.getUTCDate()).padStart(2, '0');
-  return `${y}-${m}-${d}T00:00-0300`;
+function mergeProductData(row = {}, raw = {}) {
+  const merged = { ...raw };
+  for (const [key, value] of Object.entries(row || {})) {
+    if (value !== undefined && value !== null && value !== '') merged[key] = value;
+  }
+  return merged;
 }
 
 function computeAvailability(row, raw, preorderDays = 30) {
-  const stockLocal = Number(row.stock ?? raw.stock ?? 0);
-  const normalizedAvailability = String(row.availability || raw.availability || '').trim().toLowerCase();
-  const forcedBackorder = normalizedAvailability === 'backorder';
-  const forcedPreorder = normalizedAvailability === 'preorder';
-
-  if (stockLocal > 0 && !forcedPreorder && !forcedBackorder) return { availability: 'in_stock', availabilityDate: '' };
-
-  const existingDateRaw = row.availability_date || raw.availability_date || row.preorder_date || raw.preorder_date || '';
-  const existingDate = formatMerchantAvailabilityDate(existingDateRaw);
-
-  if (forcedBackorder) return { availability: 'backorder', availabilityDate: existingDate || estimateMerchantAvailabilityDate(preorderDays) };
-  return { availability: 'preorder', availabilityDate: existingDate || estimateMerchantAvailabilityDate(preorderDays) };
+  const merged = mergeProductData(row, raw);
+  if (merged.remote_lead_days == null) merged.remote_lead_days = preorderDays;
+  const resolved = resolveProductAvailability(merged);
+  return {
+    availability: resolved.merchantAvailability || resolved.feedAvailability || '',
+    availabilityDate: resolved.availabilityDateFeed || '',
+    visibleAvailabilityText: resolved.visibleAvailabilityText || '',
+    availabilityStarts: resolved.availabilityStarts || '',
+  };
 }
 
 function isEligibleState(row, raw) {
@@ -202,7 +189,7 @@ function buildMerchantFeedEntries(rows, { limit = 500, offset = 0, preorderDays 
       additional.push(n.normalized);
       if (additional.length >= 10) break;
     }
-    const priceNum = Number(row.precio_final ?? row.price_minorista ?? row.precio_minorista ?? row.price ?? raw.precio_final ?? raw.price_minorista ?? raw.price);
+    const priceNum = getPublicPriceValue(mergeProductData(row, raw));
     if (!Number.isFinite(priceNum) || priceNum <= 0) continue;
     const av = computeAvailability(row, raw, preorderDays);
     if (!VALID_AVAILABILITY.has(av.availability)) continue;
@@ -296,8 +283,8 @@ function buildMerchantFeedAudit(rows, { limit = 500, offset = 0, preorderDays = 
     }
     const imageLink = normalizedImage.normalized;
 
-    const priceNum = Number(row.precio_final ?? row.price_minorista ?? row.precio_minorista ?? row.price ?? raw.precio_final ?? raw.price_minorista ?? raw.price);
-    if ((row.price == null && raw.price == null && row.precio_final == null && raw.precio_final == null)) { skipped.missingPrice += 1; pushSample(samplesSkipped, { id: identifier, reason: 'missingPrice' }); continue; }
+    const priceNum = getPublicPriceValue(mergeProductData(row, raw));
+    if (!priceNum) { skipped.missingPrice += 1; pushSample(samplesSkipped, { id: identifier, reason: 'missingPrice' }); continue; }
     if (!Number.isFinite(priceNum) || priceNum <= 0) { skipped.invalidPrice += 1; pushSample(samplesSkipped, { id: identifier, reason: 'invalidPrice' }); continue; }
 
     const av = computeAvailability(row, raw, preorderDays);
@@ -367,4 +354,4 @@ function buildMerchantFeedAudit(rows, { limit = 500, offset = 0, preorderDays = 
   };
 }
 
-module.exports = { GOOGLE_CATEGORY, mapProductTypeToFeed, buildMerchantTitle, computeAvailability, isEligibleState, cleanText, safeMerchantText, detectProductType, buildMerchantFeedAudit, buildMerchantFeedEntries, normalizeMerchantImageUrl, isValidFeedUrl };
+module.exports = { GOOGLE_CATEGORY, mapProductTypeToFeed, buildMerchantTitle, computeAvailability, formatMerchantAvailabilityDate, isEligibleState, cleanText, safeMerchantText, detectProductType, buildMerchantFeedAudit, buildMerchantFeedEntries, normalizeMerchantImageUrl, isValidFeedUrl };

--- a/nerin_final_updated/backend/utils/productAvailability.js
+++ b/nerin_final_updated/backend/utils/productAvailability.js
@@ -1,24 +1,130 @@
+const DAY_MS = 24 * 60 * 60 * 1000;
+const ARG_FEED_OFFSET = "-0300";
+const ARG_SCHEMA_OFFSET = "-03:00";
+const MAX_AVAILABILITY_DAYS = 365;
+
 function toFiniteNumber(value, fallback = 0) {
   const numeric = Number(value);
   return Number.isFinite(numeric) ? numeric : fallback;
 }
 
-function resolveProductAvailability(product = {}) {
-  const stockLocal = toFiniteNumber(product.stock, 0);
+function normalizeAvailability(value = "") {
+  const normalized = String(value || "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+  if (["in_stock", "instock", "available", "disponible"].includes(normalized)) return "in_stock";
+  if (["preorder", "pre_order", "a_pedido", "pedido", "remote", "remoto"].includes(normalized)) return "preorder";
+  if (["backorder", "back_order", "allow_backorder"].includes(normalized)) return "backorder";
+  if (["out_of_stock", "outofstock", "sin_stock", "agotado"].includes(normalized)) return "out_of_stock";
+  return "";
+}
+
+function getUtcDateOnly(date = new Date()) {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}
+
+function addDaysUtc(date, days) {
+  return new Date(getUtcDateOnly(date).getTime() + Math.max(0, Number(days) || 0) * DAY_MS);
+}
+
+function parseAvailabilityDate(value) {
+  const raw = String(value || "").trim();
+  if (!raw) return null;
+  const dateOnly = raw.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (dateOnly) {
+    const y = Number(dateOnly[1]);
+    const m = Number(dateOnly[2]);
+    const d = Number(dateOnly[3]);
+    const date = new Date(Date.UTC(y, m - 1, d));
+    if (date.getUTCFullYear() === y && date.getUTCMonth() === m - 1 && date.getUTCDate() === d) return date;
+  }
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return getUtcDateOnly(parsed);
+}
+
+function clampAvailabilityDate(date, now = new Date()) {
+  const today = getUtcDateOnly(now);
+  const min = addDaysUtc(today, 1);
+  const max = addDaysUtc(today, MAX_AVAILABILITY_DAYS);
+  if (!date || Number.isNaN(date.getTime()) || date <= today) return min;
+  if (date > max) return max;
+  return getUtcDateOnly(date);
+}
+
+function resolveAvailabilityDate(product = {}, leadDays = 30, now = new Date()) {
+  const explicit = [
+    product.availability_date,
+    product.availabilityDate,
+    product.preorder_date,
+    product.preorderDate,
+    product.available_at,
+    product.availableAt,
+  ].map(parseAvailabilityDate).find(Boolean);
+  if (explicit) return clampAvailabilityDate(explicit, now);
+  return clampAvailabilityDate(addDaysUtc(now, leadDays || 30), now);
+}
+
+function dateParts(date) {
+  const d = getUtcDateOnly(date);
+  return {
+    y: String(d.getUTCFullYear()).padStart(4, "0"),
+    m: String(d.getUTCMonth() + 1).padStart(2, "0"),
+    d: String(d.getUTCDate()).padStart(2, "0"),
+  };
+}
+
+function formatMerchantAvailabilityDate(value) {
+  const parsed = value instanceof Date ? value : parseAvailabilityDate(value);
+  if (!parsed) return "";
+  const p = dateParts(parsed);
+  return `${p.y}-${p.m}-${p.d}T00:00${ARG_FEED_OFFSET}`;
+}
+
+function formatSchemaAvailabilityStarts(value) {
+  const parsed = value instanceof Date ? value : parseAvailabilityDate(value);
+  if (!parsed) return "";
+  const p = dateParts(parsed);
+  return `${p.y}-${p.m}-${p.d}T00:00:00${ARG_SCHEMA_OFFSET}`;
+}
+
+function formatDisplayAvailabilityDate(value) {
+  const parsed = value instanceof Date ? value : parseAvailabilityDate(value);
+  if (!parsed) return "";
+  const p = dateParts(parsed);
+  return `${p.d}/${p.m}/${p.y}`;
+}
+
+function getPublicPriceValue(product = {}) {
+  const value = [
+    product.precio_final,
+    product.price_minorista,
+    product.precio_minorista,
+    product.price,
+    product.price_mayorista,
+    product.precio_mayorista,
+  ].find((candidate) => Number.isFinite(Number(candidate)) && Number(candidate) > 0);
+  return Number.isFinite(Number(value)) ? Number(value) : 0;
+}
+
+function resolveProductAvailability(product = {}, options = {}) {
+  const now = options.now instanceof Date ? options.now : new Date();
+  const stockLocal = toFiniteNumber(product.stock ?? product.available_stock ?? product.inventory ?? product.stock_total, 0);
   const hasLocalStock = stockLocal > 0;
-  const textSignals = [product.name, product.description, product.category, product.subcategory]
+  const textSignals = [product.name, product.title, product.description, product.category, product.subcategory]
     .filter(Boolean)
     .join(" ")
     .toLowerCase();
-  const explicitMode = String(product.stock_mode || product.fulfillment_mode || "").trim().toLowerCase();
-  const remoteStock = toFiniteNumber(product.remote_stock, 0);
-  const minLead = toFiniteNumber(product.remote_lead_min_days || product.remote_lead_days, 0);
-  const maxLead = toFiniteNumber(product.remote_lead_max_days || product.remote_lead_days, 0);
-  const hasRemoteSignal = /stock remoto|a pedido|bajo pedido|encargo/.test(textSignals);
-  const isRemote = explicitMode === "remote" || explicitMode === "remoto" || remoteStock > 0 || minLead > 0 || maxLead > 0 || hasRemoteSignal;
-  const hasRemoteStock = isRemote && (remoteStock > 0 || minLead > 0 || maxLead > 0 || hasRemoteSignal);
+  const explicitAvailability = normalizeAvailability(product.availability || product.disponibilidad || product.estado_stock);
+  const explicitMode = String(product.stock_mode || product.fulfillment_mode || product.stockMode || product.fulfillmentMode || "").trim().toLowerCase();
+  const remoteStock = toFiniteNumber(product.remote_stock ?? product.stock_remote ?? product.available_remote, 0);
+  const minLead = toFiniteNumber(product.remote_lead_min_days || product.remote_lead_days || product.lead_min_days, 0);
+  const maxLead = toFiniteNumber(product.remote_lead_max_days || product.remote_lead_days || product.lead_max_days, 0);
+  const hasRemoteSignal = /stock remoto|a pedido|bajo pedido|encargo|preorder|backorder/.test(textSignals);
+  const forcedRemote = ["preorder", "backorder"].includes(explicitAvailability);
+  const isRemote = forcedRemote || explicitMode === "remote" || explicitMode === "remoto" || remoteStock > 0 || minLead > 0 || maxLead > 0 || hasRemoteSignal;
+  const priceValue = getPublicPriceValue(product);
+  const hasRemoteStock = isRemote && (remoteStock > 0 || minLead > 0 || maxLead > 0 || hasRemoteSignal || forcedRemote || priceValue > 0);
 
-  if (hasLocalStock) {
+  if (hasLocalStock && !forcedRemote) {
     return {
       stockLocal,
       hasLocalStock,
@@ -26,36 +132,29 @@ function resolveProductAvailability(product = {}) {
       hasRemoteStock,
       isSellable: true,
       availabilityLabel: "En stock",
+      visibleAvailabilityText: "En stock",
       availabilityBadge: "in_stock",
-      deliveryLabel: "Entrega rápida",
+      merchantAvailability: "in_stock",
+      feedAvailability: "in_stock",
+      deliveryLabel: "Entrega rapida",
       checkoutAllowed: true,
       seoAvailability: "https://schema.org/InStock",
+      schemaAvailability: "https://schema.org/InStock",
+      availabilityDate: "",
+      availabilityDateFeed: "",
+      availabilityStarts: "",
+      availabilityDateDisplay: "",
       leadMinDays: minLead,
       leadMaxDays: maxLead,
     };
   }
 
-  if (hasRemoteStock) {
+  if (hasRemoteStock || (priceValue > 0 && explicitAvailability !== "out_of_stock")) {
     const leadStart = minLead > 0 ? minLead : 20;
     const leadEnd = maxLead > 0 ? maxLead : Math.max(leadStart, 30);
-    return {
-      stockLocal,
-      hasLocalStock,
-      isRemote: true,
-      hasRemoteStock: true,
-      isSellable: true,
-      availabilityLabel: "Disponible a pedido",
-      availabilityBadge: "remote_available",
-      deliveryLabel: `Entrega estimada en ${leadStart} a ${leadEnd} días`,
-      checkoutAllowed: true,
-      seoAvailability: "https://schema.org/PreOrder",
-      leadMinDays: leadStart,
-      leadMaxDays: leadEnd,
-    };
-  }
-
-  const priceValue = Number(product.price || product.precio || product.price_minorista || product.precio_minorista || product.precio_final || 0);
-  if (Number.isFinite(priceValue) && priceValue > 0) {
+    const availabilityDate = resolveAvailabilityDate(product, leadEnd, now);
+    const availabilityDateDisplay = formatDisplayAvailabilityDate(availabilityDate);
+    const merchantAvailability = explicitAvailability === "backorder" ? "backorder" : "preorder";
     return {
       stockLocal,
       hasLocalStock: false,
@@ -63,12 +162,20 @@ function resolveProductAvailability(product = {}) {
       hasRemoteStock: true,
       isSellable: true,
       availabilityLabel: "Disponible a pedido",
+      visibleAvailabilityText: `Producto a pedido. Fecha estimada de disponibilidad: ${availabilityDateDisplay}`,
       availabilityBadge: "remote_available",
-      deliveryLabel: "Entrega estimada en 20 a 30 días",
+      merchantAvailability,
+      feedAvailability: merchantAvailability,
+      deliveryLabel: `Disponible para envio estimado: ${availabilityDateDisplay}`,
       checkoutAllowed: true,
       seoAvailability: "https://schema.org/PreOrder",
-      leadMinDays: 20,
-      leadMaxDays: 30,
+      schemaAvailability: "https://schema.org/PreOrder",
+      availabilityDate,
+      availabilityDateFeed: formatMerchantAvailabilityDate(availabilityDate),
+      availabilityStarts: formatSchemaAvailabilityStarts(availabilityDate),
+      availabilityDateDisplay,
+      leadMinDays: leadStart,
+      leadMaxDays: leadEnd,
     };
   }
 
@@ -79,13 +186,28 @@ function resolveProductAvailability(product = {}) {
     hasRemoteStock: false,
     isSellable: false,
     availabilityLabel: "Sin stock",
+    visibleAvailabilityText: "Sin stock",
     availabilityBadge: "out_of_stock",
-    deliveryLabel: "Consultá disponibilidad",
+    merchantAvailability: "out_of_stock",
+    feedAvailability: "out_of_stock",
+    deliveryLabel: "Consulta disponibilidad",
     checkoutAllowed: false,
     seoAvailability: "https://schema.org/OutOfStock",
+    schemaAvailability: "https://schema.org/OutOfStock",
+    availabilityDate: "",
+    availabilityDateFeed: "",
+    availabilityStarts: "",
+    availabilityDateDisplay: "",
     leadMinDays: 0,
     leadMaxDays: 0,
   };
 }
 
-module.exports = { resolveProductAvailability };
+module.exports = {
+  resolveProductAvailability,
+  formatMerchantAvailabilityDate,
+  formatSchemaAvailabilityStarts,
+  formatDisplayAvailabilityDate,
+  parseAvailabilityDate,
+  getPublicPriceValue,
+};

--- a/nerin_final_updated/frontend/js/availability.js
+++ b/nerin_final_updated/frontend/js/availability.js
@@ -1,53 +1,165 @@
+const DAY_MS = 24 * 60 * 60 * 1000;
+const ARG_FEED_OFFSET = "-0300";
+const ARG_SCHEMA_OFFSET = "-03:00";
+const MAX_AVAILABILITY_DAYS = 365;
+
 function toFiniteNumber(value, fallback = 0) {
   const numeric = Number(value);
   return Number.isFinite(numeric) ? numeric : fallback;
 }
 
-export function resolveProductAvailability(product = {}) {
-  const stockLocal = toFiniteNumber(product.stock, 0);
+function normalizeAvailability(value = "") {
+  const normalized = String(value || "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+  if (["in_stock", "instock", "available", "disponible"].includes(normalized)) return "in_stock";
+  if (["preorder", "pre_order", "a_pedido", "pedido", "remote", "remoto"].includes(normalized)) return "preorder";
+  if (["backorder", "back_order", "allow_backorder"].includes(normalized)) return "backorder";
+  if (["out_of_stock", "outofstock", "sin_stock", "agotado"].includes(normalized)) return "out_of_stock";
+  return "";
+}
+
+function getUtcDateOnly(date = new Date()) {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}
+
+function addDaysUtc(date, days) {
+  return new Date(getUtcDateOnly(date).getTime() + Math.max(0, Number(days) || 0) * DAY_MS);
+}
+
+function parseAvailabilityDate(value) {
+  const raw = String(value || "").trim();
+  if (!raw) return null;
+  const dateOnly = raw.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (dateOnly) {
+    const y = Number(dateOnly[1]);
+    const m = Number(dateOnly[2]);
+    const d = Number(dateOnly[3]);
+    const date = new Date(Date.UTC(y, m - 1, d));
+    if (date.getUTCFullYear() === y && date.getUTCMonth() === m - 1 && date.getUTCDate() === d) return date;
+  }
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return getUtcDateOnly(parsed);
+}
+
+function clampAvailabilityDate(date, now = new Date()) {
+  const today = getUtcDateOnly(now);
+  const min = addDaysUtc(today, 1);
+  const max = addDaysUtc(today, MAX_AVAILABILITY_DAYS);
+  if (!date || Number.isNaN(date.getTime()) || date <= today) return min;
+  if (date > max) return max;
+  return getUtcDateOnly(date);
+}
+
+function resolveAvailabilityDate(product = {}, leadDays = 30, now = new Date()) {
+  const explicit = [
+    product.availability_date,
+    product.availabilityDate,
+    product.preorder_date,
+    product.preorderDate,
+    product.available_at,
+    product.availableAt,
+  ].map(parseAvailabilityDate).find(Boolean);
+  if (explicit) return clampAvailabilityDate(explicit, now);
+  return clampAvailabilityDate(addDaysUtc(now, leadDays || 30), now);
+}
+
+function dateParts(date) {
+  const d = getUtcDateOnly(date);
+  return {
+    y: String(d.getUTCFullYear()).padStart(4, "0"),
+    m: String(d.getUTCMonth() + 1).padStart(2, "0"),
+    d: String(d.getUTCDate()).padStart(2, "0"),
+  };
+}
+
+function formatMerchantAvailabilityDate(value) {
+  const parsed = value instanceof Date ? value : parseAvailabilityDate(value);
+  if (!parsed) return "";
+  const p = dateParts(parsed);
+  return `${p.y}-${p.m}-${p.d}T00:00${ARG_FEED_OFFSET}`;
+}
+
+function formatSchemaAvailabilityStarts(value) {
+  const parsed = value instanceof Date ? value : parseAvailabilityDate(value);
+  if (!parsed) return "";
+  const p = dateParts(parsed);
+  return `${p.y}-${p.m}-${p.d}T00:00:00${ARG_SCHEMA_OFFSET}`;
+}
+
+function formatDisplayAvailabilityDate(value) {
+  const parsed = value instanceof Date ? value : parseAvailabilityDate(value);
+  if (!parsed) return "";
+  const p = dateParts(parsed);
+  return `${p.d}/${p.m}/${p.y}`;
+}
+
+function getPublicPriceValue(product = {}) {
+  const value = [
+    product.precio_final,
+    product.price_minorista,
+    product.precio_minorista,
+    product.price,
+    product.price_mayorista,
+    product.precio_mayorista,
+  ].find((candidate) => Number.isFinite(Number(candidate)) && Number(candidate) > 0);
+  return Number.isFinite(Number(value)) ? Number(value) : 0;
+}
+
+export function resolveProductAvailability(product = {}, options = {}) {
+  const now = options.now instanceof Date ? options.now : new Date();
+  const stockLocal = toFiniteNumber(product.stock ?? product.available_stock ?? product.inventory ?? product.stock_total, 0);
   const hasLocalStock = stockLocal > 0;
-  const textSignals = [product.name, product.description, product.category, product.subcategory]
+  const textSignals = [product.name, product.title, product.description, product.category, product.subcategory]
     .filter(Boolean)
     .join(" ")
     .toLowerCase();
-  const explicitMode = String(product.stock_mode || product.fulfillment_mode || "").trim().toLowerCase();
-  const remoteStock = toFiniteNumber(product.remote_stock, 0);
-  const minLead = toFiniteNumber(product.remote_lead_min_days || product.remote_lead_days, 0);
-  const maxLead = toFiniteNumber(product.remote_lead_max_days || product.remote_lead_days, 0);
-  const hasRemoteSignal = /stock remoto|a pedido|bajo pedido|encargo/.test(textSignals);
-  const isRemote = explicitMode === "remote" || explicitMode === "remoto" || remoteStock > 0 || minLead > 0 || maxLead > 0 || hasRemoteSignal;
-  const hasRemoteStock = isRemote && (remoteStock > 0 || minLead > 0 || maxLead > 0 || hasRemoteSignal);
+  const explicitAvailability = normalizeAvailability(product.availability || product.disponibilidad || product.estado_stock);
+  const explicitMode = String(product.stock_mode || product.fulfillment_mode || product.stockMode || product.fulfillmentMode || "").trim().toLowerCase();
+  const remoteStock = toFiniteNumber(product.remote_stock ?? product.stock_remote ?? product.available_remote, 0);
+  const minLead = toFiniteNumber(product.remote_lead_min_days || product.remote_lead_days || product.lead_min_days, 0);
+  const maxLead = toFiniteNumber(product.remote_lead_max_days || product.remote_lead_days || product.lead_max_days, 0);
+  const hasRemoteSignal = /stock remoto|a pedido|bajo pedido|encargo|preorder|backorder/.test(textSignals);
+  const forcedRemote = ["preorder", "backorder"].includes(explicitAvailability);
+  const isRemote = forcedRemote || explicitMode === "remote" || explicitMode === "remoto" || remoteStock > 0 || minLead > 0 || maxLead > 0 || hasRemoteSignal;
+  const priceValue = getPublicPriceValue(product);
+  const hasRemoteStock = isRemote && (remoteStock > 0 || minLead > 0 || maxLead > 0 || hasRemoteSignal || forcedRemote || priceValue > 0);
 
-  if (hasLocalStock) return {
+  if (hasLocalStock && !forcedRemote) return {
     stockLocal, hasLocalStock, isRemote, hasRemoteStock, isSellable: true,
-    availabilityLabel: "En stock", availabilityBadge: "in_stock", deliveryLabel: "Entrega rápida",
-    checkoutAllowed: true, seoAvailability: "https://schema.org/InStock", leadMinDays: minLead, leadMaxDays: maxLead,
+    availabilityLabel: "En stock", visibleAvailabilityText: "En stock",
+    availabilityBadge: "in_stock", merchantAvailability: "in_stock", feedAvailability: "in_stock",
+    deliveryLabel: "Entrega rapida", checkoutAllowed: true,
+    seoAvailability: "https://schema.org/InStock", schemaAvailability: "https://schema.org/InStock",
+    availabilityDate: "", availabilityDateFeed: "", availabilityStarts: "", availabilityDateDisplay: "",
+    leadMinDays: minLead, leadMaxDays: maxLead,
   };
 
-  if (hasRemoteStock) {
+  if (hasRemoteStock || (priceValue > 0 && explicitAvailability !== "out_of_stock")) {
     const leadStart = minLead > 0 ? minLead : 20;
     const leadEnd = maxLead > 0 ? maxLead : Math.max(leadStart, 30);
-    return {
-      stockLocal, hasLocalStock, isRemote: true, hasRemoteStock: true, isSellable: true,
-      availabilityLabel: "Disponible a pedido", availabilityBadge: "remote_available",
-      deliveryLabel: `Entrega estimada en ${leadStart} a ${leadEnd} días`,
-      checkoutAllowed: true, seoAvailability: "https://schema.org/PreOrder", leadMinDays: leadStart, leadMaxDays: leadEnd,
-    };
-  }
-
-  const priceValue = Number(product.price || product.precio || product.price_minorista || product.precio_minorista || product.precio_final || 0);
-  if (Number.isFinite(priceValue) && priceValue > 0) {
+    const availabilityDate = resolveAvailabilityDate(product, leadEnd, now);
+    const availabilityDateDisplay = formatDisplayAvailabilityDate(availabilityDate);
+    const merchantAvailability = explicitAvailability === "backorder" ? "backorder" : "preorder";
     return {
       stockLocal, hasLocalStock: false, isRemote: true, hasRemoteStock: true, isSellable: true,
-      availabilityLabel: "Disponible a pedido", availabilityBadge: "remote_available",
-      deliveryLabel: "Entrega estimada en 20 a 30 días",
-      checkoutAllowed: true, seoAvailability: "https://schema.org/PreOrder", leadMinDays: 20, leadMaxDays: 30,
+      availabilityLabel: "Disponible a pedido",
+      visibleAvailabilityText: `Producto a pedido. Fecha estimada de disponibilidad: ${availabilityDateDisplay}`,
+      availabilityBadge: "remote_available", merchantAvailability, feedAvailability: merchantAvailability,
+      deliveryLabel: `Disponible para envio estimado: ${availabilityDateDisplay}`,
+      checkoutAllowed: true, seoAvailability: "https://schema.org/PreOrder", schemaAvailability: "https://schema.org/PreOrder",
+      availabilityDate, availabilityDateFeed: formatMerchantAvailabilityDate(availabilityDate),
+      availabilityStarts: formatSchemaAvailabilityStarts(availabilityDate), availabilityDateDisplay,
+      leadMinDays: leadStart, leadMaxDays: leadEnd,
     };
   }
 
   return {
     stockLocal, hasLocalStock: false, isRemote: false, hasRemoteStock: false, isSellable: false,
-    availabilityLabel: "Sin stock", availabilityBadge: "out_of_stock", deliveryLabel: "Consultá disponibilidad",
-    checkoutAllowed: false, seoAvailability: "https://schema.org/OutOfStock", leadMinDays: 0, leadMaxDays: 0,
+    availabilityLabel: "Sin stock", visibleAvailabilityText: "Sin stock",
+    availabilityBadge: "out_of_stock", merchantAvailability: "out_of_stock", feedAvailability: "out_of_stock",
+    deliveryLabel: "Consulta disponibilidad", checkoutAllowed: false,
+    seoAvailability: "https://schema.org/OutOfStock", schemaAvailability: "https://schema.org/OutOfStock",
+    availabilityDate: "", availabilityDateFeed: "", availabilityStarts: "", availabilityDateDisplay: "",
+    leadMinDays: 0, leadMaxDays: 0,
   };
 }

--- a/nerin_final_updated/frontend/js/product.js
+++ b/nerin_final_updated/frontend/js/product.js
@@ -85,7 +85,7 @@ function normalizeProductPayload(product) {
 
 function resolveProductPriceContext(product) {
   const retailRaw = Number(
-    product?.price_minorista ?? product?.price ?? product?.precio_minorista ?? product?.precio_final,
+    product?.precio_final ?? product?.price_minorista ?? product?.precio_minorista ?? product?.price,
   );
   const wholesaleRaw = Number(
     product?.price_mayorista ?? product?.price_wholesale ?? product?.precio_mayorista,
@@ -580,7 +580,8 @@ function updateJsonLd(product, images, productUrl) {
   if (!absoluteImages.length && product.image) {
     absoluteImages.push(resolveAbsoluteUrl(product.image));
   }
-  const availability = resolveProductAvailability(product).seoAvailability;
+  const availabilityInfo = resolveProductAvailability(product);
+  const availability = availabilityInfo.seoAvailability;
   const priceSource = resolveProductDisplayPrice(product);
   const numericPrice = Number(priceSource);
   const formattedPrice = Number.isFinite(numericPrice)
@@ -608,6 +609,7 @@ function updateJsonLd(product, images, productUrl) {
       priceCurrency: "ARS",
       price: formattedPrice,
       availability,
+      ...(availabilityInfo.availabilityStarts ? { availabilityStarts: availabilityInfo.availabilityStarts } : {}),
       itemCondition: "https://schema.org/NewCondition",
     },
   };
@@ -1260,7 +1262,7 @@ function renderProduct(product) {
   }
 
   const availability = resolveProductAvailability(product);
-  const stockCopy = availability.availabilityLabel.toUpperCase();
+  const stockCopy = availability.visibleAvailabilityText || availability.availabilityLabel.toUpperCase();
 
   summary.appendChild(meta);
 

--- a/nerin_final_updated/frontend/js/utils/pricing.js
+++ b/nerin_final_updated/frontend/js/utils/pricing.js
@@ -19,10 +19,11 @@ export function calculateNetNoNationalTaxes(priceFinal, taxRate = resolveNationa
 
 export function formatArs(value) {
   const amount = Number(value);
-  if (!Number.isFinite(amount)) return "$0";
-  return new Intl.NumberFormat("es-AR", {
+  if (!Number.isFinite(amount)) return "$0 ARS";
+  const formatted = new Intl.NumberFormat("es-AR", {
     style: "currency",
     currency: "ARS",
     maximumFractionDigits: 0,
   }).format(amount);
+  return `${formatted} ARS`;
 }

--- a/nerin_final_updated/scripts/audit-google-merchant-feed.js
+++ b/nerin_final_updated/scripts/audit-google-merchant-feed.js
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+
+const sqlite3 = require("sqlite3");
+const productsSqliteRepo = require("../backend/data/productsSqliteRepo");
+const {
+  buildMerchantFeedEntries,
+  isEligibleState,
+  normalizeMerchantImageUrl,
+} = require("../backend/utils/merchantFeed");
+const {
+  resolveProductAvailability,
+  getPublicPriceValue,
+  parseAvailabilityDate,
+} = require("../backend/utils/productAvailability");
+
+const BASE_URL = process.env.PUBLIC_BASE_URL || "https://nerinparts.com.ar";
+const PREORDER_DAYS = Math.max(1, Number(process.env.MERCHANT_PREORDER_DAYS || 30) || 30);
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function sqliteAll(dbConn, sql, params = []) {
+  return new Promise((resolve, reject) => {
+    dbConn.all(sql, params, (error, rows) => {
+      if (error) reject(error);
+      else resolve(rows || []);
+    });
+  });
+}
+
+function openReadonly(dbPath) {
+  return new Promise((resolve, reject) => {
+    const dbConn = new sqlite3.Database(dbPath, sqlite3.OPEN_READONLY, (error) => {
+      if (error) reject(error);
+      else resolve(dbConn);
+    });
+  });
+}
+
+function closeDb(dbConn) {
+  return new Promise((resolve) => dbConn.close(() => resolve()));
+}
+
+function extractRaw(row = {}) {
+  try {
+    return JSON.parse(row.raw_json || "{}");
+  } catch {
+    return {};
+  }
+}
+
+function mergeProductData(row = {}, raw = {}) {
+  const merged = { ...raw };
+  for (const [key, value] of Object.entries(row || {})) {
+    if (value !== undefined && value !== null && value !== "") merged[key] = value;
+  }
+  return merged;
+}
+
+function isPublic(row = {}, raw = {}) {
+  const truthy = (value) => value === true || value === 1 || String(value).toLowerCase() === "true";
+  return Number(row.is_public) === 1 || truthy(raw.is_public) || truthy(raw.publicable);
+}
+
+function getIdentifier(row = {}, raw = {}) {
+  return String(row.sku || row.id || row.mpn || row.part_number || raw.sku || raw.id || raw.mpn || raw.part_number || "").trim();
+}
+
+function getLandingUrl(row = {}, raw = {}) {
+  const slug = String(row.public_slug || row.slug || raw.public_slug || raw.slug || "").trim();
+  return slug ? `${BASE_URL}/p/${encodeURIComponent(slug)}` : "";
+}
+
+function getImageLink(row = {}, raw = {}) {
+  const image = [row.image, row.image_url, raw.image, raw.image_url, ...(Array.isArray(raw.images) ? raw.images : [])].filter(Boolean)[0];
+  return normalizeMerchantImageUrl(image || "", BASE_URL);
+}
+
+function utcDateOnly(date = new Date()) {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}
+
+function isDateOlderThanToday(value, now = new Date()) {
+  const parsed = parseAvailabilityDate(value);
+  return Boolean(parsed && parsed <= utcDateOnly(now));
+}
+
+function isDateMoreThanOneYearAhead(value, now = new Date()) {
+  const parsed = parseAvailabilityDate(value);
+  if (!parsed) return false;
+  return parsed > new Date(utcDateOnly(now).getTime() + 365 * DAY_MS);
+}
+
+function pushSample(errors, entry) {
+  if (errors.length < 20) errors.push(entry);
+}
+
+async function main() {
+  await productsSqliteRepo.ensureProductsDbOnce();
+  const dbConn = await openReadonly(productsSqliteRepo.SQLITE_PATH);
+  try {
+    const tableInfo = await sqliteAll(dbConn, "PRAGMA table_info(products)");
+    const availableColumns = new Set(tableInfo.map((col) => String(col.name || "").trim()).filter(Boolean));
+    const preferredColumns = [
+      "id","sku","slug","public_slug","name","title","description","brand","stock","remote_stock","stock_remote","available_remote",
+      "remote_lead_days","remote_lead_min_days","remote_lead_max_days","stock_mode","fulfillment_mode","availability","availability_date",
+      "preorder_date","price","price_minorista","price_mayorista","precio_minorista","precio_mayorista","precio_final","image","image_url",
+      "raw_json","status","visibility","enabled","deleted","archived","vip_only","wholesale_only","is_public","part_number","mpn","category",
+    ];
+    const selected = ["rowid", ...preferredColumns.map((col) => availableColumns.has(col) ? col : `NULL AS ${col}`)];
+    const rows = await sqliteAll(dbConn, `SELECT ${selected.join(", ")} FROM products ORDER BY rowid ASC`);
+    const feed = buildMerchantFeedEntries(rows, { limit: Math.max(rows.length, 1), offset: 0, preorderDays: PREORDER_DAYS, baseUrl: BASE_URL });
+    const entriesById = new Map(feed.entries.map((entry) => [String(entry.id), entry]));
+    const summary = {
+      totalProducts: rows.length,
+      publicProducts: 0,
+      preorderProducts: 0,
+      preorderMissingAvailabilityDate: 0,
+      preorderMissingVisibleDate: 0,
+      preorderMissingJsonLdAvailabilityStarts: 0,
+      productsWithAvailabilityDateOlderThanToday: 0,
+      productsWithAvailabilityDateMoreThanOneYearAhead: 0,
+      productsWithPriceMismatch: 0,
+      productsWithMissingImage: 0,
+      productsWithMissingLandingUrl: 0,
+      criticalErrorCount: 0,
+      sampleErrors: [],
+    };
+
+    for (const row of rows) {
+      const raw = extractRaw(row);
+      if (!isPublic(row, raw)) continue;
+      summary.publicProducts += 1;
+      const product = mergeProductData(row, raw);
+      const id = getIdentifier(row, raw) || `row:${row.rowid}`;
+      const title = row.name || row.title || raw.name || raw.title || "";
+      const landingUrl = getLandingUrl(row, raw);
+      const image = getImageLink(row, raw);
+      if (!landingUrl) {
+        summary.productsWithMissingLandingUrl += 1;
+        pushSample(summary.sampleErrors, { id, title, reason: "missingLandingUrl" });
+      }
+      if (!image.valid) {
+        summary.productsWithMissingImage += 1;
+        pushSample(summary.sampleErrors, { id, title, reason: `missingImage:${image.reason}` });
+      }
+      if (!isEligibleState(row, raw)) continue;
+      const availability = resolveProductAvailability(product);
+      const feedEntry = entriesById.get(String(id));
+      if (["preorder", "backorder"].includes(availability.merchantAvailability)) {
+        summary.preorderProducts += 1;
+        const feedDate = feedEntry?.availability_date || "";
+        if (!feedDate) {
+          summary.preorderMissingAvailabilityDate += 1;
+          pushSample(summary.sampleErrors, { id, title, reason: "preorderMissingAvailabilityDate" });
+        }
+        if (!availability.availabilityDateDisplay || !availability.visibleAvailabilityText.includes(availability.availabilityDateDisplay)) {
+          summary.preorderMissingVisibleDate += 1;
+          pushSample(summary.sampleErrors, { id, title, reason: "preorderMissingVisibleDate" });
+        }
+        if (!availability.availabilityStarts) {
+          summary.preorderMissingJsonLdAvailabilityStarts += 1;
+          pushSample(summary.sampleErrors, { id, title, reason: "preorderMissingJsonLdAvailabilityStarts" });
+        }
+        if (isDateOlderThanToday(feedDate)) {
+          summary.productsWithAvailabilityDateOlderThanToday += 1;
+          pushSample(summary.sampleErrors, { id, title, reason: "availabilityDateOlderThanToday", availabilityDate: feedDate });
+        }
+        if (isDateMoreThanOneYearAhead(feedDate)) {
+          summary.productsWithAvailabilityDateMoreThanOneYearAhead += 1;
+          pushSample(summary.sampleErrors, { id, title, reason: "availabilityDateMoreThanOneYearAhead", availabilityDate: feedDate });
+        }
+      }
+      if (feedEntry) {
+        const visiblePrice = `${getPublicPriceValue(product).toFixed(2)} ARS`;
+        if (feedEntry.price !== visiblePrice) {
+          summary.productsWithPriceMismatch += 1;
+          pushSample(summary.sampleErrors, { id, title, reason: "priceMismatch", feedPrice: feedEntry.price, visiblePrice });
+        }
+      }
+    }
+
+    summary.criticalErrorCount =
+      summary.preorderMissingAvailabilityDate +
+      summary.preorderMissingVisibleDate +
+      summary.preorderMissingJsonLdAvailabilityStarts +
+      summary.productsWithAvailabilityDateOlderThanToday +
+      summary.productsWithAvailabilityDateMoreThanOneYearAhead +
+      summary.productsWithPriceMismatch +
+      summary.productsWithMissingLandingUrl;
+
+    console.log(JSON.stringify(summary, null, 2));
+    if (summary.criticalErrorCount > 0) process.exitCode = 1;
+  } finally {
+    await closeDb(dbConn);
+  }
+}
+
+main().catch((error) => {
+  console.error("[audit-google-merchant-feed] failed", error);
+  process.exit(1);
+});


### PR DESCRIPTION
## What changed

- Unified Merchant availability calculation across the Google feed, product landing SSR, frontend product JSON-LD, and visible product availability copy.
- Added preorder/backorder availability dates with feed format `YYYY-MM-DDT00:00-0300` and JSON-LD `availabilityStarts` format `YYYY-MM-DDT00:00:00-03:00`.
- Added product `?debugMerchant=1` diagnostics for feed availability/date, visible availability, JSON-LD availability, price, image, canonical URL, and mismatch flags.
- Added `scripts/audit-google-merchant-feed.js` to audit public products for Merchant Center-critical errors.
- Added bilingual technical search normalization for Spanish/English repair-part jargon before ranking.
- Kept exact Apple iPhone model/variant ranking intact while adding part-type intent scoring.

## Why

Merchant Center can reject preorder/backorder products when the feed sends `availability_date` but the landing page and JSON-LD do not expose the same availability date. The internal search also needed to understand local technician/customer terms like `bateria`, `pantalla`, `modulo`, `pin de carga`, `tapa`, and `camara` when products are named in English.

## Validation

- `node -c` passed for changed backend/frontend scripts.
- `jest __tests__/backend/product-search-ranking.test.js __tests__/backend/merchant-feed.test.js --runInBand`
  - Test Suites: 2 passed
  - Tests: 52 passed
- `node scripts/audit-google-merchant-feed.js`
  - `criticalErrorCount: 0`
- `node scripts/test-search-ranking-cases.js`
  - Confirms `iphone 12 display` ranks `Display (Original), Apple iPhone 12` first.

## Notes

The local fixture catalog has no Samsung A54 or Honor 200 rows, so live local queries for those return zero products. The ranking behavior for those required cases is covered with deterministic test fixtures in `product-search-ranking.test.js`.