### PR TITLE
Build catalog intelligence layer and real faceted search

### DIFF
--- a/nerin_final_updated/__tests__/backend/catalog-classifier.test.js
+++ b/nerin_final_updated/__tests__/backend/catalog-classifier.test.js
@@ -1,0 +1,43 @@
+const { classifyCatalogProduct, parseCatalogQuery } = require("../../backend/utils/catalogClassifier");
+
+describe("catalogClassifier", () => {
+  test.each([
+    ["Display Incl Frame Original Green Honor 9X Lite", { part_type: "display", device_brand: "Honor", model_base: "Honor 9X Lite", quality_tier: "original", has_frame: true, color: "green" }],
+    ["Battery High Capacity Best Possible for iPhone 6S", { part_type: "battery", device_brand: "Apple", compatible_brand: "Apple", is_compatible_for_brand: true, model_base: "iPhone 6S", quality_tier: "compatible" }],
+    ["Keyset Simcard Tray Black for iPhone 14 Pro", { part_type: "sim_tray", model_base: "iPhone 14 Pro", model_variant: "pro", color: "black" }],
+    ["Display JK Compatible Hard OLED for iPhone 15 Pro", { part_type: "display", device_brand: "Apple", model_base: "iPhone 15 Pro", model_variant: "pro", quality_tier: "compatible" }],
+    ["Display Original Lavender Samsung Galaxy S23 Plus SM-S916B", { part_type: "display", device_brand: "Samsung", model_base: "Galaxy S23 Plus", model_variant: "plus", color: "lavender" }],
+    ["Back Glass Gold Huawei Mate 10 Lite", { part_type: "back_cover", device_brand: "Huawei", model_base: "Huawei Mate 10 Lite", model_variant: "lite", color: "gold" }],
+    ["Flex Cable Rear Camera for iPhone 15 Pro Max", { part_type: "flex", device_brand: "Apple", model_base: "iPhone 15 Pro Max", model_variant: "pro max" }],
+    ["Antenna GPS Compatible for iPhone 17 Air", { part_type: "antenna", device_brand: "Apple", model_base: "iPhone 17 Air", model_variant: "air", compatible_brand: "Apple" }],
+  ])("classifies %s", (title, expected) => {
+    const result = classifyCatalogProduct({ title, name: title });
+    Object.entries(expected).forEach(([key, value]) => {
+      expect(result[key]).toEqual(value);
+    });
+  });
+
+  test("does not promote for Huawei to official brand without original signal", () => {
+    const result = classifyCatalogProduct({ title: "Back Glass Gold for Huawei Mate 10 Lite" });
+    expect(result.compatible_brand).toBe("Huawei");
+    expect(result.is_compatible_for_brand).toBe(true);
+    expect(result.official_brand).toBe("");
+  });
+
+  test("parses query intent for exact network and variants", () => {
+    expect(parseCatalogQuery("display samsung a15 5g")).toMatchObject({
+      part_type: "display",
+      device_brand: "Samsung",
+      model_base: "Galaxy A15 5G",
+      network_variant: "5g",
+    });
+    expect(parseCatalogQuery("iphone 12 pro display")).toMatchObject({
+      model_base: "iPhone 12 Pro",
+      model_variant: "pro",
+    });
+    expect(parseCatalogQuery("iphone 12 pro max display")).toMatchObject({
+      model_base: "iPhone 12 Pro Max",
+      model_variant: "pro max",
+    });
+  });
+});

--- a/nerin_final_updated/backend/data/productsSqliteRepo.js
+++ b/nerin_final_updated/backend/data/productsSqliteRepo.js
@@ -4,14 +4,20 @@ const path = require("path");
 const sqlite3 = require("sqlite3");
 const productsStreamRepo = require("./productsStreamRepo");
 const { dataPath } = require("../utils/dataDir");
+const {
+  PART_LABELS,
+  classifyCatalogProduct,
+  normalizeText: normalizeCatalogText,
+  parseCatalogQuery,
+} = require("../utils/catalogClassifier");
 
 const PRODUCTS_JSON_PATH = dataPath("products.json");
 const SQLITE_PATH = dataPath("products.sqlite");
 const MANIFEST_PATH = dataPath("products.manifest.json");
 const OVERRIDES_PATH = dataPath("products.overrides.json");
 const COUNT_CACHE_TTL_MS = 60_000;
-const PRODUCTS_SQLITE_SCHEMA_VERSION = 5;
-const CATALOG_MAPPING_VERSION = 2;
+const PRODUCTS_SQLITE_SCHEMA_VERSION = 6;
+const CATALOG_MAPPING_VERSION = 3;
 const BULK_PUBLISH_CHUNK_SIZE = 1000;
 const SEARCH_RANK_CANDIDATE_LIMIT = 1200;
 
@@ -1002,6 +1008,68 @@ async function createSchema(db) {
     await run(db, sql);
   }
 
+  await run(
+    db,
+    `CREATE TABLE IF NOT EXISTS product_search_index (
+      product_id TEXT,
+      product_rowid INTEGER,
+      public_slug TEXT,
+      title TEXT,
+      normalized_title TEXT,
+      sku TEXT,
+      mpn TEXT,
+      part_number TEXT,
+      brand TEXT,
+      device_brand TEXT,
+      compatible_brand TEXT,
+      official_brand TEXT,
+      is_compatible_for_brand INTEGER,
+      part_type TEXT,
+      model_family TEXT,
+      model_base TEXT,
+      model_generation TEXT,
+      model_variant TEXT,
+      network_variant TEXT,
+      quality_tier TEXT,
+      has_frame INTEGER,
+      color TEXT,
+      stock INTEGER,
+      stock_status TEXT,
+      is_stock_real INTEGER,
+      price REAL,
+      has_image INTEGER,
+      is_public INTEGER,
+      classification_confidence REAL,
+      search_blob TEXT,
+      filters_blob TEXT,
+      updated_at TEXT
+    )`,
+  );
+
+  const searchIndexSql = [
+    "CREATE INDEX IF NOT EXISTS idx_search_product_id ON product_search_index(product_id)",
+    "CREATE INDEX IF NOT EXISTS idx_search_product_rowid ON product_search_index(product_rowid)",
+    "CREATE INDEX IF NOT EXISTS idx_search_public_slug ON product_search_index(public_slug)",
+    "CREATE INDEX IF NOT EXISTS idx_search_sku ON product_search_index(sku)",
+    "CREATE INDEX IF NOT EXISTS idx_search_mpn ON product_search_index(mpn)",
+    "CREATE INDEX IF NOT EXISTS idx_search_part_type ON product_search_index(part_type)",
+    "CREATE INDEX IF NOT EXISTS idx_search_device_brand ON product_search_index(device_brand)",
+    "CREATE INDEX IF NOT EXISTS idx_search_model_base ON product_search_index(model_base)",
+    "CREATE INDEX IF NOT EXISTS idx_search_model_variant ON product_search_index(model_variant)",
+    "CREATE INDEX IF NOT EXISTS idx_search_network_variant ON product_search_index(network_variant)",
+    "CREATE INDEX IF NOT EXISTS idx_search_quality_tier ON product_search_index(quality_tier)",
+    "CREATE INDEX IF NOT EXISTS idx_search_color ON product_search_index(color)",
+    "CREATE INDEX IF NOT EXISTS idx_search_has_frame ON product_search_index(has_frame)",
+    "CREATE INDEX IF NOT EXISTS idx_search_stock_status ON product_search_index(stock_status)",
+    "CREATE INDEX IF NOT EXISTS idx_search_is_stock_real ON product_search_index(is_stock_real)",
+    "CREATE INDEX IF NOT EXISTS idx_search_price ON product_search_index(price)",
+    "CREATE INDEX IF NOT EXISTS idx_search_is_public ON product_search_index(is_public)",
+  ];
+
+  for (const sql of searchIndexSql) {
+    await run(db, sql);
+  }
+
   await detectFtsAvailability(db);
 }
 
@@ -1587,6 +1655,186 @@ function mapProductRow(product = {}, options = {}) {
   };
 }
 
+function serializeSearchFilters(classification = {}) {
+  return JSON.stringify({
+    part_type: classification.part_type || "",
+    device_brand: classification.device_brand || "",
+    model_base: classification.model_base || "",
+    model_variant: classification.model_variant || "",
+    network_variant: classification.network_variant || "",
+    quality_tier: classification.quality_tier || "",
+    color: classification.color || "",
+    has_frame: classification.has_frame,
+    stock_status: classification.stock_status || "",
+    is_stock_real: Boolean(classification.is_stock_real),
+    compatible_brand: classification.compatible_brand || "",
+    official_brand: classification.official_brand || "",
+    blockers: classification.blockers || [],
+    reasons: classification.classification_reasons || [],
+  });
+}
+
+function buildSearchIndexEntry(row = {}, rawProduct = {}) {
+  const product = {
+    ...rawProduct,
+    id: rawProduct.id ?? row.id,
+    sku: rawProduct.sku ?? row.sku,
+    code: rawProduct.code ?? row.code,
+    publicSlug: rawProduct.publicSlug ?? rawProduct.public_slug ?? row.public_slug,
+    public_slug: rawProduct.public_slug ?? rawProduct.publicSlug ?? row.public_slug,
+    slug: rawProduct.slug ?? row.slug,
+    name: rawProduct.name ?? row.name,
+    title: rawProduct.title ?? row.title,
+    brand: rawProduct.brand ?? row.brand,
+    model: rawProduct.model ?? row.model,
+    category: rawProduct.category ?? row.category,
+    stock: rawProduct.stock ?? row.stock,
+    price: rawProduct.price ?? row.price,
+    price_minorista: rawProduct.price_minorista ?? row.price_minorista,
+    mpn: rawProduct.mpn ?? row.mpn,
+    partNumber: rawProduct.partNumber ?? row.part_number,
+    part_number: rawProduct.part_number ?? row.part_number,
+  };
+  const classification = classifyCatalogProduct(product);
+  const title = firstText([row.name, row.title, product.name, product.title]) || "Producto";
+  const price = toFiniteNumberOrNull(row.price) ?? toFiniteNumberOrNull(row.price_minorista);
+  const image = firstText([row.image, product.image, product.thumbnail, Array.isArray(product.images) ? product.images[0] : ""]);
+  const blobTerms = uniqueValues([
+    row.search_text,
+    title,
+    row.brand,
+    row.model,
+    row.category,
+    row.sku,
+    row.code,
+    row.mpn,
+    row.part_number,
+    classification.normalized_title,
+    classification.part_type,
+    PART_LABELS[classification.part_type],
+    classification.device_brand,
+    classification.compatible_brand,
+    classification.official_brand,
+    classification.model_family,
+    classification.model_base,
+    classification.model_generation,
+    classification.model_variant,
+    classification.network_variant,
+    classification.quality_tier,
+    ...(classification.quality_signals || []),
+    classification.color,
+    classification.frame_status,
+    ...(classification.searchable_terms || []),
+    ...(classification.synonyms || []),
+  ].map(normalizeCatalogText).filter(Boolean));
+  return {
+    product_id: firstText([row.id, row.sku, row.code, classification.product_id]),
+    product_rowid: Number(row.rowid || 0),
+    public_slug: row.public_slug || row.slug || "",
+    title,
+    normalized_title: classification.normalized_title || normalizeCatalogText(title),
+    sku: row.sku || row.code || "",
+    mpn: row.mpn || row.part_number || "",
+    part_number: row.part_number || "",
+    brand: row.brand || "",
+    device_brand: classification.device_brand || "",
+    compatible_brand: classification.compatible_brand || "",
+    official_brand: classification.official_brand || "",
+    is_compatible_for_brand: classification.is_compatible_for_brand ? 1 : 0,
+    part_type: classification.part_type || "",
+    model_family: classification.model_family || "",
+    model_base: classification.model_base || "",
+    model_generation: classification.model_generation || "",
+    model_variant: classification.model_variant || "",
+    network_variant: classification.network_variant || "",
+    quality_tier: classification.quality_tier || "",
+    has_frame: classification.has_frame === true ? 1 : classification.has_frame === false ? 0 : null,
+    color: classification.color || "",
+    stock: Math.trunc(toNumber(row.stock, 0)),
+    stock_status: classification.stock_status || "",
+    is_stock_real: classification.is_stock_real ? 1 : 0,
+    price,
+    has_image: image ? 1 : 0,
+    is_public: Number(row.is_public || 0) === 1 ? 1 : 0,
+    classification_confidence: Number(classification.classification_confidence || 0),
+    search_blob: blobTerms.join(" "),
+    filters_blob: serializeSearchFilters(classification),
+    updated_at: new Date().toISOString(),
+    classification,
+  };
+}
+
+async function rebuildProductSearchIndex(db) {
+  await run(db, "DELETE FROM product_search_index");
+  const insertSql = `INSERT INTO product_search_index (
+    product_id, product_rowid, public_slug, title, normalized_title, sku, mpn, part_number, brand,
+    device_brand, compatible_brand, official_brand, is_compatible_for_brand, part_type,
+    model_family, model_base, model_generation, model_variant, network_variant, quality_tier,
+    has_frame, color, stock, stock_status, is_stock_real, price, has_image, is_public,
+    classification_confidence, search_blob, filters_blob, updated_at
+  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
+  const pageSize = 1000;
+  let offset = 0;
+  let indexed = 0;
+  while (true) {
+    const rows = await all(
+      db,
+      `SELECT rowid, id, sku, code, slug, public_slug, image, name, title, brand, model, category, stock, price, price_minorista, part_number, mpn, search_text, is_public, raw_json
+       FROM products ORDER BY rowid LIMIT ? OFFSET ?`,
+      [pageSize, offset],
+    );
+    if (!rows.length) break;
+    await withTransaction(db, async () => {
+      for (const row of rows) {
+        let raw = {};
+        try {
+          raw = row.raw_json ? JSON.parse(row.raw_json) : {};
+        } catch {
+          raw = {};
+        }
+        const item = buildSearchIndexEntry(row, raw);
+        await run(db, insertSql, [
+          item.product_id,
+          item.product_rowid,
+          item.public_slug,
+          item.title,
+          item.normalized_title,
+          item.sku,
+          item.mpn,
+          item.part_number,
+          item.brand,
+          item.device_brand,
+          item.compatible_brand,
+          item.official_brand,
+          item.is_compatible_for_brand,
+          item.part_type,
+          item.model_family,
+          item.model_base,
+          item.model_generation,
+          item.model_variant,
+          item.network_variant,
+          item.quality_tier,
+          item.has_frame,
+          item.color,
+          item.stock,
+          item.stock_status,
+          item.is_stock_real,
+          item.price,
+          item.has_image,
+          item.is_public,
+          item.classification_confidence,
+          item.search_blob,
+          item.filters_blob,
+          item.updated_at,
+        ]);
+      }
+    });
+    indexed += rows.length;
+    offset += rows.length;
+  }
+  return indexed;
+}
+
 function parseImageLikeField(value) {
   if (!value) return [];
   if (Array.isArray(value)) {
@@ -1967,6 +2215,7 @@ async function rebuildProductsDbFromJson({ force = true, reason = "manual" } = {
           SELECT rowid, id, sku, code, slug, name, title, brand, model, category, search_text FROM products`,
         );
       }
+      const searchIndexCount = await rebuildProductSearchIndex(tmpDb);
 
       await new Promise((resolve, reject) => {
         tmpDb.close((error) => {
@@ -1994,6 +2243,7 @@ async function rebuildProductsDbFromJson({ force = true, reason = "manual" } = {
         mappingVersion: CATALOG_MAPPING_VERSION,
         productCount: count,
         publicProductCount: publicCount,
+        searchIndexCount,
         productsJsonSizeBytes: Number(productsStats.size || 0),
         productsJsonMtimeMs: Number(productsStats.mtimeMs || 0),
         sqliteBuiltAt: new Date().toISOString(),
@@ -2365,6 +2615,319 @@ function buildProductSummary(row = {}) {
     slug: firstText([row.slug, publicSlug]) || "",
     url: `/p/${encodeURIComponent(publicSlug || fallbackId)}`,
     source: "sqlite",
+    part_type: row.part_type || "",
+    device_brand: row.device_brand || "",
+    compatible_brand: row.compatible_brand || "",
+    official_brand: row.official_brand || "",
+    is_compatible_for_brand: Boolean(row.is_compatible_for_brand),
+    model_family: row.model_family || "",
+    model_base: row.model_base || row.model || "",
+    model_variant: row.model_variant || "",
+    network_variant: row.network_variant || "",
+    quality_tier: row.quality_tier || "",
+    has_frame: row.has_frame === 1 ? true : row.has_frame === 0 ? false : null,
+    color: row.color || "",
+    stock_status: row.stock_status || "",
+    is_stock_real: Boolean(row.is_stock_real),
+    classification_confidence: toFiniteNumberOrNull(row.classification_confidence),
+  };
+}
+
+function normalizeFacetValue(value = "") {
+  return normalizeCatalogText(value);
+}
+
+function buildSearchIndexWhere({
+  search = "",
+  isPublicOnly = false,
+  category = "",
+  brand = "",
+  model = "",
+  stock = "",
+  priceMax = null,
+  partType = "",
+  deviceBrand = "",
+  modelBase = "",
+  qualityTier = "",
+  color = "",
+  hasFrame = "",
+  stockStatus = "",
+} = {}) {
+  const intent = parseCatalogQuery(search || "");
+  const where = [];
+  const params = [];
+  if (isPublicOnly) where.push("si.is_public = 1");
+  const requestedPartType = normalizeFacetValue(partType || category || "");
+  if (requestedPartType) {
+    where.push("si.part_type = ?");
+    params.push(requestedPartType);
+  }
+  const requestedBrand = normalizeFacetValue(deviceBrand || brand || "");
+  if (requestedBrand) {
+    where.push("(lower(si.device_brand) = lower(?) OR lower(si.compatible_brand) = lower(?))");
+    params.push(requestedBrand, requestedBrand);
+  }
+  const requestedModel = normalizeFacetValue(modelBase || model || "");
+  if (requestedModel) {
+    where.push("lower(si.model_base) = lower(?)");
+    params.push(requestedModel);
+  }
+  const requestedQuality = normalizeFacetValue(qualityTier || "");
+  if (requestedQuality) {
+    where.push("si.quality_tier = ?");
+    params.push(requestedQuality);
+  }
+  const requestedColor = normalizeFacetValue(color || "");
+  if (requestedColor) {
+    where.push("si.color = ?");
+    params.push(requestedColor);
+  }
+  if (hasFrame !== "" && hasFrame !== null && hasFrame !== undefined) {
+    const frameValue = String(hasFrame) === "true" || String(hasFrame) === "1" ? 1 : String(hasFrame) === "false" || String(hasFrame) === "0" ? 0 : null;
+    if (frameValue !== null) {
+      where.push("si.has_frame = ?");
+      params.push(frameValue);
+    }
+  }
+  const requestedStock = normalizeFacetValue(stockStatus || stock || "");
+  if (requestedStock === "in_stock" || requestedStock === "stock-real" || requestedStock === "in-stock" || requestedStock === "physical") {
+    where.push("si.is_stock_real = 1");
+  } else if (requestedStock === "preorder" || requestedStock === "backorder" || requestedStock === "remote") {
+    where.push("si.stock_status = 'preorder'");
+  } else if (requestedStock === "out_of_stock" || requestedStock === "out" || requestedStock === "sin-stock") {
+    where.push("si.stock_status = 'out_of_stock'");
+  }
+  const numericPriceMax = Number(priceMax);
+  if (Number.isFinite(numericPriceMax) && numericPriceMax > 0) {
+    where.push("si.price <= ?");
+    params.push(numericPriceMax);
+  }
+  const searchTerms = uniqueValues([
+    intent.model_code,
+    intent.part_type,
+    intent.device_brand,
+    intent.model_base,
+    intent.network_variant,
+    intent.quality_tier,
+    intent.color,
+    ...(intent.tokens || []).filter((token) => token.length >= 2 && !SEARCH_STOPWORDS.has(token)),
+  ].map(normalizeFacetValue).filter(Boolean));
+  if (intent.normalized_query) {
+    const strictTerms = searchTerms.filter((term) => !["display", "pantalla", "modulo", "battery", "bateria"].includes(term)).slice(0, 8);
+    for (const term of strictTerms) {
+      where.push("si.search_blob LIKE ?");
+      params.push(`%${term}%`);
+    }
+  }
+  return {
+    sql: where.length ? `WHERE ${where.join(" AND ")}` : "",
+    params,
+    intent,
+  };
+}
+
+function addStructuredReason(entry, label, score) {
+  if (!score) return;
+  entry.score += score;
+  entry.reasons.push({ label, score });
+}
+
+function scoreSearchIndexRow(row = {}, intent = {}) {
+  const entry = { score: 0, reasons: [] };
+  const blob = normalizeFacetValue(row.search_blob || "");
+  const rowModel = normalizeFacetValue(row.model_base || "");
+  const queryModel = normalizeFacetValue(intent.model_base || "");
+  const rowVariant = normalizeFacetValue(row.model_variant || "base") || "base";
+  const queryVariant = normalizeFacetValue(intent.model_variant || "");
+  const rowNetwork = normalizeFacetValue(row.network_variant || "");
+  const queryNetwork = normalizeFacetValue(intent.network_variant || "");
+  if (intent.model_code && blob.includes(normalizeFacetValue(intent.model_code))) addStructuredReason(entry, "SKU/MPN/model code exacto", 800);
+  if (queryModel && rowModel === queryModel) addStructuredReason(entry, "modelo exacto estructurado", 3000);
+  else if (intent.model_generation && row.model_generation === intent.model_generation && row.model_family === intent.model_family) addStructuredReason(entry, "generacion/familia modelo", 900);
+  else if (queryModel && rowModel && rowModel !== queryModel) addStructuredReason(entry, "modelo parecido pero no exacto", -1000);
+  if (queryVariant) {
+    if (rowVariant === queryVariant) addStructuredReason(entry, "variante exacta", 2500);
+    else addStructuredReason(entry, `variante incorrecta ${rowVariant} vs ${queryVariant}`, -2500);
+  } else if (queryModel && rowModel !== queryModel && /iphone\s+\d+/.test(queryModel) && /iphone\s+\d+/.test(rowModel)) {
+    addStructuredReason(entry, "variante iphone no solicitada", -1800);
+  }
+  if (queryNetwork) {
+    if (rowNetwork === queryNetwork) addStructuredReason(entry, "red exacta", 1200);
+    else if (rowNetwork) addStructuredReason(entry, `red incorrecta ${rowNetwork} vs ${queryNetwork}`, -1500);
+  }
+  if (intent.part_type) {
+    if (row.part_type === intent.part_type) addStructuredReason(entry, `tipo exacto ${intent.part_type}`, 2200);
+    else if (row.part_type) addStructuredReason(entry, `tipo incorrecto ${row.part_type}`, -2200);
+  }
+  if (intent.device_brand) {
+    if (normalizeFacetValue(row.device_brand) === normalizeFacetValue(intent.device_brand) || normalizeFacetValue(row.compatible_brand) === normalizeFacetValue(intent.device_brand)) {
+      addStructuredReason(entry, `marca/dispositivo ${intent.device_brand}`, 1200);
+    } else if (row.device_brand) {
+      addStructuredReason(entry, `marca incorrecta ${row.device_brand}`, -800);
+    }
+  }
+  if (intent.quality_tier) {
+    if (row.quality_tier === intent.quality_tier) addStructuredReason(entry, "calidad pedida coincide", 700);
+    else if (row.quality_tier) addStructuredReason(entry, "calidad distinta", -250);
+  }
+  if (intent.color) {
+    if (row.color === intent.color) addStructuredReason(entry, "color pedido coincide", 500);
+    else if (row.color) addStructuredReason(entry, "color distinto", -250);
+  }
+  if (intent.has_frame !== null && intent.has_frame !== undefined && intent.has_frame !== "") {
+    const wantedFrame = intent.has_frame === true ? 1 : 0;
+    if (Number(row.has_frame) === wantedFrame) addStructuredReason(entry, "frame pedido coincide", 500);
+    else if (row.has_frame !== null && row.has_frame !== undefined) addStructuredReason(entry, "frame distinto", -300);
+  }
+  if (Number(row.is_stock_real) === 1) addStructuredReason(entry, "stock real", 1800);
+  else if (row.stock_status === "preorder") addStructuredReason(entry, "a pedido debajo de stock real", -900);
+  else addStructuredReason(entry, "sin stock", -1500);
+  if (Number(row.has_image) === 1) addStructuredReason(entry, "imagen valida", 400);
+  else addStructuredReason(entry, "sin imagen", -700);
+  if (Number(row.price) > 0) addStructuredReason(entry, "precio valido", 400);
+  else addStructuredReason(entry, "sin precio", -700);
+  for (const token of intent.tokens || []) {
+    if (token.length >= 3 && blob.includes(token)) addStructuredReason(entry, `token ${token}`, 20);
+  }
+  return entry;
+}
+
+function facetLabel(group, value) {
+  if (group === "part_type") return PART_LABELS[value] || value;
+  if (group === "has_frame") return Number(value) === 1 ? "Con marco" : "Sin marco";
+  if (group === "stock_status") {
+    if (value === "in_stock") return "Stock real";
+    if (value === "preorder") return "A pedido";
+    if (value === "out_of_stock") return "Sin stock";
+  }
+  return String(value || "")
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (m) => m.toUpperCase())
+    .replace(/\bIPhone\b/g, "iPhone")
+    .replace(/\bIphone\b/g, "iPhone")
+    .replace(/\bMacbook\b/g, "MacBook");
+}
+
+async function buildSearchFacets(db, whereClause) {
+  const groups = ["part_type", "device_brand", "model_base", "quality_tier", "color", "has_frame", "stock_status"];
+  const facets = {};
+  for (const group of groups) {
+    const prefix = whereClause.sql ? `${whereClause.sql} AND` : "WHERE";
+    const rows = await all(
+      db,
+      `SELECT ${group} AS value, COUNT(*) AS count FROM product_search_index si ${prefix} ${group} IS NOT NULL AND ${group} != '' GROUP BY ${group} ORDER BY count DESC, value ASC LIMIT ${group === "model_base" ? 40 : 20}`,
+      whereClause.params,
+    );
+    facets[group] = rows.map((row) => ({ value: String(row.value), label: facetLabel(group, row.value), count: Number(row.count || 0) }));
+  }
+  const priceRow = await get(db, `SELECT MIN(price) AS min, MAX(price) AS max FROM product_search_index si ${whereClause.sql}`, whereClause.params);
+  facets.price_range = {
+    min: Number(priceRow?.min || 0),
+    max: Number(priceRow?.max || 0),
+  };
+  return facets;
+}
+
+async function querySearchIndex(params = {}) {
+  await ensureDbReadyForRequest();
+  const db = await openDb();
+  const safePage = Math.max(1, Number(params.page) || 1);
+  const safePageSize = Math.max(1, Number(params.pageSize) || 24);
+  const offset = (safePage - 1) * safePageSize;
+  const whereClause = buildSearchIndexWhere(params);
+  const countStartedAt = Date.now();
+  const totalRow = await get(db, `SELECT COUNT(*) AS totalItems FROM product_search_index si ${whereClause.sql}`, whereClause.params);
+  const totalItems = Number(totalRow?.totalItems || 0);
+  const countMs = Date.now() - countStartedAt;
+  const selectStartedAt = Date.now();
+  const hasSearch = Boolean(normalizeFacetValue(params.search || ""));
+  const candidateLimit = hasSearch ? Math.max(safePageSize, Math.min(SEARCH_RANK_CANDIDATE_LIMIT, totalItems || SEARCH_RANK_CANDIDATE_LIMIT)) : safePageSize;
+  const candidateOffset = hasSearch ? 0 : offset;
+  const orderBy =
+    params.sort === "price_asc" ? "si.price ASC, si.title ASC" :
+    params.sort === "price_desc" ? "si.price DESC, si.title ASC" :
+    params.sort === "name_desc" ? "si.title DESC" :
+    params.sort === "name_asc" ? "si.title ASC" :
+    params.sort === "stock_real" ? "si.is_stock_real DESC, si.title ASC" :
+    "si.is_stock_real DESC, si.classification_confidence DESC, si.title ASC";
+  const candidates = await all(
+    db,
+    `SELECT si.*, p.rowid, p.id, p.code, p.slug, p.image, p.name, p.category, p.status, p.visibility, p.price_minorista, p.price_mayorista, p.precio_minorista, p.precio_mayorista, p.precio_final, p.precio_sin_impuestos, p.cost, p.currency, p.raw_json
+     FROM product_search_index si
+     JOIN products p ON p.rowid = si.product_rowid
+     ${whereClause.sql}
+     ORDER BY ${orderBy}
+     LIMIT ? OFFSET ?`,
+    [...whereClause.params, candidateLimit, candidateOffset],
+  );
+  let ranked = candidates.map((row, index) => ({ row, index, ...scoreSearchIndexRow(row, whereClause.intent) }));
+  if (hasSearch && (!params.sort || String(params.sort) === "relevance")) {
+    ranked.sort((a, b) => b.score - a.score || Number(b.row.is_stock_real || 0) - Number(a.row.is_stock_real || 0) || a.index - b.index);
+  }
+  const pageEntries = hasSearch ? ranked.slice(offset, offset + safePageSize) : ranked;
+  const rows = pageEntries.map((entry) => entry.row);
+  const items = rows.map((row) => buildProductSummary(row));
+  const facets = await buildSearchFacets(db, whereClause);
+  const selectMs = Date.now() - selectStartedAt;
+  const searchDebug = params.debugSearch ? {
+    engine: "product_search_index",
+    queryOriginal: params.search || "",
+    queryNormalized: whereClause.intent.normalized_query || "",
+    intent: whereClause.intent,
+    inferredFilters: {
+      part_type: whereClause.intent.part_type || "",
+      device_brand: whereClause.intent.device_brand || "",
+      model_base: whereClause.intent.model_base || "",
+      model_variant: whereClause.intent.model_variant || "",
+      network_variant: whereClause.intent.network_variant || "",
+      quality_tier: whereClause.intent.quality_tier || "",
+      color: whereClause.intent.color || "",
+      has_frame: whereClause.intent.has_frame,
+    },
+    tokensUsed: whereClause.intent.tokens || [],
+    results: pageEntries.slice(0, 20).map((entry, position) => ({
+      position: position + 1,
+      score: entry.score,
+      reasons: entry.reasons,
+      penalties: entry.reasons.filter((reason) => reason.score < 0),
+      title: entry.row.title,
+      product_id: entry.row.product_id,
+      sku: entry.row.sku,
+      structured: {
+        part_type: entry.row.part_type,
+        device_brand: entry.row.device_brand,
+        compatible_brand: entry.row.compatible_brand,
+        official_brand: entry.row.official_brand,
+        is_compatible_for_brand: Boolean(entry.row.is_compatible_for_brand),
+        model_base: entry.row.model_base,
+        model_variant: entry.row.model_variant,
+        network_variant: entry.row.network_variant,
+        quality_tier: entry.row.quality_tier,
+        color: entry.row.color,
+        has_frame: entry.row.has_frame,
+        stock_status: entry.row.stock_status,
+        is_stock_real: Boolean(entry.row.is_stock_real),
+      },
+    })),
+  } : undefined;
+  const totalPages = Math.max(1, Math.ceil(totalItems / safePageSize));
+  return {
+    rows,
+    items,
+    page: safePage,
+    pageSize: safePageSize,
+    totalItems,
+    totalPages,
+    hasNextPage: safePage < totalPages,
+    hasPrevPage: safePage > 1,
+    source: "sqlite_search_index",
+    search: params.search || undefined,
+    facets,
+    searchDebug,
+    countMs,
+    selectMs,
+    parseItemsMs: 0,
+    totalDurationMs: countMs + selectMs,
   };
 }
 
@@ -2488,12 +3051,12 @@ async function queryBase({
 async function queryProducts(params = {}) {
   let result;
   try {
-    result = await queryBase({ ...params, isPublicOnly: true });
+    result = await querySearchIndex({ ...params, isPublicOnly: true });
   } catch (error) {
     if (isSqliteCorruptionError(error)) {
       markSqliteCorruption(error, { phase: "query_products", reason: "sqlite_corrupt" });
       await repairCorruptSqlite({ reason: "query_products_corrupt" });
-      result = await queryBase({ ...params, isPublicOnly: true });
+      result = await querySearchIndex({ ...params, isPublicOnly: true });
     } else {
       throw error;
     }

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -7259,6 +7259,13 @@ async function requestHandler(req, res) {
         category: queryParams.category || "",
         brand: queryParams.brand || "",
         model: queryParams.model || "",
+        partType: queryParams.part_type || queryParams.partType || "",
+        deviceBrand: queryParams.device_brand || queryParams.deviceBrand || "",
+        modelBase: queryParams.model_base || queryParams.modelBase || "",
+        qualityTier: queryParams.quality_tier || queryParams.qualityTier || "",
+        color: queryParams.color || "",
+        hasFrame: queryParams.has_frame ?? queryParams.hasFrame ?? "",
+        stockStatus: queryParams.stock_status || queryParams.stockStatus || "",
         stock: queryParams.stock || "",
         priceMax: queryParams.price_max ?? queryParams.priceMax,
         sort: queryParams.sort || "",
@@ -7327,7 +7334,15 @@ async function requestHandler(req, res) {
         category: parsedUrl.query?.category || "",
         brand: parsedUrl.query?.brand || "",
         model: parsedUrl.query?.model || "",
+        partType: parsedUrl.query?.part_type || parsedUrl.query?.partType || "",
+        deviceBrand: parsedUrl.query?.device_brand || parsedUrl.query?.deviceBrand || "",
+        modelBase: parsedUrl.query?.model_base || parsedUrl.query?.modelBase || "",
+        qualityTier: parsedUrl.query?.quality_tier || parsedUrl.query?.qualityTier || "",
+        color: parsedUrl.query?.color || "",
+        hasFrame: parsedUrl.query?.has_frame ?? parsedUrl.query?.hasFrame ?? "",
+        stockStatus: parsedUrl.query?.stock_status || parsedUrl.query?.stockStatus || "",
         stock: parsedUrl.query?.stock || "",
+        debugSearch: debug,
       });
       const results = data.items.map((item) => ({
         id: item.id,
@@ -7350,8 +7365,8 @@ async function requestHandler(req, res) {
         queryParsed: { normalizedQuery: q },
         tookMs: Date.now() - startedAt,
         suggestions: [],
-        facets: {},
-        debug: debug ? { source: "basic", note: "Use /api/catalog/debug-search for row-level details." } : undefined,
+        facets: data.facets || {},
+        debug: debug ? data.searchDebug : undefined,
       });
     } catch (error) {
       return sendJson(res, 500, { ok: false, error: error?.message || "search_failed" });

--- a/nerin_final_updated/backend/utils/catalogClassifier.js
+++ b/nerin_final_updated/backend/utils/catalogClassifier.js
@@ -1,0 +1,434 @@
+"use strict";
+
+function normalizeText(value = "") {
+  let text = String(value || "");
+  const mojibake = [
+    ["ÃƒÂ³", "o"], ["ÃƒÂ¡", "a"], ["ÃƒÂ©", "e"], ["ÃƒÂ­", "i"], ["ÃƒÂº", "u"], ["ÃƒÂ±", "n"], ["ÃƒÂ¼", "u"],
+    ["Ã³", "o"], ["Ã¡", "a"], ["Ã©", "e"], ["Ã­", "i"], ["Ãº", "u"], ["Ã±", "n"], ["Ã¼", "u"],
+    ["Â", ""],
+  ];
+  for (const [from, to] of mojibake) text = text.split(from).join(to);
+  try {
+    text = text.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+  } catch {}
+  return text
+    .toLowerCase()
+    .replace(/[_/\\|+,.;:()[\]{}]+/g, " ")
+    .replace(/[^a-z0-9\s-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function cleanDisplay(value = "") {
+  return String(value || "").replace(/\s+/g, " ").trim();
+}
+
+function firstText(values = []) {
+  for (const value of values) {
+    const text = cleanDisplay(value);
+    if (text) return text;
+  }
+  return "";
+}
+
+function numberOrNull(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function unique(values = []) {
+  return Array.from(new Set(values.filter(Boolean)));
+}
+
+const PART_TYPE_DICTIONARY = Object.freeze({
+  charging_board: ["pin de carga", "placa de carga", "puerto de carga", "centro de carga", "conector de carga", "charging board", "charging connector", "charge port", "dock connector", "usb connector", "usb board", "sub board", "daughterboard"],
+  sim_tray: ["keyset simcard tray", "bandeja sim", "sim tray", "charola sim", "porta sim", "simcard tray", "card tray"],
+  back_cover: ["tapa trasera", "vidrio trasero", "back glass", "rear cover", "back cover", "battery cover", "housing", "tapa", "carcasa"],
+  adhesive: ["adhesivo pantalla", "display adhesive", "adhesive tape", "rear cover adhesive", "battery adhesive", "adhesivo", "adhesive", "gasket", "seal", "pegamento", "cinta adhesiva", "cinta"],
+  display: ["display incl frame", "display excl frame", "hard oled", "soft oled", "super amoled", "pantalla", "modulo", "modulo pantalla", "display", "screen", "lcd", "oled", "amoled", "tactil", "touch", "glass", "assembly"],
+  battery: ["high capacity", "bateria", "battery", "bateria", "baterias", "pila", "accu", "acumulador"],
+  camera: ["rear camera", "front camera", "camera lens", "lente camara", "camara", "camera", "lens"],
+  flex: ["flex cable rear camera", "interconnection flex", "main flex", "cable flex", "flex principal", "flex cable", "flex"],
+  speaker: ["loud speaker", "ear speaker", "parlante", "speaker", "loudspeaker", "altavoz", "auricular interno"],
+  button: ["power button", "volume button", "slider key", "keyset", "boton", "button", "key"],
+  antenna: ["gps antenna", "antenna", "antena"],
+  bracket: ["bracket", "soporte"],
+  component: ["daughterboard", "sub board", "board", "pcb", "ic", "chip", "componente", "component"],
+});
+
+const PART_LABELS = Object.freeze({
+  display: "Pantallas",
+  battery: "Baterias",
+  charging_board: "Pin de carga",
+  back_cover: "Tapas",
+  camera: "Camaras",
+  flex: "Flex",
+  speaker: "Parlantes",
+  sim_tray: "Bandeja SIM",
+  adhesive: "Adhesivos",
+  button: "Botones",
+  antenna: "Antenas",
+  bracket: "Soportes",
+  component: "Componentes",
+});
+
+const BRAND_PATTERNS = [
+  { value: "Apple", aliases: ["apple", "iphone", "ipad", "macbook"] },
+  { value: "Samsung", aliases: ["samsung", "galaxy", "sm-"] },
+  { value: "Xiaomi", aliases: ["xiaomi", "redmi", "poco"] },
+  { value: "Motorola", aliases: ["motorola", "moto"] },
+  { value: "Huawei", aliases: ["huawei"] },
+  { value: "Honor", aliases: ["honor"] },
+  { value: "OnePlus", aliases: ["oneplus", "one plus"] },
+  { value: "Oppo", aliases: ["oppo"] },
+  { value: "Realme", aliases: ["realme"] },
+  { value: "Vivo", aliases: ["vivo"] },
+  { value: "Nokia", aliases: ["nokia"] },
+  { value: "Sony", aliases: ["sony"] },
+  { value: "Apple Watch", aliases: ["apple watch", "watch"] },
+];
+
+const VARIANT_TERMS = ["pro max", "pro", "mini", "plus", "ultra", "lite", "air", "base"];
+const NETWORK_VARIANTS = ["5g", "4g"];
+
+const QUALITY_RULES = [
+  { tier: "service_pack", terms: ["service pack", "servicepack"] },
+  { tier: "pulled_a", terms: ["pulled a", "pull a"] },
+  { tier: "pulled_b", terms: ["pulled b", "pull b"] },
+  { tier: "pulled_c", terms: ["pulled c", "pull c"] },
+  { tier: "refurbished", terms: ["refurbished", "reacondicionado"] },
+  { tier: "soft_oled", terms: ["soft oled"] },
+  { tier: "hard_oled", terms: ["hard oled"] },
+  { tier: "incell", terms: ["incell", "in-cell"] },
+  { tier: "jk", terms: [" jk ", " jk", "jk "] },
+  { tier: "high_capacity", terms: ["high capacity", "alta capacidad"] },
+  { tier: "best_possible", terms: ["best possible"] },
+  { tier: "original", terms: ["original", "genuine", "oem"] },
+  { tier: "compatible", terms: ["compatible", "replacement", "for "] },
+];
+
+const COLORS = Object.freeze({
+  black: ["black", "negro"],
+  white: ["white", "blanco"],
+  silver: ["silver", "plata"],
+  gold: ["gold", "dorado"],
+  green: ["green", "verde"],
+  blue: ["blue", "azul"],
+  red: ["red", "rojo"],
+  purple: ["purple", "violeta", "morado"],
+  lavender: ["lavender", "lavanda"],
+  graphite: ["graphite", "grafito"],
+  titanium: ["titanium", "titanio"],
+  pink: ["pink", "rosa"],
+  yellow: ["yellow", "amarillo"],
+  orange: ["orange", "naranja"],
+  gray: ["gray", "grey", "gris"],
+  midnight: ["midnight"],
+  starlight: ["starlight"],
+});
+
+const STOPWORDS = new Set(["for", "para", "de", "del", "la", "el", "con", "sin", "and", "the", "a", "an"]);
+
+function includesPhrase(haystack, phrase) {
+  const normalized = normalizeText(phrase);
+  if (!normalized) return false;
+  return new RegExp(`(^|\\s)${normalized.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(\\s|$)`).test(` ${haystack} `);
+}
+
+function detectPartType(text) {
+  let best = { part_type: "", confidence: 0, terms: [] };
+  for (const [partType, terms] of Object.entries(PART_TYPE_DICTIONARY)) {
+    const matched = terms.filter((term) => includesPhrase(text, term));
+    if (!matched.length) continue;
+    const score = Math.min(1, 0.52 + matched.reduce((sum, term) => sum + Math.min(0.25, normalizeText(term).length / 40), 0));
+    if (score > best.confidence) best = { part_type: partType, confidence: score, terms: matched };
+  }
+  return best;
+}
+
+function detectBrand(text, rawBrand = "") {
+  const normalizedBrand = normalizeText(rawBrand);
+  const forMatch = text.match(/\bfor\s+(apple|iphone|samsung|galaxy|xiaomi|redmi|poco|huawei|honor|oneplus|oppo|realme|vivo|nokia|sony|motorola|moto)\b/);
+  let detected = null;
+  for (const brand of BRAND_PATTERNS) {
+    if (brand.aliases.some((alias) => includesPhrase(text, alias) || normalizedBrand === normalizeText(alias))) {
+      detected = brand;
+      break;
+    }
+  }
+  if (!detected && forMatch) {
+    detected = BRAND_PATTERNS.find((brand) => brand.aliases.some((alias) => normalizeText(alias) === forMatch[1] || forMatch[1] === "iphone" && brand.value === "Apple"));
+  }
+  const brandName = detected?.value || "";
+  const isCompatible = Boolean(forMatch || /^\s*for\s+/i.test(String(rawBrand || "")) || includesPhrase(text, "compatible"));
+  return {
+    device_brand: brandName,
+    device_brand_confidence: brandName ? (forMatch ? 0.88 : 0.78) : 0,
+    compatible_brand: isCompatible ? brandName : "",
+    official_brand: !isCompatible && brandName && /\b(original|service pack|genuine|oem)\b/.test(text) ? brandName : "",
+    is_compatible_for_brand: isCompatible && Boolean(brandName),
+  };
+}
+
+function titleCaseModel(value = "") {
+  return cleanDisplay(value)
+    .replace(/\biphone\b/ig, "iPhone")
+    .replace(/\bmacbook\b/ig, "MacBook")
+    .replace(/\bgalaxy\b/ig, "Galaxy")
+    .replace(/\bredmi\b/ig, "Redmi")
+    .replace(/\bpoco\b/ig, "Poco")
+    .replace(/\bhonor\b/ig, "Honor")
+    .replace(/\bhuawei\b/ig, "Huawei")
+    .replace(/\bsamsung\b/ig, "Samsung")
+    .replace(/\b([a-z])/g, (m) => m.toUpperCase())
+    .replace(/\bIPhone\b/g, "iPhone")
+    .replace(/\bMacbook\b/g, "MacBook")
+    .replace(/(\d)([a-z])\b/g, (_, n, ch) => `${n}${ch.toUpperCase()}`);
+}
+
+function normalizeVariant(value = "") {
+  const text = normalizeText(value);
+  if (includesPhrase(text, "pro max")) return "pro max";
+  for (const variant of VARIANT_TERMS) {
+    if (variant !== "base" && includesPhrase(text, variant)) return variant;
+  }
+  return "base";
+}
+
+function detectModel(text, brand = "") {
+  const rules = [
+    { family: "iphone", regex: /\biphone\s+(\d{1,2}s?)(?:\s+(pro\s+max|pro|max|mini|plus|air))?\b/ },
+    { family: "macbook", regex: /\bmacbook\s+(air|pro)?\s*(\d{2})?\s*(\d{4})?\b/ },
+    { family: "galaxy", regex: /\b(?:samsung\s+)?(?:galaxy\s+)?((?:a|s|m|note|z)\d{1,3})(?:\s+(ultra|plus|lite))?(?:\s+(5g|4g))?\b/ },
+    { family: "redmi", regex: /\b(?:xiaomi\s+)?(?:redmi\s+)?(?:note\s+)?(\d{1,2})(?:\s+(pro|max|plus))?(?:\s+(5g|4g))?\b/ },
+    { family: "honor", regex: /\bhonor\s+([a-z0-9]+(?:\s*[a-z0-9]+){0,2})(?:\s+(lite|pro|plus|air|5g|4g))?\b/ },
+    { family: "huawei", regex: /\bhuawei\s+([a-z0-9]+(?:\s*[a-z0-9]+){0,2})(?:\s+(lite|pro|plus|5g|4g))?\b/ },
+    { family: "oneplus", regex: /\bone\s*plus\s+([a-z0-9]+(?:\s*[a-z0-9]+){0,2})\b|\boneplus\s+([a-z0-9]+(?:\s*[a-z0-9]+){0,2})\b/ },
+  ];
+  for (const rule of rules) {
+    if (rule.family === "redmi" && !/\b(xiaomi|redmi|poco|note)\b/.test(text)) continue;
+    const match = text.match(rule.regex);
+    if (!match) continue;
+    if (rule.family === "iphone") {
+      const gen = match[1];
+      const variant = normalizeVariant(match[2] || "base");
+      return {
+        model_family: "iPhone",
+        model_base: titleCaseModel(`iPhone ${gen}${variant === "base" ? "" : ` ${variant}`}`),
+        model_generation: gen,
+        model_variant: variant,
+        network_variant: "",
+      };
+    }
+    if (rule.family === "macbook") {
+      const variant = normalizeText(match[1] || "") || "base";
+      const generation = match[3] || match[2] || "";
+      return {
+        model_family: "MacBook",
+        model_base: titleCaseModel(`MacBook ${variant === "base" ? "" : variant} ${match[2] || ""} ${match[3] || ""}`.trim()),
+        model_generation: generation,
+        model_variant: variant,
+        network_variant: "",
+      };
+    }
+    if (rule.family === "galaxy") {
+      const code = String(match[1] || "").toUpperCase();
+      const variant = normalizeVariant(match[2] || "base");
+      const network = normalizeText(match[3] || "");
+      return {
+        model_family: "Galaxy",
+        model_base: titleCaseModel(`Galaxy ${code}${variant === "base" ? "" : ` ${variant}`}${network ? ` ${network.toUpperCase()}` : ""}`),
+        model_generation: code.replace(/^[A-Z]+/, ""),
+        model_variant: variant,
+        network_variant: network,
+      };
+    }
+    const modelRaw = cleanDisplay(match[1] || match[2] || "");
+    const variantRaw = normalizeVariant(match[2] || modelRaw || "");
+    const network = NETWORK_VARIANTS.find((network) => includesPhrase(text, network)) || "";
+    const modelAlreadyHasVariant = variantRaw && variantRaw !== "base" && includesPhrase(normalizeText(modelRaw), variantRaw);
+    return {
+      model_family: titleCaseModel(rule.family),
+      model_base: titleCaseModel(`${brand || rule.family} ${modelRaw}${variantRaw && variantRaw !== "base" && !modelAlreadyHasVariant ? ` ${variantRaw}` : ""}${network ? ` ${network.toUpperCase()}` : ""}`),
+      model_generation: (modelRaw.match(/\d+/) || [""])[0],
+      model_variant: variantRaw || "base",
+      network_variant: network,
+    };
+  }
+  return { model_family: "", model_base: "", model_generation: "", model_variant: "", network_variant: "" };
+}
+
+function detectModelCode(text) {
+  const match = text.match(/\b(sm-[a-z0-9]+|gh\d{2}-\d{5}[a-z]?|a\d{4}|m\d{4})\b/i);
+  return match ? match[1].toUpperCase() : "";
+}
+
+function detectQuality(text) {
+  const signals = [];
+  for (const rule of QUALITY_RULES) {
+    if (rule.terms.some((term) => includesPhrase(text, term) || text.includes(normalizeText(term)))) signals.push(rule.tier);
+  }
+  let quality_tier = signals[0] || "";
+  if (signals.includes("original")) quality_tier = "original";
+  if (signals.includes("compatible") && !signals.includes("original") && !signals.includes("service_pack")) quality_tier = "compatible";
+  if (signals.includes("service_pack")) quality_tier = "service_pack";
+  return { quality_tier, quality_signals: unique(signals) };
+}
+
+function detectFrame(text) {
+  if (/\b(incl|with|con|incluye)\s+(frame|marco)\b/.test(text) || includesPhrase(text, "display incl frame")) {
+    return { has_frame: true, frame_status: "with_frame" };
+  }
+  if (/\b(excl|without|sin)\s+(frame|marco)\b/.test(text) || includesPhrase(text, "display excl frame")) {
+    return { has_frame: false, frame_status: "without_frame" };
+  }
+  return { has_frame: null, frame_status: "" };
+}
+
+function detectColor(text) {
+  for (const [color, aliases] of Object.entries(COLORS)) {
+    if (aliases.some((alias) => includesPhrase(text, alias))) return { color, color_confidence: 0.9 };
+  }
+  return { color: "", color_confidence: 0 };
+}
+
+function detectStock(product = {}) {
+  const stock = numberOrNull(product.stock ?? product.quantity ?? product.available_quantity ?? product.stockQty) ?? 0;
+  const availability = normalizeText([product.availability, product.stock_status, product.stockStatus, product.stock_mode, product.fulfillment_mode].filter(Boolean).join(" "));
+  const isPreorder = /preorder|backorder|pedido|remote|remoto/.test(availability) || Boolean(product.allow_backorder || product.allowBackorder || product.remote_stock || product.remoteStock);
+  const isStockReal = stock > 0 && !isPreorder;
+  const isOutOfStock = stock <= 0 && !isPreorder;
+  return {
+    stock_status: isStockReal ? "in_stock" : isPreorder ? "preorder" : "out_of_stock",
+    is_stock_real: isStockReal,
+    is_preorder: isPreorder,
+    is_out_of_stock: isOutOfStock,
+  };
+}
+
+function buildSearchableTerms(product, classification) {
+  const terms = [
+    classification.normalized_title,
+    classification.part_type,
+    PART_LABELS[classification.part_type],
+    classification.device_brand,
+    classification.compatible_brand,
+    classification.model_family,
+    classification.model_base,
+    classification.model_generation,
+    classification.model_variant,
+    classification.network_variant,
+    classification.quality_tier,
+    ...(classification.quality_signals || []),
+    classification.color,
+    classification.frame_status,
+    product.sku,
+    product.code,
+    product.mpn,
+    product.partNumber,
+    product.part_number,
+  ];
+  return unique(terms.map(normalizeText).filter(Boolean));
+}
+
+function classifyCatalogProduct(product = {}) {
+  const title = firstText([product.name, product.title, product.productName, product.description, product.model]);
+  const fields = [
+    title,
+    product.description,
+    product.shortDescription,
+    product.short_description,
+    product.model,
+    product.brand,
+    product.category,
+    product.sku,
+    product.code,
+    product.mpn,
+    product.partNumber,
+    product.part_number,
+  ];
+  const normalized = normalizeText(fields.filter(Boolean).join(" "));
+  const part = detectPartType(normalized);
+  const brand = detectBrand(normalized, product.brand);
+  const model = detectModel(normalized, brand.device_brand);
+  const quality = detectQuality(` ${normalized} `);
+  const frame = detectFrame(normalized);
+  const color = detectColor(normalized);
+  const stock = detectStock(product);
+  const blockers = [];
+  const reasons = [];
+  if (!part.part_type) blockers.push("missing_part_type");
+  else reasons.push(`part_type:${part.part_type}`);
+  if (!brand.device_brand) blockers.push("missing_device_brand");
+  else reasons.push(`brand:${brand.device_brand}`);
+  if (!model.model_base) blockers.push("missing_model");
+  else reasons.push(`model:${model.model_base}`);
+  if (!quality.quality_tier) blockers.push("missing_quality");
+  if (!color.color) blockers.push("missing_color");
+  const confidenceParts = [
+    part.confidence,
+    brand.device_brand_confidence,
+    model.model_base ? 0.9 : 0,
+    quality.quality_tier ? 0.7 : 0.25,
+    color.color ? 0.55 : 0.2,
+  ];
+  const classification_confidence = Number((confidenceParts.reduce((sum, n) => sum + n, 0) / confidenceParts.length).toFixed(3));
+  const classification = {
+    product_id: firstText([product.id, product.product_id, product.productId]),
+    sku: firstText([product.sku, product.code]),
+    mpn: firstText([product.mpn, product.partNumber, product.part_number]),
+    public_slug: firstText([product.publicSlug, product.public_slug, product.slug]),
+    normalized_title: normalizeText(title),
+    part_type: part.part_type,
+    part_type_confidence: Number(part.confidence.toFixed(3)),
+    ...brand,
+    ...model,
+    model_code: detectModelCode(normalized),
+    ...quality,
+    ...frame,
+    ...color,
+    ...stock,
+    searchable_terms: [],
+    synonyms: part.part_type ? PART_TYPE_DICTIONARY[part.part_type].map(normalizeText) : [],
+    blockers,
+    classification_confidence,
+    classification_reasons: reasons,
+  };
+  classification.searchable_terms = buildSearchableTerms(product, classification);
+  return classification;
+}
+
+function parseCatalogQuery(query = "") {
+  const normalized = normalizeText(query);
+  const pseudoProduct = { name: query, title: query, description: query, brand: "" };
+  const classification = classifyCatalogProduct(pseudoProduct);
+  const tokens = unique(normalized.split(/\s+/).filter((token) => token && !STOPWORDS.has(token)));
+  const modelCode = detectModelCode(normalized);
+  return {
+    original_query: query,
+    normalized_query: normalized,
+    tokens,
+    part_type: classification.part_type,
+    device_brand: classification.device_brand,
+    model_base: classification.model_base,
+    model_family: classification.model_family,
+    model_generation: classification.model_generation,
+    model_variant: classification.model_variant || "",
+    network_variant: classification.network_variant || "",
+    quality_tier: classification.quality_tier,
+    color: classification.color,
+    has_frame: classification.has_frame,
+    model_code: modelCode,
+    synonyms: classification.synonyms,
+  };
+}
+
+module.exports = {
+  PART_TYPE_DICTIONARY,
+  PART_LABELS,
+  BRAND_PATTERNS,
+  COLORS,
+  normalizeText,
+  classifyCatalogProduct,
+  parseCatalogQuery,
+};

--- a/nerin_final_updated/exports/catalog-classification-audit.csv
+++ b/nerin_final_updated/exports/catalog-classification-audit.csv
@@ -1,0 +1,7 @@
+id,sku,title,public_slug,part_type,device_brand,model_base,model_variant,quality_tier,color,has_frame,stock_status,confidence,blockers
+"1","LCD-IPH12","Pantalla iPhone 12","pantalla-iphone-12","display","Apple","iPhone 12","base","original","","1","in_stock","0.68","missing_color"
+"2","LCD-SAM-S21","Pantalla Samsung S21","pantalla-samsung-s21","display","Samsung","Galaxy S21","base","","","","in_stock","0.6","missing_quality|missing_color"
+"a16-amoled","SM-A165-DS","Pantalla Samsung Galaxy A16 4G SM-A165 original negra con marco AMOLED","pantalla-samsung-galaxy-a16-4g-sm-a165-original-negra-con-marco-amoled","display","Samsung","Galaxy A16 4G","base","original","black","1","in_stock","0.76",""
+"3","LCD-XIA-MI11","Pantalla Xiaomi Mi 11","pantalla-xiaomi-mi-11","display","Xiaomi","Xiaomi 11","base","","","","in_stock","0.625","missing_quality|missing_color"
+"4","BAT-IPH12","Batería iPhone 12","bateria-iphone-12","battery","Apple","iPhone 12","base","","","","in_stock","0.626","missing_quality|missing_color"
+"5","EAR-IPH11","Auricular iPhone 11","auricular-iphone-11","speaker","Apple","iPhone 11","base","","","","in_stock","0.58","missing_quality|missing_color"

--- a/nerin_final_updated/frontend/js/shop.js
+++ b/nerin_final_updated/frontend/js/shop.js
@@ -82,6 +82,9 @@ const brandFilter = document.getElementById("brandFilter");
 const modelFilter = document.getElementById("modelFilter");
 const categoryFilter = document.getElementById("categoryFilter");
 const stockFilter = document.getElementById("stockFilter");
+const qualityFilter = document.getElementById("qualityFilter");
+const colorFilter = document.getElementById("colorFilter");
+const frameFilter = document.getElementById("frameFilter");
 const priceRange = document.getElementById("priceRange");
 const priceRangeValue = document.getElementById("priceRangeValue");
 const sortSelect = document.getElementById("sortSelect");
@@ -376,6 +379,41 @@ function populateSelect(select, values) {
   select.value = values.includes(current) ? current : "";
 }
 
+function populateSelectFromFacet(select, facetValues = [], fallbackLabel = "") {
+  if (!select) return;
+  const current = select.value;
+  while (select.options.length > 1) select.remove(1);
+  facetValues.forEach((item) => {
+    const value = item?.value ?? "";
+    if (value === "") return;
+    const option = document.createElement("option");
+    option.value = String(value);
+    option.textContent = `${item?.label || value}${Number.isFinite(Number(item?.count)) ? ` (${item.count})` : ""}`;
+    select.appendChild(option);
+  });
+  if (fallbackLabel && select.options[0]) select.options[0].textContent = fallbackLabel;
+  select.value = Array.from(select.options).some((option) => option.value === current) ? current : "";
+  select.parentElement?.classList.toggle("filter-block--empty", facetValues.length === 0 && !current);
+}
+
+function applyFacets(facets = {}) {
+  populateSelectFromFacet(categoryFilter, facets.part_type || [], "Todos los tipos");
+  populateSelectFromFacet(brandFilter, facets.device_brand || [], "Todas las marcas");
+  populateSelectFromFacet(modelFilter, facets.model_base || [], "Todos los modelos");
+  populateSelectFromFacet(qualityFilter, facets.quality_tier || [], "Todas las calidades");
+  populateSelectFromFacet(colorFilter, facets.color || [], "Todos los colores");
+  populateSelectFromFacet(frameFilter, facets.has_frame || [], "Con o sin marco");
+  if (priceRange && facets.price_range && !priceFilterTouched) {
+    const max = Number(facets.price_range.max || 0);
+    if (Number.isFinite(max) && max > 0) {
+      const normalizedMax = Math.max(1000, Math.ceil(max / 500) * 500);
+      priceRange.max = String(normalizedMax);
+      priceRange.value = String(normalizedMax);
+      updatePriceRangeDisplay();
+    }
+  }
+}
+
 function populateFilters(products) {
   const localeCompare = (a, b) => a.localeCompare(b, "es", { sensitivity: "base" });
   const brands = new Map();
@@ -440,6 +478,9 @@ function resetAllFilters() {
   if (modelFilter) modelFilter.value = "";
   if (categoryFilter) categoryFilter.value = "";
   if (stockFilter) stockFilter.value = "";
+  if (qualityFilter) qualityFilter.value = "";
+  if (colorFilter) colorFilter.value = "";
+  if (frameFilter) frameFilter.value = "";
   if (sortSelect) sortSelect.value = "relevance";
   if (priceRange) {
     priceRange.value = priceRange.max;
@@ -709,6 +750,9 @@ function syncQueryParams(filters) {
   if (filters.model) params.set("model", filters.model);
   if (filters.category) params.set("category", filters.category);
   if (filters.stock) params.set("stock", filters.stock);
+  if (filters.quality) params.set("quality_tier", filters.quality);
+  if (filters.color) params.set("color", filters.color);
+  if (filters.hasFrame) params.set("has_frame", filters.hasFrame);
   if (filters.priceActive && filters.price) params.set("price_max", String(filters.price));
   if (filters.sort && filters.sort !== "relevance") params.set("sort", filters.sort);
   if (SEARCH_DEBUG) params.set("debugSearch", "1");
@@ -724,13 +768,16 @@ function updateActiveFilters(filters) {
     ["Marca", filters.brand],
     ["Modelo", filters.model],
     ["Tipo", filters.category],
+    ["Calidad", filters.quality],
+    ["Color", filters.color],
+    ["Marco", filters.hasFrame === "true" || filters.hasFrame === "1" ? "Con marco" : filters.hasFrame === "false" || filters.hasFrame === "0" ? "Sin marco" : ""],
     ["Stock",
-      filters.stock === "in-stock"
-        ? "Solo con stock"
-        : filters.stock === "physical"
-          ? "Stock físico"
-          : filters.stock === "remote"
-            ? "Stock remoto"
+      filters.stock === "in_stock"
+        ? "Stock real"
+        : filters.stock === "preorder"
+          ? "A pedido"
+          : filters.stock === "out_of_stock"
+            ? "Sin stock"
             : ""],
     ["Precio ≤", filters.priceActive ? formatCurrency(filters.price) : ""],
   ];
@@ -748,11 +795,14 @@ function getCurrentFilters() {
   const model = modelFilter?.value || "";
   const category = categoryFilter?.value || "";
   const stock = stockFilter?.value || "";
+  const quality = qualityFilter?.value || "";
+  const color = colorFilter?.value || "";
+  const hasFrame = frameFilter?.value || "";
   const sort = sortSelect?.value || "relevance";
   const price = Number(priceRange?.value) || 0;
   const priceMax = Number(priceRange?.max) || 0;
   const priceActive = priceFilterTouched && priceMax > 0 && price < priceMax;
-  return { search, brand, model, category, stock, sort, price, priceActive };
+  return { search, brand, model, category, stock, quality, color, hasFrame, sort, price, priceActive };
 }
 
 function mapSortForBackend(sortValue) {
@@ -761,6 +811,7 @@ function mapSortForBackend(sortValue) {
     price_desc: "price_desc",
     name_asc: "name_asc",
     name_desc: "name_desc",
+    stock_real: "stock_real",
     stock_desc: "stock_desc",
     stock_asc: "stock_asc",
     "price-asc": "price_asc",
@@ -882,7 +933,14 @@ async function renderProducts({ page = currentProductsPage, scrollToTop = false 
     category: filters.category,
     brand: filters.brand,
     model: filters.model,
+    part_type: filters.category,
+    device_brand: filters.brand,
+    model_base: filters.model,
     stock: filters.stock,
+    stock_status: filters.stock,
+    quality_tier: filters.quality,
+    color: filters.color,
+    has_frame: filters.hasFrame,
     price_max: filters.priceActive ? filters.price : "",
     sort: mapSortForBackend(filters.sort),
   };
@@ -954,7 +1012,7 @@ async function renderProducts({ page = currentProductsPage, scrollToTop = false 
     shopLog("response:ignored-fallback-after-real", { requestId });
     return;
   }
-  if (response?.source !== "sqlite") {
+  if (response?.source !== "sqlite" && response?.source !== "sqlite_search_index") {
     console.warn("[shop-products] backend did not use sqlite", response?.source);
   }
 
@@ -962,7 +1020,7 @@ async function renderProducts({ page = currentProductsPage, scrollToTop = false 
     .map(normalizeStorefrontProduct)
     .map(sanitizePublicProduct)
     .filter(Boolean);
-  const filteredItems = normalizedItems.filter((product) => matchesStockFilter(product, filters.stock));
+  const filteredItems = normalizedItems;
   console.log("[catalog:first-product]", normalizedItems?.[0]);
   console.log("[catalog:first-product-keys]", normalizedItems?.[0] ? Object.keys(normalizedItems[0]) : null);
 
@@ -988,17 +1046,11 @@ async function renderProducts({ page = currentProductsPage, scrollToTop = false 
       : null;
 
   totalFilteredItems = publicProductsTotalItems ?? allProducts.length;
-  if (filters.stock) {
-    totalFilteredItems = allProducts.length;
-    publicProductsTotalItems = null;
-    publicProductsTotalPages = null;
-    publicProductsHasNextPage = false;
-    publicProductsHasPrevPage = currentProductsPage > 1;
-  }
+  applyFacets(response.facets || {});
   productGrid.innerHTML = "";
   console.info("[shop-products] render start");
   if (!allProducts.length) {
-    productGrid.innerHTML = "<p>No encontramos productos para esos filtros.</p>";
+    productGrid.innerHTML = '<p>No encontramos exactamente ese repuesto. Probá buscar por modelo, código o escribinos por WhatsApp.</p>';
   } else {
     allProducts.forEach((product) => productGrid.appendChild(createProductCard(product)));
   }
@@ -1069,9 +1121,12 @@ function applyInitialFilters() {
   updateModelOptions(brandFilter?.value || "");
   if (modelFilter && params.get("model")) modelFilter.value = params.get("model");
   if (categoryFilter && params.get("category")) categoryFilter.value = params.get("category");
+  if (qualityFilter && params.get("quality_tier")) qualityFilter.value = params.get("quality_tier");
+  if (colorFilter && params.get("color")) colorFilter.value = params.get("color");
+  if (frameFilter && params.get("has_frame")) frameFilter.value = params.get("has_frame");
   if (stockFilter) {
     const stockParam = params.get("stock");
-    if (["in-stock", "physical", "remote"].includes(stockParam)) {
+    if (["in_stock", "preorder", "out_of_stock", "in-stock", "physical", "remote"].includes(stockParam)) {
       stockFilter.value = stockParam;
     }
   }
@@ -1166,6 +1221,12 @@ async function initShop() {
     stockFilter?.addEventListener("change", () => {
       currentProductsPage = 1;
       safelyRenderProducts({ page: 1 });
+    });
+    [qualityFilter, colorFilter, frameFilter].forEach((select) => {
+      select?.addEventListener("change", () => {
+        currentProductsPage = 1;
+        safelyRenderProducts({ page: 1 });
+      });
     });
     sortSelect?.addEventListener("change", () => {
       currentProductsPage = 1;

--- a/nerin_final_updated/frontend/shop.html
+++ b/nerin_final_updated/frontend/shop.html
@@ -227,9 +227,29 @@
             <label for="stockFilter">Disponibilidad</label>
             <select id="stockFilter">
               <option value="">Todo el catálogo</option>
-              <option value="in-stock">Solo con stock</option>
-              <option value="physical">Stock físico inmediato</option>
-              <option value="remote">Stock remoto (a pedido)</option>
+              <option value="in_stock">Stock real</option>
+              <option value="preorder">A pedido</option>
+              <option value="out_of_stock">Sin stock</option>
+            </select>
+          </div>
+          <div class="filter-block">
+            <label for="qualityFilter">Calidad</label>
+            <select id="qualityFilter">
+              <option value="">Todas las calidades</option>
+            </select>
+          </div>
+          <div class="filter-block">
+            <label for="colorFilter">Color</label>
+            <select id="colorFilter">
+              <option value="">Todos los colores</option>
+            </select>
+          </div>
+          <div class="filter-block">
+            <label for="frameFilter">Marco</label>
+            <select id="frameFilter">
+              <option value="">Con o sin marco</option>
+              <option value="true">Con marco</option>
+              <option value="false">Sin marco</option>
             </select>
           </div>
           <div class="filter-block">
@@ -254,6 +274,7 @@
               <label for="sortSelect" class="visually-hidden">Ordenar</label>
               <select id="sortSelect">
                 <option value="relevance">Orden recomendado</option>
+                <option value="stock_real">Stock real primero</option>
                 <option value="price_asc">Precio: menor a mayor</option>
                 <option value="price_desc">Precio: mayor a menor</option>
                 <option value="name_asc">Nombre: A → Z</option>

--- a/nerin_final_updated/scripts/audit-catalog-classification.js
+++ b/nerin_final_updated/scripts/audit-catalog-classification.js
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const sqlite3 = require("sqlite3");
+const productsSqliteRepo = require("../backend/data/productsSqliteRepo");
+
+const root = path.resolve(__dirname, "..");
+const exportDir = path.join(root, "exports");
+const csvPath = path.join(exportDir, "catalog-classification-audit.csv");
+
+function openDb(filePath) {
+  return new Promise((resolve, reject) => {
+    const db = new sqlite3.Database(filePath, sqlite3.OPEN_READONLY, (error) => {
+      if (error) reject(error);
+      else resolve(db);
+    });
+  });
+}
+
+function all(db, sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.all(sql, params, (error, rows) => (error ? reject(error) : resolve(rows || [])));
+  });
+}
+
+function closeDb(db) {
+  return new Promise((resolve) => db.close(() => resolve()));
+}
+
+function pct(part, total) {
+  return total > 0 ? Number(((part / total) * 100).toFixed(2)) : 0;
+}
+
+function csvEscape(value) {
+  return `"${String(value ?? "").replace(/"/g, '""')}"`;
+}
+
+function topCounts(rows, key, limit = 12) {
+  return rows
+    .filter((row) => row[key])
+    .sort((a, b) => Number(b.count || 0) - Number(a.count || 0))
+    .slice(0, limit);
+}
+
+async function main() {
+  await productsSqliteRepo.ensureProductsDbOnce();
+  const db = await openDb(productsSqliteRepo.SQLITE_PATH);
+  try {
+    const total = (await all(db, "SELECT COUNT(*) AS count FROM product_search_index WHERE is_public = 1"))[0]?.count || 0;
+    const stats = (await all(db, `SELECT
+      SUM(CASE WHEN part_type != '' THEN 1 ELSE 0 END) AS partType,
+      SUM(CASE WHEN device_brand != '' THEN 1 ELSE 0 END) AS brand,
+      SUM(CASE WHEN model_base != '' THEN 1 ELSE 0 END) AS model,
+      SUM(CASE WHEN quality_tier != '' THEN 1 ELSE 0 END) AS quality,
+      SUM(CASE WHEN color != '' THEN 1 ELSE 0 END) AS color,
+      SUM(CASE WHEN classification_confidence < 0.55 THEN 1 ELSE 0 END) AS lowConfidence
+      FROM product_search_index WHERE is_public = 1`))[0] || {};
+    const missing = await all(db, `SELECT product_id, sku, title, public_slug, part_type, device_brand, model_base, model_variant, quality_tier, color, has_frame, stock_status, classification_confidence, filters_blob
+      FROM product_search_index
+      WHERE is_public = 1 AND (part_type = '' OR device_brand = '' OR model_base = '' OR classification_confidence < 0.55)
+      ORDER BY classification_confidence ASC, title ASC LIMIT 50`);
+    const brandCounts = await all(db, "SELECT device_brand AS value, COUNT(*) AS count FROM product_search_index WHERE is_public = 1 AND device_brand != '' GROUP BY device_brand ORDER BY count DESC LIMIT 20");
+    const modelCounts = await all(db, "SELECT model_base AS value, COUNT(*) AS count FROM product_search_index WHERE is_public = 1 AND model_base != '' GROUP BY model_base ORDER BY count DESC LIMIT 20");
+    const partCounts = await all(db, "SELECT part_type AS value, COUNT(*) AS count FROM product_search_index WHERE is_public = 1 AND part_type != '' GROUP BY part_type ORDER BY count DESC LIMIT 20");
+    const examples = await all(db, `SELECT part_type, product_id, sku, title, device_brand, model_base, quality_tier, color, classification_confidence
+      FROM product_search_index WHERE is_public = 1 AND part_type != ''
+      ORDER BY part_type, classification_confidence DESC LIMIT 120`);
+    const csvRows = await all(db, `SELECT product_id, sku, title, public_slug, part_type, device_brand, model_base, model_variant, quality_tier, color, has_frame, stock_status, classification_confidence, filters_blob
+      FROM product_search_index WHERE is_public = 1 ORDER BY product_rowid ASC`);
+    await fs.promises.mkdir(exportDir, { recursive: true });
+    const lines = [
+      ["id", "sku", "title", "public_slug", "part_type", "device_brand", "model_base", "model_variant", "quality_tier", "color", "has_frame", "stock_status", "confidence", "blockers"].join(","),
+      ...csvRows.map((row) => {
+        let blockers = [];
+        try {
+          blockers = JSON.parse(row.filters_blob || "{}").blockers || [];
+        } catch {}
+        return [
+          row.product_id,
+          row.sku,
+          row.title,
+          row.public_slug,
+          row.part_type,
+          row.device_brand,
+          row.model_base,
+          row.model_variant,
+          row.quality_tier,
+          row.color,
+          row.has_frame,
+          row.stock_status,
+          row.classification_confidence,
+          blockers.join("|"),
+        ].map(csvEscape).join(",");
+      }),
+    ];
+    await fs.promises.writeFile(csvPath, `${lines.join("\n")}\n`, "utf8");
+    const report = {
+      totalProducts: Number(total),
+      publicProducts: Number(total),
+      classifiedPartTypePercent: pct(Number(stats.partType || 0), total),
+      brandDetectedPercent: pct(Number(stats.brand || 0), total),
+      modelDetectedPercent: pct(Number(stats.model || 0), total),
+      qualityDetectedPercent: pct(Number(stats.quality || 0), total),
+      colorDetectedPercent: pct(Number(stats.color || 0), total),
+      productsWithoutClassification: missing.length,
+      lowConfidenceCount: Number(stats.lowConfidence || 0),
+      commonBrands: topCounts(brandCounts, "value"),
+      commonModels: topCounts(modelCounts, "value"),
+      commonPartTypes: topCounts(partCounts, "value"),
+      probableErrors: missing.slice(0, 12).map((row) => ({ id: row.product_id, sku: row.sku, title: row.title, confidence: row.classification_confidence })),
+      examplesByCategory: examples.slice(0, 30),
+      csvExport: path.relative(root, csvPath).replace(/\\/g, "/"),
+    };
+    console.log(JSON.stringify(report, null, 2));
+  } finally {
+    await closeDb(db);
+  }
+}
+
+main().catch((error) => {
+  console.error("[audit-catalog-classification]", error?.stack || error?.message || error);
+  process.exit(1);
+});

--- a/nerin_final_updated/scripts/test-catalog-intelligence-search.js
+++ b/nerin_final_updated/scripts/test-catalog-intelligence-search.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("assert/strict");
+const productsSqliteRepo = require("../backend/data/productsSqliteRepo");
+
+function titleOf(item) {
+  return String(item?.title || item?.name || "");
+}
+
+async function firstTitle(query, extra = {}) {
+  const result = await productsSqliteRepo.queryProducts({ page: 1, pageSize: 10, search: query, debugSearch: true, ...extra });
+  assert.ok(result.source === "sqlite_search_index", `${query} debe usar product_search_index`);
+  return { result, title: titleOf(result.items[0]) };
+}
+
+async function main() {
+  await productsSqliteRepo.rebuildProductsDbFromJson({ force: true, reason: "catalog_intelligence_search_test" });
+
+  const pantalla = await firstTitle("pantalla iphone 12");
+  assert.match(pantalla.title, /iphone/i);
+  assert.match(pantalla.title, /12/i);
+  assert.equal(pantalla.result.items[0].part_type, "display");
+  assert.ok(!/mini|pro max/i.test(pantalla.title), "iphone 12 base no debe arrancar con mini/pro max");
+
+  const display = await firstTitle("display iphone 12");
+  assert.equal(display.result.items[0].part_type, "display");
+
+  const modulo = await firstTitle("modulo iphone 12");
+  assert.equal(modulo.result.items[0].part_type, "display");
+
+  const bateria = await firstTitle("bateria iphone 12");
+  assert.equal(bateria.result.items[0].part_type, "battery");
+
+  const samsungA16 = await firstTitle("display samsung a16 4g");
+  assert.match(samsungA16.title, /a16/i);
+  assert.equal(samsungA16.result.items[0].network_variant, "4g");
+
+  const displayFilter = await productsSqliteRepo.queryProducts({ page: 1, pageSize: 20, partType: "display" });
+  assert.ok(displayFilter.items.length > 0, "filtro display debe devolver resultados");
+  assert.ok(displayFilter.items.every((item) => item.part_type === "display"), "part_type=display solo devuelve displays");
+
+  const stockFilter = await productsSqliteRepo.queryProducts({ page: 1, pageSize: 20, stockStatus: "in_stock" });
+  assert.ok(stockFilter.items.length > 0, "filtro stock real debe devolver resultados");
+  assert.ok(stockFilter.items.every((item) => item.is_stock_real === true), "stock_status=in_stock solo devuelve stock real");
+
+  const samsungFilter = await productsSqliteRepo.queryProducts({ page: 1, pageSize: 20, deviceBrand: "Samsung" });
+  assert.ok(samsungFilter.items.length > 0, "filtro Samsung debe devolver resultados");
+  assert.ok(samsungFilter.items.every((item) => item.device_brand === "Samsung" || item.compatible_brand === "Samsung"), "device_brand=Samsung respeta marca/compatibilidad");
+
+  const modelFilter = await productsSqliteRepo.queryProducts({ page: 1, pageSize: 20, modelBase: "iPhone 12" });
+  assert.ok(modelFilter.items.length > 0, "filtro iPhone 12 debe devolver resultados");
+  assert.ok(modelFilter.items.every((item) => item.model_base === "iPhone 12"), "model_base=iPhone 12 no devuelve otros modelos");
+
+  const frameFilter = await productsSqliteRepo.queryProducts({ page: 1, pageSize: 20, partType: "display", hasFrame: "true" });
+  assert.ok(frameFilter.items.length > 0, "has_frame=true debe devolver displays con marco en fixtures");
+  assert.ok(frameFilter.items.every((item) => item.has_frame === true), "has_frame=true solo devuelve productos con marco");
+
+  const noCrashQueries = [
+    "pin de carga samsung a54",
+    "display samsung a15 5g",
+    "tapa honor 200",
+    "sim tray iphone 15 pro",
+    "camara iphone 15 pro max",
+    "adhesivo pantalla iphone 16",
+    "macbook air 13 2020 display",
+  ];
+  for (const query of noCrashQueries) {
+    const result = await productsSqliteRepo.queryProducts({ page: 1, pageSize: 10, search: query, debugSearch: true });
+    assert.ok(result.facets && typeof result.facets === "object", `${query} debe devolver facets`);
+    assert.ok(result.searchDebug?.engine === "product_search_index", `${query} debe devolver debug avanzado`);
+  }
+
+  console.log(JSON.stringify({
+    ok: true,
+    examples: {
+      pantalla_iphone_12: pantalla.result.searchDebug.results.slice(0, 3),
+      bateria_iphone_12: bateria.result.searchDebug.results.slice(0, 3),
+      display_samsung_a16_4g: samsungA16.result.searchDebug.results.slice(0, 3),
+    },
+    facets: pantalla.result.facets,
+  }, null, 2));
+}
+
+main().catch((error) => {
+  console.error("[test-catalog-intelligence-search]", error?.stack || error?.message || error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add a structured catalog classifier for part type, device brand, model/variant/network, quality, frame, color, stock status, and compatible-vs-official brand signals.
- Persist the classification in SQLite through `product_search_index`, with indexed fields and search/facet blobs rebuilt alongside `products.sqlite`.
- Move public product search to the structured index, returning real facets and debug scoring reasons from `/api/products` and `/api/search`.
- Update shop filters to use backend facets for part type, brand, model, stock status, quality, color, frame, price range, and stock-real sorting.
- Add classification/search audit and deterministic tests.

## Architecture
- Classifier: `backend/utils/catalogClassifier.js` normalizes Argentine Spanish/English repair terms and extracts structured product facts.
- Index: `backend/data/productsSqliteRepo.js` creates and rebuilds `product_search_index` with SQLite indexes for scalable filtering.
- Search: public queries score structured matches first: exact model, variant, part type, stock real, device brand, SKU/MPN, quality, color, frame, image, and price.
- Facets: API responses include real `part_type`, `device_brand`, `model_base`, `quality_tier`, `color`, `has_frame`, `stock_status`, and `price_range` facets.
- Debug: `debugSearch=1` now exposes query intent, inferred filters, top ranking reasons, penalties, and indexed structured fields.

## Validation
- `node --check backend/utils/catalogClassifier.js`
- `node --check backend/data/productsSqliteRepo.js`
- `node --check backend/server.js`
- `node --check frontend/js/shop.js`
- `node --check scripts/audit-catalog-classification.js`
- `node --check scripts/test-catalog-intelligence-search.js`
- `npx jest __tests__/backend/catalog-classifier.test.js --runInBand`
- `node scripts/test-catalog-intelligence-search.js`
- `node scripts/audit-catalog-classification.js`

## Search examples from local deterministic fixture
- `pantalla iphone 12` ranks `Pantalla iPhone 12` first with model exact, variant exact, type display, Apple, stock real, image, and price boosts.
- `bateria iphone 12` ranks `Bateria iPhone 12` first and penalizes the display as wrong part type.
- `display samsung a16 4g` ranks `Pantalla Samsung Galaxy A16 4G...` first with exact model/network/type/brand and stock-real boosts.

## Audit output
Local fixture audit: 6 total/public products, 100% classified by part type, 100% brand detected, 100% model detected, 0 low-confidence products, CSV exported to `exports/catalog-classification-audit.csv`.

## Not touched
- Mercado Pago
- webhooks
- inventory mutation logic
- orders mutation logic
- base prices
- critical checkout flow
- real Andreani integration