### PR TITLE
Improve organic SEO for stock-real products and indexable category pages

### DIFF
--- a/nerin_final_updated/backend/__tests__/organic-seo-stock-real.test.js
+++ b/nerin_final_updated/backend/__tests__/organic-seo-stock-real.test.js
@@ -1,0 +1,175 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const request = require("supertest");
+
+function writeCatalog(dir) {
+  const products = [
+    {
+      id: "sam-a15-display",
+      sku: "SAM-A15-DISPLAY",
+      slug: "pantalla-samsung-galaxy-a15",
+      public_slug: "pantalla-samsung-galaxy-a15",
+      name: "Pantalla Samsung Galaxy A15 Original",
+      description: "Display para Samsung Galaxy A15.",
+      brand: "Samsung",
+      model: "Galaxy A15",
+      category: "Display",
+      stock: 5,
+      availability: "in_stock",
+      price_minorista: 71500,
+      image: "/assets/product1.png",
+      visibility: "public",
+      enabled: true,
+      is_public: true,
+    },
+    {
+      id: "iphone-12-battery",
+      sku: "IPH12-BAT",
+      slug: "bateria-iphone-12",
+      public_slug: "bateria-iphone-12",
+      name: "Bateria Apple iPhone 12",
+      description: "Battery para iPhone 12.",
+      brand: "Apple",
+      model: "iPhone 12",
+      category: "Battery",
+      stock: 4,
+      availability: "in_stock",
+      price_minorista: 35000,
+      image: "/assets/product2.png",
+      visibility: "public",
+      enabled: true,
+      is_public: true,
+    },
+    {
+      id: "pedido",
+      sku: "PEDIDO-SEO",
+      slug: "display-iphone-13-pedido",
+      public_slug: "display-iphone-13-pedido",
+      name: "Display Apple iPhone 13 A Pedido",
+      description: "Display bajo pedido para iPhone 13.",
+      brand: "Apple",
+      model: "iPhone 13",
+      category: "Display",
+      stock: 0,
+      stock_mode: "remote",
+      availability: "backorder",
+      remote_lead_min_days: 20,
+      remote_lead_max_days: 30,
+      availability_date: "2026-06-19",
+      price_minorista: 1200,
+      image: "/assets/product3.png",
+      visibility: "public",
+      enabled: true,
+      is_public: true,
+    },
+    {
+      id: "out",
+      sku: "OUT-SEO",
+      slug: "display-out-of-stock",
+      public_slug: "display-out-of-stock",
+      name: "Pantalla Sin Stock",
+      description: "Display sin stock.",
+      brand: "Samsung",
+      model: "Galaxy A16",
+      category: "Display",
+      stock: 0,
+      availability: "out_of_stock",
+      price_minorista: 2000,
+      image: "/assets/product4.png",
+      visibility: "public",
+      enabled: true,
+      is_public: true,
+    },
+  ];
+  fs.writeFileSync(path.join(dir, "products.json"), JSON.stringify({ products }, null, 2), "utf8");
+  fs.writeFileSync(path.join(dir, "config.json"), JSON.stringify({ publicUrl: "https://nerinparts.example" }, null, 2), "utf8");
+}
+
+async function withServer(testFn) {
+  const previousDataDir = process.env.DATA_DIR;
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nerin-organic-seo-"));
+  process.env.DATA_DIR = dir;
+  writeCatalog(dir);
+  jest.resetModules();
+  const { createServer } = require("../server");
+  await require("../data/productsSqliteRepo").ensureProductsDbOnce();
+  const server = createServer();
+  try {
+    await testFn(server);
+  } finally {
+    if (server.close) server.close();
+    process.env.DATA_DIR = previousDataDir;
+    jest.resetModules();
+  }
+}
+
+describe("organic stock-real SEO", () => {
+  test("/stock-real solo muestra productos con stock real", async () => {
+    await withServer(async (server) => {
+      const res = await request(server).get("/stock-real");
+      expect(res.status).toBe(200);
+      expect(res.text).toContain("Repuestos para celulares en stock real");
+      expect(res.text).toContain("Pantalla Samsung Galaxy A15 Original");
+      expect(res.text).toContain("Bateria Apple iPhone 12");
+      expect(res.text).not.toContain("Pantalla Sin Stock");
+      expect(res.text).not.toContain("Display Apple iPhone 13 A Pedido");
+    });
+  });
+
+  test("/pantallas-en-stock solo muestra pantallas en stock", async () => {
+    await withServer(async (server) => {
+      const res = await request(server).get("/pantallas-en-stock");
+      expect(res.status).toBe(200);
+      expect(res.text).toContain("Pantallas para celulares en stock");
+      expect(res.text).toContain("Pantalla Samsung Galaxy A15 Original");
+      expect(res.text).not.toContain("Bateria Apple iPhone 12");
+      expect(res.text).not.toContain("Pantalla Sin Stock");
+    });
+  });
+
+  test("producto in_stock tiene JSON-LD InStock y titulo organico", async () => {
+    await withServer(async (server) => {
+      const res = await request(server).get("/p/pantalla-samsung-galaxy-a15?debugSeo=1");
+      expect(res.status).toBe(200);
+      expect(res.text).toContain("<title>Pantalla Samsung Galaxy A15 en stock | NERIN Parts</title>");
+      expect(res.text).toContain("https://schema.org/InStock");
+      expect(res.text).not.toContain("availabilityStarts");
+      expect(res.text).toContain("data-debug-seo=\"1\"");
+    });
+  });
+
+  test("producto preorder conserva availabilityStarts y fecha visible", async () => {
+    await withServer(async (server) => {
+      const res = await request(server).get("/p/display-iphone-13-pedido");
+      expect(res.status).toBe(200);
+      expect(res.text).toContain("Disponible a pedido");
+      expect(res.text).toContain('<time datetime="2026-06-19T00:00:00-03:00">19/06/2026</time>');
+      expect(res.text).toContain('"availabilityStarts":"2026-06-19T00:00:00-03:00"');
+      expect(res.text).not.toContain("stock real en CABA. Factura");
+    });
+  });
+
+  test("sitemap incluye paginas SEO validas y no genera paginas vacias", async () => {
+    await withServer(async (server) => {
+      const res = await request(server).get("/sitemap.xml");
+      expect(res.status).toBe(200);
+      expect(res.text).toContain("<loc>https://nerinparts.example/stock-real</loc>");
+      expect(res.text).toContain("<loc>https://nerinparts.example/pantallas-en-stock</loc>");
+      expect(res.text).toContain("<loc>https://nerinparts.example/baterias-en-stock</loc>");
+      expect(res.text).toContain("<loc>https://nerinparts.example/repuestos-samsung</loc>");
+      expect(res.text).toContain("<loc>https://nerinparts.example/repuestos-iphone</loc>");
+      expect(res.text).not.toContain("sin-productos");
+    });
+  });
+
+  test("endpoint free listings priority resume bloqueos y top organico", async () => {
+    await withServer(async (server) => {
+      const res = await request(server).get("/api/catalog/free-listings-priority?limit=20");
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.eligibleInStockProducts).toBeGreaterThanOrEqual(2);
+      expect(res.body.topOrganicPriorityProducts[0].title).toContain("Samsung Galaxy A15");
+    });
+  });
+});

--- a/nerin_final_updated/backend/data/productsSqliteRepo.js
+++ b/nerin_final_updated/backend/data/productsSqliteRepo.js
@@ -558,7 +558,16 @@ function scoreProductAgainstIntent(product = {}, intent = {}, options = {}) {
     if (intent.modelPhrase.includes("pro") && !intent.modelPhrase.includes("pro max") && haystack.includes(`${intent.modelPhrase} max`)) addScoreReason(state, "pro max no solicitado", -500);
   }
   const stock = Number(getField(product, ["stock"]));
-  if (Number.isFinite(stock) && stock > 0) addScoreReason(state, "stock disponible", 120);
+  const availabilityText = normalizeSearchText(
+    [
+      getField(product, ["availability", "disponibilidad", "estado_stock"]),
+      getField(product, ["stock_mode", "stockMode", "fulfillment_mode", "fulfillmentMode"]),
+      getField(raw, ["availability", "disponibilidad", "estado_stock", "stock_mode", "fulfillment_mode"]),
+    ].join(" "),
+  );
+  if (Number.isFinite(stock) && stock > 0) addScoreReason(state, "stock real disponible", 500);
+  else if (/preorder|backorder|pedido|remote|remoto/.test(availabilityText)) addScoreReason(state, "producto a pedido debajo de stock real", -120);
+  else addScoreReason(state, "sin stock debajo de alternativas disponibles", -300);
   if (!options?.debug) return state.score;
   return {
     score: state.score,

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -88,6 +88,12 @@ const {
   resolveProductAvailability,
   getPublicPriceValue,
 } = require("./utils/productAvailability");
+const {
+  computeOrganicSeoPriority,
+  getPartLabel: getOrganicPartLabel,
+  isBrandDoubtful,
+  matchesOrganicPage,
+} = require("./utils/organicSeo");
 const { readJsonFile } = require("./utils/jsonFile");
 const {
   appendEvent,
@@ -1843,6 +1849,293 @@ function renderShopListing(products, siteBase) {
   const count = valid.length;
   const summary = count === 1 ? "producto disponible." : "productos listados.";
   return { cards, count, summary };
+}
+
+const ORGANIC_SEO_PAGE_CONFIG = {
+  "/stock-real": {
+    key: "stock-real",
+    title: "Repuestos en stock real | NERIN Parts",
+    h1: "Repuestos para celulares en stock real",
+    description: "Repuestos listos para enviar desde CABA. Factura A/B, garantia tecnica y soporte para verificar compatibilidad antes de comprar.",
+    intro: "Repuestos listos para enviar desde CABA. Factura A/B, garantia tecnica y soporte para verificar compatibilidad antes de comprar.",
+    canonicalPath: "/stock-real",
+    priority: "0.9",
+  },
+  "/pantallas-en-stock": {
+    key: "pantallas-en-stock",
+    title: "Pantallas para celulares en stock | NERIN Parts",
+    h1: "Pantallas para celulares en stock",
+    description: "Pantallas y modulos de display con stock real en CABA. Verificamos compatibilidad, factura A/B y garantia tecnica.",
+    intro: "Pantallas, displays y modulos listos para enviar, con soporte para confirmar modelo y version antes de comprar.",
+    canonicalPath: "/pantallas-en-stock",
+    priority: "0.85",
+  },
+  "/baterias-en-stock": {
+    key: "baterias-en-stock",
+    title: "Baterias para celulares en stock | NERIN Parts",
+    h1: "Baterias para celulares en stock",
+    description: "Baterias para celulares con stock real, factura A/B y soporte tecnico para verificar compatibilidad.",
+    intro: "Baterias disponibles para despacho desde CABA, con asesoria tecnica para validar compatibilidad.",
+    canonicalPath: "/baterias-en-stock",
+    priority: "0.82",
+  },
+  "/repuestos-samsung": {
+    key: "repuestos-samsung",
+    title: "Repuestos Samsung en Argentina | NERIN Parts",
+    h1: "Repuestos Samsung en Argentina",
+    description: "Repuestos Samsung con stock real en Argentina. Pantallas, baterias, tapas, pines de carga y soporte especializado.",
+    intro: "Catalogo Samsung priorizado por stock real, precio valido, imagen y compatibilidad clara.",
+    canonicalPath: "/repuestos-samsung",
+    priority: "0.82",
+  },
+  "/repuestos-iphone": {
+    key: "repuestos-iphone",
+    title: "Repuestos iPhone en Argentina | NERIN Parts",
+    h1: "Repuestos iPhone en Argentina",
+    description: "Repuestos iPhone con stock real en Argentina. Displays, baterias, tapas y soporte para validar compatibilidad.",
+    intro: "Repuestos para iPhone priorizados por stock real, compatibilidad clara, factura y garantia tecnica.",
+    canonicalPath: "/repuestos-iphone",
+    priority: "0.82",
+  },
+};
+
+function parseSqliteProductRow(row = {}) {
+  let raw = {};
+  try {
+    raw = row.raw_json ? JSON.parse(row.raw_json) : {};
+  } catch {
+    raw = {};
+  }
+  const merged = { ...raw };
+  for (const [key, value] of Object.entries(row || {})) {
+    if (key === "raw_json" || key === "rowid") continue;
+    if (value !== undefined && value !== null && value !== "") merged[key] = value;
+  }
+  if (row.public_slug && !merged.publicSlug) merged.publicSlug = row.public_slug;
+  return normalizeProductImages(merged);
+}
+
+function getOrganicProductSelectSql(where = "is_public = 1", orderBy = "stock DESC, rowid ASC") {
+  return `SELECT rowid, id, sku, code, slug, public_slug, image, name, title, brand, model, category, status, visibility, stock, price, price_minorista, price_mayorista, precio_minorista, precio_mayorista, precio_final, part_number, mpn, raw_json FROM products WHERE ${where} ORDER BY ${orderBy}`;
+}
+
+async function fetchOrganicProducts({ limit = 300, stockRealOnly = false } = {}) {
+  await productsSqliteRepo.ensureProductsDbOnce();
+  let dbConn;
+  try {
+    dbConn = await openSqliteReadonly(productsSqliteRepo.SQLITE_PATH);
+    const where = stockRealOnly ? "is_public = 1 AND stock > 0" : "is_public = 1";
+    const rows = await sqliteAll(dbConn, `${getOrganicProductSelectSql(where)} LIMIT ?`, [Math.max(1, Number(limit) || 300)]);
+    return rows.map(parseSqliteProductRow);
+  } finally {
+    if (dbConn) {
+      try { dbConn.close(); } catch {}
+    }
+  }
+}
+
+function sortOrganicProducts(products = []) {
+  return [...products].sort((a, b) => {
+    const seoA = computeOrganicSeoPriority(a);
+    const seoB = computeOrganicSeoPriority(b);
+    const stockA = Number(a.stock || 0);
+    const stockB = Number(b.stock || 0);
+    return seoB.priorityScore - seoA.priorityScore || stockB - stockA || String(a.name || "").localeCompare(String(b.name || ""), "es", { sensitivity: "base" });
+  });
+}
+
+async function getOrganicProductsForPage(pageKey, limit = 48) {
+  const candidates = await fetchOrganicProducts({ limit: 800, stockRealOnly: true });
+  return sortOrganicProducts(candidates.filter((product) => matchesOrganicPage(product, pageKey))).slice(0, limit);
+}
+
+function buildOrganicProductCard(product, siteBase) {
+  const seo = computeOrganicSeoPriority(product);
+  const url = absoluteUrl(buildProductUrl(product), siteBase) || buildProductUrl(product);
+  const { imageList } = buildProductImages(product, siteBase);
+  const image = imageList[0] || absoluteUrl("/assets/hero.png", siteBase) || "/assets/hero.png";
+  const price = getPublicPriceValue(product);
+  const part = getOrganicPartLabel(seo.partTypeKey);
+  return `
+    <article class="organic-product-card" role="listitem">
+      <a class="organic-product-card__media" href="${esc(url)}">
+        <img loading="lazy" src="${esc(image)}" alt="${esc(product.name || seo.seoTitle || "Repuesto NERIN")}">
+      </a>
+      <div class="organic-product-card__body">
+        <span class="organic-product-card__badge">Stock real</span>
+        <p class="organic-product-card__eyebrow">${esc([seo.brand, seo.model, part].filter(Boolean).join(" · "))}</p>
+        <h2><a href="${esc(url)}">${esc(product.name || seo.seoTitle || "Repuesto")}</a></h2>
+        <p>${esc(seo.seoDescription)}</p>
+        <div class="organic-product-card__footer">
+          ${price > 0 ? `<strong>${esc(formatArs(price))}</strong>` : ""}
+          <a href="${esc(url)}">Ver producto</a>
+        </div>
+      </div>
+    </article>`;
+}
+
+function buildOrganicItemListSchema(products = [], siteBase, pageUrl) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    url: pageUrl,
+    numberOfItems: products.length,
+    itemListElement: products.map((product, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      url: absoluteUrl(buildProductUrl(product), siteBase),
+      name: product.name || product.title || `Producto ${index + 1}`,
+    })),
+  };
+}
+
+function buildOrganicBreadcrumbSchema(config, siteBase, pageUrl) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Inicio", item: absoluteUrl("/", siteBase) },
+      { "@type": "ListItem", position: 2, name: config.h1, item: pageUrl },
+    ],
+  };
+}
+
+function renderSeoDebugBlock(payload = {}) {
+  return `<section class="seo-debug" data-debug-seo="1"><h2>SEO debug</h2><pre>${esc(JSON.stringify(payload, null, 2))}</pre></section>`;
+}
+
+function renderOrganicSeoPage(config, products, siteBase, { debugSeo = false, includedInSitemap = true } = {}) {
+  const canonical = absoluteUrl(config.canonicalPath, siteBase);
+  const cards = products.map((product) => buildOrganicProductCard(product, siteBase)).join("");
+  const itemList = buildOrganicItemListSchema(products, siteBase, canonical);
+  const breadcrumbs = buildOrganicBreadcrumbSchema(config, siteBase, canonical);
+  const debug = debugSeo
+    ? renderSeoDebugBlock({
+        title: config.title,
+        metaDescription: config.description,
+        canonical,
+        h1: config.h1,
+        structuredData: ["BreadcrumbList", "ItemList"],
+        stock_status: "stock_real_only",
+        isOrganicPriority: true,
+        targetKeywords: products.slice(0, 8).flatMap((product) => computeOrganicSeoPriority(product).targetKeywords).slice(0, 20),
+        blockersSeo: [],
+        includedInSitemap,
+      })
+    : "";
+  return `<!doctype html>
+<html lang="es-AR">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${esc(config.title)}</title>
+  <meta name="description" content="${esc(config.description)}">
+  <meta name="robots" content="index,follow">
+  <link rel="canonical" href="${esc(canonical)}">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="${esc(config.title)}">
+  <meta property="og:description" content="${esc(config.description)}">
+  <meta property="og:url" content="${esc(canonical)}">
+  <link rel="stylesheet" href="/style.css?v=organic-seo">
+  <script type="application/ld+json" id="organic-itemlist">${safeJsonForScript(itemList)}</script>
+  <script type="application/ld+json" id="organic-breadcrumbs">${safeJsonForScript(breadcrumbs)}</script>
+</head>
+<body>
+  <header class="organic-header">
+    <a class="organic-header__brand" href="/">NERIN Parts</a>
+    <nav aria-label="Categorias organicas">
+      <a href="/stock-real">Stock real</a>
+      <a href="/pantallas-en-stock">Pantallas</a>
+      <a href="/baterias-en-stock">Baterias</a>
+      <a href="/repuestos-samsung">Samsung</a>
+      <a href="/repuestos-iphone">iPhone</a>
+    </nav>
+  </header>
+  <main class="organic-page">
+    <nav class="organic-breadcrumb" aria-label="Breadcrumb"><a href="/">Inicio</a><span>/</span><span>${esc(config.h1)}</span></nav>
+    <section class="organic-hero">
+      <p class="eyebrow">Stock real · Envio desde CABA · Factura A/B</p>
+      <h1>${esc(config.h1)}</h1>
+      <p>${esc(config.intro)}</p>
+      <div class="organic-hero__trust">
+        <span>Listo para enviar desde CABA</span>
+        <span>Garantia tecnica</span>
+        <span>Soporte por WhatsApp</span>
+        <span>Verificacion de compatibilidad</span>
+      </div>
+    </section>
+    <section class="organic-grid" aria-label="Productos en stock real" role="list">
+      ${cards}
+    </section>
+    <section class="organic-conversion">
+      <h2>Compra con compatibilidad verificada</h2>
+      <p>Antes de comprar, podemos confirmar modelo, version y codigo de pieza para reducir cambios y demoras.</p>
+      <div>
+        <a class="button primary" href="/shop.html?stock=in-stock">Comprar ahora</a>
+        <a class="button secondary" href="https://wa.me/5491130341550?text=Hola%20NERIN%2C%20quiero%20consultar%20compatibilidad" target="_blank" rel="noopener">Consultar compatibilidad por WhatsApp</a>
+      </div>
+    </section>
+    ${debug}
+  </main>
+</body>
+</html>`;
+}
+
+async function buildOrganicSitemapEntries(siteBase, generatedAt) {
+  const entries = [];
+  for (const config of Object.values(ORGANIC_SEO_PAGE_CONFIG)) {
+    const products = await getOrganicProductsForPage(config.key, 1);
+    if (!products.length) continue;
+    entries.push({
+      loc: absoluteUrl(config.canonicalPath, siteBase),
+      lastmod: generatedAt,
+      changefreq: "daily",
+      priority: config.priority || "0.8",
+    });
+  }
+  return entries;
+}
+
+async function buildFreeListingsPriorityReport({ limit = 100 } = {}) {
+  const products = await fetchOrganicProducts({ limit: 5000, stockRealOnly: false });
+  const summary = {
+    totalPublicProducts: products.length,
+    freeListingsEligibleProducts: 0,
+    eligibleInStockProducts: 0,
+    blockedMissingImage: 0,
+    blockedMissingPrice: 0,
+    blockedMissingSlug: 0,
+    doubtfulBrandProducts: 0,
+    topOrganicPriorityProducts: [],
+  };
+  const top = [];
+  for (const product of products) {
+    const seo = computeOrganicSeoPriority(product);
+    if (seo.blockers.includes("missing_image")) summary.blockedMissingImage += 1;
+    if (seo.blockers.includes("missing_price")) summary.blockedMissingPrice += 1;
+    if (seo.blockers.includes("missing_slug")) summary.blockedMissingSlug += 1;
+    if (isBrandDoubtful(product)) summary.doubtfulBrandProducts += 1;
+    const merchantReady = !seo.blockers.includes("missing_image") && !seo.blockers.includes("missing_price") && !seo.blockers.includes("missing_slug") && !seo.blockers.includes("not_public");
+    if (merchantReady) summary.freeListingsEligibleProducts += 1;
+    if (merchantReady && seo.isStockReal) summary.eligibleInStockProducts += 1;
+    if (seo.isOrganicPriority) {
+      top.push({
+        id: product.id || product.sku || null,
+        sku: product.sku || "",
+        title: product.name || product.title || "",
+        slug: product.publicSlug || product.public_slug || product.slug || "",
+        stock: Number(product.stock || 0),
+        price: getPublicPriceValue(product),
+        priorityScore: seo.priorityScore,
+        targetKeywords: seo.targetKeywords,
+        reasons: seo.reasons,
+      });
+    }
+  }
+  summary.topOrganicPriorityProducts = top
+    .sort((a, b) => b.priorityScore - a.priorityScore || b.stock - a.stock)
+    .slice(0, Math.max(1, Math.min(100, Number(limit) || 100)));
+  return summary;
 }
 
 function replaceBasePlaceholders(html, siteBase) {
@@ -6875,6 +7168,24 @@ async function requestHandler(req, res) {
         ok: false,
         source: "sqlite",
         error: error?.message || "performance test unavailable",
+      });
+    }
+  }
+
+  if (pathname === "/api/catalog/free-listings-priority" && req.method === "GET") {
+    try {
+      const limit = Math.max(1, Math.min(100, Number(parsedUrl.query?.limit || 100) || 100));
+      const report = await buildFreeListingsPriorityReport({ limit });
+      return sendJson(res, 200, {
+        ok: true,
+        source: "sqlite",
+        ...report,
+      });
+    } catch (error) {
+      return sendJson(res, 500, {
+        ok: false,
+        source: "sqlite",
+        error: error?.message || "No se pudo calcular prioridad de free listings",
       });
     }
   }
@@ -12887,6 +13198,8 @@ async function requestHandler(req, res) {
     const siteBase = getPublicBaseUrl(cfg);
     const products = loadSmallCatalogProducts({ filePath: PRODUCTS_FILE_PATH });
     const plan = buildSitemapPlan(siteBase, products);
+    const organicEntries = await buildOrganicSitemapEntries(plan.siteBase, toIsoString(new Date()));
+    plan.staticEntries = [...plan.staticEntries, ...organicEntries];
     const productCount = plan.productEntries.length;
     const needsIndex = productCount > 45000;
     if (pathname === "/sitemap.xml") {
@@ -12916,6 +13229,26 @@ async function requestHandler(req, res) {
     const xml = buildSitemapPartXml(plan.siteBase, plan.productSitemaps[idx]);
     res.writeHead(200, { "Content-Type": "application/xml; charset=utf-8", "Cache-Control": "public, max-age=3600" });
     res.end(xml);
+    return;
+  }
+
+  if (ORGANIC_SEO_PAGE_CONFIG[pathname] && req.method === "GET") {
+    const cfg = getConfig();
+    const siteBase = getPublicBaseUrl(cfg);
+    const config = ORGANIC_SEO_PAGE_CONFIG[pathname];
+    const products = await getOrganicProductsForPage(config.key, 48);
+    if (!products.length) {
+      const html = `<!doctype html><html lang="es-AR"><head><meta charset="utf-8"><meta name="robots" content="noindex,follow"><title>${esc(config.h1)} | Sin productos disponibles</title></head><body><main><h1>${esc(config.h1)}</h1><p>No hay productos en stock real para esta pagina en este momento.</p></main></body></html>`;
+      res.writeHead(404, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "no-store" });
+      res.end(html);
+      return;
+    }
+    const html = renderOrganicSeoPage(config, products, siteBase, {
+      debugSeo: parsedUrl.query?.debugSeo === "1",
+      includedInSitemap: true,
+    });
+    res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=600" });
+    res.end(html);
     return;
   }
 
@@ -13088,8 +13421,9 @@ async function requestHandler(req, res) {
     const formattedPrice = Number.isFinite(numericPrice)
       ? numericPrice.toFixed(2)
       : "0.00";
-    const seoTitle = productSeo.title || buildProductSeoTitle(product);
-    const description = productSeo.description || buildProductMetaDescription(product);
+    const organicSeo = computeOrganicSeoPriority(product);
+    const seoTitle = organicSeo.seoTitle || productSeo.title || buildProductSeoTitle(product);
+    const description = organicSeo.seoDescription || productSeo.description || buildProductMetaDescription(product);
     const h1 = buildProductHeading(product);
     const ld = {
       "@context": "https://schema.org",
@@ -13197,7 +13531,22 @@ async function requestHandler(req, res) {
       .join("");
     const galleryHtml = renderProductGallerySsr(product, siteBase);
     const debugMerchant = parsedUrl.query?.debugMerchant === "1";
-    const infoHtml = renderProductInfoSsr(product, siteBase) + (debugMerchant ? renderMerchantDebugSsr(product, { canonical, imageLink: primaryImage || "" }) : "");
+    const debugSeo = parsedUrl.query?.debugSeo === "1";
+    const seoDebugHtml = debugSeo
+      ? renderSeoDebugBlock({
+          title,
+          metaDescription,
+          canonical,
+          h1,
+          structuredData: ["Product", "Offer", "BreadcrumbList"],
+          stock_status: availabilityInfo.merchantAvailability,
+          isOrganicPriority: organicSeo.isOrganicPriority,
+          targetKeywords: organicSeo.targetKeywords,
+          blockersSeo: organicSeo.blockers,
+          includedInSitemap: Boolean(product?.publicSlug || product?.public_slug || product?.slug),
+        })
+      : "";
+    const infoHtml = renderProductInfoSsr(product, siteBase) + (debugMerchant ? renderMerchantDebugSsr(product, { canonical, imageLink: primaryImage || "" }) : "") + seoDebugHtml;
     const hydratedBody = injectProductContent(templateBody, galleryHtml, infoHtml);
     const html = `<!DOCTYPE html><html lang="es-AR"><head>${head}</head>${hydratedBody}</html>`;
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });

--- a/nerin_final_updated/backend/utils/organicSeo.js
+++ b/nerin_final_updated/backend/utils/organicSeo.js
@@ -1,0 +1,308 @@
+const { detectProductType } = require("./productTaxonomy");
+const {
+  getPublicPriceValue,
+  resolveProductAvailability,
+} = require("./productAvailability");
+
+const DEMAND_PART_TYPES = new Set([
+  "display",
+  "battery",
+  "charging",
+  "back_cover",
+  "camera",
+  "flex",
+  "speaker",
+  "sim_tray",
+]);
+
+const BRAND_PATTERNS = [
+  ["Apple", /\b(apple|iphone)\b/i],
+  ["Samsung", /\b(samsung|galaxy|sm-[a-z0-9]+)\b/i],
+  ["Xiaomi", /\b(xiaomi|redmi|poco)\b/i],
+  ["Huawei", /\bhuawei\b/i],
+  ["Honor", /\bhonor\b/i],
+  ["OnePlus", /\b(oneplus|one plus)\b/i],
+  ["Motorola", /\b(motorola|moto)\b/i],
+];
+
+function cleanText(value) {
+  if (value == null) return "";
+  return String(value).replace(/\s+/g, " ").trim();
+}
+
+function lowerText(value) {
+  return cleanText(value)
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+}
+
+function truncateText(value, limit = 155) {
+  const text = cleanText(value);
+  if (text.length <= limit) return text;
+  const slice = text.slice(0, Math.max(0, limit - 1));
+  const lastSpace = slice.lastIndexOf(" ");
+  return `${(lastSpace > 40 ? slice.slice(0, lastSpace) : slice).replace(/[\s,.:-]+$/, "")}...`;
+}
+
+function pickField(product = {}, keys = []) {
+  const metadata = product && typeof product.metadata === "object" && product.metadata ? product.metadata : {};
+  const supplierImport =
+    metadata && typeof metadata.supplierImport === "object" && metadata.supplierImport ? metadata.supplierImport : {};
+  for (const key of keys) {
+    if (!key) continue;
+    if (product[key] != null && product[key] !== "") return product[key];
+    if (metadata[key] != null && metadata[key] !== "") return metadata[key];
+    if (supplierImport[key] != null && supplierImport[key] !== "") return supplierImport[key];
+  }
+  return "";
+}
+
+function isPublicProduct(product = {}) {
+  if (!product || typeof product !== "object") return false;
+  const flags = [
+    product.visibility,
+    product.status,
+    product.publication_status,
+    product.estado,
+  ].map(lowerText).join(" ");
+  if (/(hidden|private|draft|disabled|archived|deleted|borrado|oculto)/.test(flags)) return false;
+  if (product.enabled === false || product.deleted === true || product.archived === true) return false;
+  if (product.hidden === true || product.private === true || product.draft === true || product.disabled === true) return false;
+  if (product.vip_only === true || product.wholesaleOnly === true || product.wholesale_only === true) return false;
+  return Boolean(getPublicSlug(product) || pickField(product, ["id", "sku", "code", "mpn", "part_number"]));
+}
+
+function getPublicSlug(product = {}) {
+  return cleanText(
+    pickField(product, [
+      "publicSlug",
+      "public_slug",
+      "slug",
+      "seo_slug",
+    ]),
+  );
+}
+
+function getTitle(product = {}) {
+  return cleanText(pickField(product, ["name", "title", "product_title", "description"])) || "Repuesto";
+}
+
+function getImageCandidates(product = {}) {
+  const rawImages = Array.isArray(product.images) ? product.images : [];
+  return [
+    product.image,
+    product.image_url,
+    product.thumbnail,
+    product.picture,
+    ...rawImages,
+  ].map(cleanText).filter(Boolean);
+}
+
+function isValidImageUrl(value = "") {
+  const raw = cleanText(value);
+  if (!raw) return false;
+  if (/^(data:|blob:|javascript:|base64[,;])/i.test(raw)) return false;
+  if (/^https?:\/\//i.test(raw)) {
+    try {
+      const parsed = new URL(raw);
+      return Boolean(parsed.hostname && parsed.hostname.includes("."));
+    } catch {
+      return false;
+    }
+  }
+  return raw.startsWith("/") || /\.(png|jpe?g|webp|gif)(\?|#|$)/i.test(raw);
+}
+
+function inferBrand(product = {}) {
+  const explicit = cleanText(pickField(product, ["brand", "marca", "manufacturer"]));
+  if (explicit) return explicit.replace(/^for\s+/i, "").trim();
+  const text = [getTitle(product), product.model, product.category, product.description].map(cleanText).join(" ");
+  for (const [brand, pattern] of BRAND_PATTERNS) {
+    if (pattern.test(text)) return brand;
+  }
+  return "";
+}
+
+function inferModel(product = {}) {
+  const explicit = cleanText(pickField(product, ["model", "modelo", "compatible_model", "compatibleModels"]));
+  if (explicit) return explicit;
+  const text = lowerText([getTitle(product), product.description, product.category, product.subcategory].join(" "));
+  const patterns = [
+    /\biphone\s+\d{1,2}(?:\s+(?:mini|plus|pro(?:\s+max)?|air))?\b/i,
+    /\bgalaxy\s+[a-z]\d{1,3}(?:\s+\d+g)?\b/i,
+    /\bsamsung\s+[a-z]\d{1,3}(?:\s+\d+g)?\b/i,
+    /\bredmi\s+note\s+\d{1,2}(?:\s+pro)?\b/i,
+    /\bhonor\s+\d{2,3}(?:\s+pro)?\b/i,
+    /\bmoto\s+g\d{1,3}\b/i,
+  ];
+  for (const pattern of patterns) {
+    const match = text.match(pattern);
+    if (match) return match[0].replace(/\b\w/g, (letter) => letter.toUpperCase());
+  }
+  return "";
+}
+
+function getPartTypeKey(product = {}) {
+  const text = lowerText([getTitle(product), product.description, product.category, product.subcategory].join(" "));
+  if (/\b(pantalla|display|screen|lcd|oled|amoled|modulo)\b/.test(text) && !/\b(adhesivo|adhesive|tape|protector|templado)\b/.test(text)) return "display";
+  if (/\b(bateria|battery|pila)\b/.test(text)) return "battery";
+  if (/\b(pin de carga|placa de carga|charging|dock|usb connector|puerto de carga)\b/.test(text)) return "charging";
+  if (/\b(tapa|back glass|rear cover|back cover|carcasa)\b/.test(text)) return "back_cover";
+  if (/\b(camara|camera|camera lens|lente)\b/.test(text)) return "camera";
+  if (/\b(flex|flex cable)\b/.test(text)) return "flex";
+  if (/\b(parlante|speaker|auricular|ear speaker)\b/.test(text)) return "speaker";
+  if (/\b(bandeja sim|sim tray)\b/.test(text)) return "sim_tray";
+  if (/\b(adhesivo|adhesive|gasket|seal)\b/.test(text)) return "adhesive";
+  const detected = detectProductType(product);
+  const normalized = lowerText(detected);
+  if (normalized.includes("pantalla") || normalized.includes("display")) return "display";
+  if (normalized.includes("bateria")) return "battery";
+  if (normalized.includes("carga")) return "charging";
+  if (normalized.includes("tapa") || normalized.includes("carcasa")) return "back_cover";
+  if (normalized.includes("camara") || normalized.includes("lente")) return "camera";
+  if (normalized.includes("flex")) return "flex";
+  if (normalized.includes("audio") || normalized.includes("parlante")) return "speaker";
+  if (normalized.includes("sim")) return "sim_tray";
+  if (normalized.includes("adhesivo")) return "adhesive";
+  return "other";
+}
+
+function getPartLabel(partTypeKey) {
+  switch (partTypeKey) {
+    case "display":
+      return "Pantalla";
+    case "battery":
+      return "Bateria";
+    case "charging":
+      return "Pin de carga";
+    case "back_cover":
+      return "Tapa trasera";
+    case "camera":
+      return "Camara";
+    case "flex":
+      return "Flex";
+    case "speaker":
+      return "Parlante";
+    case "sim_tray":
+      return "Bandeja SIM";
+    case "adhesive":
+      return "Adhesivo";
+    default:
+      return "Repuesto";
+  }
+}
+
+function buildTargetKeywords(product = {}, { brand = "", model = "", partTypeKey = "other" } = {}) {
+  const part = getPartLabel(partTypeKey).toLowerCase();
+  const tokens = [
+    [part, brand, model].filter(Boolean).join(" "),
+    [part, model, "stock real"].filter(Boolean).join(" "),
+    ["repuesto", brand, model, "Argentina"].filter(Boolean).join(" "),
+    [brand, model, "NERIN Parts"].filter(Boolean).join(" "),
+  ].map(cleanText).filter(Boolean);
+  return Array.from(new Set(tokens)).slice(0, 8);
+}
+
+function computeOrganicSeoPriority(product = {}) {
+  const reasons = [];
+  const blockers = [];
+  let priorityScore = 0;
+
+  const title = getTitle(product);
+  const slug = getPublicSlug(product);
+  const price = getPublicPriceValue(product);
+  const images = getImageCandidates(product);
+  const hasValidImage = images.some(isValidImageUrl);
+  const availability = resolveProductAvailability(product);
+  const isStockReal = availability.merchantAvailability === "in_stock" && Number(availability.stockLocal || 0) > 0;
+  const brand = inferBrand(product);
+  const model = inferModel(product);
+  const partTypeKey = getPartTypeKey(product);
+  const category = cleanText(pickField(product, ["category", "categoria", "productType"])) || getPartLabel(partTypeKey);
+  const skuOrMpn = cleanText(pickField(product, ["sku", "mpn", "part_number", "partNumber", "code"]));
+
+  if (!isPublicProduct(product)) blockers.push("not_public");
+  if (!isStockReal) blockers.push("not_stock_real");
+  if (!(price > 0)) blockers.push("missing_price");
+  if (!hasValidImage) blockers.push("missing_image");
+  if (!slug) blockers.push("missing_slug");
+  if (!title || title === "Repuesto") blockers.push("missing_clear_title");
+  if (!brand) blockers.push("missing_brand");
+  if (!model) blockers.push("missing_model");
+  if (!category) blockers.push("missing_category");
+
+  if (isStockReal) { priorityScore += 1000; reasons.push("stock_real"); }
+  if (price > 0) { priorityScore += 250; reasons.push("valid_price"); }
+  if (hasValidImage) { priorityScore += 250; reasons.push("valid_image"); }
+  if (slug) { priorityScore += 200; reasons.push("public_slug"); }
+  if (brand) { priorityScore += 200; reasons.push("identified_brand"); }
+  if (model) { priorityScore += 350; reasons.push("identified_model"); }
+  if (skuOrMpn) { priorityScore += 180; reasons.push("sku_or_mpn"); }
+  if (category) { priorityScore += 180; reasons.push("clear_category"); }
+  if (DEMAND_PART_TYPES.has(partTypeKey)) { priorityScore += 300; reasons.push(`high_demand_${partTypeKey}`); }
+
+  const partLabel = getPartLabel(partTypeKey);
+  const modelCopy = [brand, model].filter(Boolean).join(" ").trim();
+  const productLabel = [partLabel, modelCopy].filter(Boolean).join(" ").trim() || title;
+  const seoTitle = isStockReal
+    ? truncateText(`${productLabel} en stock | NERIN Parts`, 70)
+    : truncateText(`${productLabel} | NERIN Parts`, 70);
+  const seoDescription = isStockReal
+    ? truncateText(`${productLabel} con stock real en CABA. Factura A/B, garantia tecnica y soporte para verificar compatibilidad antes de comprar.`, 160)
+    : truncateText(`${productLabel} en NERIN Parts. Consultanos disponibilidad, compatibilidad, factura y garantia tecnica.`, 160);
+
+  return {
+    isStockReal,
+    isOrganicPriority: blockers.length === 0,
+    priorityScore,
+    targetKeywords: buildTargetKeywords(product, { brand, model, partTypeKey }),
+    seoTitle,
+    seoDescription,
+    reasons,
+    blockers,
+    brand,
+    model,
+    category,
+    partTypeKey,
+    availability: availability.merchantAvailability,
+  };
+}
+
+function isBrandDoubtful(product = {}) {
+  return !inferBrand(product);
+}
+
+function matchesOrganicPage(product = {}, pageKey = "") {
+  const priority = computeOrganicSeoPriority(product);
+  const brand = lowerText(priority.brand);
+  const model = lowerText(priority.model);
+  switch (pageKey) {
+    case "stock-real":
+      return priority.isOrganicPriority;
+    case "pantallas-en-stock":
+      return priority.isOrganicPriority && priority.partTypeKey === "display";
+    case "baterias-en-stock":
+      return priority.isOrganicPriority && priority.partTypeKey === "battery";
+    case "repuestos-samsung":
+      return priority.isOrganicPriority && brand.includes("samsung");
+    case "repuestos-iphone":
+      return priority.isOrganicPriority && (brand.includes("apple") || model.includes("iphone"));
+    default:
+      return false;
+  }
+}
+
+module.exports = {
+  computeOrganicSeoPriority,
+  getImageCandidates,
+  getPartLabel,
+  getPartTypeKey,
+  getPublicSlug,
+  inferBrand,
+  inferModel,
+  isBrandDoubtful,
+  isPublicProduct,
+  isValidImageUrl,
+  matchesOrganicPage,
+};

--- a/nerin_final_updated/frontend/index.html
+++ b/nerin_final_updated/frontend/index.html
@@ -242,6 +242,19 @@
         </div>
       </section>
 
+      <section class="organic-seo-links" aria-label="Categorias indexables con stock real">
+        <p class="eyebrow">Stock real para Google y clientes</p>
+        <h2>Repuestos listos para comprar</h2>
+        <p>Accesos directos a productos con stock real, precio visible, factura A/B y soporte para verificar compatibilidad.</p>
+        <div class="organic-seo-links__grid">
+          <a href="/stock-real">Repuestos en stock real</a>
+          <a href="/pantallas-en-stock">Pantallas en stock</a>
+          <a href="/baterias-en-stock">Baterias en stock</a>
+          <a href="/repuestos-samsung">Repuestos Samsung</a>
+          <a href="/repuestos-iphone">Repuestos iPhone</a>
+        </div>
+      </section>
+
       <section class="home-featured" data-home-section="featured">
         <div class="home-featured__header">
           <p class="eyebrow">Destacados</p>

--- a/nerin_final_updated/frontend/shop.html
+++ b/nerin_final_updated/frontend/shop.html
@@ -271,6 +271,18 @@
           <div id="publicProductsPagination" class="products-pagination" aria-label="Paginación del catálogo"></div>
         </section>
       </section>
+      <section class="organic-seo-links" aria-label="Categorias principales de repuestos">
+        <p class="eyebrow">Accesos indexables</p>
+        <h2>Comprar por stock real y marca</h2>
+        <p>Atajos para encontrar repuestos disponibles, con precio visible, factura A/B y soporte de compatibilidad.</p>
+        <div class="organic-seo-links__grid">
+          <a href="/stock-real">Repuestos en stock real</a>
+          <a href="/pantallas-en-stock">Pantallas en stock</a>
+          <a href="/baterias-en-stock">Baterias en stock</a>
+          <a href="/repuestos-samsung">Repuestos Samsung</a>
+          <a href="/repuestos-iphone">Repuestos iPhone</a>
+        </div>
+      </section>
       <div class="shop-filters-backdrop" id="filtersBackdrop" hidden></div>
     </main>
     <div id="whatsapp-button">

--- a/nerin_final_updated/frontend/style.css
+++ b/nerin_final_updated/frontend/style.css
@@ -948,6 +948,237 @@ body.cart-indicator-visible .toastify {
   display: none;
 }
 
+.organic-header {
+  align-items: center;
+  background: rgba(255, 255, 255, 0.94);
+  border-bottom: 1px solid #e6e8ee;
+  display: flex;
+  gap: 24px;
+  justify-content: space-between;
+  padding: 18px clamp(18px, 5vw, 64px);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.organic-header__brand {
+  color: #111827;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-decoration: none;
+}
+
+.organic-header nav,
+.organic-seo-links__grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.organic-header nav a,
+.organic-seo-links__grid a {
+  border: 1px solid #d9dde6;
+  border-radius: 999px;
+  color: #1f2937;
+  font-size: 0.92rem;
+  padding: 8px 12px;
+  text-decoration: none;
+}
+
+.organic-page {
+  background: #ffffff;
+  color: #111827;
+  margin: 0 auto;
+  max-width: 1180px;
+  padding: 34px clamp(18px, 5vw, 64px) 72px;
+}
+
+.organic-breadcrumb {
+  align-items: center;
+  color: #6b7280;
+  display: flex;
+  font-size: 0.92rem;
+  gap: 8px;
+  margin-bottom: 28px;
+}
+
+.organic-breadcrumb a {
+  color: #374151;
+  text-decoration: none;
+}
+
+.organic-hero {
+  border-bottom: 1px solid #eceff4;
+  margin-bottom: 28px;
+  padding-bottom: 28px;
+}
+
+.organic-hero h1 {
+  color: #111827;
+  font-size: clamp(2rem, 4vw, 3.4rem);
+  letter-spacing: 0;
+  line-height: 1.05;
+  margin: 8px 0 12px;
+  max-width: 820px;
+}
+
+.organic-hero p {
+  color: #4b5563;
+  font-size: 1.05rem;
+  line-height: 1.65;
+  max-width: 820px;
+}
+
+.organic-hero__trust {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.organic-hero__trust span {
+  background: #f7f8fb;
+  border: 1px solid #e5e7eb;
+  border-radius: 999px;
+  color: #334155;
+  font-size: 0.92rem;
+  padding: 8px 12px;
+}
+
+.organic-grid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.organic-product-card {
+  border: 1px solid #e4e7ee;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.organic-product-card__media {
+  aspect-ratio: 4 / 3;
+  background: #f8fafc;
+  display: block;
+}
+
+.organic-product-card__media img {
+  height: 100%;
+  object-fit: contain;
+  padding: 18px;
+  width: 100%;
+}
+
+.organic-product-card__body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px;
+}
+
+.organic-product-card__badge {
+  align-self: flex-start;
+  background: #eaf7ef;
+  border: 1px solid #b9e4c8;
+  border-radius: 999px;
+  color: #166534;
+  font-size: 0.78rem;
+  font-weight: 800;
+  padding: 5px 9px;
+  text-transform: uppercase;
+}
+
+.organic-product-card__eyebrow {
+  color: #64748b;
+  font-size: 0.86rem;
+  margin: 0;
+}
+
+.organic-product-card h2 {
+  font-size: 1.02rem;
+  line-height: 1.3;
+  margin: 0;
+}
+
+.organic-product-card h2 a {
+  color: #111827;
+  text-decoration: none;
+}
+
+.organic-product-card p {
+  color: #4b5563;
+  font-size: 0.94rem;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.organic-product-card__footer {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  margin-top: auto;
+}
+
+.organic-product-card__footer a {
+  color: #111827;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.organic-conversion,
+.organic-seo-links {
+  background: #f8fafc;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  margin-top: 28px;
+  padding: 22px;
+}
+
+.organic-conversion h2,
+.organic-seo-links h2 {
+  color: #111827;
+  font-size: 1.25rem;
+  margin: 0 0 8px;
+}
+
+.organic-conversion p,
+.organic-seo-links p {
+  color: #4b5563;
+  line-height: 1.55;
+  margin: 0 0 16px;
+}
+
+.seo-debug {
+  background: #111827;
+  border-radius: 8px;
+  color: #f9fafb;
+  margin-top: 28px;
+  overflow: auto;
+  padding: 18px;
+}
+
+.seo-debug pre {
+  white-space: pre-wrap;
+}
+
+@media (max-width: 760px) {
+  .organic-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .organic-product-card__footer {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
 .price {
   font-size: 1rem;
   font-weight: 600;

--- a/nerin_final_updated/scripts/audit-organic-seo-stock-real.js
+++ b/nerin_final_updated/scripts/audit-organic-seo-stock-real.js
@@ -1,0 +1,122 @@
+const sqlite3 = require("sqlite3");
+const productsSqliteRepo = require("../backend/data/productsSqliteRepo");
+const {
+  computeOrganicSeoPriority,
+  matchesOrganicPage,
+} = require("../backend/utils/organicSeo");
+const { getPublicPriceValue } = require("../backend/utils/productAvailability");
+
+function openReadonly(dbPath) {
+  return new Promise((resolve, reject) => {
+    const db = new sqlite3.Database(dbPath, sqlite3.OPEN_READONLY, (error) => {
+      if (error) reject(error);
+      else resolve(db);
+    });
+  });
+}
+
+function all(db, sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.all(sql, params, (error, rows) => {
+      if (error) reject(error);
+      else resolve(rows || []);
+    });
+  });
+}
+
+function parseRow(row = {}) {
+  let raw = {};
+  try {
+    raw = row.raw_json ? JSON.parse(row.raw_json) : {};
+  } catch {
+    raw = {};
+  }
+  const product = { ...raw };
+  for (const [key, value] of Object.entries(row)) {
+    if (key === "raw_json" || key === "rowid") continue;
+    if (value !== undefined && value !== null && value !== "") product[key] = value;
+  }
+  if (row.public_slug && !product.publicSlug) product.publicSlug = row.public_slug;
+  return product;
+}
+
+async function main() {
+  await productsSqliteRepo.ensureProductsDbOnce();
+  const db = await openReadonly(productsSqliteRepo.SQLITE_PATH);
+  try {
+    const rows = await all(db, `
+      SELECT rowid, id, sku, code, slug, public_slug, image, name, title,
+             brand, model, category, status, visibility, stock, price, price_minorista,
+             precio_minorista, precio_final, part_number, mpn, raw_json, is_public
+      FROM products
+      WHERE is_public = 1
+      ORDER BY rowid ASC
+    `);
+    const products = rows.map(parseRow);
+    const report = {
+      totalPublicProducts: products.length,
+      seoPagesCreated: [],
+      blockedMissingImage: [],
+      blockedMissingPrice: [],
+      blockedMissingSlug: [],
+      doubtfulBrandProducts: [],
+      productsWithoutEnoughStructuredData: [],
+      topOrganicPriorityProducts: [],
+      keywordRecommendations: [],
+    };
+    const pageKeys = [
+      ["stock-real", "/stock-real"],
+      ["pantallas-en-stock", "/pantallas-en-stock"],
+      ["baterias-en-stock", "/baterias-en-stock"],
+      ["repuestos-samsung", "/repuestos-samsung"],
+      ["repuestos-iphone", "/repuestos-iphone"],
+    ];
+    for (const [key, path] of pageKeys) {
+      const count = products.filter((product) => matchesOrganicPage(product, key)).length;
+      if (count > 0) report.seoPagesCreated.push({ path, productCount: count });
+    }
+    const priorities = [];
+    for (const product of products) {
+      const seo = computeOrganicSeoPriority(product);
+      const entry = {
+        id: product.id || null,
+        sku: product.sku || "",
+        title: product.name || product.title || "",
+        slug: product.publicSlug || product.public_slug || product.slug || "",
+        stock: Number(product.stock || 0),
+        price: getPublicPriceValue(product),
+        priorityScore: seo.priorityScore,
+        targetKeywords: seo.targetKeywords,
+        blockers: seo.blockers,
+      };
+      if (seo.blockers.includes("missing_image")) report.blockedMissingImage.push(entry);
+      if (seo.blockers.includes("missing_price")) report.blockedMissingPrice.push(entry);
+      if (seo.blockers.includes("missing_slug")) report.blockedMissingSlug.push(entry);
+      if (seo.blockers.includes("missing_brand")) report.doubtfulBrandProducts.push(entry);
+      if (seo.blockers.includes("missing_image") || seo.blockers.includes("missing_price") || seo.blockers.includes("missing_slug")) {
+        report.productsWithoutEnoughStructuredData.push(entry);
+      }
+      if (seo.isOrganicPriority) priorities.push(entry);
+    }
+    priorities.sort((a, b) => b.priorityScore - a.priorityScore || b.stock - a.stock);
+    report.topOrganicPriorityProducts = priorities.slice(0, 20);
+    report.keywordRecommendations = priorities.slice(0, 20).map((entry) => ({
+      title: entry.title,
+      slug: entry.slug,
+      keywords: entry.targetKeywords,
+    }));
+    report.blockedMissingImage = report.blockedMissingImage.slice(0, 20);
+    report.blockedMissingPrice = report.blockedMissingPrice.slice(0, 20);
+    report.blockedMissingSlug = report.blockedMissingSlug.slice(0, 20);
+    report.doubtfulBrandProducts = report.doubtfulBrandProducts.slice(0, 20);
+    report.productsWithoutEnoughStructuredData = report.productsWithoutEnoughStructuredData.slice(0, 20);
+    console.log(JSON.stringify(report, null, 2));
+  } finally {
+    db.close();
+  }
+}
+
+main().catch((error) => {
+  console.error("[audit-organic-seo-stock-real] failed", error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- Adds an organic SEO priority layer for stock-real products with target keywords, SEO title/description, reasons, and blockers.
- Adds indexable SSR category pages: `/stock-real`, `/pantallas-en-stock`, `/baterias-en-stock`, `/repuestos-samsung`, and `/repuestos-iphone`.
- Adds ItemList/Breadcrumb structured data, canonical/meta/debug SEO output, and sitemap inclusion only when a page has real stock products.
- Adds a free listings priority endpoint: `GET /api/catalog/free-listings-priority`.
- Adds internal links from Home and Shop so Google can discover the new pages without relying on internal search.
- Raises public search ranking preference for stock-real products while keeping exact model and part-type scoring intact.

## Pages created
- `/stock-real` — Repuestos para celulares en stock real
- `/pantallas-en-stock` — Pantallas para celulares en stock
- `/baterias-en-stock` — Baterias para celulares en stock
- `/repuestos-samsung` — Repuestos Samsung en Argentina
- `/repuestos-iphone` — Repuestos iPhone en Argentina

## Product SEO behavior
- Stock-real products get more specific title/meta copy such as `Pantalla Samsung Galaxy A15 en stock | NERIN Parts`.
- Preorder/backorder products do not claim stock real and preserve `availability_date`, visible dispatch date, and JSON-LD `availabilityStarts`.
- Out-of-stock products remain `OutOfStock` and are not listed as stock real.

## Merchant / free listings
- Keeps Merchant feed fields intact.
- Adds organic/free listings diagnostics with counts for eligible products, stock-real eligible products, missing image, missing price, missing slug, doubtful brand, and top organic priorities.

## Safety notes
- Did not touch Mercado Pago, webhooks, critical checkout, inventory/order mutation logic, Andreani real integration, or base pricing.

## Validation
- `node --check` passed for modified JS files.
- `jest backend/__tests__/organic-seo-stock-real.test.js backend/__tests__/merchant-availability-ui.test.js backend/__tests__/product-ssr.test.js --runInBand --silent --forceExit`: 3 suites passed, 17 tests passed.
- `node scripts/audit-organic-seo-stock-real.js`: generated SEO pages and top stock-real organic products; no missing image/price/slug blockers in sample data.
- `node scripts/audit-google-merchant-feed.js`: criticalErrorCount 0.
- `node scripts/test-search-ranking-cases.js`: all key search ranking cases passed.