### PR TITLE
Improve Merchant-safe availability UI and prepare Andreani shipping UX

### DIFF
--- a/nerin_final_updated/backend/__tests__/merchant-availability-ui.test.js
+++ b/nerin_final_updated/backend/__tests__/merchant-availability-ui.test.js
@@ -1,0 +1,170 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const request = require("supertest");
+
+function writeCatalog(dir) {
+  const products = [
+    {
+      id: "stock-real",
+      sku: "STOCK-REAL",
+      slug: "stock-real",
+      public_slug: "stock-real",
+      name: "Display iPhone 12 Stock Real",
+      description: "Display original para iPhone 12.",
+      brand: "Apple",
+      category: "Display",
+      stock: 3,
+      availability: "in_stock",
+      price_minorista: 1000,
+      image: "/assets/product1.png",
+      visibility: "public",
+      enabled: true,
+      is_public: true,
+    },
+    {
+      id: "pedido",
+      sku: "PEDIDO-1",
+      slug: "pedido",
+      public_slug: "pedido",
+      name: "Display iPhone 12 A Pedido",
+      description: "Display bajo pedido para iPhone 12.",
+      brand: "Apple",
+      category: "Display",
+      stock: 0,
+      stock_mode: "remote",
+      availability: "backorder",
+      remote_lead_min_days: 20,
+      remote_lead_max_days: 30,
+      availability_date: "2026-06-19",
+      price_minorista: 1200,
+      image: "/assets/product2.png",
+      visibility: "public",
+      enabled: true,
+      is_public: true,
+    },
+    {
+      id: "sin-stock",
+      sku: "SIN-STOCK",
+      slug: "sin-stock",
+      public_slug: "sin-stock",
+      name: "Battery iPhone 12 Sin Stock",
+      description: "Bateria sin stock para iPhone 12.",
+      brand: "Apple",
+      category: "Battery",
+      stock: 0,
+      availability: "out_of_stock",
+      price_minorista: 900,
+      image: "/assets/product3.png",
+      visibility: "public",
+      enabled: true,
+      is_public: true,
+    },
+  ];
+  fs.writeFileSync(path.join(dir, "products.json"), JSON.stringify({ products }, null, 2));
+  fs.writeFileSync(path.join(dir, "config.json"), JSON.stringify({ publicUrl: "https://nerinparts.com.ar" }, null, 2));
+}
+
+async function withServer(testFn) {
+  const previousDataDir = process.env.DATA_DIR;
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nerin-merchant-ui-"));
+  process.env.DATA_DIR = dir;
+  writeCatalog(dir);
+  jest.resetModules();
+  const { createServer } = require("../server");
+  await require("../data/productsSqliteRepo").ensureProductsDbOnce();
+  const server = createServer();
+  try {
+    await testFn(server);
+  } finally {
+    if (server.close) server.close();
+    process.env.DATA_DIR = previousDataDir;
+    jest.resetModules();
+  }
+}
+
+describe("Merchant-safe availability UI", () => {
+  test("producto in_stock no muestra fecha Merchant ni availabilityStarts", async () => {
+    await withServer(async (server) => {
+      const res = await request(server).get("/p/stock-real");
+      expect(res.status).toBe(200);
+      expect(res.text).toContain("En stock real");
+      expect(res.text).toContain("Listo para enviar desde CABA");
+      expect(res.text).not.toContain("availabilityStarts");
+      expect(res.text).not.toContain("Fecha estimada de despacho:");
+      expect(res.text).toContain("https://schema.org/InStock");
+    });
+  });
+
+  test("producto a pedido muestra fecha exacta visible y JSON-LD availabilityStarts", async () => {
+    await withServer(async (server) => {
+      const res = await request(server).get("/p/pedido");
+      expect(res.status).toBe(200);
+      expect(res.text).toContain("Disponible a pedido");
+      expect(res.text).toContain("Entrega estimada: 20 a 30 dias");
+      expect(res.text).toContain('<time datetime="2026-06-19T00:00:00-03:00">19/06/2026</time>');
+      expect(res.text).toContain('"availabilityStarts":"2026-06-19T00:00:00-03:00"');
+      expect(res.text).toContain("Primero gestionamos el ingreso del repuesto.");
+      expect(res.text).not.toContain("despacho prioritario en 24 h");
+    });
+  });
+
+  test("producto out_of_stock no genera availabilityStarts ni fecha visible", async () => {
+    await withServer(async (server) => {
+      const res = await request(server).get("/p/sin-stock");
+      expect(res.status).toBe(200);
+      expect(res.text).toContain("Sin stock");
+      expect(res.text).toContain("Consultanos disponibilidad");
+      expect(res.text).toContain("https://schema.org/OutOfStock");
+      expect(res.text).not.toContain("availabilityStarts");
+      expect(res.text).not.toContain("Fecha estimada de despacho:");
+    });
+  });
+
+  test("endpoint Andreani mock no usa credenciales ni promete cotizacion real", async () => {
+    await withServer(async (server) => {
+      const res = await request(server)
+        .post("/api/shipping/quote")
+        .send({ postalCode: "1001", productId: "stock-real" });
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        carrier: "Andreani",
+        service: "mock",
+        isMock: true,
+        price: null,
+        estimatedDays: null,
+        message: "Cotizacion Andreani pendiente de integracion real",
+      });
+      expect(res.body.futureEnvVars).toContain("ANDREANI_CLIENT_SECRET");
+    });
+  });
+});
+
+describe("Merchant feed availability fields", () => {
+  test("in_stock y out_of_stock no emiten availability_date; backorder si", () => {
+    const { buildMerchantFeedEntries } = require("../utils/merchantFeed");
+    const base = {
+      description: "Repuesto para celulares disponible en NERIN Parts.",
+      brand: "Apple",
+      price_minorista: 1000,
+      image: "/assets/product.png",
+      visibility: "public",
+      enabled: 1,
+      is_public: 1,
+      raw_json: "{}",
+    };
+    const rows = [
+      { ...base, id: "stock", sku: "STOCK", slug: "stock", public_slug: "stock", name: "Producto en stock", stock: 2, availability: "in_stock" },
+      { ...base, id: "pedido", sku: "PEDIDO", slug: "pedido", public_slug: "pedido", name: "Producto a pedido", stock: 0, stock_mode: "remote", availability: "backorder", availability_date: "2026-06-19", remote_lead_min_days: 20, remote_lead_max_days: 30 },
+      { ...base, id: "out", sku: "OUT", slug: "out", public_slug: "out", name: "Producto sin stock", stock: 0, availability: "out_of_stock" },
+    ];
+    const { entries } = buildMerchantFeedEntries(rows, { limit: 10, baseUrl: "https://nerinparts.com.ar" });
+    const byId = Object.fromEntries(entries.map((entry) => [entry.id, entry]));
+    expect(byId.STOCK.availability).toBe("in_stock");
+    expect(byId.STOCK.availability_date).toBe("");
+    expect(byId.PEDIDO.availability).toBe("backorder");
+    expect(byId.PEDIDO.availability_date).toBe("2026-06-19T00:00-0300");
+    expect(byId.OUT.availability).toBe("out_of_stock");
+    expect(byId.OUT.availability_date).toBe("");
+  });
+});

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -75,6 +75,7 @@ const {
   validateServiceReview,
 } = require("./utils/reviewValidation");
 const { importStockXlsxFile } = require("./services/stockXlsxImport");
+const { buildMockAndreaniQuote } = require("./services/andreaniService");
 const productsStreamRepo = require("./data/productsStreamRepo");
 const productsSqliteRepo = require("./data/productsSqliteRepo");
 const catalogInventoryRepo = require("./data/catalogInventoryRepo");
@@ -83,6 +84,7 @@ const {
   revertInventoryForOrder,
 } = require("./services/inventory");
 const {
+  buildAvailabilityPresentation,
   resolveProductAvailability,
   getPublicPriceValue,
 } = require("./utils/productAvailability");
@@ -1586,10 +1588,67 @@ function renderProductGallerySsr(product, siteBase) {
   return `<div class=\"product-gallery product-gallery--ssr\">${items}</div>`;
 }
 
+function renderAvailabilityPresentationSsr(presentation = {}) {
+  const trustItems = Array.isArray(presentation.trustItems) ? presentation.trustItems : [];
+  const trustHtml = trustItems.map((item) => `<li>${esc(item)}</li>`).join("");
+  const deliveryHtml = presentation.isPreorderOrBackorder && presentation.merchantDate && presentation.merchantDateDisplay
+    ? `Fecha estimada de despacho: <time datetime=\"${esc(presentation.merchantDate)}\">${esc(presentation.merchantDateDisplay)}</time>`
+    : esc(presentation.deliveryLabel || "");
+  const note = presentation.isPreorderOrBackorder
+    ? `<p class=\"availability-panel__note\">Este repuesto se gestiona bajo pedido. Te mantenemos informado durante el proceso.</p>`
+    : "";
+  return `
+    <section class=\"availability-panel availability-panel--${esc(presentation.cssModifier || "")}\" aria-label=\"Disponibilidad del producto\">
+      <span class=\"availability-panel__badge\">${esc(presentation.primaryLabel || "")}</span>
+      <div class=\"availability-panel__copy\">
+        <strong>${esc(presentation.secondaryLabel || "")}</strong>
+        ${deliveryHtml ? `<p class=\"availability-panel__delivery\">${deliveryHtml}</p>` : ""}
+        ${note}
+      </div>
+      ${trustHtml ? `<ul class=\"availability-trust-list\">${trustHtml}</ul>` : ""}
+    </section>
+  `;
+}
+
+function renderAndreaniShippingSsr(presentation = {}) {
+  if (presentation.isStockReal) {
+    return `
+      <section class=\"andreani-quote andreani-quote--in-stock\" aria-label=\"Opciones de envio Andreani\">
+        <h3>Calcula tu envio Andreani</h3>
+        <div class=\"andreani-quote__form\">
+          <input type=\"text\" inputmode=\"numeric\" placeholder=\"Codigo postal\" aria-label=\"Codigo postal\">
+          <button type=\"button\" class=\"button secondary\">Ver opciones</button>
+        </div>
+        <div class=\"andreani-quote__options\"><span>Andreani a domicilio</span><span>Andreani a sucursal</span></div>
+        <p class=\"andreani-quote__note\">La cotizacion final se confirma en el checkout.</p>
+      </section>
+    `;
+  }
+  if (presentation.isPreorderOrBackorder) {
+    return `
+      <section class=\"andreani-quote andreani-quote--preorder\" aria-label=\"Opciones de envio Andreani\">
+        <h3>Envio Andreani cuando el repuesto este listo</h3>
+        <div class=\"andreani-quote__steps\">
+          <p>Primero gestionamos el ingreso del repuesto.</p>
+          ${presentation.deliveryLabel ? `<p>${esc(presentation.deliveryLabel)}</p>` : ""}
+          <p>Cuando el producto este listo, se despacha por Andreani al domicilio o sucursal elegida.</p>
+        </div>
+      </section>
+    `;
+  }
+  return `
+    <section class=\"andreani-quote andreani-quote--out-of-stock\" aria-label=\"Opciones de envio Andreani\">
+      <h3>Envio a coordinar</h3>
+      <p class=\"andreani-quote__note\">Consultanos disponibilidad antes de coordinar envio.</p>
+    </section>
+  `;
+}
+
 function renderProductInfoSsr(product, siteBase) {
   const heading = buildProductHeading(product);
   const description = buildFeaturePhrase(product);
   const availabilityInfo = resolveProductAvailability(product);
+  const availabilityPresentation = buildAvailabilityPresentation(product);
   const brand = normalizeTextInput(product?.brand);
   const model = normalizeTextInput(product?.model);
   const sku = normalizeTextInput(product?.sku);
@@ -1598,7 +1657,7 @@ function renderProductInfoSsr(product, siteBase) {
   const technology = inferDisplayTechnology(product);
   const frame = inferHasFrame(product);
   const color = inferColor(product);
-  let stockCopy = availabilityInfo.visibleAvailabilityText || availabilityInfo.availabilityLabel || "";
+  let stockCopy = availabilityPresentation.primaryLabel || availabilityInfo.availabilityLabel || "";
   if (!stockCopy && stockValue != null) {
     if (stockValue <= 0) stockCopy = "Sin stock disponible";
     else if (product?.min_stock != null && stockValue < product.min_stock) {
@@ -1652,7 +1711,7 @@ function renderProductInfoSsr(product, siteBase) {
   return `
     <header class=\"product-summary\">
       <h1>${esc(heading)}</h1>
-      ${stockCopy ? `<span class=\"product-stock-badge\">${esc(stockCopy)}</span>` : ""}
+      ${stockCopy ? `<span class=\"product-stock-badge product-stock-badge--${esc(availabilityPresentation.cssModifier || "")}\">${esc(stockCopy)}</span>` : ""}
       ${infoItems ? `<ul class=\"product-meta-list\">${infoItems}</ul>` : ""}
     </header>
     <div class=\"product-info-panels\">
@@ -1672,7 +1731,9 @@ function renderProductInfoSsr(product, siteBase) {
       </section>
       <aside class=\"product-pricing-panel\" aria-label=\"Acciones de compra\">
         <h2>Comprar este repuesto</h2>
-        ${stockCopy ? `<p class=\"product-stock-info\">${esc(stockCopy)}</p>` : ""}
+        ${renderAvailabilityPresentationSsr(availabilityPresentation)}
+        ${renderAndreaniShippingSsr(availabilityPresentation)}
+        <div class=\"quiet-trust-banner\">Seguimos operando normalmente. Estamos mejorando la experiencia de compra. Ante cualquier duda de compatibilidad o stock, escribinos por WhatsApp.</div>
         ${priceBlock}
         <p class=\"product-promo\">Consultá por instalación y descuentos para servicios técnicos.</p>
         ${backLink}
@@ -7026,6 +7087,11 @@ async function requestHandler(req, res) {
     } catch (error) {
       return sendJson(res, 500, { ok: false, error: error?.message || "search_failed" });
     }
+  }
+
+  if (pathname === "/api/shipping/quote" && req.method === "POST") {
+    await parseBody(req);
+    return sendJson(res, 200, buildMockAndreaniQuote(req.body || {}));
   }
 
   if (pathname === "/api/admin/products" && req.method === "GET") {

--- a/nerin_final_updated/backend/services/andreaniService.js
+++ b/nerin_final_updated/backend/services/andreaniService.js
@@ -1,0 +1,30 @@
+const FUTURE_ENV_VARS = [
+  "ANDREANI_API_BASE_URL",
+  "ANDREANI_CLIENT_ID",
+  "ANDREANI_CLIENT_SECRET",
+  "ANDREANI_CONTRACT_ID",
+  "ANDREANI_SUCURSAL_ORIGEN",
+  "ANDREANI_ENVIRONMENT",
+];
+
+function buildMockAndreaniQuote(payload = {}) {
+  return {
+    carrier: "Andreani",
+    service: "mock",
+    isMock: true,
+    price: null,
+    estimatedDays: null,
+    postalCode: payload.postalCode || payload.cp || payload.zip || null,
+    options: [
+      { type: "home", label: "Andreani a domicilio", isMock: true },
+      { type: "branch", label: "Andreani a sucursal", isMock: true },
+    ],
+    message: "Cotizacion Andreani pendiente de integracion real",
+    futureEnvVars: FUTURE_ENV_VARS,
+  };
+}
+
+module.exports = {
+  FUTURE_ENV_VARS,
+  buildMockAndreaniQuote,
+};

--- a/nerin_final_updated/backend/utils/merchantFeed.js
+++ b/nerin_final_updated/backend/utils/merchantFeed.js
@@ -6,7 +6,7 @@ const {
 } = require('./productAvailability');
 
 const GOOGLE_CATEGORY = 'Electrónica > Comunicaciones > Telefonía > Accesorios para móviles';
-const VALID_AVAILABILITY = new Set(['in_stock', 'preorder', 'backorder']);
+const VALID_AVAILABILITY = new Set(['in_stock', 'preorder', 'backorder', 'out_of_stock']);
 
 function safeMerchantText(value, max = 150) {
   const mojibakeFixes = [
@@ -68,7 +68,14 @@ function mergeProductData(row = {}, raw = {}) {
 
 function computeAvailability(row, raw, preorderDays = 30) {
   const merged = mergeProductData(row, raw);
-  if (merged.remote_lead_days == null) merged.remote_lead_days = preorderDays;
+  const explicitAvailability = String(merged.availability || merged.disponibilidad || merged.estado_stock || '').toLowerCase();
+  const explicitMode = String(merged.stock_mode || merged.fulfillment_mode || '').toLowerCase();
+  const hasRemoteSignal =
+    /preorder|backorder|a_pedido|pedido|remote|remoto/.test(explicitAvailability) ||
+    /remote|remoto/.test(explicitMode) ||
+    Number(merged.remote_stock || merged.stock_remote || merged.available_remote || 0) > 0 ||
+    Number(merged.remote_lead_days || merged.remote_lead_min_days || merged.remote_lead_max_days || 0) > 0;
+  if (hasRemoteSignal && merged.remote_lead_days == null) merged.remote_lead_days = preorderDays;
   const resolved = resolveProductAvailability(merged);
   return {
     availability: resolved.merchantAvailability || resolved.feedAvailability || '',

--- a/nerin_final_updated/backend/utils/productAvailability.js
+++ b/nerin_final_updated/backend/utils/productAvailability.js
@@ -105,6 +105,13 @@ function getPublicPriceValue(product = {}) {
   return Number.isFinite(Number(value)) ? Number(value) : 0;
 }
 
+function formatLeadRange(minDays, maxDays) {
+  const min = Math.max(1, Number(minDays) || 20);
+  const max = Math.max(min, Number(maxDays) || 30);
+  if (min === max) return `${min} dia${min === 1 ? "" : "s"}`;
+  return `${min} a ${max} dias`;
+}
+
 function resolveProductAvailability(product = {}, options = {}) {
   const now = options.now instanceof Date ? options.now : new Date();
   const stockLocal = toFiniteNumber(product.stock ?? product.available_stock ?? product.inventory ?? product.stock_total, 0);
@@ -121,8 +128,7 @@ function resolveProductAvailability(product = {}, options = {}) {
   const hasRemoteSignal = /stock remoto|a pedido|bajo pedido|encargo|preorder|backorder/.test(textSignals);
   const forcedRemote = ["preorder", "backorder"].includes(explicitAvailability);
   const isRemote = forcedRemote || explicitMode === "remote" || explicitMode === "remoto" || remoteStock > 0 || minLead > 0 || maxLead > 0 || hasRemoteSignal;
-  const priceValue = getPublicPriceValue(product);
-  const hasRemoteStock = isRemote && (remoteStock > 0 || minLead > 0 || maxLead > 0 || hasRemoteSignal || forcedRemote || priceValue > 0);
+  const hasRemoteStock = isRemote && (remoteStock > 0 || minLead > 0 || maxLead > 0 || hasRemoteSignal || forcedRemote);
 
   if (hasLocalStock && !forcedRemote) {
     return {
@@ -131,12 +137,12 @@ function resolveProductAvailability(product = {}, options = {}) {
       isRemote,
       hasRemoteStock,
       isSellable: true,
-      availabilityLabel: "En stock",
-      visibleAvailabilityText: "En stock",
+      availabilityLabel: "En stock real",
+      visibleAvailabilityText: "En stock real",
       availabilityBadge: "in_stock",
       merchantAvailability: "in_stock",
       feedAvailability: "in_stock",
-      deliveryLabel: "Entrega rapida",
+      deliveryLabel: "Listo para enviar desde CABA",
       checkoutAllowed: true,
       seoAvailability: "https://schema.org/InStock",
       schemaAvailability: "https://schema.org/InStock",
@@ -149,7 +155,7 @@ function resolveProductAvailability(product = {}, options = {}) {
     };
   }
 
-  if (hasRemoteStock || (priceValue > 0 && explicitAvailability !== "out_of_stock")) {
+  if (hasRemoteStock) {
     const leadStart = minLead > 0 ? minLead : 20;
     const leadEnd = maxLead > 0 ? maxLead : Math.max(leadStart, 30);
     const availabilityDate = resolveAvailabilityDate(product, leadEnd, now);
@@ -162,11 +168,11 @@ function resolveProductAvailability(product = {}, options = {}) {
       hasRemoteStock: true,
       isSellable: true,
       availabilityLabel: "Disponible a pedido",
-      visibleAvailabilityText: `Producto a pedido. Fecha estimada de disponibilidad: ${availabilityDateDisplay}`,
+      visibleAvailabilityText: `Disponible a pedido. Fecha estimada de despacho: ${availabilityDateDisplay}`,
       availabilityBadge: "remote_available",
       merchantAvailability,
       feedAvailability: merchantAvailability,
-      deliveryLabel: `Disponible para envio estimado: ${availabilityDateDisplay}`,
+      deliveryLabel: `Fecha estimada de despacho: ${availabilityDateDisplay}`,
       checkoutAllowed: true,
       seoAvailability: "https://schema.org/PreOrder",
       schemaAvailability: "https://schema.org/PreOrder",
@@ -203,8 +209,68 @@ function resolveProductAvailability(product = {}, options = {}) {
   };
 }
 
+function buildAvailabilityPresentation(product = {}, options = {}) {
+  const resolved = resolveProductAvailability(product, options);
+  const merchantDate = resolved.availabilityStarts || "";
+  const merchantDateDisplay = resolved.availabilityDateDisplay || "";
+
+  if (resolved.merchantAvailability === "in_stock") {
+    return {
+      statusKey: "in_stock",
+      primaryLabel: "En stock real",
+      secondaryLabel: "Listo para enviar desde CABA",
+      deliveryLabel: "Despacho rapido",
+      merchantDate: "",
+      merchantDateDisplay: "",
+      technicalDateLabel: "",
+      trustItems: ["Factura A/B", "Garantia tecnica", "Soporte especializado", "Envio por Andreani / retiro coordinado"],
+      cssModifier: "in-stock",
+      isStockReal: true,
+      isPreorderOrBackorder: false,
+      isOutOfStock: false,
+      availability: resolved,
+    };
+  }
+
+  if (["preorder", "backorder"].includes(resolved.merchantAvailability)) {
+    const leadCopy = formatLeadRange(resolved.leadMinDays, resolved.leadMaxDays);
+    return {
+      statusKey: resolved.merchantAvailability,
+      primaryLabel: "Disponible a pedido",
+      secondaryLabel: `Entrega estimada: ${leadCopy}`,
+      deliveryLabel: merchantDateDisplay ? `Fecha estimada de despacho: ${merchantDateDisplay}` : "",
+      merchantDate,
+      merchantDateDisplay,
+      technicalDateLabel: merchantDateDisplay ? `Fecha estimada de despacho: ${merchantDateDisplay}` : "",
+      trustItems: ["Importacion bajo pedido", "Seguimiento del estado", "Soporte por WhatsApp"],
+      cssModifier: "preorder",
+      isStockReal: false,
+      isPreorderOrBackorder: true,
+      isOutOfStock: false,
+      availability: resolved,
+    };
+  }
+
+  return {
+    statusKey: "out_of_stock",
+    primaryLabel: "Sin stock",
+    secondaryLabel: "Consultanos disponibilidad",
+    deliveryLabel: "",
+    merchantDate: "",
+    merchantDateDisplay: "",
+    technicalDateLabel: "",
+    trustItems: ["Podemos ayudarte a buscar una alternativa"],
+    cssModifier: "out-of-stock",
+    isStockReal: false,
+    isPreorderOrBackorder: false,
+    isOutOfStock: true,
+    availability: resolved,
+  };
+}
+
 module.exports = {
   resolveProductAvailability,
+  buildAvailabilityPresentation,
   formatMerchantAvailabilityDate,
   formatSchemaAvailabilityStarts,
   formatDisplayAvailabilityDate,

--- a/nerin_final_updated/frontend/js/availability.js
+++ b/nerin_final_updated/frontend/js/availability.js
@@ -105,6 +105,13 @@ function getPublicPriceValue(product = {}) {
   return Number.isFinite(Number(value)) ? Number(value) : 0;
 }
 
+function formatLeadRange(minDays, maxDays) {
+  const min = Math.max(1, Number(minDays) || 20);
+  const max = Math.max(min, Number(maxDays) || 30);
+  if (min === max) return `${min} dia${min === 1 ? "" : "s"}`;
+  return `${min} a ${max} dias`;
+}
+
 export function resolveProductAvailability(product = {}, options = {}) {
   const now = options.now instanceof Date ? options.now : new Date();
   const stockLocal = toFiniteNumber(product.stock ?? product.available_stock ?? product.inventory ?? product.stock_total, 0);
@@ -121,20 +128,19 @@ export function resolveProductAvailability(product = {}, options = {}) {
   const hasRemoteSignal = /stock remoto|a pedido|bajo pedido|encargo|preorder|backorder/.test(textSignals);
   const forcedRemote = ["preorder", "backorder"].includes(explicitAvailability);
   const isRemote = forcedRemote || explicitMode === "remote" || explicitMode === "remoto" || remoteStock > 0 || minLead > 0 || maxLead > 0 || hasRemoteSignal;
-  const priceValue = getPublicPriceValue(product);
-  const hasRemoteStock = isRemote && (remoteStock > 0 || minLead > 0 || maxLead > 0 || hasRemoteSignal || forcedRemote || priceValue > 0);
+  const hasRemoteStock = isRemote && (remoteStock > 0 || minLead > 0 || maxLead > 0 || hasRemoteSignal || forcedRemote);
 
   if (hasLocalStock && !forcedRemote) return {
     stockLocal, hasLocalStock, isRemote, hasRemoteStock, isSellable: true,
-    availabilityLabel: "En stock", visibleAvailabilityText: "En stock",
+    availabilityLabel: "En stock real", visibleAvailabilityText: "En stock real",
     availabilityBadge: "in_stock", merchantAvailability: "in_stock", feedAvailability: "in_stock",
-    deliveryLabel: "Entrega rapida", checkoutAllowed: true,
+    deliveryLabel: "Listo para enviar desde CABA", checkoutAllowed: true,
     seoAvailability: "https://schema.org/InStock", schemaAvailability: "https://schema.org/InStock",
     availabilityDate: "", availabilityDateFeed: "", availabilityStarts: "", availabilityDateDisplay: "",
     leadMinDays: minLead, leadMaxDays: maxLead,
   };
 
-  if (hasRemoteStock || (priceValue > 0 && explicitAvailability !== "out_of_stock")) {
+  if (hasRemoteStock) {
     const leadStart = minLead > 0 ? minLead : 20;
     const leadEnd = maxLead > 0 ? maxLead : Math.max(leadStart, 30);
     const availabilityDate = resolveAvailabilityDate(product, leadEnd, now);
@@ -143,9 +149,9 @@ export function resolveProductAvailability(product = {}, options = {}) {
     return {
       stockLocal, hasLocalStock: false, isRemote: true, hasRemoteStock: true, isSellable: true,
       availabilityLabel: "Disponible a pedido",
-      visibleAvailabilityText: `Producto a pedido. Fecha estimada de disponibilidad: ${availabilityDateDisplay}`,
+      visibleAvailabilityText: `Disponible a pedido. Fecha estimada de despacho: ${availabilityDateDisplay}`,
       availabilityBadge: "remote_available", merchantAvailability, feedAvailability: merchantAvailability,
-      deliveryLabel: `Disponible para envio estimado: ${availabilityDateDisplay}`,
+      deliveryLabel: `Fecha estimada de despacho: ${availabilityDateDisplay}`,
       checkoutAllowed: true, seoAvailability: "https://schema.org/PreOrder", schemaAvailability: "https://schema.org/PreOrder",
       availabilityDate, availabilityDateFeed: formatMerchantAvailabilityDate(availabilityDate),
       availabilityStarts: formatSchemaAvailabilityStarts(availabilityDate), availabilityDateDisplay,
@@ -161,5 +167,64 @@ export function resolveProductAvailability(product = {}, options = {}) {
     seoAvailability: "https://schema.org/OutOfStock", schemaAvailability: "https://schema.org/OutOfStock",
     availabilityDate: "", availabilityDateFeed: "", availabilityStarts: "", availabilityDateDisplay: "",
     leadMinDays: 0, leadMaxDays: 0,
+  };
+}
+
+export function buildAvailabilityPresentation(product = {}, options = {}) {
+  const resolved = resolveProductAvailability(product, options);
+  const merchantDate = resolved.availabilityStarts || "";
+  const merchantDateDisplay = resolved.availabilityDateDisplay || "";
+
+  if (resolved.merchantAvailability === "in_stock") {
+    return {
+      statusKey: "in_stock",
+      primaryLabel: "En stock real",
+      secondaryLabel: "Listo para enviar desde CABA",
+      deliveryLabel: "Despacho rapido",
+      merchantDate: "",
+      merchantDateDisplay: "",
+      technicalDateLabel: "",
+      trustItems: ["Factura A/B", "Garantia tecnica", "Soporte especializado", "Envio por Andreani / retiro coordinado"],
+      cssModifier: "in-stock",
+      isStockReal: true,
+      isPreorderOrBackorder: false,
+      isOutOfStock: false,
+      availability: resolved,
+    };
+  }
+
+  if (["preorder", "backorder"].includes(resolved.merchantAvailability)) {
+    const leadCopy = formatLeadRange(resolved.leadMinDays, resolved.leadMaxDays);
+    return {
+      statusKey: resolved.merchantAvailability,
+      primaryLabel: "Disponible a pedido",
+      secondaryLabel: `Entrega estimada: ${leadCopy}`,
+      deliveryLabel: merchantDateDisplay ? `Fecha estimada de despacho: ${merchantDateDisplay}` : "",
+      merchantDate,
+      merchantDateDisplay,
+      technicalDateLabel: merchantDateDisplay ? `Fecha estimada de despacho: ${merchantDateDisplay}` : "",
+      trustItems: ["Importacion bajo pedido", "Seguimiento del estado", "Soporte por WhatsApp"],
+      cssModifier: "preorder",
+      isStockReal: false,
+      isPreorderOrBackorder: true,
+      isOutOfStock: false,
+      availability: resolved,
+    };
+  }
+
+  return {
+    statusKey: "out_of_stock",
+    primaryLabel: "Sin stock",
+    secondaryLabel: "Consultanos disponibilidad",
+    deliveryLabel: "",
+    merchantDate: "",
+    merchantDateDisplay: "",
+    technicalDateLabel: "",
+    trustItems: ["Podemos ayudarte a buscar una alternativa"],
+    cssModifier: "out-of-stock",
+    isStockReal: false,
+    isPreorderOrBackorder: false,
+    isOutOfStock: true,
+    availability: resolved,
   };
 }

--- a/nerin_final_updated/frontend/js/product.js
+++ b/nerin_final_updated/frontend/js/product.js
@@ -12,7 +12,7 @@ import {
 import { createPriceLegalBlock } from "./components/PriceLegalBlock.js";
 import { buildCartItemFromProduct, readCart, writeCart, getProductIdentifier } from "./cart-utils.js";
 import { calculateNetNoNationalTaxes } from "./utils/pricing.js";
-import { resolveProductAvailability } from "./availability.js";
+import { buildAvailabilityPresentation, resolveProductAvailability } from "./availability.js";
 
 const detailSection = document.getElementById("productDetail");
 const galleryContainer = document.getElementById("gallery");
@@ -1095,6 +1095,130 @@ function createQuantityControl(product) {
   };
 }
 
+function createAvailabilityPanel(presentation) {
+  const panel = document.createElement("section");
+  panel.className = `availability-panel availability-panel--${presentation.cssModifier}`;
+  panel.setAttribute("aria-label", "Disponibilidad del producto");
+
+  const badge = document.createElement("span");
+  badge.className = "availability-panel__badge";
+  badge.textContent = presentation.primaryLabel;
+
+  const copy = document.createElement("div");
+  copy.className = "availability-panel__copy";
+  const primary = document.createElement("strong");
+  primary.textContent = presentation.secondaryLabel;
+  copy.appendChild(primary);
+
+  if (presentation.deliveryLabel) {
+    const delivery = document.createElement("p");
+    delivery.className = "availability-panel__delivery";
+    if (presentation.isPreorderOrBackorder && presentation.merchantDate && presentation.merchantDateDisplay) {
+      delivery.append("Fecha estimada de despacho: ");
+      const time = document.createElement("time");
+      time.dateTime = presentation.merchantDate;
+      time.textContent = presentation.merchantDateDisplay;
+      delivery.appendChild(time);
+    } else {
+      delivery.textContent = presentation.deliveryLabel;
+    }
+    copy.appendChild(delivery);
+  }
+
+  if (presentation.isPreorderOrBackorder) {
+    const note = document.createElement("p");
+    note.className = "availability-panel__note";
+    note.textContent = "Este repuesto se gestiona bajo pedido. Te mantenemos informado durante el proceso.";
+    copy.appendChild(note);
+  }
+
+  panel.append(badge, copy);
+  return panel;
+}
+
+function createTrustList(items = []) {
+  const list = document.createElement("ul");
+  list.className = "availability-trust-list";
+  items.forEach((item) => {
+    const li = document.createElement("li");
+    li.textContent = item;
+    list.appendChild(li);
+  });
+  return list;
+}
+
+function createAndreaniShippingBlock(presentation) {
+  const block = document.createElement("section");
+  block.className = `andreani-quote andreani-quote--${presentation.cssModifier}`;
+  block.setAttribute("aria-label", "Opciones de envio Andreani");
+
+  const title = document.createElement("h3");
+  title.textContent = presentation.isStockReal
+    ? "Calcula tu envio Andreani"
+    : presentation.isPreorderOrBackorder
+      ? "Envio Andreani cuando el repuesto este listo"
+      : "Envio a coordinar";
+  block.appendChild(title);
+
+  if (presentation.isStockReal) {
+    const form = document.createElement("div");
+    form.className = "andreani-quote__form";
+    const input = document.createElement("input");
+    input.type = "text";
+    input.inputMode = "numeric";
+    input.placeholder = "Codigo postal";
+    input.setAttribute("aria-label", "Codigo postal");
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "button secondary";
+    button.textContent = "Ver opciones";
+    form.append(input, button);
+
+    const options = document.createElement("div");
+    options.className = "andreani-quote__options";
+    ["Andreani a domicilio", "Andreani a sucursal"].forEach((label) => {
+      const item = document.createElement("span");
+      item.textContent = label;
+      options.appendChild(item);
+    });
+
+    const note = document.createElement("p");
+    note.className = "andreani-quote__note";
+    note.textContent = "La cotizacion final se confirma en el checkout.";
+    block.append(form, options, note);
+    return block;
+  }
+
+  if (presentation.isPreorderOrBackorder) {
+    const steps = document.createElement("div");
+    steps.className = "andreani-quote__steps";
+    [
+      "Primero gestionamos el ingreso del repuesto.",
+      presentation.deliveryLabel,
+      "Cuando el producto este listo, se despacha por Andreani al domicilio o sucursal elegida.",
+    ].filter(Boolean).forEach((text) => {
+      const p = document.createElement("p");
+      p.textContent = text;
+      steps.appendChild(p);
+    });
+    block.appendChild(steps);
+    return block;
+  }
+
+  const note = document.createElement("p");
+  note.className = "andreani-quote__note";
+  note.textContent = "Consultanos disponibilidad antes de coordinar envio.";
+  block.appendChild(note);
+  return block;
+}
+
+function createQuietTrustBanner() {
+  const banner = document.createElement("aside");
+  banner.className = "quiet-trust-banner";
+  banner.textContent = "Seguimos operando normalmente. Estamos mejorando la experiencia de compra. Ante cualquier duda de compatibilidad o stock, escribinos por WhatsApp.";
+  return banner;
+}
+
 
 
 function addToCart(product, { quantity = 1, sku = "", image = "" } = {}) {
@@ -1262,7 +1386,8 @@ function renderProduct(product) {
   }
 
   const availability = resolveProductAvailability(product);
-  const stockCopy = availability.visibleAvailabilityText || availability.availabilityLabel.toUpperCase();
+  const availabilityPresentation = buildAvailabilityPresentation(product);
+  const stockCopy = availabilityPresentation.primaryLabel || availability.availabilityLabel;
 
   summary.appendChild(meta);
 
@@ -1291,14 +1416,18 @@ function renderProduct(product) {
   if (stockCopy) {
     const stockBadge = document.createElement("span");
     stockBadge.className = "product-stock-badge";
-    if (availability.availabilityBadge === "out_of_stock") stockBadge.classList.add("product-stock-badge--out");
-    else if (availability.availabilityBadge === "remote_available") stockBadge.classList.add("product-stock-badge--low");
+    if (availabilityPresentation.isOutOfStock) stockBadge.classList.add("product-stock-badge--out");
+    else if (availabilityPresentation.isPreorderOrBackorder) stockBadge.classList.add("product-stock-badge--low");
     else stockBadge.classList.add("product-stock-badge--in");
     stockBadge.textContent = stockCopy;
     purchaseHeader.appendChild(stockBadge);
   }
 
   purchaseCard.appendChild(purchaseHeader);
+  purchaseCard.appendChild(createAvailabilityPanel(availabilityPresentation));
+  purchaseCard.appendChild(createTrustList(availabilityPresentation.trustItems));
+  purchaseCard.appendChild(createAndreaniShippingBlock(availabilityPresentation));
+  purchaseCard.appendChild(createQuietTrustBanner());
 
   const shippingBanner = document.createElement("div");
   shippingBanner.className = "product-shipping-banner";
@@ -1396,6 +1525,7 @@ function renderProduct(product) {
   const addBtn = document.createElement("button");
   addBtn.type = "button";
   addBtn.className = "button primary product-buy-main-cta";
+  addBtn.disabled = !availability.checkoutAllowed;
 
   const priceLabel = document.createElement("p");
   priceLabel.className = "product-detail-unit-price";
@@ -1554,6 +1684,7 @@ function renderProduct(product) {
   const stickyBtn = document.createElement("button");
   stickyBtn.type = "button";
   stickyBtn.className = "button primary product-buy-main-cta";
+  stickyBtn.disabled = !availability.checkoutAllowed;
   stickyBtn.addEventListener("click", handleAddToCart);
   stickyCta.append(stickyPrice, stickyBtn);
   if (detailSection) {
@@ -1589,7 +1720,8 @@ function renderProduct(product) {
 
   const setCtaLabels = () => {
     const isMobile = window.matchMedia("(max-width: 768px)").matches;
-    const label = "COMPRAR AHORA";
+    void isMobile;
+    const label = availability.checkoutAllowed ? "COMPRAR AHORA" : "CONSULTAR DISPONIBILIDAD";
     addBtn.textContent = label;
     stickyBtn.textContent = label;
   };

--- a/nerin_final_updated/frontend/js/shop.js
+++ b/nerin_final_updated/frontend/js/shop.js
@@ -1,6 +1,7 @@
 import { fetchProductsPage, getUserRole, isWholesale } from "./api.js";
 import { createPriceLegalBlock } from "./components/PriceLegalBlock.js";
 import { calculateNetNoNationalTaxes } from "./utils/pricing.js";
+import { buildAvailabilityPresentation } from "./availability.js";
 import { buildCartItemFromProduct, readCart, writeCart } from "./cart-utils.js";
 
 console.info("[shop-products] shop.js loaded", {
@@ -519,8 +520,9 @@ function createChip(label) {
 }
 
 function createProductCard(product) {
+  const availabilityPresentation = buildAvailabilityPresentation(product);
   const card = document.createElement("article");
-  card.className = "product-card";
+  card.className = `product-card product-card--${availabilityPresentation.cssModifier}`;
   card.setAttribute("role", "listitem");
 
   const img = document.createElement("img");
@@ -547,18 +549,25 @@ function createProductCard(product) {
   title.textContent = product.name || "Producto";
   card.appendChild(title);
 
-  const availability = document.createElement("p");
-  availability.className = "description";
+  const availability = document.createElement("div");
+  availability.className = `catalog-availability catalog-availability--${availabilityPresentation.cssModifier}`;
   const status = getStockStatus(product);
   const fulfillmentMode = getFulfillmentMode(product);
-  if (fulfillmentMode === "remote") {
-    availability.textContent =
-      status === "out"
-        ? "Stock remoto (a pedido)"
-        : `Stock remoto: ${resolveStockQuantity(product) || 0} unidades`;
-  } else if (status === "out") availability.textContent = "Sin stock";
-  else if (status === "low") availability.textContent = `Pocas unidades (${product.stock})`;
-  else availability.textContent = `Stock: ${resolveStockQuantity(product) || 0} unidades`;
+  const statusLabel = document.createElement("span");
+  statusLabel.className = "catalog-availability__badge";
+  statusLabel.textContent = availabilityPresentation.isStockReal
+    ? "Stock real"
+    : availabilityPresentation.isPreorderOrBackorder
+      ? "A pedido"
+      : "Sin stock";
+  const statusCopy = document.createElement("span");
+  statusCopy.className = "catalog-availability__copy";
+  statusCopy.textContent = availabilityPresentation.isStockReal
+    ? "Listo para enviar"
+    : availabilityPresentation.isPreorderOrBackorder
+      ? availabilityPresentation.secondaryLabel
+      : "Consultar";
+  availability.append(statusLabel, statusCopy);
   card.appendChild(availability);
 
   if (fulfillmentMode === "remote") {
@@ -637,9 +646,13 @@ function createProductCard(product) {
   const addBtn = document.createElement("button");
   addBtn.type = "button";
   addBtn.className = "button";
-  addBtn.textContent = "Agregar";
+  addBtn.textContent = availabilityPresentation.isOutOfStock ? "Consultar" : "Agregar";
   addBtn.addEventListener("click", (event) => {
     event.stopPropagation();
+    if (availabilityPresentation.isOutOfStock) {
+      window.location.href = buildProductUrl(product);
+      return;
+    }
     addToCart(product);
   });
 

--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -901,6 +901,53 @@ body.cart-indicator-visible .toastify {
   font-weight: 800;
 }
 
+.catalog-availability {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.55rem;
+  margin: 0 0 0.55rem;
+  padding: 0.5rem 0.6rem;
+  border-radius: 10px;
+  border: 1px solid #e5e7eb;
+  background: #f8fafc;
+  color: #111827;
+}
+
+.catalog-availability__badge {
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.catalog-availability__copy {
+  font-size: 0.78rem;
+  color: #475569;
+  text-align: right;
+}
+
+.catalog-availability--in-stock {
+  border-color: #bbf7d0;
+  background: #f0fdf4;
+}
+
+.catalog-availability--preorder {
+  border-color: #bfdbfe;
+  background: #eff6ff;
+}
+
+.catalog-availability--out-of-stock {
+  border-color: #e5e7eb;
+  background: #f9fafb;
+}
+
+.product-card--preorder .product-delivery-promise,
+.product-card--preorder .product-fulfillment-note,
+.product-card--preorder .product-legal-banner {
+  display: none;
+}
+
 .price {
   font-size: 1rem;
   font-weight: 600;
@@ -5005,6 +5052,150 @@ footer .legal {
   box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
   display: grid;
   gap: 1rem;
+}
+
+.product-purchase-card > .product-shipping-banner,
+.product-purchase-card > .product-fulfillment-trust {
+  display: none;
+}
+
+.availability-panel,
+.andreani-quote,
+.quiet-trust-banner {
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 16px;
+  background: #fff;
+  padding: 0.9rem 1rem;
+}
+
+.availability-panel {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.8rem;
+  align-items: start;
+}
+
+.availability-panel__badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.38rem 0.68rem;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: #f8fafc;
+  color: #0f172a;
+}
+
+.availability-panel--in-stock .availability-panel__badge {
+  background: #ecfdf5;
+  color: #047857;
+}
+
+.availability-panel--preorder .availability-panel__badge {
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.availability-panel--out-of-stock .availability-panel__badge {
+  background: #f3f4f6;
+  color: #4b5563;
+}
+
+.availability-panel__copy {
+  display: grid;
+  gap: 0.28rem;
+  color: #0f172a;
+}
+
+.availability-panel__copy strong {
+  font-size: 0.98rem;
+}
+
+.availability-panel__delivery,
+.availability-panel__note,
+.andreani-quote__note,
+.andreani-quote__steps p {
+  margin: 0;
+  color: #475569;
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.availability-panel__delivery time {
+  font-weight: 800;
+  color: #0f172a;
+}
+
+.availability-trust-list {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(145px, 1fr));
+  gap: 0.5rem;
+  padding: 0;
+  margin: 0;
+}
+
+.availability-trust-list li {
+  padding: 0.55rem 0.65rem;
+  border-radius: 12px;
+  background: #f8fafc;
+  color: #334155;
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.andreani-quote {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.andreani-quote h3 {
+  margin: 0;
+  font-size: 0.98rem;
+  color: #0f172a;
+}
+
+.andreani-quote__form {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.55rem;
+}
+
+.andreani-quote__form input {
+  width: 100%;
+  border: 1px solid #dbe3ef;
+  border-radius: 12px;
+  padding: 0.72rem 0.8rem;
+  font: inherit;
+}
+
+.andreani-quote__options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.andreani-quote__options span {
+  border-radius: 999px;
+  background: #eff6ff;
+  color: #1d4ed8;
+  padding: 0.35rem 0.6rem;
+  font-size: 0.8rem;
+  font-weight: 800;
+}
+
+.andreani-quote__steps {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.quiet-trust-banner {
+  background: #f8fafc;
+  color: #475569;
+  font-size: 0.88rem;
+  line-height: 1.45;
 }
 
 .product-shipping-banner {


### PR DESCRIPTION
## Summary
- Adds a Merchant-safe availability presentation layer for in-stock, preorder/backorder/remote, and out-of-stock products.
- Updates product landing SSR and frontend product detail UI so preorder/backorder dates remain visibly rendered and JSON-LD/feed rules stay aligned.
- Adds concise catalog availability badges and a mock Andreani shipping UX without credentials or real carrier integration.
- Adds focused tests for availability presentation, Merchant feed behavior, SSR visible date/JSON-LD, and Andreani mock behavior.

## Merchant / availability behavior
- In stock: shows "En stock real", does not emit `availability_date`, and keeps JSON-LD as `https://schema.org/InStock`.
- A pedido / preorder / backorder: shows "Disponible a pedido", delivery range, and visible dispatch date with `<time datetime="...">`; keeps feed `availability_date` and JSON-LD `availabilityStarts`.
- Out of stock: shows "Sin stock" / "Consultanos disponibilidad", does not emit `availability_date` or `availabilityStarts`.

## Andreani UX
- Adds `POST /api/shipping/quote` returning a clearly marked mock Andreani response.
- Adds a visual shipping block for stock real, a pedido, and sin stock states.
- Documents future Andreani env vars in the mock service and does not include secrets or real API calls.

## Safety notes
- Did not touch Mercado Pago, checkout critical flow, webhooks, inventory, or orders.
- Did not add real Andreani credentials or real carrier integration.

## Validation
- `node --check` passed for modified backend/frontend JS files.
- `jest backend/__tests__/merchant-availability-ui.test.js backend/__tests__/product-ssr.test.js --runInBand --silent`: 2 suites passed, 11 tests passed.
- `node scripts/audit-google-merchant-feed.js`: criticalErrorCount 0; preorder missing availability/date/JSON-LD counts 0.