### PR TITLE
Fix organic SEO config runtime crash

### DIFF
--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -94,6 +94,10 @@ const {
   isBrandDoubtful,
   matchesOrganicPage,
 } = require("./utils/organicSeo");
+const {
+  getOrganicSeoPageConfig,
+  listOrganicSeoPages,
+} = require("./utils/organicSeoPages");
 const { readJsonFile } = require("./utils/jsonFile");
 const {
   appendEvent,
@@ -1851,54 +1855,6 @@ function renderShopListing(products, siteBase) {
   return { cards, count, summary };
 }
 
-const ORGANIC_SEO_PAGE_CONFIG = {
-  "/stock-real": {
-    key: "stock-real",
-    title: "Repuestos en stock real | NERIN Parts",
-    h1: "Repuestos para celulares en stock real",
-    description: "Repuestos listos para enviar desde CABA. Factura A/B, garantia tecnica y soporte para verificar compatibilidad antes de comprar.",
-    intro: "Repuestos listos para enviar desde CABA. Factura A/B, garantia tecnica y soporte para verificar compatibilidad antes de comprar.",
-    canonicalPath: "/stock-real",
-    priority: "0.9",
-  },
-  "/pantallas-en-stock": {
-    key: "pantallas-en-stock",
-    title: "Pantallas para celulares en stock | NERIN Parts",
-    h1: "Pantallas para celulares en stock",
-    description: "Pantallas y modulos de display con stock real en CABA. Verificamos compatibilidad, factura A/B y garantia tecnica.",
-    intro: "Pantallas, displays y modulos listos para enviar, con soporte para confirmar modelo y version antes de comprar.",
-    canonicalPath: "/pantallas-en-stock",
-    priority: "0.85",
-  },
-  "/baterias-en-stock": {
-    key: "baterias-en-stock",
-    title: "Baterias para celulares en stock | NERIN Parts",
-    h1: "Baterias para celulares en stock",
-    description: "Baterias para celulares con stock real, factura A/B y soporte tecnico para verificar compatibilidad.",
-    intro: "Baterias disponibles para despacho desde CABA, con asesoria tecnica para validar compatibilidad.",
-    canonicalPath: "/baterias-en-stock",
-    priority: "0.82",
-  },
-  "/repuestos-samsung": {
-    key: "repuestos-samsung",
-    title: "Repuestos Samsung en Argentina | NERIN Parts",
-    h1: "Repuestos Samsung en Argentina",
-    description: "Repuestos Samsung con stock real en Argentina. Pantallas, baterias, tapas, pines de carga y soporte especializado.",
-    intro: "Catalogo Samsung priorizado por stock real, precio valido, imagen y compatibilidad clara.",
-    canonicalPath: "/repuestos-samsung",
-    priority: "0.82",
-  },
-  "/repuestos-iphone": {
-    key: "repuestos-iphone",
-    title: "Repuestos iPhone en Argentina | NERIN Parts",
-    h1: "Repuestos iPhone en Argentina",
-    description: "Repuestos iPhone con stock real en Argentina. Displays, baterias, tapas y soporte para validar compatibilidad.",
-    intro: "Repuestos para iPhone priorizados por stock real, compatibilidad clara, factura y garantia tecnica.",
-    canonicalPath: "/repuestos-iphone",
-    priority: "0.82",
-  },
-};
-
 function parseSqliteProductRow(row = {}) {
   let raw = {};
   try {
@@ -2084,7 +2040,8 @@ function renderOrganicSeoPage(config, products, siteBase, { debugSeo = false, in
 
 async function buildOrganicSitemapEntries(siteBase, generatedAt) {
   const entries = [];
-  for (const config of Object.values(ORGANIC_SEO_PAGE_CONFIG)) {
+  for (const config of listOrganicSeoPages()) {
+    if (!config?.canonicalPath || !config?.key) continue;
     const products = await getOrganicProductsForPage(config.key, 1);
     if (!products.length) continue;
     entries.push({
@@ -13233,10 +13190,17 @@ async function requestHandler(req, res) {
     return;
   }
 
-  if (ORGANIC_SEO_PAGE_CONFIG[pathname] && req.method === "GET") {
+  const organicPageConfig = getOrganicSeoPageConfig(pathname);
+  if (organicPageConfig && req.method === "GET") {
     const cfg = getConfig();
     const siteBase = getPublicBaseUrl(cfg);
-    const config = ORGANIC_SEO_PAGE_CONFIG[pathname];
+    const config = organicPageConfig;
+    if (!config?.key || !config?.h1) {
+      const html = '<!doctype html><html lang="es-AR"><head><meta charset="utf-8"><meta name="robots" content="noindex,follow"><title>Pagina no disponible</title></head><body><main><h1>Pagina no disponible</h1></main></body></html>';
+      res.writeHead(404, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "no-store" });
+      res.end(html);
+      return;
+    }
     const products = await getOrganicProductsForPage(config.key, 48);
     if (!products.length) {
       const html = `<!doctype html><html lang="es-AR"><head><meta charset="utf-8"><meta name="robots" content="noindex,follow"><title>${esc(config.h1)} | Sin productos disponibles</title></head><body><main><h1>${esc(config.h1)}</h1><p>No hay productos en stock real para esta pagina en este momento.</p></main></body></html>`;

--- a/nerin_final_updated/backend/utils/organicSeoPages.js
+++ b/nerin_final_updated/backend/utils/organicSeoPages.js
@@ -1,0 +1,70 @@
+"use strict";
+
+const ORGANIC_SEO_PAGE_CONFIG = Object.freeze({
+  "/stock-real": Object.freeze({
+    key: "stock-real",
+    title: "Repuestos en stock real | NERIN Parts",
+    h1: "Repuestos para celulares en stock real",
+    description: "Repuestos listos para enviar desde CABA. Factura A/B, garantia tecnica y soporte para verificar compatibilidad antes de comprar.",
+    intro: "Repuestos listos para enviar desde CABA. Factura A/B, garantia tecnica y soporte para verificar compatibilidad antes de comprar.",
+    canonicalPath: "/stock-real",
+    priority: "0.9",
+  }),
+  "/pantallas-en-stock": Object.freeze({
+    key: "pantallas-en-stock",
+    title: "Pantallas para celulares en stock | NERIN Parts",
+    h1: "Pantallas para celulares en stock",
+    description: "Pantallas y modulos de display con stock real en CABA. Verificamos compatibilidad, factura A/B y garantia tecnica.",
+    intro: "Pantallas, displays y modulos listos para enviar, con soporte para confirmar modelo y version antes de comprar.",
+    canonicalPath: "/pantallas-en-stock",
+    priority: "0.85",
+  }),
+  "/baterias-en-stock": Object.freeze({
+    key: "baterias-en-stock",
+    title: "Baterias para celulares en stock | NERIN Parts",
+    h1: "Baterias para celulares en stock",
+    description: "Baterias para celulares con stock real, factura A/B y soporte tecnico para verificar compatibilidad.",
+    intro: "Baterias disponibles para despacho desde CABA, con asesoria tecnica para validar compatibilidad.",
+    canonicalPath: "/baterias-en-stock",
+    priority: "0.82",
+  }),
+  "/repuestos-samsung": Object.freeze({
+    key: "repuestos-samsung",
+    title: "Repuestos Samsung en Argentina | NERIN Parts",
+    h1: "Repuestos Samsung en Argentina",
+    description: "Repuestos Samsung con stock real en Argentina. Pantallas, baterias, tapas, pines de carga y soporte especializado.",
+    intro: "Catalogo Samsung priorizado por stock real, precio valido, imagen y compatibilidad clara.",
+    canonicalPath: "/repuestos-samsung",
+    priority: "0.82",
+  }),
+  "/repuestos-iphone": Object.freeze({
+    key: "repuestos-iphone",
+    title: "Repuestos iPhone en Argentina | NERIN Parts",
+    h1: "Repuestos iPhone en Argentina",
+    description: "Repuestos iPhone con stock real en Argentina. Displays, baterias, tapas y soporte para validar compatibilidad.",
+    intro: "Repuestos para iPhone priorizados por stock real, compatibilidad clara, factura y garantia tecnica.",
+    canonicalPath: "/repuestos-iphone",
+    priority: "0.82",
+  }),
+});
+
+function normalizePathname(pathname) {
+  const raw = String(pathname || "").split("?")[0].trim();
+  if (!raw) return "/";
+  const withSlash = raw.startsWith("/") ? raw : `/${raw}`;
+  return withSlash.length > 1 ? withSlash.replace(/\/+$/, "") : withSlash;
+}
+
+function getOrganicSeoPageConfig(pathname) {
+  return ORGANIC_SEO_PAGE_CONFIG[normalizePathname(pathname)] || null;
+}
+
+function listOrganicSeoPages() {
+  return Object.values(ORGANIC_SEO_PAGE_CONFIG);
+}
+
+module.exports = {
+  ORGANIC_SEO_PAGE_CONFIG,
+  getOrganicSeoPageConfig,
+  listOrganicSeoPages,
+};

--- a/nerin_final_updated/scripts/applyCodexSeoBulkPatch.js
+++ b/nerin_final_updated/scripts/applyCodexSeoBulkPatch.js
@@ -67,8 +67,7 @@ function filterShopProductsForSsr(products = [], { search = "", category = "", b
       return haystack.includes(cleanSearch);
     });
 }
-
-function replaceBasePlaceholders`;
+`;
 
 const seoHelpers = String.raw`function buildShopSeoState({ siteBase, search = "", category = "", brand = "", count = 0, products = [] } = {}) {
   const normalizedBase = normalizeBaseUrl(siteBase) || FALLBACK_BASE_URL;
@@ -220,18 +219,22 @@ const shopRoute = String.raw`  // SSR del catalogo
 patch("backend/server.js", (text) => {
   let next = text;
   next = next.replace(/\n\s*"Disallow: \/\*\?\*",/g, "");
-  next = replaceRequired(
-    next,
-    /function renderShopListing\(products, siteBase\) \{[\s\S]*?\n\}\n\nfunction replaceBasePlaceholders/,
-    shopHelpers,
-    "shop listing helpers",
-  );
-  next = replaceRequired(
-    next,
-    /function replaceBasePlaceholders/,
-    seoHelpers,
-    "shop seo helpers",
-  );
+  if (!next.includes("function filterShopProductsForSsr(")) {
+    next = replaceRequired(
+      next,
+      /function renderShopListing\(products, siteBase\) \{[\s\S]*?return \{ cards, count, summary \};\n\}/,
+      shopHelpers.trimEnd(),
+      "shop listing helpers",
+    );
+  }
+  if (!next.includes("function buildShopSeoState(")) {
+    next = replaceRequired(
+      next,
+      /function replaceBasePlaceholders/,
+      seoHelpers,
+      "shop seo helpers",
+    );
+  }
   next = replaceRequired(
     next,
     /  \/\/ SSR del cat[^\n]*\n  if \(\n    \(pathname === "\/shop\.html"[\s\S]*?\n  \/\/ Servir componentes/,

--- a/nerin_final_updated/scripts/applySitemapHotfix.js
+++ b/nerin_final_updated/scripts/applySitemapHotfix.js
@@ -3,7 +3,7 @@ const path = require("path");
 
 const root = path.resolve(__dirname, "..");
 const serverPath = path.join(root, "backend/server.js");
-const marker = "async function requestHandler(req, res) {\n";
+const markerRegex = /async function requestHandler\(req, res\) \{\r?\n/;
 const flag = "[sitemap-hotfix-large-catalog]";
 
 let text = fs.readFileSync(serverPath, "utf8");
@@ -13,7 +13,7 @@ if (text.includes(flag)) {
   process.exit(0);
 }
 
-if (!text.includes(marker)) {
+if (!markerRegex.test(text)) {
   console.warn("[sitemap-hotfix] marker not found; server.js was not changed");
   process.exit(0);
 }
@@ -36,12 +36,21 @@ const snippet = String.raw`async function requestHandler(req, res) {
       const base = normalizeBaseUrl(siteBase) || FALLBACK_BASE_URL;
       const generatedAt = toIsoString(new Date());
       const pageSize = 45000;
-      const staticEntries = ["/", "/shop.html", "/shop", "/contact.html", "/garantia.html"].map((pathSegment) => ({
+      const baseStaticEntries = ["/", "/shop.html", "/shop", "/contact.html", "/garantia.html"].map((pathSegment) => ({
         loc: absoluteUrl(pathSegment, base),
         lastmod: generatedAt,
         changefreq: pathSegment === "/" || pathSegment === "/shop.html" || pathSegment === "/shop" ? "daily" : "monthly",
         priority: pathSegment === "/" ? "1.0" : pathSegment === "/shop.html" || pathSegment === "/shop" ? "0.9" : "0.5",
       }));
+      let organicEntries = [];
+      if (typeof buildOrganicSitemapEntries === "function") {
+        try {
+          organicEntries = await buildOrganicSitemapEntries(base, generatedAt);
+        } catch (organicError) {
+          console.warn("[sitemap:organic-skip]", organicError?.message || organicError);
+        }
+      }
+      const staticEntries = [...baseStaticEntries, ...organicEntries];
       const toProductEntry = (product) => {
         try {
           const slug = product?.publicSlug || product?.public_slug || product?.slug;
@@ -110,6 +119,6 @@ const snippet = String.raw`async function requestHandler(req, res) {
   }
 `;
 
-text = text.replace(marker, snippet);
+text = text.replace(markerRegex, snippet);
 fs.writeFileSync(serverPath, text, "utf8");
 console.log("[sitemap-hotfix] updated backend/server.js");

--- a/nerin_final_updated/scripts/test-organic-seo-runtime.js
+++ b/nerin_final_updated/scripts/test-organic-seo-runtime.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+"use strict";
+
+process.env.NODE_ENV = process.env.NODE_ENV || "test";
+process.env.PORT = "0";
+
+const http = require("http");
+const { createServer } = require("../backend/server");
+
+const paths = [
+  "/stock-real",
+  "/pantallas-en-stock",
+  "/baterias-en-stock",
+  "/repuestos-samsung",
+  "/repuestos-iphone",
+  "/sitemap.xml",
+];
+
+function request(baseUrl, pathname) {
+  return new Promise((resolve, reject) => {
+    const req = http.get(`${baseUrl}${pathname}`, (res) => {
+      res.resume();
+      res.on("end", () => resolve({ pathname, statusCode: res.statusCode || 0 }));
+    });
+    req.setTimeout(15000, () => {
+      req.destroy(new Error(`timeout ${pathname}`));
+    });
+    req.on("error", reject);
+  });
+}
+
+async function main() {
+  const server = createServer();
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const results = [];
+  try {
+    for (const pathname of paths) {
+      const result = await request(baseUrl, pathname);
+      results.push(result);
+      if (result.statusCode >= 500) {
+        throw new Error(`${pathname} returned ${result.statusCode}`);
+      }
+    }
+    console.log(JSON.stringify({ ok: true, results }, null, 2));
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+main().catch((error) => {
+  console.error("[organic-seo-runtime-test]", error?.stack || error?.message || error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Fixes the production crash reported on organic SEO routes:

`ReferenceError: ORGANIC_SEO_PAGE_CONFIG is not defined`

## Root cause

`ORGANIC_SEO_PAGE_CONFIG` lived as a loose block inside `backend/server.js`. The Render start command runs scripts that patch `backend/server.js` at runtime, and one of those script regexes could replace a broad section starting near `renderShopListing` through `replaceBasePlaceholders`. That made the organic SEO layer vulnerable to being removed or left inconsistent before requests reached the SEO route handler.

## What changed

- Moved organic SEO page config into stable module `backend/utils/organicSeoPages.js`.
- `backend/server.js` now imports `getOrganicSeoPageConfig()` and `listOrganicSeoPages()` instead of relying on a local loose constant.
- Added a defensive 404/noindex response if an organic route has an invalid config shape.
- Updated `scripts/applyCodexSeoBulkPatch.js` so its shop helper patch no longer spans across organic SEO functions.
- Updated `scripts/applySitemapHotfix.js` to:
  - handle CRLF/LF request handler markers,
  - preserve organic sitemap entries,
  - avoid crashing sitemap generation if organic entries cannot be built.
- Added `scripts/test-organic-seo-runtime.js` to start the server locally and verify the organic SEO routes and sitemap do not return 500.

## Validation

- `node --check backend/server.js`
- `node --check backend/utils/organicSeoPages.js`
- `node --check scripts/applyCodexSeoBulkPatch.js`
- `node --check scripts/applySitemapHotfix.js`
- `node --check scripts/test-organic-seo-runtime.js`
- `node scripts/test-organic-seo-runtime.js`
  - `/stock-real` -> 200
  - `/pantallas-en-stock` -> 200
  - `/baterias-en-stock` -> 200
  - `/repuestos-samsung` -> 200
  - `/repuestos-iphone` -> 200
  - `/sitemap.xml` -> 200
- Startup-script simulation in a temp copy:
  - `node scripts/applyCodexSeoBulkPatch.js`
  - `node scripts/applySitemapHotfix.js`
  - `node --check backend/server.js`
  - `node scripts/test-organic-seo-runtime.js` -> all organic routes and sitemap returned 200

## Explicitly not touched

- Mercado Pago
- webhooks
- inventory
- orders
- base prices
- critical checkout flow