### PR TITLE
Add ecommerce analytics layer for organic sales funnel

### DIFF
--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -2077,6 +2077,7 @@ function renderOrganicSeoPage(config, products, siteBase, { debugSeo = false, in
     </section>
     ${debug}
   </main>
+  <script type="module" src="/js/analytics-autotrack.js?v=ecommerce-organic-funnel"></script>
 </body>
 </html>`;
 }

--- a/nerin_final_updated/frontend/cart.html
+++ b/nerin_final_updated/frontend/cart.html
@@ -121,5 +121,6 @@
     <!-- Configuración y analíticas globales -->
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
     <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>
+    <script type="module" src="/js/analytics-autotrack.js?v=ecommerce-organic-funnel"></script>
   </body>
 </html>

--- a/nerin_final_updated/frontend/checkout-steps.html
+++ b/nerin_final_updated/frontend/checkout-steps.html
@@ -177,5 +177,6 @@
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
     <script type="module" src="/js/checkout-steps.js?v=__BUILD_ID__"></script>
     <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>
+    <script type="module" src="/js/analytics-autotrack.js?v=ecommerce-organic-funnel"></script>
   </body>
 </html>

--- a/nerin_final_updated/frontend/index.html
+++ b/nerin_final_updated/frontend/index.html
@@ -314,5 +314,6 @@
     <script type="module" src="/js/index.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
     <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>
+    <script type="module" src="/js/analytics-autotrack.js?v=ecommerce-organic-funnel"></script>
   </body>
 </html>

--- a/nerin_final_updated/frontend/js/analytics-autotrack.js
+++ b/nerin_final_updated/frontend/js/analytics-autotrack.js
@@ -1,0 +1,98 @@
+import { trackSelectItem, trackViewItemList, trackWhatsappClick } from "./analytics.js";
+
+const SEO_PATHS = new Set([
+  "/stock-real",
+  "/pantallas-en-stock",
+  "/baterias-en-stock",
+  "/repuestos-samsung",
+  "/repuestos-iphone",
+]);
+
+function pageSource() {
+  const path = window.location.pathname || "";
+  if (path === "/" || path.endsWith("/index.html")) return "home";
+  if (path.includes("checkout")) return "checkout";
+  if (path.includes("cart")) return "cart";
+  if (path.includes("shop")) return new URLSearchParams(window.location.search).get("stock") === "real" ? "shop_stock_real" : "shop";
+  if (SEO_PATHS.has(path) || path.startsWith("/repuestos-samsung/") || path.startsWith("/repuestos-iphone/")) return path.replace(/^\//, "") || "seo";
+  if (path.startsWith("/p/") || path.includes("product.html")) return "product_page";
+  return "site";
+}
+
+function productFromElement(element) {
+  const node = element?.closest?.("[data-product-id], [data-sku], .organic-product-card, .product-card");
+  if (!node) return {};
+  const title = node.dataset.productName || node.dataset.title || node.querySelector("h2,h3,.product-title,.organic-product-card__title")?.textContent || "";
+  const priceText = node.dataset.price || node.querySelector("[data-price],.price,.price-final,.organic-product-card__price")?.textContent || "";
+  const price = Number(String(priceText).replace(/[^0-9.,-]/g, "").replace(/\./g, "").replace(",", ".")) || 0;
+  return {
+    id: node.dataset.productId || node.dataset.id || "",
+    sku: node.dataset.sku || "",
+    slug: node.dataset.slug || node.querySelector("a[href^='/p/']")?.getAttribute("href")?.split("/p/")[1] || "",
+    name: title.trim(),
+    title: title.trim(),
+    price,
+    brand: node.dataset.brand || "",
+    category: node.dataset.category || "",
+    stock: Number(node.dataset.stock || node.dataset.stockQty || 0) || 0,
+    availability: node.dataset.availability || node.dataset.stockStatus || "",
+  };
+}
+
+function collectSeoProducts() {
+  return Array.from(document.querySelectorAll("[data-product-id], [data-sku], .organic-product-card, .product-card"))
+    .map(productFromElement)
+    .filter((product) => product.name || product.id || product.sku)
+    .slice(0, 100);
+}
+
+function bindWhatsappTracking() {
+  document.addEventListener("click", (event) => {
+    const link = event.target?.closest?.("a[href*='wa.me'], a[href*='api.whatsapp.com'], a[href*='whatsapp.com/send'], [data-whatsapp-link]");
+    if (!link) return;
+    const product = productFromElement(link);
+    trackWhatsappClick({
+      source: link.dataset.analyticsSource || pageSource(),
+      product_id: product.id,
+      sku: product.sku,
+      product_name: product.name,
+      stock_status: product.availability,
+      is_stock_real: product.stock > 0 && product.availability !== "preorder" && product.availability !== "backorder",
+      href: link.getAttribute("href") || "",
+    });
+  }, true);
+}
+
+function bindSeoListTracking() {
+  const source = pageSource();
+  const path = window.location.pathname || "";
+  if (!(SEO_PATHS.has(path) || path.startsWith("/repuestos-samsung/") || path.startsWith("/repuestos-iphone/"))) return;
+  const products = collectSeoProducts();
+  if (products.length) {
+    trackViewItemList(products, {
+      source,
+      page_path: path,
+      item_list_id: source,
+      item_list_name: document.querySelector("h1")?.textContent?.trim() || source,
+    });
+  }
+  document.addEventListener("click", (event) => {
+    const link = event.target?.closest?.("a[href^='/p/'], .organic-product-card a, .product-card a");
+    if (!link) return;
+    const product = productFromElement(link);
+    if (product.name || product.id || product.sku) {
+      trackSelectItem(product, { source, page_path: path });
+    }
+  }, true);
+}
+
+function init() {
+  bindWhatsappTracking();
+  bindSeoListTracking();
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", init, { once: true });
+} else {
+  init();
+}

--- a/nerin_final_updated/frontend/js/analytics.js
+++ b/nerin_final_updated/frontend/js/analytics.js
@@ -1,5 +1,413 @@
 import { apiFetch } from "./api.js";
 
+const ANALYTICS_CURRENCY = "ARS";
+const PURCHASE_DEDUPE_PREFIX = "nerin.analytics.purchase.";
+const RECENT_EVENT_LIMIT = 80;
+
+const hasWindow = () => typeof window !== "undefined";
+const safeNumber = (value, fallback = 0) => {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+};
+const cleanText = (value) => String(value ?? "").trim();
+const lower = (value) => cleanText(value).toLowerCase();
+const firstValue = (...values) => values.find((value) => value !== undefined && value !== null && cleanText(value) !== "");
+
+function getConfigValue(...keys) {
+  if (!hasWindow()) return "";
+  const config = window.NERIN_CONFIG || window.__NERIN_CONFIG__ || {};
+  for (const key of keys) {
+    if (config[key]) return config[key];
+  }
+  return "";
+}
+
+function stockQty(product = {}) {
+  return safeNumber(firstValue(product.stock, product.stock_qty, product.stockQty, product.quantity, product.available_stock), 0);
+}
+
+function hasStockQuantity(product = {}) {
+  return firstValue(product.stock, product.stock_qty, product.stockQty, product.available_stock) !== undefined;
+}
+
+function normalizeAvailability(product = {}) {
+  const raw = lower(firstValue(product.availability, product.stock_status, product.stockStatus, product.status, ""));
+  if (raw.includes("preorder")) return "preorder";
+  if (raw.includes("backorder") || raw.includes("pedido") || raw.includes("remote")) return "backorder";
+  if (raw.includes("out_of_stock") || raw.includes("sin stock") || raw.includes("unavailable")) return "out_of_stock";
+  if (raw.includes("in_stock") || raw.includes("stock")) return "in_stock";
+  return stockQty(product) > 0 ? "in_stock" : "out_of_stock";
+}
+
+function isPreorderProduct(product = {}) {
+  const availability = normalizeAvailability(product);
+  return availability === "preorder" || availability === "backorder" || Boolean(product.allow_backorder || product.allowBackorder || product.remote_stock || product.remoteStock);
+}
+
+function isStockRealProduct(product = {}) {
+  const availability = normalizeAvailability(product);
+  return availability === "in_stock" && !isPreorderProduct(product) && (stockQty(product) > 0 || !hasStockQuantity(product));
+}
+
+function productPrice(product = {}) {
+  return safeNumber(firstValue(product.price, product.final_price, product.finalPrice, product.sale_price, product.salePrice), 0);
+}
+
+function productId(product = {}) {
+  return cleanText(firstValue(product.id, product.product_id, product.productId, product.sku, product.code, product.mpn, product.slug, product.publicSlug));
+}
+
+function productName(product = {}) {
+  return cleanText(firstValue(product.title, product.name, product.product_name, product.productName, product.description, productId(product), "Producto NERIN"));
+}
+
+function productBrand(product = {}) {
+  return cleanText(firstValue(product.brand, product.marca, product.manufacturer, product.vendor, "NERIN Parts"));
+}
+
+function productCategory(product = {}) {
+  return cleanText(firstValue(product.category, product.categoria, product.product_type, product.productType, product.part_type, product.partType, "Repuestos"));
+}
+
+function productVariant(product = {}) {
+  return cleanText(firstValue(product.variant, product.model, product.modelo, product.compatibility, product.compatibilidad, product.exactModel, ""));
+}
+
+export function normalizeAnalyticsItem(product = {}, quantity = 1) {
+  const availability = normalizeAvailability(product);
+  const item = {
+    item_id: productId(product),
+    item_name: productName(product),
+    item_brand: productBrand(product),
+    item_category: productCategory(product),
+    item_variant: productVariant(product),
+    price: productPrice(product),
+    quantity: Math.max(1, safeNumber(quantity || product.quantity || product.qty, 1)),
+    currency: ANALYTICS_CURRENCY,
+    sku: cleanText(firstValue(product.sku, product.code, product.product_sku, "")),
+    mpn: cleanText(firstValue(product.mpn, product.MPN, "")),
+    public_slug: cleanText(firstValue(product.publicSlug, product.public_slug, product.slug, "")),
+    stock_status: availability,
+    stock_qty: stockQty(product),
+    is_stock_real: isStockRealProduct(product),
+    is_preorder: isPreorderProduct(product),
+    availability,
+  };
+  if (!item.item_id) item.item_id = item.sku || item.mpn || item.public_slug || item.item_name;
+  return item;
+}
+
+function normalizeItems(items = []) {
+  const source = Array.isArray(items) ? items : [items];
+  return source.filter(Boolean).map((item) => normalizeAnalyticsItem(item, item.quantity || item.qty || 1)).filter((item) => item.item_id && item.item_name);
+}
+
+function cartValue(cart = []) {
+  return normalizeItems(cart).reduce((sum, item) => sum + safeNumber(item.price) * safeNumber(item.quantity, 1), 0);
+}
+
+function debugEnabled() {
+  if (!hasWindow()) return false;
+  const params = new URLSearchParams(window.location.search || "");
+  return params.get("debugAnalytics") === "1" || window.NERIN_ANALYTICS_DEBUG?.enabled === true || window.localStorage?.getItem("NERIN_ANALYTICS_DEBUG") === "1";
+}
+
+function ensureDebugState() {
+  if (!hasWindow()) return null;
+  if (!window.NERIN_ANALYTICS_DEBUG || !Array.isArray(window.NERIN_ANALYTICS_DEBUG.events)) {
+    window.NERIN_ANALYTICS_DEBUG = {
+      enabled: debugEnabled(),
+      events: [],
+      hasGtag: typeof window.gtag === "function",
+      hasFbq: typeof window.fbq === "function",
+      hasDataLayer: Array.isArray(window.dataLayer),
+    };
+  }
+  return window.NERIN_ANALYTICS_DEBUG;
+}
+
+function recordDebug(name, payload, status = "sent") {
+  if (!hasWindow()) return;
+  const state = ensureDebugState();
+  if (!state) return;
+  const event = {
+    name,
+    status,
+    payload,
+    page_path: window.location?.pathname || "",
+    sent_at: new Date().toISOString(),
+    hasGtag: typeof window.gtag === "function",
+    hasFbq: typeof window.fbq === "function",
+    hasDataLayer: Array.isArray(window.dataLayer),
+  };
+  state.events.push(event);
+  state.events.splice(0, Math.max(0, state.events.length - RECENT_EVENT_LIMIT));
+  state.lastEvent = event;
+  state.enabled = debugEnabled();
+  state.hasGtag = event.hasGtag;
+  state.hasFbq = event.hasFbq;
+  state.hasDataLayer = event.hasDataLayer;
+  if (state.enabled) {
+    renderDebugPanel(state);
+    console.info("[NERIN analytics]", name, payload);
+  }
+}
+
+function renderDebugPanel(state) {
+  if (!hasWindow() || !state?.enabled || !document?.body) return;
+  let panel = document.getElementById("nerin-analytics-debug-panel");
+  if (!panel) {
+    panel = document.createElement("aside");
+    panel.id = "nerin-analytics-debug-panel";
+    panel.style.cssText = "position:fixed;right:16px;bottom:16px;z-index:2147483647;width:min(420px,calc(100vw - 32px));max-height:55vh;overflow:auto;background:#111827;color:#f9fafb;border:1px solid rgba(255,255,255,.18);border-radius:14px;box-shadow:0 18px 45px rgba(0,0,0,.25);font:12px/1.4 system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif;padding:12px;";
+    document.body.appendChild(panel);
+  }
+  const rows = state.events.slice(-10).reverse().map((event) => `<li><strong>${escapeHtml(event.name)}</strong> <span>${escapeHtml(event.status)}</span><pre>${escapeHtml(JSON.stringify(event.payload, null, 2)).slice(0, 1600)}</pre></li>`).join("");
+  panel.innerHTML = `<strong>NERIN_ANALYTICS_DEBUG</strong><p>gtag: ${state.hasGtag ? "si" : "no"} · fbq: ${state.hasFbq ? "si" : "no"} · dataLayer: ${state.hasDataLayer ? "si" : "no"}</p><ol style="padding-left:18px;margin:0;display:grid;gap:8px">${rows}</ol>`;
+}
+
+function escapeHtml(value) {
+  return String(value ?? "").replace(/[&<>"']/g, (ch) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", "\"": "&quot;", "'": "&#039;" }[ch]));
+}
+
+function loadOptionalTags() {
+  if (!hasWindow() || !document?.head) return;
+  const ga4Id = getConfigValue("GA4_MEASUREMENT_ID", "ga4MeasurementId", "ga4_measurement_id");
+  if (ga4Id && typeof window.gtag !== "function" && !document.getElementById("nerin-ga4-loader")) {
+    window.dataLayer = window.dataLayer || [];
+    window.gtag = function gtag(){ window.dataLayer.push(arguments); };
+    window.gtag("js", new Date());
+    window.gtag("config", ga4Id);
+    const script = document.createElement("script");
+    script.id = "nerin-ga4-loader";
+    script.async = true;
+    script.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(ga4Id)}`;
+    document.head.appendChild(script);
+  }
+  const metaPixelId = getConfigValue("META_PIXEL_ID", "metaPixelId", "meta_pixel_id");
+  if (metaPixelId && typeof window.fbq !== "function" && !document.getElementById("nerin-meta-pixel-loader")) {
+    const fbq = function fbq(){ fbq.callMethod ? fbq.callMethod.apply(fbq, arguments) : fbq.queue.push(arguments); };
+    fbq.push = fbq;
+    fbq.loaded = true;
+    fbq.version = "2.0";
+    fbq.queue = [];
+    window.fbq = fbq;
+    window._fbq = fbq;
+    fbq("init", metaPixelId);
+    fbq("track", "PageView");
+    const script = document.createElement("script");
+    script.id = "nerin-meta-pixel-loader";
+    script.async = true;
+    script.src = "https://connect.facebook.net/en_US/fbevents.js";
+    document.head.appendChild(script);
+  }
+}
+
+function metaPayload(payload = {}) {
+  const items = Array.isArray(payload.items) ? payload.items : [];
+  return {
+    content_ids: items.map((item) => item.item_id).filter(Boolean),
+    contents: items.map((item) => ({ id: item.item_id, quantity: item.quantity, item_price: item.price })),
+    content_type: "product",
+    value: safeNumber(payload.value),
+    currency: ANALYTICS_CURRENCY,
+  };
+}
+
+function emitAnalyticsEvent(name, payload = {}, options = {}) {
+  if (!hasWindow()) return false;
+  loadOptionalTags();
+  const eventPayload = { ...payload };
+  if (!eventPayload.currency && ["add_to_cart", "view_cart", "begin_checkout", "add_shipping_info", "add_payment_info", "purchase"].includes(name)) {
+    eventPayload.currency = ANALYTICS_CURRENCY;
+  }
+  window.dataLayer = window.dataLayer || [];
+  if (typeof window.gtag === "function") {
+    window.gtag("event", name, eventPayload);
+  } else {
+    if (eventPayload.items) window.dataLayer.push({ ecommerce: null });
+    window.dataLayer.push({ event: name, ...eventPayload });
+  }
+  if (options.metaEvent && typeof window.fbq === "function") window.fbq("track", options.metaEvent, options.metaPayload || metaPayload(eventPayload));
+  recordDebug(name, eventPayload);
+  return true;
+}
+
+export function trackViewItem(product = {}) {
+  const item = normalizeAnalyticsItem(product, 1);
+  return emitAnalyticsEvent("view_item", { currency: ANALYTICS_CURRENCY, value: item.price, items: [item] }, { metaEvent: "ViewContent" });
+}
+
+export function trackViewItemList(products = [], context = {}) {
+  const items = normalizeItems(products);
+  if (!items.length) return false;
+  return emitAnalyticsEvent("view_item_list", {
+    item_list_id: cleanText(context.item_list_id || context.source || context.page_path || "catalog"),
+    item_list_name: cleanText(context.item_list_name || context.source || "Catalogo"),
+    context,
+    items,
+  });
+}
+
+export function trackSelectItem(product = {}, context = {}) {
+  const item = normalizeAnalyticsItem(product, 1);
+  return emitAnalyticsEvent("select_item", {
+    item_list_id: cleanText(context.item_list_id || context.source || "catalog"),
+    item_list_name: cleanText(context.item_list_name || context.source || "Catalogo"),
+    context,
+    items: [item],
+  });
+}
+
+export function trackSearch(query = "", resultCount = 0, context = {}) {
+  const searchTerm = cleanText(query);
+  if (!searchTerm) return false;
+  return emitAnalyticsEvent("search", {
+    search_term: searchTerm,
+    result_count: safeNumber(resultCount),
+    context,
+  });
+}
+
+export function trackAddToCart(product = {}, quantity = 1) {
+  const item = normalizeAnalyticsItem(product, quantity);
+  return emitAnalyticsEvent("add_to_cart", { currency: ANALYTICS_CURRENCY, value: item.price * item.quantity, items: [item] }, { metaEvent: "AddToCart" });
+}
+
+export function trackRemoveFromCart(product = {}, quantity = 1) {
+  const item = normalizeAnalyticsItem(product, quantity);
+  return emitAnalyticsEvent("remove_from_cart", { currency: ANALYTICS_CURRENCY, value: item.price * item.quantity, items: [item] });
+}
+
+export function trackViewCart(cart = []) {
+  const items = normalizeItems(cart);
+  return emitAnalyticsEvent("view_cart", { currency: ANALYTICS_CURRENCY, value: cartValue(cart), items });
+}
+
+export function trackBeginCheckout(cart = []) {
+  const items = normalizeItems(cart);
+  return emitAnalyticsEvent("begin_checkout", { currency: ANALYTICS_CURRENCY, value: cartValue(cart), items }, { metaEvent: "InitiateCheckout" });
+}
+
+export function trackAddShippingInfo(cart = [], shippingInfo = {}) {
+  const items = normalizeItems(cart);
+  return emitAnalyticsEvent("add_shipping_info", {
+    currency: ANALYTICS_CURRENCY,
+    value: cartValue(cart),
+    shipping_tier: cleanText(firstValue(shippingInfo.shipping_tier, shippingInfo.method, shippingInfo.tipo, shippingInfo.carrier, "pending")),
+    shipping_info: shippingInfo,
+    items,
+  });
+}
+
+export function trackAddPaymentInfo(cart = [], paymentInfo = {}) {
+  const items = normalizeItems(cart);
+  return emitAnalyticsEvent("add_payment_info", {
+    currency: ANALYTICS_CURRENCY,
+    value: cartValue(cart),
+    payment_type: cleanText(firstValue(paymentInfo.payment_type, paymentInfo.method, paymentInfo.metodo, paymentInfo.type, "pending")),
+    payment_info: paymentInfo,
+    items,
+  });
+}
+
+function orderItems(order = {}) {
+  return normalizeItems(firstValue(order.items, order.cart, order.order?.items, order.order?.cart, []));
+}
+
+function orderTransactionId(order = {}) {
+  return cleanText(firstValue(order.transaction_id, order.transactionId, order.orderId, order.order_id, order.id, order.nrn, order.order?.id, order.order?.orderId));
+}
+
+function orderValue(order = {}, items = []) {
+  return safeNumber(firstValue(order.value, order.total, order.amount, order.totalAmount, order.order?.total, order.order?.amount), items.reduce((sum, item) => sum + item.price * item.quantity, 0));
+}
+
+function storageHas(key) {
+  try {
+    return window.localStorage?.getItem(key) === "1" || window.sessionStorage?.getItem(key) === "1";
+  } catch (_) {
+    return false;
+  }
+}
+
+function storageSet(key) {
+  try { window.localStorage?.setItem(key, "1"); } catch (_) {}
+  try { window.sessionStorage?.setItem(key, "1"); } catch (_) {}
+}
+
+export function trackPurchase(order = {}) {
+  if (!hasWindow()) return false;
+  const transactionId = orderTransactionId(order);
+  if (!transactionId) {
+    recordDebug("purchase", { error: "missing transaction_id", order }, "skipped");
+    return false;
+  }
+  const dedupeKey = `${PURCHASE_DEDUPE_PREFIX}${transactionId}`;
+  if (storageHas(dedupeKey)) {
+    recordDebug("purchase", { transaction_id: transactionId, reason: "deduplicated" }, "skipped");
+    return false;
+  }
+  const items = orderItems(order);
+  const payload = {
+    transaction_id: transactionId,
+    value: orderValue(order, items),
+    currency: ANALYTICS_CURRENCY,
+    shipping: safeNumber(firstValue(order.shipping, order.shipping_total, order.envio?.costo, order.order?.shipping), 0),
+    tax: safeNumber(firstValue(order.tax, order.tax_total, order.order?.tax), 0),
+    payment_type: cleanText(firstValue(order.payment_type, order.paymentType, order.method, order.payment?.type, order.payment?.method, "")),
+    items,
+  };
+  const sent = emitAnalyticsEvent("purchase", payload, { metaEvent: "Purchase" });
+  if (sent) storageSet(dedupeKey);
+  return sent;
+}
+
+export function trackWhatsappClick(context = {}) {
+  return emitAnalyticsEvent("whatsapp_click", {
+    source: cleanText(context.source || "unknown"),
+    product_id: cleanText(firstValue(context.product_id, context.productId, context.id, "")),
+    sku: cleanText(context.sku || ""),
+    product_name: cleanText(firstValue(context.product_name, context.productName, context.title, context.name, "")),
+    stock_status: cleanText(context.stock_status || ""),
+    is_stock_real: Boolean(context.is_stock_real),
+    page_path: hasWindow() ? window.location.pathname : "",
+    context,
+  }, { metaEvent: "Contact", metaPayload: { content_name: context.product_name || context.productName || context.source || "WhatsApp", currency: ANALYTICS_CURRENCY } });
+}
+
+export function trackStockRealProductView(product = {}) {
+  if (!isStockRealProduct(product)) return false;
+  return emitAnalyticsEvent("stock_real_product_view", { currency: ANALYTICS_CURRENCY, value: productPrice(product), items: [normalizeAnalyticsItem(product, 1)] });
+}
+
+export function trackStockRealAddToCart(product = {}, quantity = 1) {
+  if (!isStockRealProduct(product)) return false;
+  const item = normalizeAnalyticsItem(product, quantity);
+  return emitAnalyticsEvent("stock_real_add_to_cart", { currency: ANALYTICS_CURRENCY, value: item.price * item.quantity, items: [item] });
+}
+
+export function trackStockRealPurchase(order = {}) {
+  const transactionId = orderTransactionId(order);
+  const items = orderItems(order).filter((item) => item.is_stock_real);
+  if (!items.length || !transactionId) return false;
+  const dedupeKey = `${PURCHASE_DEDUPE_PREFIX}stock_real.${transactionId}`;
+  if (storageHas(dedupeKey)) {
+    recordDebug("stock_real_purchase", { transaction_id: transactionId, reason: "deduplicated" }, "skipped");
+    return false;
+  }
+  const sent = emitAnalyticsEvent("stock_real_purchase", {
+    transaction_id: transactionId,
+    value: items.reduce((sum, item) => sum + item.price * item.quantity, 0),
+    currency: ANALYTICS_CURRENCY,
+    items,
+  });
+  if (sent) storageSet(dedupeKey);
+  return sent;
+}
+
+if (hasWindow()) ensureDebugState();
+
 const LIVE_MS = 8000;
 const DETAIL_MS = 120000;
 const state = { range: "7d", from: "", to: "" };

--- a/nerin_final_updated/frontend/js/cart.js
+++ b/nerin_final_updated/frontend/js/cart.js
@@ -12,8 +12,8 @@
 import { isWholesale, fetchProducts } from "./api.js";
 import { createPriceLegalBlock } from "./components/PriceLegalBlock.js";
 import { calculateNetNoNationalTaxes, formatArs } from "./utils/pricing.js";
-import { buildPixelContents, trackPixelOnce } from "./meta-pixel.js";
 import { readCart, writeCart } from "./cart-utils.js";
+import { trackBeginCheckout, trackRemoveFromCart, trackViewCart, trackWhatsappClick } from "./analytics.js";
 
 // Referencias a los elementos del DOM
 const itemsContainer = document.getElementById("cartItems");
@@ -57,6 +57,7 @@ function getStoredCart() {
 // Renderizar el carrito completo
 async function renderCart() {
   const cart = getStoredCart();
+  trackViewCart(cart);
   itemsContainer.innerHTML = "";
   itemsContainer.classList.toggle("cart-items--empty", cart.length === 0);
   let subtotal = 0;
@@ -206,6 +207,7 @@ async function renderCart() {
     removeBtn.className = "remove-item-btn";
     removeBtn.textContent = "Eliminar";
     removeBtn.addEventListener("click", () => {
+      trackRemoveFromCart(cart[index], cart[index]?.quantity || 1);
       cart.splice(index, 1);
       writeCart(cart);
       renderCart();
@@ -253,6 +255,11 @@ async function renderCart() {
       message += `- ${item.name} x${item.quantity} ($${price.toLocaleString("es-AR")} c/u)%0A`;
     });
     message += `%0ATotal: $${subtotal.toLocaleString("es-AR")}`;
+    trackWhatsappClick({
+      source: "cart",
+      cart_value: subtotal,
+      items: cart.map((item) => ({ product_id: item.id, sku: item.sku, product_name: item.name })),
+    });
     window.open(
       `https://api.whatsapp.com/send?phone=${phone}&text=${message}`,
       "_blank",
@@ -260,21 +267,7 @@ async function renderCart() {
   };
 
   payBtn.onclick = () => {
-    const { contents, value } = buildPixelContents(cart);
-    const contentIds = contents.map((item) => item.id);
-    if (contentIds.length) {
-      trackPixelOnce(
-        "InitiateCheckout",
-        {
-          content_type: "product",
-          content_ids: contentIds,
-          contents,
-          value,
-          currency: "ARS",
-        },
-        contentIds.join("|"),
-      );
-    }
+    trackBeginCheckout(cart);
     // Siempre redirigimos al flujo de checkout para que el usuario revise sus datos
     window.location.href = "/checkout-steps.html";
   };

--- a/nerin_final_updated/frontend/js/checkout-steps.js
+++ b/nerin_final_updated/frontend/js/checkout-steps.js
@@ -1,7 +1,7 @@
 import { apiFetch } from "./api.js";
-import { buildPixelContents, trackPixelOnce } from "./meta-pixel.js";
 import { calculateNetNoNationalTaxes, formatArs } from "./utils/pricing.js";
 import { readCart } from "./cart-utils.js";
+import { trackAddPaymentInfo, trackAddShippingInfo, trackBeginCheckout, trackPurchase, trackStockRealPurchase } from "./analytics.js";
 
 const API_BASE_URL = ''; // dejamos vacío para usar rutas relativas
 const step1 = document.getElementById('step1');
@@ -51,21 +51,8 @@ function applyRolePricingToCart() {
   }
 }
 applyRolePricingToCart();
-const { contents: checkoutContents, value: checkoutValue } = buildPixelContents(cart);
-const checkoutIds = checkoutContents.map((item) => item.id).filter(Boolean);
-if (checkoutIds.length) {
-  trackPixelOnce(
-    "InitiateCheckout",
-    {
-      content_type: "product",
-      content_ids: checkoutIds,
-      contents: checkoutContents,
-      value: checkoutValue,
-      currency: "ARS",
-    },
-    checkoutIds.join("|"),
-  );
-}
+const checkoutValue = cart.reduce((total, item) => total + Number(item.price || 0) * Number(item.quantity || 0), 0);
+trackBeginCheckout(cart);
 if (typeof window.NERIN_TRACK_EVENT === "function") {
   window.NERIN_TRACK_EVENT("checkout_start", {
     step: "Checkout",
@@ -299,6 +286,14 @@ formEnvio.addEventListener('submit', (ev) => {
   buildResumen();
   step2.style.display = 'none';
   step3.style.display = 'block';
+  trackAddShippingInfo(cart, {
+    method: envio.metodo,
+    shipping_tier: envio.metodoLabel || envio.metodo,
+    provincia: envio.provincia,
+    localidad: envio.localidad,
+    cp: envio.cp,
+    cost: envio.costo || 0,
+  });
   updateMetodoInfo();
 });
 
@@ -425,13 +420,16 @@ function updateMetodoInfo() {
   if (metodoInfo) metodoInfo.innerHTML = html;
   renderProtectionNote(metodo);
   toggleCashValidation();
-  if (typeof window.NERIN_TRACK_EVENT === "function" && metodo !== lastTrackedPaymentMethod) {
-    window.NERIN_TRACK_EVENT("checkout_payment", {
-      step: "Pago",
-      metadata: {
-        method: metodo,
-      },
-    });
+  if (metodo !== lastTrackedPaymentMethod) {
+    trackAddPaymentInfo(cart, { payment_type: metodo, method: metodo });
+    if (typeof window.NERIN_TRACK_EVENT === "function") {
+      window.NERIN_TRACK_EVENT("checkout_payment", {
+        step: "Pago",
+        metadata: {
+          method: metodo,
+        },
+      });
+    }
     lastTrackedPaymentMethod = metodo;
   }
 }
@@ -585,6 +583,21 @@ async function submitOfflineOrder(paymentMethod) {
         metadata: {
           paymentMethod,
         },
+      });
+    }
+    const finalStatus = String(data.status || data.payment_status || data.paymentStatus || '').toLowerCase();
+    const isFinalPurchase = ['approved', 'aprobado', 'paid', 'pagado', 'completed', 'completado'].includes(finalStatus);
+    if (isFinalPurchase) {
+      trackPurchase({
+        transaction_id: orderId,
+        value: totalValue,
+        shipping: envio.costo || 0,
+        payment_type: paymentMethod,
+        items: cart,
+      });
+      trackStockRealPurchase({
+        transaction_id: orderId,
+        items: cart,
       });
     }
     localStorage.setItem('nerinUserInfo', JSON.stringify(customer));

--- a/nerin_final_updated/frontend/js/product.js
+++ b/nerin_final_updated/frontend/js/product.js
@@ -1,10 +1,6 @@
 import { apiFetch, isWholesale } from "./api.js";
 import { applySeoDefaults, stripBrandSuffix } from "./seo-helpers.js";
-import {
-  normalizeContentId,
-  trackPixel,
-  trackPixelOnce,
-} from "./meta-pixel.js";
+import { normalizeContentId } from "./meta-pixel.js";
 import {
   createComparisonQualityTable,
   removeQualitySelector,
@@ -13,6 +9,7 @@ import { createPriceLegalBlock } from "./components/PriceLegalBlock.js";
 import { buildCartItemFromProduct, readCart, writeCart, getProductIdentifier } from "./cart-utils.js";
 import { calculateNetNoNationalTaxes } from "./utils/pricing.js";
 import { buildAvailabilityPresentation, resolveProductAvailability } from "./availability.js";
+import { trackAddToCart, trackStockRealAddToCart, trackStockRealProductView, trackViewItem } from "./analytics.js";
 
 const detailSection = document.getElementById("productDetail");
 const galleryContainer = document.getElementById("gallery");
@@ -1263,6 +1260,8 @@ function addToCart(product, { quantity = 1, sku = "", image = "" } = {}) {
 
   console.log("[product-detail:cart:before-save]", cart);
   writeCart(cart);
+  trackAddToCart(product, qty);
+  trackStockRealAddToCart(product, qty);
   return true;
 }
 
@@ -1300,20 +1299,8 @@ function renderProduct(product) {
   syncBrowserUrl(metaInfo.relativeUrl);
   updateJsonLd(product, images, metaInfo.productUrl);
   updateBreadcrumbJsonLd(product, metaInfo.productUrl);
-  const priceSource = resolveProductDisplayPrice(product);
-  const numericPrice = Number(priceSource) || 0;
-  if (skuValue) {
-    trackPixelOnce(
-      "ViewContent",
-      {
-        content_type: "product",
-        content_ids: [skuValue],
-        value: numericPrice,
-        currency: "ARS",
-      },
-      skuValue,
-    );
-  }
+  trackViewItem(product);
+  trackStockRealProductView(product);
   if (typeof window.NERIN_TRACK_EVENT === "function") {
     window.NERIN_TRACK_EVENT("product_view", {
       productId: product.id != null ? String(product.id) : undefined,
@@ -1575,16 +1562,6 @@ function renderProduct(product) {
     setTimeout(() => {
       setCtaLabels();
     }, 1500);
-    if (skuValue) {
-      const unitPrice = resolveProductDisplayPrice(product);
-      trackPixel("AddToCart", {
-        content_type: "product",
-        content_ids: [skuValue],
-        contents: [{ id: skuValue, quantity: qty }],
-        value: unitPrice * qty,
-        currency: "ARS",
-      });
-    }
   });
 
   const legalNote = document.createElement("p");

--- a/nerin_final_updated/frontend/js/shop.js
+++ b/nerin_final_updated/frontend/js/shop.js
@@ -3,6 +3,7 @@ import { createPriceLegalBlock } from "./components/PriceLegalBlock.js";
 import { calculateNetNoNationalTaxes } from "./utils/pricing.js";
 import { buildAvailabilityPresentation } from "./availability.js";
 import { buildCartItemFromProduct, readCart, writeCart } from "./cart-utils.js";
+import { trackAddToCart, trackSearch, trackSelectItem, trackStockRealAddToCart, trackViewItemList } from "./analytics.js";
 
 console.info("[shop-products] shop.js loaded", {
   version: "sqlite-public-debug-v3",
@@ -480,6 +481,8 @@ function addToCart(product) {
     cart.push({ ...cartItem, url, name: product.name, price: display.active, quantity: 1, image: getPrimaryImage(product) || PLACEHOLDER_IMAGE });
   }
   writeCart(cart);
+  trackAddToCart(product, 1);
+  trackStockRealAddToCart(product, 1);
   if (window.updateNav) window.updateNav();
   console.log("[shop:add-to-cart:indicator-available]", {
     showCartIndicator: typeof window.showCartIndicator,
@@ -650,6 +653,7 @@ function createProductCard(product) {
   addBtn.addEventListener("click", (event) => {
     event.stopPropagation();
     if (availabilityPresentation.isOutOfStock) {
+      trackSelectItem(product, { source: "shop_card_consult", page_path: window.location.pathname });
       window.location.href = buildProductUrl(product);
       return;
     }
@@ -662,6 +666,7 @@ function createProductCard(product) {
   detailBtn.textContent = "Ver detalle";
   detailBtn.addEventListener("click", (event) => {
     event.stopPropagation();
+    trackSelectItem(product, { source: "shop_card_detail", page_path: window.location.pathname });
     window.location.href = buildProductUrl(product);
   });
 
@@ -669,6 +674,7 @@ function createProductCard(product) {
   card.appendChild(actions);
 
   card.addEventListener("click", () => {
+    trackSelectItem(product, { source: "shop_card", page_path: window.location.pathname });
     window.location.href = buildProductUrl(product);
   });
 
@@ -995,6 +1001,26 @@ async function renderProducts({ page = currentProductsPage, scrollToTop = false 
     productGrid.innerHTML = "<p>No encontramos productos para esos filtros.</p>";
   } else {
     allProducts.forEach((product) => productGrid.appendChild(createProductCard(product)));
+  }
+  trackViewItemList(allProducts, {
+    source: "shop",
+    page_path: window.location.pathname,
+    search: filters.search,
+    stock_filter: filters.stock,
+    category: filters.category,
+    brand: filters.brand,
+    model: filters.model,
+    page: currentProductsPage,
+  });
+  if (filters.search) {
+    trackSearch(filters.search, totalFilteredItems || allProducts.length, {
+      source: "shop",
+      page_path: window.location.pathname,
+      stock_filter: filters.stock,
+      category: filters.category,
+      brand: filters.brand,
+      model: filters.model,
+    });
   }
   console.info("[shop-products] render done");
   renderPublicProductsPagination();

--- a/nerin_final_updated/frontend/js/success.js
+++ b/nerin_final_updated/frontend/js/success.js
@@ -1,5 +1,5 @@
 import { apiFetch } from "./api.js";
-import { buildPixelContents, trackPixelOnce } from "./meta-pixel.js";
+import { trackPurchase, trackStockRealPurchase } from "./analytics.js";
 
 const receipt = document.getElementById('card');
 
@@ -62,7 +62,7 @@ function mapData(data = {}, fallbackId) {
   const email =
     order.cliente?.email || order.buyer?.email || order.email || null;
   const fecha = new Date(order.created_at || order.fecha || Date.now());
-  return { nrn, items, status, total, tracking, email, fecha };
+  return { nrn, items, status, total, tracking, email, fecha, order, payment };
 }
 
 const currency = new Intl.NumberFormat('es-AR', {
@@ -203,21 +203,18 @@ async function init() {
   render(info);
   persist(info);
   if (info.status === "aprobado") {
-    const { contents, value } = buildPixelContents(info.items || []);
-    const contentIds = contents.map((item) => item.id);
-    if (contentIds.length) {
-      trackPixelOnce(
-        "Purchase",
-        {
-          contents,
-          content_type: "product",
-          content_ids: contentIds,
-          value: Number(info.total || value || 0),
-          currency: "ARS",
-        },
-        `${info.nrn || ""}:${contentIds.join("|")}`,
-      );
-    }
+    trackPurchase({
+      transaction_id: info.nrn,
+      value: Number(info.total || 0),
+      payment_type: info.payment?.payment_type_id || info.payment?.method || "mercado_pago",
+      items: info.items || [],
+      order: info.order,
+      payment: info.payment,
+    });
+    trackStockRealPurchase({
+      transaction_id: info.nrn,
+      items: info.items || [],
+    });
   }
   localStorage.removeItem('mp_last_pref');
   localStorage.removeItem('mp_last_nrn');

--- a/nerin_final_updated/frontend/product.html
+++ b/nerin_final_updated/frontend/product.html
@@ -161,5 +161,6 @@
     <!-- Configuración y analíticas globales -->
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
     <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>
+    <script type="module" src="/js/analytics-autotrack.js?v=ecommerce-organic-funnel"></script>
   </body>
 </html>

--- a/nerin_final_updated/frontend/shop.html
+++ b/nerin_final_updated/frontend/shop.html
@@ -293,6 +293,7 @@
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
     <script type="module" src="/js/delivery-policy.js?v=delivery-policy-20260503"></script>
     <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>
+    <script type="module" src="/js/analytics-autotrack.js?v=ecommerce-organic-funnel"></script>
     <script type="module" src="/js/shop.js?v=delivery-policy-20260503"></script>
   </body>
 </html>

--- a/nerin_final_updated/frontend/success.html
+++ b/nerin_final_updated/frontend/success.html
@@ -76,5 +76,6 @@
     </main>
     <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>
     <script type="module" src="/js/success.js"></script>
+    <script type="module" src="/js/analytics-autotrack.js?v=ecommerce-organic-funnel"></script>
   </body>
 </html>

--- a/nerin_final_updated/scripts/audit-analytics-events.js
+++ b/nerin_final_updated/scripts/audit-analytics-events.js
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const root = path.resolve(__dirname, "..");
+const read = (file) => fs.readFileSync(path.join(root, file), "utf8");
+const exists = (file) => fs.existsSync(path.join(root, file));
+
+const files = {
+  analytics: "frontend/js/analytics.js",
+  autotrack: "frontend/js/analytics-autotrack.js",
+  shop: "frontend/js/shop.js",
+  product: "frontend/js/product.js",
+  cart: "frontend/js/cart.js",
+  checkout: "frontend/js/checkout-steps.js",
+  success: "frontend/js/success.js",
+};
+
+const sources = Object.fromEntries(
+  Object.entries(files).map(([key, file]) => [key, exists(file) ? read(file) : ""]),
+);
+
+function hasAll(source, patterns) {
+  return patterns.every((pattern) => source.includes(pattern));
+}
+
+const requiredExports = [
+  "trackViewItem",
+  "trackViewItemList",
+  "trackSelectItem",
+  "trackSearch",
+  "trackAddToCart",
+  "trackViewCart",
+  "trackBeginCheckout",
+  "trackAddShippingInfo",
+  "trackAddPaymentInfo",
+  "trackPurchase",
+  "trackWhatsappClick",
+  "trackStockRealProductView",
+  "trackStockRealAddToCart",
+  "trackStockRealPurchase",
+  "normalizeAnalyticsItem",
+];
+
+const hookChecks = [
+  { event: "view_item", ok: hasAll(sources.product, ["trackViewItem(product)", "trackStockRealProductView(product)"]) },
+  { event: "view_item_list", ok: sources.shop.includes("trackViewItemList(") && sources.autotrack.includes("trackViewItemList(") },
+  { event: "select_item", ok: sources.shop.includes("trackSelectItem(") && sources.autotrack.includes("trackSelectItem(") },
+  { event: "search", ok: sources.shop.includes("trackSearch(") },
+  { event: "add_to_cart", ok: sources.shop.includes("trackAddToCart(") && sources.product.includes("trackAddToCart(") },
+  { event: "remove_from_cart", ok: sources.cart.includes("trackRemoveFromCart(") },
+  { event: "view_cart", ok: sources.cart.includes("trackViewCart(cart)") },
+  { event: "begin_checkout", ok: sources.cart.includes("trackBeginCheckout(cart)") && sources.checkout.includes("trackBeginCheckout(cart)") },
+  { event: "add_shipping_info", ok: sources.checkout.includes("trackAddShippingInfo(") },
+  { event: "add_payment_info", ok: sources.checkout.includes("trackAddPaymentInfo(") },
+  { event: "purchase", ok: sources.success.includes("trackPurchase(") && sources.checkout.includes("trackPurchase(") },
+  { event: "whatsapp_click", ok: sources.autotrack.includes("trackWhatsappClick(") && sources.cart.includes("trackWhatsappClick(") },
+];
+
+function countMatches(text, regex) {
+  return (text.match(regex) || []).length;
+}
+
+const htmlFiles = fs.readdirSync(path.join(root, "frontend"))
+  .filter((name) => name.endsWith(".html"))
+  .map((name) => `frontend/${name}`);
+
+const duplicateTags = [];
+for (const file of htmlFiles) {
+  const html = read(file);
+  const gaLoaders = countMatches(html, /googletagmanager\.com\/gtag\/js\?id=/g);
+  const gaConfigs = countMatches(html, /gtag\(['"]config['"]/g);
+  const metaInits = countMatches(html, /fbq\(['"]init['"]/g);
+  const metaScripts = countMatches(html, /connect\.facebook\.net\/[^"']+\/fbevents\.js/g);
+  if (gaLoaders > 1 || gaConfigs > 1 || metaInits > 1 || metaScripts > 1) {
+    duplicateTags.push({ file, gaLoaders, gaConfigs, metaInits, metaScripts });
+  }
+}
+
+const exportChecks = requiredExports.map((name) => ({
+  name,
+  ok: sources.analytics.includes(`export function ${name}`),
+}));
+
+const coreChecks = [
+  {
+    name: "normalizeAnalyticsItem genera item_id, item_name, price y currency ARS",
+    ok: hasAll(sources.analytics, ["item_id:", "item_name:", "price:", 'currency: ANALYTICS_CURRENCY']),
+  },
+  {
+    name: "purchase requiere transaction_id",
+    ok: hasAll(sources.analytics, ["function orderTransactionId", "if (!transactionId)"]),
+  },
+  {
+    name: "purchase se deduplica con localStorage/sessionStorage",
+    ok: hasAll(sources.analytics, ["PURCHASE_DEDUPE_PREFIX", "localStorage", "sessionStorage", "storageHas", "storageSet"]),
+  },
+  {
+    name: "stock real agrega is_stock_real=true",
+    ok: hasAll(sources.analytics, ["is_stock_real:", "isStockRealProduct"]),
+  },
+  {
+    name: "preorder agrega is_preorder=true",
+    ok: hasAll(sources.analytics, ["is_preorder:", "isPreorderProduct"]),
+  },
+  {
+    name: "whatsapp_click incluye source",
+    ok: hasAll(sources.analytics, ['"whatsapp_click"', "source:"]),
+  },
+  {
+    name: "no rompe si gtag/fbq no existen",
+    ok: hasAll(sources.analytics, ['typeof window.gtag === "function"', 'typeof window.fbq === "function"']),
+  },
+  {
+    name: "eventos ecommerce usan items array y ARS",
+    ok: hasAll(sources.analytics, ["items:", 'const ANALYTICS_CURRENCY = "ARS"']),
+  },
+];
+
+const htmlAutotrack = [
+  "frontend/index.html",
+  "frontend/shop.html",
+  "frontend/product.html",
+  "frontend/cart.html",
+  "frontend/checkout-steps.html",
+  "frontend/success.html",
+].map((file) => ({ file, ok: read(file).includes("/js/analytics-autotrack.js") }));
+
+const failures = [
+  ...exportChecks.filter((check) => !check.ok).map((check) => `export faltante: ${check.name}`),
+  ...hookChecks.filter((check) => !check.ok).map((check) => `hook faltante: ${check.event}`),
+  ...coreChecks.filter((check) => !check.ok).map((check) => `check fallido: ${check.name}`),
+  ...htmlAutotrack.filter((check) => !check.ok).map((check) => `autotrack no incluido: ${check.file}`),
+  ...duplicateTags.map((entry) => `tag duplicado: ${entry.file}`),
+];
+
+const report = {
+  totalChecks: exportChecks.length + hookChecks.length + coreChecks.length + htmlAutotrack.length,
+  requiredExports: exportChecks,
+  hooks: hookChecks,
+  coreChecks,
+  htmlAutotrack,
+  duplicateTags,
+  purchaseDeduplication: {
+    requiresTransactionId: coreChecks[1].ok,
+    usesLocalStorage: sources.analytics.includes("localStorage"),
+    usesSessionStorage: sources.analytics.includes("sessionStorage"),
+  },
+  failures,
+};
+
+console.log(JSON.stringify(report, null, 2));
+if (failures.length) process.exit(1);


### PR DESCRIPTION
## Summary

Adds a central ecommerce analytics layer for the organic funnel without touching Mercado Pago webhooks, inventory, order mutation logic, base prices, or real Andreani integration.

## What changed

- Added `frontend/js/analytics.js` ecommerce tracking helpers for GA4-style events, `dataLayer`, optional `gtag`, and safe Meta Pixel equivalents.
- Added purchase deduplication by `transaction_id` using `localStorage` and `sessionStorage`.
- Added stock-real and preorder flags to analytics item normalization.
- Wired non-invasive tracking into product, shop, cart, checkout, success, SEO pages, and WhatsApp clicks.
- Added `?debugAnalytics=1` support through `window.NERIN_ANALYTICS_DEBUG` and an on-page debug panel.
- Added `scripts/audit-analytics-events.js` to verify hooks, duplicate tags, purchase dedupe, ARS/items payloads, and autotrack coverage.

## Events covered

- `view_item_list`
- `select_item`
- `view_item`
- `search`
- `add_to_cart`
- `remove_from_cart`
- `view_cart`
- `begin_checkout`
- `add_shipping_info`
- `add_payment_info`
- `purchase`
- `whatsapp_click`
- `stock_real_product_view`
- `stock_real_add_to_cart`
- `stock_real_purchase`

## Validation

- `node --check backend/server.js`
- `node --check frontend/js/analytics.js`
- `node --check frontend/js/analytics-autotrack.js`
- `node --check frontend/js/shop.js`
- `node --check frontend/js/product.js`
- `node --check frontend/js/cart.js`
- `node --check frontend/js/checkout-steps.js`
- `node --check frontend/js/success.js`
- `node --check scripts/audit-analytics-events.js`
- `node scripts/audit-analytics-events.js` -> 41 checks, 0 failures, 0 duplicate tags

## Explicitly not touched

- Mercado Pago webhook logic
- Inventory mutation logic
- Orders repository/mutation logic
- Base price logic
- Real Andreani integration