### PR TITLE
Harden catalog classifier coverage and unify admin search

### DIFF
--- a/nerin_final_updated/__tests__/backend/catalog-classifier.test.js
+++ b/nerin_final_updated/__tests__/backend/catalog-classifier.test.js
@@ -10,6 +10,15 @@ describe("catalogClassifier", () => {
     ["Back Glass Gold Huawei Mate 10 Lite", { part_type: "back_cover", device_brand: "Huawei", model_base: "Huawei Mate 10 Lite", model_variant: "lite", color: "gold" }],
     ["Flex Cable Rear Camera for iPhone 15 Pro Max", { part_type: "flex", device_brand: "Apple", model_base: "iPhone 15 Pro Max", model_variant: "pro max" }],
     ["Antenna GPS Compatible for iPhone 17 Air", { part_type: "antenna", device_brand: "Apple", model_base: "iPhone 17 Air", model_variant: "air", compatible_brand: "Apple" }],
+    ["Display Original Black Google Pixel 7 Pro", { part_type: "display", device_brand: "Google", model_family: "Pixel", model_base: "Pixel 7 Pro", model_generation: "7", model_variant: "pro", quality_tier: "original", color: "black" }],
+    ["Battery Compatible for Google Pixel 6a", { part_type: "battery", device_brand: "Google", compatible_brand: "Google", is_compatible_for_brand: true, official_brand: "", model_family: "Pixel", model_base: "Pixel 6a", model_generation: "6", model_variant: "a", quality_tier: "compatible" }],
+    ["Back Cover for Pixel 8 Pro", { part_type: "back_cover", device_brand: "Google", compatible_brand: "Google", model_base: "Pixel 8 Pro", model_variant: "pro" }],
+    ["Camera Lens Google Pixel 7", { part_type: "camera_lens", device_brand: "Google", model_base: "Pixel 7", model_variant: "base" }],
+    ["Charging Board for Google Pixel 6", { part_type: "charging_board", device_brand: "Google", compatible_brand: "Google", model_base: "Pixel 6", model_variant: "base" }],
+    ["Display Adhesive Tape for iPhone 16", { part_type: "display_adhesive", device_brand: "Apple", model_base: "iPhone 16" }],
+    ["Bracket Display Galaxy XCover6 Pro", { part_type: "bracket", device_brand: "Samsung", model_base: "Galaxy XCover6 Pro", model_variant: "pro" }],
+    ["Camera Lens for iPhone 12", { part_type: "camera_lens", device_brand: "Apple", model_base: "iPhone 12" }],
+    ["GPS Antenna Compatible for iPhone 17 Air", { part_type: "antenna", device_brand: "Apple", model_base: "iPhone 17 Air", model_variant: "air" }],
   ])("classifies %s", (title, expected) => {
     const result = classifyCatalogProduct({ title, name: title });
     Object.entries(expected).forEach(([key, value]) => {
@@ -38,6 +47,13 @@ describe("catalogClassifier", () => {
     expect(parseCatalogQuery("iphone 12 pro max display")).toMatchObject({
       model_base: "iPhone 12 Pro Max",
       model_variant: "pro max",
+    });
+    expect(parseCatalogQuery("pixel 7 display")).toMatchObject({
+      part_type: "display",
+      device_brand: "Google",
+      model_family: "Pixel",
+      model_base: "Pixel 7",
+      model_variant: "base",
     });
   });
 });

--- a/nerin_final_updated/backend/data/productsSqliteRepo.js
+++ b/nerin_final_updated/backend/data/productsSqliteRepo.js
@@ -17,7 +17,7 @@ const MANIFEST_PATH = dataPath("products.manifest.json");
 const OVERRIDES_PATH = dataPath("products.overrides.json");
 const COUNT_CACHE_TTL_MS = 60_000;
 const PRODUCTS_SQLITE_SCHEMA_VERSION = 6;
-const CATALOG_MAPPING_VERSION = 3;
+const CATALOG_MAPPING_VERSION = 4;
 const BULK_PUBLISH_CHUNK_SIZE = 1000;
 const SEARCH_RANK_CANDIDATE_LIMIT = 1200;
 
@@ -2587,6 +2587,12 @@ function buildWhereClause({
 function buildProductSummary(row = {}) {
   const publicSlug = firstText([row.public_slug, row.slug]) || "";
   const fallbackId = String(row.id || row.sku || row.code || "producto");
+  let filters = {};
+  try {
+    filters = JSON.parse(row.filters_blob || "{}") || {};
+  } catch {
+    filters = {};
+  }
   return {
     id: firstText([row.id]) || "",
     sku: firstText([row.sku]) || "",
@@ -2630,6 +2636,8 @@ function buildProductSummary(row = {}) {
     stock_status: row.stock_status || "",
     is_stock_real: Boolean(row.is_stock_real),
     classification_confidence: toFiniteNumberOrNull(row.classification_confidence),
+    classification_blockers: Array.isArray(filters.blockers) ? filters.blockers : [],
+    classification_reasons: Array.isArray(filters.reasons) ? filters.reasons : [],
   };
 }
 
@@ -2652,15 +2660,55 @@ function buildSearchIndexWhere({
   color = "",
   hasFrame = "",
   stockStatus = "",
+  visibility = "",
+  status = "",
+  missingImage = "",
+  missingPrice = "",
+  lowConfidence = "",
+  missingModel = "",
+  missingBrand = "",
+  missingPartType = "",
 } = {}) {
   const intent = parseCatalogQuery(search || "");
   const where = [];
   const params = [];
   if (isPublicOnly) where.push("si.is_public = 1");
-  const requestedPartType = normalizeFacetValue(partType || category || "");
+  const requestedVisibility = normalizeFacetValue(visibility || "");
+  if (requestedVisibility) {
+    if (requestedVisibility === "public") where.push("si.is_public = 1");
+    else if (requestedVisibility === "private" || requestedVisibility === "hidden") {
+      where.push("(si.is_public = 0 OR lower(p.visibility) = lower(?))");
+      params.push(requestedVisibility);
+    } else {
+      where.push("lower(p.visibility) = lower(?)");
+      params.push(requestedVisibility);
+    }
+  }
+  const requestedStatus = normalizeFacetValue(status || "");
+  if (requestedStatus) {
+    where.push("lower(p.status) = lower(?)");
+    params.push(requestedStatus);
+  }
+  if (String(missingImage) === "1" || String(missingImage) === "true") where.push("si.has_image = 0");
+  if (String(missingPrice) === "1" || String(missingPrice) === "true") where.push("(si.price IS NULL OR si.price <= 0)");
+  if (String(lowConfidence) === "1" || String(lowConfidence) === "true") where.push("si.classification_confidence < 0.55");
+  if (String(missingModel) === "1" || String(missingModel) === "true") where.push("(si.model_base IS NULL OR si.model_base = '')");
+  if (String(missingBrand) === "1" || String(missingBrand) === "true") where.push("(si.device_brand IS NULL OR si.device_brand = '')");
+  if (String(missingPartType) === "1" || String(missingPartType) === "true") where.push("(si.part_type IS NULL OR si.part_type = '')");
+  const requestedPartType = normalizeFacetValue(partType || "");
   if (requestedPartType) {
     where.push("si.part_type = ?");
     params.push(requestedPartType);
+  }
+  const requestedCategory = normalizeFacetValue(category || "");
+  if (requestedCategory && !requestedPartType) {
+    if (PART_LABELS[requestedCategory]) {
+      where.push("si.part_type = ?");
+      params.push(requestedCategory);
+    } else {
+      where.push("lower(p.category) = lower(?)");
+      params.push(category);
+    }
   }
   const requestedBrand = normalizeFacetValue(deviceBrand || brand || "");
   if (requestedBrand) {
@@ -2692,6 +2740,8 @@ function buildSearchIndexWhere({
   const requestedStock = normalizeFacetValue(stockStatus || stock || "");
   if (requestedStock === "in_stock" || requestedStock === "stock-real" || requestedStock === "in-stock" || requestedStock === "physical") {
     where.push("si.is_stock_real = 1");
+  } else if (requestedStock === "low") {
+    where.push("si.stock > 0 AND si.stock <= 5");
   } else if (requestedStock === "preorder" || requestedStock === "backorder" || requestedStock === "remote") {
     where.push("si.stock_status = 'preorder'");
   } else if (requestedStock === "out_of_stock" || requestedStock === "out" || requestedStock === "sin-stock") {
@@ -2741,6 +2791,9 @@ function scoreSearchIndexRow(row = {}, intent = {}) {
   const queryVariant = normalizeFacetValue(intent.model_variant || "");
   const rowNetwork = normalizeFacetValue(row.network_variant || "");
   const queryNetwork = normalizeFacetValue(intent.network_variant || "");
+  const queryText = normalizeFacetValue(intent.normalized_query || intent.original_query || "");
+  const identifiers = [row.sku, row.mpn, row.part_number, row.product_id, row.public_slug, row.id, row.code].map(normalizeFacetValue).filter(Boolean);
+  if (queryText && identifiers.includes(queryText)) addStructuredReason(entry, "SKU/MPN/slug exacto", 2600);
   if (intent.model_code && blob.includes(normalizeFacetValue(intent.model_code))) addStructuredReason(entry, "SKU/MPN/model code exacto", 800);
   if (queryModel && rowModel === queryModel) addStructuredReason(entry, "modelo exacto estructurado", 3000);
   else if (intent.model_generation && row.model_generation === intent.model_generation && row.model_family === intent.model_family) addStructuredReason(entry, "generacion/familia modelo", 900);
@@ -2808,19 +2861,46 @@ function facetLabel(group, value) {
     .replace(/\bMacbook\b/g, "MacBook");
 }
 
-async function buildSearchFacets(db, whereClause) {
+async function buildSearchFacets(db, whereClause, options = {}) {
   const groups = ["part_type", "device_brand", "model_base", "quality_tier", "color", "has_frame", "stock_status"];
   const facets = {};
   for (const group of groups) {
     const prefix = whereClause.sql ? `${whereClause.sql} AND` : "WHERE";
     const rows = await all(
       db,
-      `SELECT ${group} AS value, COUNT(*) AS count FROM product_search_index si ${prefix} ${group} IS NOT NULL AND ${group} != '' GROUP BY ${group} ORDER BY count DESC, value ASC LIMIT ${group === "model_base" ? 40 : 20}`,
+      `SELECT si.${group} AS value, COUNT(*) AS count FROM product_search_index si JOIN products p ON p.rowid = si.product_rowid ${prefix} si.${group} IS NOT NULL AND si.${group} != '' GROUP BY si.${group} ORDER BY count DESC, value ASC LIMIT ${group === "model_base" ? 40 : 20}`,
       whereClause.params,
     );
     facets[group] = rows.map((row) => ({ value: String(row.value), label: facetLabel(group, row.value), count: Number(row.count || 0) }));
   }
-  const priceRow = await get(db, `SELECT MIN(price) AS min, MAX(price) AS max FROM product_search_index si ${whereClause.sql}`, whereClause.params);
+  if (options.adminMode) {
+    const adminGroups = [
+      { key: "visibility", expr: "COALESCE(NULLIF(p.visibility, ''), CASE WHEN si.is_public = 1 THEN 'public' ELSE 'private' END)" },
+      { key: "status", expr: "COALESCE(NULLIF(p.status, ''), 'unknown')" },
+    ];
+    for (const group of adminGroups) {
+      const rows = await all(
+        db,
+        `SELECT ${group.expr} AS value, COUNT(*) AS count FROM product_search_index si JOIN products p ON p.rowid = si.product_rowid ${whereClause.sql} GROUP BY value ORDER BY count DESC, value ASC LIMIT 20`,
+        whereClause.params,
+      );
+      facets[group.key] = rows.map((row) => ({ value: String(row.value), label: facetLabel(group.key, row.value), count: Number(row.count || 0) }));
+    }
+    const issueRows = await all(
+      db,
+      `SELECT
+        SUM(CASE WHEN si.has_image = 0 THEN 1 ELSE 0 END) AS missing_image,
+        SUM(CASE WHEN si.price IS NULL OR si.price <= 0 THEN 1 ELSE 0 END) AS missing_price,
+        SUM(CASE WHEN si.classification_confidence < 0.55 THEN 1 ELSE 0 END) AS low_confidence,
+        SUM(CASE WHEN si.model_base IS NULL OR si.model_base = '' THEN 1 ELSE 0 END) AS missing_model,
+        SUM(CASE WHEN si.device_brand IS NULL OR si.device_brand = '' THEN 1 ELSE 0 END) AS missing_brand,
+        SUM(CASE WHEN si.part_type IS NULL OR si.part_type = '' THEN 1 ELSE 0 END) AS missing_part_type
+       FROM product_search_index si JOIN products p ON p.rowid = si.product_rowid ${whereClause.sql}`,
+      whereClause.params,
+    );
+    facets.issues = issueRows[0] || {};
+  }
+  const priceRow = await get(db, `SELECT MIN(si.price) AS min, MAX(si.price) AS max FROM product_search_index si JOIN products p ON p.rowid = si.product_rowid ${whereClause.sql}`, whereClause.params);
   facets.price_range = {
     min: Number(priceRow?.min || 0),
     max: Number(priceRow?.max || 0),
@@ -2836,7 +2916,7 @@ async function querySearchIndex(params = {}) {
   const offset = (safePage - 1) * safePageSize;
   const whereClause = buildSearchIndexWhere(params);
   const countStartedAt = Date.now();
-  const totalRow = await get(db, `SELECT COUNT(*) AS totalItems FROM product_search_index si ${whereClause.sql}`, whereClause.params);
+  const totalRow = await get(db, `SELECT COUNT(*) AS totalItems FROM product_search_index si JOIN products p ON p.rowid = si.product_rowid ${whereClause.sql}`, whereClause.params);
   const totalItems = Number(totalRow?.totalItems || 0);
   const countMs = Date.now() - countStartedAt;
   const selectStartedAt = Date.now();
@@ -2844,6 +2924,8 @@ async function querySearchIndex(params = {}) {
   const candidateLimit = hasSearch ? Math.max(safePageSize, Math.min(SEARCH_RANK_CANDIDATE_LIMIT, totalItems || SEARCH_RANK_CANDIDATE_LIMIT)) : safePageSize;
   const candidateOffset = hasSearch ? 0 : offset;
   const orderBy =
+    params.sort === "recent" ? "si.product_rowid DESC" :
+    params.sort === "stock" || params.sort === "stock_desc" ? "si.stock DESC, si.title ASC" :
     params.sort === "price_asc" ? "si.price ASC, si.title ASC" :
     params.sort === "price_desc" ? "si.price DESC, si.title ASC" :
     params.sort === "name_desc" ? "si.title DESC" :
@@ -2867,10 +2949,10 @@ async function querySearchIndex(params = {}) {
   const pageEntries = hasSearch ? ranked.slice(offset, offset + safePageSize) : ranked;
   const rows = pageEntries.map((entry) => entry.row);
   const items = rows.map((row) => buildProductSummary(row));
-  const facets = await buildSearchFacets(db, whereClause);
+  const facets = await buildSearchFacets(db, whereClause, { adminMode: Boolean(params.adminMode) });
   const selectMs = Date.now() - selectStartedAt;
   const searchDebug = params.debugSearch ? {
-    engine: "product_search_index",
+    engine: params.adminMode ? "product_search_index_admin" : "product_search_index",
     queryOriginal: params.search || "",
     queryNormalized: whereClause.intent.normalized_query || "",
     intent: whereClause.intent,
@@ -2920,7 +3002,7 @@ async function querySearchIndex(params = {}) {
     totalPages,
     hasNextPage: safePage < totalPages,
     hasPrevPage: safePage > 1,
-    source: "sqlite_search_index",
+    source: params.adminMode ? "sqlite_search_index_admin" : "sqlite_search_index",
     search: params.search || undefined,
     facets,
     searchDebug,
@@ -3079,12 +3161,12 @@ async function queryProducts(params = {}) {
 async function queryAdminProducts(params = {}) {
   let result;
   try {
-    result = await queryBase({ ...params, isPublicOnly: false });
+    result = await querySearchIndex({ ...params, isPublicOnly: false, adminMode: true });
   } catch (error) {
     if (isSqliteCorruptionError(error)) {
       markSqliteCorruption(error, { phase: "query_admin_products", reason: "sqlite_corrupt" });
       await repairCorruptSqlite({ reason: "query_admin_products_corrupt" });
-      result = await queryBase({ ...params, isPublicOnly: false });
+      result = await querySearchIndex({ ...params, isPublicOnly: false, adminMode: true });
     } else {
       throw error;
     }

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -7378,7 +7378,7 @@ async function requestHandler(req, res) {
     return sendJson(res, 200, buildMockAndreaniQuote(req.body || {}));
   }
 
-  if (pathname === "/api/admin/products" && req.method === "GET") {
+  if ((pathname === "/api/admin/products" || pathname === "/api/admin/products/search") && req.method === "GET") {
     if (!requireAdmin(req, res)) return;
     registerProductsTraffic("admin");
     try {
@@ -7400,6 +7400,11 @@ async function requestHandler(req, res) {
           visibility: queryParams.visibility || "",
           status: queryParams.status || "",
           stock: queryParams.stockStatus || queryParams.stock || "",
+          partType: queryParams.part_type || queryParams.partType || "",
+          deviceBrand: queryParams.device_brand || queryParams.deviceBrand || "",
+          modelBase: queryParams.model_base || queryParams.modelBase || "",
+          lowConfidence: queryParams.low_confidence || queryParams.lowConfidence || "",
+          missingModel: queryParams.missing_model || queryParams.missingModel || "",
         },
       });
       const sqliteData = await productsSqliteRepo.queryAdminProducts({
@@ -7408,15 +7413,30 @@ async function requestHandler(req, res) {
         search: queryParams.search || queryParams.q || "",
         category: queryParams.category || "",
         brand: queryParams.brand || "",
+        model: queryParams.model || "",
+        partType: queryParams.part_type || queryParams.partType || "",
+        deviceBrand: queryParams.device_brand || queryParams.deviceBrand || "",
+        modelBase: queryParams.model_base || queryParams.modelBase || "",
+        qualityTier: queryParams.quality_tier || queryParams.qualityTier || "",
+        color: queryParams.color || "",
+        hasFrame: queryParams.has_frame ?? queryParams.hasFrame ?? "",
         visibility: queryParams.visibility || "",
         status: queryParams.status || "",
         stock: queryParams.stockStatus || queryParams.stock || "",
+        stockStatus: queryParams.stock_status || queryParams.stockStatus || "",
+        missingImage: queryParams.missing_image || queryParams.missingImage || "",
+        missingPrice: queryParams.missing_price || queryParams.missingPrice || "",
+        lowConfidence: queryParams.low_confidence || queryParams.lowConfidence || "",
+        missingModel: queryParams.missing_model || queryParams.missingModel || "",
+        missingBrand: queryParams.missing_brand || queryParams.missingBrand || "",
+        missingPartType: queryParams.missing_part_type || queryParams.missingPartType || "",
+        debugSearch: queryParams.debug === "1" || queryParams.debugSearch === "1",
         sort: queryParams.sort || "",
       });
       const responsePayload = {
         ...sqliteData,
         items: sqliteData.items.map((item) => normalizeProductImages(item)),
-        source: "sqlite",
+        source: sqliteData.source || "sqlite_search_index_admin",
       };
       const durationMs = Date.now() - startedAt;
       console.info("[admin-products:respond]", {
@@ -7447,6 +7467,51 @@ async function requestHandler(req, res) {
         source: "sqlite",
         error: err?.message || "Catálogo SQLite no disponible",
         catalogState,
+      });
+    }
+  }
+
+  if (pathname === "/api/admin/catalog-classification/debug" && req.method === "GET") {
+    if (!requireAdmin(req, res)) return;
+    try {
+      const query = String(parsedUrl.query?.query || parsedUrl.query?.q || "").trim();
+      const data = await productsSqliteRepo.queryAdminProducts({
+        page: 1,
+        pageSize: 20,
+        search: query,
+        debugSearch: true,
+      });
+      return sendJson(res, 200, {
+        ok: true,
+        query,
+        source: data.source,
+        totalItems: data.totalItems,
+        facets: data.facets,
+        debug: data.searchDebug,
+        examples: data.items.map((item) => ({
+          id: item.id,
+          sku: item.sku,
+          title: item.title || item.name,
+          part_type: item.part_type,
+          device_brand: item.device_brand,
+          compatible_brand: item.compatible_brand,
+          official_brand: item.official_brand,
+          is_compatible_for_brand: item.is_compatible_for_brand,
+          model_family: item.model_family,
+          model_base: item.model_base,
+          model_variant: item.model_variant,
+          quality_tier: item.quality_tier,
+          color: item.color,
+          stock_status: item.stock_status,
+          classification_confidence: item.classification_confidence,
+          blockers: item.classification_blockers || [],
+        })),
+      }, { "Cache-Control": "no-store, no-cache, must-revalidate" });
+    } catch (error) {
+      return sendJson(res, 500, {
+        ok: false,
+        error: error?.message || "classification_debug_failed",
+        catalogState: productsSqliteRepo.catalogStateSnapshot(),
       });
     }
   }

--- a/nerin_final_updated/backend/utils/catalogClassifier.js
+++ b/nerin_final_updated/backend/utils/catalogClassifier.js
@@ -41,40 +41,75 @@ function unique(values = []) {
 }
 
 const PART_TYPE_DICTIONARY = Object.freeze({
-  charging_board: ["pin de carga", "placa de carga", "puerto de carga", "centro de carga", "conector de carga", "charging board", "charging connector", "charge port", "dock connector", "usb connector", "usb board", "sub board", "daughterboard"],
+  display_adhesive: ["display adhesive tape", "display adhesive", "adhesivo pantalla", "adhesivo de pantalla", "lcd adhesive", "screen adhesive"],
+  back_cover_adhesive: ["rear cover adhesive", "back cover adhesive", "back glass adhesive", "adhesivo tapa", "adhesivo tapa trasera"],
+  battery_adhesive: ["battery adhesive", "battery adhesive tape", "adhesivo bateria", "adhesivo de bateria"],
+  camera_lens: ["camera lens", "camera glass", "lens glass", "lente camara", "lente de camara", "cristal camara", "vidrio camara"],
+  rear_camera: ["rear camera", "main camera", "camara trasera", "camara principal"],
+  front_camera: ["front camera", "selfie camera", "camara frontal", "camara selfie"],
+  charging_board: ["pin de carga", "placa de carga", "centro de carga", "charging board", "usb board", "sub board", "daughterboard"],
+  charging_port: ["puerto de carga", "conector de carga", "charging port", "charging connector", "charge port", "dock connector", "usb connector"],
   sim_tray: ["keyset simcard tray", "bandeja sim", "sim tray", "charola sim", "porta sim", "simcard tray", "card tray"],
-  back_cover: ["tapa trasera", "vidrio trasero", "back glass", "rear cover", "back cover", "battery cover", "housing", "tapa", "carcasa"],
-  adhesive: ["adhesivo pantalla", "display adhesive", "adhesive tape", "rear cover adhesive", "battery adhesive", "adhesivo", "adhesive", "gasket", "seal", "pegamento", "cinta adhesiva", "cinta"],
+  antenna: ["gps antenna", "wifi antenna", "nfc antenna", "antenna", "antena"],
+  bracket: ["bracket display", "display bracket", "camera bracket", "bracket", "soporte"],
+  fingerprint_sensor: ["fingerprint sensor", "sensor huella", "huella digital"],
+  sensor: ["proximity sensor", "light sensor", "sensor proximidad", "sensor"],
+  microphone: ["microphone", "mic", "microfono"],
+  vibrator: ["vibration motor", "motor vibrador", "vibrador"],
+  earpiece: ["ear speaker", "earpiece", "auricular interno", "speaker receiver"],
+  loudspeaker: ["loud speaker", "loudspeaker", "bottom speaker", "parlante", "altavoz"],
+  back_cover: ["tapa trasera", "vidrio trasero", "back glass", "rear cover", "back cover", "battery cover", "tapa"],
+  housing: ["housing", "carcasa", "middle frame housing", "back housing"],
+  frame: ["middle frame", "lcd frame", "display frame", "marco", "frame"],
+  adhesive: ["adhesive tape", "adhesivo", "adhesive", "gasket", "seal", "pegamento", "cinta adhesiva", "cinta"],
+  camera: ["camera", "camara"],
   display: ["display incl frame", "display excl frame", "hard oled", "soft oled", "super amoled", "pantalla", "modulo", "modulo pantalla", "display", "screen", "lcd", "oled", "amoled", "tactil", "touch", "glass", "assembly"],
   battery: ["high capacity", "bateria", "battery", "bateria", "baterias", "pila", "accu", "acumulador"],
-  camera: ["rear camera", "front camera", "camera lens", "lente camara", "camara", "camera", "lens"],
   flex: ["flex cable rear camera", "interconnection flex", "main flex", "cable flex", "flex principal", "flex cable", "flex"],
   speaker: ["loud speaker", "ear speaker", "parlante", "speaker", "loudspeaker", "altavoz", "auricular interno"],
   button: ["power button", "volume button", "slider key", "keyset", "boton", "button", "key"],
-  antenna: ["gps antenna", "antenna", "antena"],
-  bracket: ["bracket", "soporte"],
-  component: ["daughterboard", "sub board", "board", "pcb", "ic", "chip", "componente", "component"],
+  motherboard_component: ["motherboard component", "logic board component", "mainboard component", "componentes electronicos", "ic", "chip", "componente"],
+  component: ["board", "pcb", "component"],
 });
 
 const PART_LABELS = Object.freeze({
   display: "Pantallas",
+  display_adhesive: "Adhesivo de pantalla",
+  back_cover_adhesive: "Adhesivo de tapa",
+  battery_adhesive: "Adhesivo de bateria",
   battery: "Baterias",
   charging_board: "Pin de carga",
+  charging_port: "Puerto de carga",
   back_cover: "Tapas",
+  housing: "Carcasas",
+  frame: "Marcos",
   camera: "Camaras",
+  camera_lens: "Lente de camara",
+  rear_camera: "Camara trasera",
+  front_camera: "Camara frontal",
   flex: "Flex",
   speaker: "Parlantes",
+  earpiece: "Auricular interno",
+  loudspeaker: "Parlante",
   sim_tray: "Bandeja SIM",
   adhesive: "Adhesivos",
   button: "Botones",
+  vibrator: "Vibradores",
+  microphone: "Microfonos",
   antenna: "Antenas",
   bracket: "Soportes",
+  sensor: "Sensores",
+  fingerprint_sensor: "Sensor de huella",
+  motherboard_component: "Componentes de placa",
   component: "Componentes",
 });
 
 const BRAND_PATTERNS = [
   { value: "Apple", aliases: ["apple", "iphone", "ipad", "macbook"] },
   { value: "Samsung", aliases: ["samsung", "galaxy", "sm-"] },
+  { value: "Google", aliases: ["google", "pixel"] },
+  { value: "Nothing", aliases: ["nothing", "nothing phone", "cmf phone"] },
+  { value: "Asus", aliases: ["asus", "zenfone", "rog phone"] },
   { value: "Xiaomi", aliases: ["xiaomi", "redmi", "poco"] },
   { value: "Motorola", aliases: ["motorola", "moto"] },
   { value: "Huawei", aliases: ["huawei"] },
@@ -85,10 +120,21 @@ const BRAND_PATTERNS = [
   { value: "Vivo", aliases: ["vivo"] },
   { value: "Nokia", aliases: ["nokia"] },
   { value: "Sony", aliases: ["sony"] },
+  { value: "TCL", aliases: ["tcl"] },
+  { value: "ZTE", aliases: ["zte", "nubia"] },
+  { value: "Lenovo", aliases: ["lenovo"] },
+  { value: "LG", aliases: ["lg"] },
+  { value: "Meizu", aliases: ["meizu"] },
+  { value: "HTC", aliases: ["htc"] },
+  { value: "Fairphone", aliases: ["fairphone"] },
+  { value: "Tecno", aliases: ["tecno"] },
+  { value: "Infinix", aliases: ["infinix"] },
+  { value: "Alcatel", aliases: ["alcatel"] },
+  { value: "Microsoft", aliases: ["microsoft", "surface"] },
   { value: "Apple Watch", aliases: ["apple watch", "watch"] },
 ];
 
-const VARIANT_TERMS = ["pro max", "pro", "mini", "plus", "ultra", "lite", "air", "base"];
+const VARIANT_TERMS = ["pro max", "pro xl", "pro", "mini", "plus", "ultra", "lite", "air", "fold", "tablet", "base", "a"];
 const NETWORK_VARIANTS = ["5g", "4g"];
 
 const QUALITY_RULES = [
@@ -148,7 +194,9 @@ function detectPartType(text) {
 
 function detectBrand(text, rawBrand = "") {
   const normalizedBrand = normalizeText(rawBrand);
-  const forMatch = text.match(/\bfor\s+(apple|iphone|samsung|galaxy|xiaomi|redmi|poco|huawei|honor|oneplus|oppo|realme|vivo|nokia|sony|motorola|moto)\b/);
+  const forBrand = BRAND_PATTERNS.find((brand) =>
+    brand.aliases.some((alias) => includesPhrase(text, `for ${alias}`) || includesPhrase(text, `compatible for ${alias}`)),
+  );
   let detected = null;
   for (const brand of BRAND_PATTERNS) {
     if (brand.aliases.some((alias) => includesPhrase(text, alias) || normalizedBrand === normalizeText(alias))) {
@@ -156,14 +204,12 @@ function detectBrand(text, rawBrand = "") {
       break;
     }
   }
-  if (!detected && forMatch) {
-    detected = BRAND_PATTERNS.find((brand) => brand.aliases.some((alias) => normalizeText(alias) === forMatch[1] || forMatch[1] === "iphone" && brand.value === "Apple"));
-  }
+  if (!detected && forBrand) detected = forBrand;
   const brandName = detected?.value || "";
-  const isCompatible = Boolean(forMatch || /^\s*for\s+/i.test(String(rawBrand || "")) || includesPhrase(text, "compatible"));
+  const isCompatible = Boolean(forBrand || /^\s*for\s+/i.test(String(rawBrand || "")) || includesPhrase(text, "compatible"));
   return {
     device_brand: brandName,
-    device_brand_confidence: brandName ? (forMatch ? 0.88 : 0.78) : 0,
+    device_brand_confidence: brandName ? (forBrand ? 0.88 : 0.78) : 0,
     compatible_brand: isCompatible ? brandName : "",
     official_brand: !isCompatible && brandName && /\b(original|service pack|genuine|oem)\b/.test(text) ? brandName : "",
     is_compatible_for_brand: isCompatible && Boolean(brandName),
@@ -174,31 +220,181 @@ function titleCaseModel(value = "") {
   return cleanDisplay(value)
     .replace(/\biphone\b/ig, "iPhone")
     .replace(/\bmacbook\b/ig, "MacBook")
+    .replace(/\bipad\b/ig, "iPad")
+    .replace(/\bpixel\b/ig, "Pixel")
+    .replace(/\bnothing\b/ig, "Nothing")
+    .replace(/\bcmf\b/ig, "CMF")
+    .replace(/\bzenfone\b/ig, "Zenfone")
+    .replace(/\brog\b/ig, "ROG")
     .replace(/\bgalaxy\b/ig, "Galaxy")
     .replace(/\bredmi\b/ig, "Redmi")
     .replace(/\bpoco\b/ig, "Poco")
     .replace(/\bhonor\b/ig, "Honor")
     .replace(/\bhuawei\b/ig, "Huawei")
     .replace(/\bsamsung\b/ig, "Samsung")
+    .replace(/\bsurface\b/ig, "Surface")
     .replace(/\b([a-z])/g, (m) => m.toUpperCase())
     .replace(/\bIPhone\b/g, "iPhone")
     .replace(/\bMacbook\b/g, "MacBook")
-    .replace(/(\d)([a-z])\b/g, (_, n, ch) => `${n}${ch.toUpperCase()}`);
+    .replace(/\bIPad\b/g, "iPad")
+    .replace(/\bXl\b/g, "XL")
+    .replace(/(\d)([a-z])\b/g, (_, n, ch) => `${n}${ch.toUpperCase()}`)
+    .replace(/\bPixel\s+(\d+)A\b/g, "Pixel $1a")
+    .replace(/\bNothing\s+Phone\s+(\d+)A\b/g, "Nothing Phone $1a");
 }
 
 function normalizeVariant(value = "") {
   const text = normalizeText(value);
   if (includesPhrase(text, "pro max")) return "pro max";
+  if (includesPhrase(text, "pro xl")) return "pro xl";
   for (const variant of VARIANT_TERMS) {
-    if (variant !== "base" && includesPhrase(text, variant)) return variant;
+    if (variant !== "base" && variant !== "a" && includesPhrase(text, variant)) return variant;
   }
   return "base";
 }
 
 function detectModel(text, brand = "") {
+  let match = text.match(/\bpixel\s+(fold|tablet)\b/);
+  if (match) {
+    const variant = normalizeText(match[1]);
+    return {
+      model_family: "Pixel",
+      model_base: titleCaseModel(`Pixel ${variant}`),
+      model_generation: variant,
+      model_variant: variant,
+      network_variant: "",
+    };
+  }
+  match = text.match(/\bpixel\s+(\d{1,2})(a)?(?:\s+(pro\s+xl|pro|xl))?\b/);
+  if (match) {
+    const generation = match[1];
+    const variant = match[2] ? "a" : match[3] ? normalizeVariant(match[3]) : "base";
+    const suffix = variant === "base" ? "" : variant === "a" ? "a" : ` ${variant}`;
+    return {
+      model_family: "Pixel",
+      model_base: titleCaseModel(`Pixel ${generation}${suffix}`),
+      model_generation: generation,
+      model_variant: variant,
+      network_variant: "",
+    };
+  }
+
+  match = text.match(/\bnothing\s+phone\s+(\d)(a)?\b/);
+  if (match) {
+    const generation = match[1];
+    const variant = match[2] ? "a" : "base";
+    return {
+      model_family: "Nothing Phone",
+      model_base: titleCaseModel(`Nothing Phone ${generation}${variant === "a" ? "a" : ""}`),
+      model_generation: generation,
+      model_variant: variant,
+      network_variant: "",
+    };
+  }
+  match = text.match(/\bcmf\s+phone\s+(\d)\b/);
+  if (match) {
+    return {
+      model_family: "CMF Phone",
+      model_base: titleCaseModel(`CMF Phone ${match[1]}`),
+      model_generation: match[1],
+      model_variant: "base",
+      network_variant: "",
+    };
+  }
+
+  match = text.match(/\b(zenfone|rog\s+phone)\s+(\d{1,2})\b/);
+  if (match) {
+    const family = normalizeText(match[1]) === "zenfone" ? "Zenfone" : "ROG Phone";
+    return {
+      model_family: family,
+      model_base: titleCaseModel(`${family} ${match[2]}`),
+      model_generation: match[2],
+      model_variant: "base",
+      network_variant: "",
+    };
+  }
+
+  match = text.match(/\bipad\s+(pro|air|mini)?\s*(\d{1,2}(?:\s*9)?|se)?\s*(\d{4})?\b/);
+  if (match && includesPhrase(text, "ipad")) {
+    const variant = normalizeText(match[1] || "base");
+    const sizeOrGen = cleanDisplay(match[2] || "");
+    const year = cleanDisplay(match[3] || "");
+    const base = `iPad ${variant === "base" ? "" : variant} ${sizeOrGen} ${year}`.trim();
+    return {
+      model_family: "iPad",
+      model_base: titleCaseModel(base),
+      model_generation: year || sizeOrGen || variant,
+      model_variant: variant,
+      network_variant: "",
+    };
+  }
+
+  match = text.match(/\bgalaxy\s+tab\s+([as])\s*(\d{1,2})?(?:\s+(fe|plus|ultra))?\b/);
+  if (match) {
+    const series = String(match[1] || "").toUpperCase();
+    const generation = match[2] || "";
+    const variant = normalizeVariant(match[3] || "base");
+    return {
+      model_family: "Galaxy Tab",
+      model_base: titleCaseModel(`Galaxy Tab ${series}${generation}${variant === "base" ? "" : ` ${variant}`}`),
+      model_generation: `${series}${generation}`,
+      model_variant: variant,
+      network_variant: "",
+    };
+  }
+
+  match = text.match(/\b(?:samsung\s+)?(?:galaxy\s+)?xcover\s*(\d{1,2})(?:\s+(pro))?\b/);
+  if (match) {
+    const variant = normalizeVariant(match[2] || "base");
+    return {
+      model_family: "Galaxy",
+      model_base: titleCaseModel(`Galaxy XCover${match[1]}${variant === "base" ? "" : ` ${variant}`}`),
+      model_generation: match[1],
+      model_variant: variant,
+      network_variant: "",
+    };
+  }
+
+  match = text.match(/\bapple\s+watch\s+(?:series\s+)?(\d{1,2}|se|ultra)(?:\s+(\d{1,2}))?\b/);
+  if (match) {
+    const generation = match[1] === "ultra" && match[2] ? `${match[1]} ${match[2]}` : match[1];
+    return {
+      model_family: "Apple Watch",
+      model_base: titleCaseModel(`Apple Watch ${generation}`),
+      model_generation: generation,
+      model_variant: normalizeText(match[1]),
+      network_variant: "",
+    };
+  }
+
+  match = text.match(/\bgalaxy\s+watch\s+(\d{1,2})(?:\s+(classic|pro))?\b/);
+  if (match) {
+    const variant = normalizeVariant(match[2] || "base");
+    return {
+      model_family: "Galaxy Watch",
+      model_base: titleCaseModel(`Galaxy Watch ${match[1]}${variant === "base" ? "" : ` ${variant}`}`),
+      model_generation: match[1],
+      model_variant: variant,
+      network_variant: "",
+    };
+  }
+
+  match = text.match(/\bsurface\s+(pro|go|book|laptop)?\s*(\d{1,2})?\b/);
+  if (match && includesPhrase(text, "surface")) {
+    const variant = normalizeText(match[1] || "base");
+    const generation = match[2] || variant;
+    return {
+      model_family: "Surface",
+      model_base: titleCaseModel(`Surface ${variant === "base" ? "" : variant} ${match[2] || ""}`.trim()),
+      model_generation: generation,
+      model_variant: variant,
+      network_variant: "",
+    };
+  }
+
   const rules = [
     { family: "iphone", regex: /\biphone\s+(\d{1,2}s?)(?:\s+(pro\s+max|pro|max|mini|plus|air))?\b/ },
-    { family: "macbook", regex: /\bmacbook\s+(air|pro)?\s*(\d{2})?\s*(\d{4})?\b/ },
+    { family: "macbook", regex: /\bmacbook\s+(air|pro)?\s*(\d{2})?\s*(\d{4})?(?:\s+(a\d{4}))?\b/ },
     { family: "galaxy", regex: /\b(?:samsung\s+)?(?:galaxy\s+)?((?:a|s|m|note|z)\d{1,3})(?:\s+(ultra|plus|lite))?(?:\s+(5g|4g))?\b/ },
     { family: "redmi", regex: /\b(?:xiaomi\s+)?(?:redmi\s+)?(?:note\s+)?(\d{1,2})(?:\s+(pro|max|plus))?(?:\s+(5g|4g))?\b/ },
     { family: "honor", regex: /\bhonor\s+([a-z0-9]+(?:\s*[a-z0-9]+){0,2})(?:\s+(lite|pro|plus|air|5g|4g))?\b/ },

--- a/nerin_final_updated/exports/catalog-classification-audit.csv
+++ b/nerin_final_updated/exports/catalog-classification-audit.csv
@@ -4,4 +4,4 @@ id,sku,title,public_slug,part_type,device_brand,model_base,model_variant,quality
 "a16-amoled","SM-A165-DS","Pantalla Samsung Galaxy A16 4G SM-A165 original negra con marco AMOLED","pantalla-samsung-galaxy-a16-4g-sm-a165-original-negra-con-marco-amoled","display","Samsung","Galaxy A16 4G","base","original","black","1","in_stock","0.76",""
 "3","LCD-XIA-MI11","Pantalla Xiaomi Mi 11","pantalla-xiaomi-mi-11","display","Xiaomi","Xiaomi 11","base","","","","in_stock","0.625","missing_quality|missing_color"
 "4","BAT-IPH12","Batería iPhone 12","bateria-iphone-12","battery","Apple","iPhone 12","base","","","","in_stock","0.626","missing_quality|missing_color"
-"5","EAR-IPH11","Auricular iPhone 11","auricular-iphone-11","speaker","Apple","iPhone 11","base","","","","in_stock","0.58","missing_quality|missing_color"
+"5","EAR-IPH11","Auricular iPhone 11","auricular-iphone-11","earpiece","Apple","iPhone 11","base","","","","in_stock","0.58","missing_quality|missing_color"

--- a/nerin_final_updated/frontend/admin.html
+++ b/nerin_final_updated/frontend/admin.html
@@ -360,13 +360,44 @@
               <input
                 type="search"
                 id="productSearch"
-                placeholder="SKU, nombre, modelo o tag"
+                placeholder="SKU, MPN, pixel 7 display, modelo o tag"
                 autocomplete="off"
               />
             </label>
             <label class="filter-field">
+              <span>Modo</span>
+              <select id="productStructuredSearch">
+                <option value="1">Búsqueda técnica estructurada</option>
+                <option value="">Búsqueda normal</option>
+              </select>
+            </label>
+            <label class="filter-field">
               <span>Categoría</span>
               <select id="productFilterCategory">
+                <option value="">Todas</option>
+              </select>
+            </label>
+            <label class="filter-field">
+              <span>Tipo detectado</span>
+              <select id="productFilterPartType">
+                <option value="">Todos</option>
+              </select>
+            </label>
+            <label class="filter-field">
+              <span>Marca detectada</span>
+              <select id="productFilterDeviceBrand">
+                <option value="">Todas</option>
+              </select>
+            </label>
+            <label class="filter-field">
+              <span>Modelo detectado</span>
+              <select id="productFilterModelBase">
+                <option value="">Todos</option>
+              </select>
+            </label>
+            <label class="filter-field">
+              <span>Calidad</span>
+              <select id="productFilterQuality">
                 <option value="">Todas</option>
               </select>
             </label>
@@ -377,6 +408,18 @@
                 <option value="public">Público</option>
                 <option value="private">Privado</option>
                 <option value="draft">Borrador</option>
+              </select>
+            </label>
+            <label class="filter-field">
+              <span>Auditoría</span>
+              <select id="productFilterIssue">
+                <option value="">Sin filtro</option>
+                <option value="low_confidence">Baja confianza</option>
+                <option value="missing_model">Sin modelo detectado</option>
+                <option value="missing_brand">Sin marca detectada</option>
+                <option value="missing_part_type">Sin tipo detectado</option>
+                <option value="missing_image">Sin imagen</option>
+                <option value="missing_price">Sin precio</option>
               </select>
             </label>
             <label class="filter-field">
@@ -397,6 +440,7 @@
                 <option value="price_asc">Precio (min. ↑)</option>
               </select>
             </label>
+            <button class="button secondary" id="productClearFilters" type="button">Limpiar filtros</button>
           </div>
         </div>
         <div class="table-wrapper">
@@ -411,6 +455,8 @@
                 <th>Categoría</th>
                 <th>Subcategoría</th>
                 <th>Explorador</th>
+                <th>Clasificación</th>
+                <th>Confianza</th>
                 <th>Tags</th>
                 <th>Stock</th>
                 <th>Mín. Stock</th>

--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -1711,10 +1711,17 @@ if (wholesaleRefreshBtn) {
 const productsTableBody = document.querySelector("#productsTable tbody");
 const productsSummaryEl = document.getElementById("productsSummary");
 const productSearchInput = document.getElementById("productSearch");
+const productStructuredSearch = document.getElementById("productStructuredSearch");
 const productFilterCategory = document.getElementById("productFilterCategory");
+const productFilterPartType = document.getElementById("productFilterPartType");
+const productFilterDeviceBrand = document.getElementById("productFilterDeviceBrand");
+const productFilterModelBase = document.getElementById("productFilterModelBase");
+const productFilterQuality = document.getElementById("productFilterQuality");
 const productFilterVisibility = document.getElementById("productFilterVisibility");
 const productFilterStock = document.getElementById("productFilterStock");
+const productFilterIssue = document.getElementById("productFilterIssue");
 const productSortSelect = document.getElementById("productSort");
+const productClearFilters = document.getElementById("productClearFilters");
 const productCategorySelect = document.getElementById("productCategory");
 const productSubcategorySelect = document.getElementById("productSubcategory");
 const productCatalogBrandInput = document.getElementById("productCatalogBrand");
@@ -1805,8 +1812,14 @@ let productFilters = {
   query: "",
   category: "",
   brand: "",
+  partType: "",
+  deviceBrand: "",
+  modelBase: "",
+  qualityTier: "",
   visibility: "",
   stock: "",
+  issue: "",
+  structuredSearch: "1",
   sort: "recent",
 };
 let productsPage = 1;
@@ -1818,6 +1831,7 @@ let productsTotalPages = null;
 let productsLoadErrorMessage = "";
 let adminProductsAbortController = null;
 let adminProductsRequestSeq = 0;
+let adminProductsFacets = {};
 
 let isApplyingAutoSeo = false;
 let isApplyingAutoTags = false;
@@ -1980,6 +1994,28 @@ function syncProductTaxonomies(products) {
   }
 }
 
+function populateAdminFacetSelect(selectEl, values = [], fallbackLabel = "Todos") {
+  if (!selectEl) return;
+  const previous = selectEl.value;
+  const options = [`<option value="">${escapeHtml(fallbackLabel)}</option>`];
+  (Array.isArray(values) ? values : []).forEach((item) => {
+    const value = item?.value == null ? "" : String(item.value);
+    if (!value) return;
+    const count = Number.isFinite(Number(item?.count)) ? ` (${Number(item.count)})` : "";
+    options.push(`<option value="${escapeHtml(value)}">${escapeHtml(item?.label || value)}${count}</option>`);
+  });
+  selectEl.innerHTML = options.join("");
+  selectEl.value = Array.from(selectEl.options).some((option) => option.value === previous) ? previous : "";
+}
+
+function applyAdminFacets(facets = {}) {
+  adminProductsFacets = facets && typeof facets === "object" ? facets : {};
+  populateAdminFacetSelect(productFilterPartType, adminProductsFacets.part_type || [], "Todos");
+  populateAdminFacetSelect(productFilterDeviceBrand, adminProductsFacets.device_brand || [], "Todas");
+  populateAdminFacetSelect(productFilterModelBase, adminProductsFacets.model_base || [], "Todos");
+  populateAdminFacetSelect(productFilterQuality, adminProductsFacets.quality_tier || [], "Todas");
+}
+
 function describeActiveFilters() {
   const active = [];
   if (productFilters.query) {
@@ -1988,6 +2024,10 @@ function describeActiveFilters() {
   if (productFilters.category) {
     active.push(`Categoría: ${escapeHtml(productFilters.category)}`);
   }
+  if (productFilters.partType) active.push(`Tipo: ${escapeHtml(productFilters.partType)}`);
+  if (productFilters.deviceBrand) active.push(`Marca detectada: ${escapeHtml(productFilters.deviceBrand)}`);
+  if (productFilters.modelBase) active.push(`Modelo detectado: ${escapeHtml(productFilters.modelBase)}`);
+  if (productFilters.qualityTier) active.push(`Calidad: ${escapeHtml(productFilters.qualityTier)}`);
   if (productFilters.visibility) {
     const label =
       productFilters.visibility === "public"
@@ -2002,6 +2042,7 @@ function describeActiveFilters() {
   } else if (productFilters.stock === "out") {
     active.push("Solo sin stock");
   }
+  if (productFilters.issue) active.push(`Auditoría: ${escapeHtml(productFilters.issue)}`);
   return active.length ? active.join(" • ") : "Sin filtros activos";
 }
 
@@ -2128,6 +2169,23 @@ function buildProductRow(product) {
   const explorerCellAttr = hasManualExplorer ? "" : ' data-mode="auto"';
   const safeExplorer = escapeHtml(compactText(explorerText, 64));
   const safeTags = escapeHtml(compactText(tagsPreview, 72));
+  const classificationBadges = [
+    product.part_type,
+    product.device_brand,
+    product.model_base,
+    product.quality_tier,
+    product.stock_status,
+  ]
+    .filter(Boolean)
+    .map((value) => `<span class="badge">${escapeHtml(compactText(value, 28))}</span>`)
+    .join(" ");
+  const blockers = Array.isArray(product.classification_blockers) ? product.classification_blockers : [];
+  const confidence = Number(product.classification_confidence);
+  const confidenceText = Number.isFinite(confidence) ? `${Math.round(confidence * 100)}%` : "";
+  const confidenceCell = [
+    confidenceText ? `<strong>${escapeHtml(confidenceText)}</strong>` : "",
+    blockers.length ? `<small>${escapeHtml(blockers.join(", "))}</small>` : "",
+  ].filter(Boolean).join("<br>");
 
   tr.innerHTML = `
     <td><input type="checkbox" class="select-product" /></td>
@@ -2138,6 +2196,8 @@ function buildProductRow(product) {
     <td class="product-cell" title="${escapeHtml(product.category || "")}">${safeCategory}</td>
     <td class="product-cell" title="${escapeHtml(product.subcategory || "")}">${safeSubcategory}</td>
     <td class="product-cell"${explorerCellAttr} title="${escapeHtml(explorerText)}">${safeExplorer}</td>
+    <td class="product-cell" title="${escapeHtml([product.part_type, product.device_brand, product.model_base, product.quality_tier, product.stock_status].filter(Boolean).join(" | "))}">${classificationBadges || "-"}</td>
+    <td class="product-cell" title="${escapeHtml(blockers.join(", "))}">${confidenceCell || "-"}</td>
     <td class="product-cell" title="${escapeHtml(tagsArray.join(", "))}">${safeTags}</td>
     <td><input type="number" class="inline-edit inline-edit--compact" data-field="stock" min="0" value="${product.stock ?? 0}" />${stockBadge}</td>
     <td>${product.min_stock ?? ""}</td>
@@ -2164,7 +2224,7 @@ function renderProductsTable() {
     const message = productsCache.length
       ? "No hay productos que coincidan con los filtros actuales."
       : "No hay productos";
-    productsTableBody.innerHTML = `<tr><td colspan="15">${message}</td></tr>`;
+    productsTableBody.innerHTML = `<tr><td colspan="17">${message}</td></tr>`;
   } else {
     const fragment = document.createDocumentFragment();
     rows.forEach((product) => {
@@ -2239,6 +2299,42 @@ if (productFilterCategory) {
     updateProductFilters({ category: productFilterCategory.value });
   });
 }
+[
+  [productStructuredSearch, "structuredSearch"],
+  [productFilterPartType, "partType"],
+  [productFilterDeviceBrand, "deviceBrand"],
+  [productFilterModelBase, "modelBase"],
+  [productFilterQuality, "qualityTier"],
+  [productFilterIssue, "issue"],
+].forEach(([select, key]) => {
+  select?.addEventListener("change", () => {
+    updateProductFilters({ [key]: select.value });
+  });
+});
+productClearFilters?.addEventListener("click", () => {
+  productFilters = {
+    query: "",
+    category: "",
+    brand: "",
+    partType: "",
+    deviceBrand: "",
+    modelBase: "",
+    qualityTier: "",
+    visibility: "",
+    stock: "",
+    issue: "",
+    structuredSearch: "1",
+    sort: "recent",
+  };
+  if (productSearchInput) productSearchInput.value = "";
+  [productFilterCategory, productFilterPartType, productFilterDeviceBrand, productFilterModelBase, productFilterQuality, productFilterVisibility, productFilterStock, productFilterIssue].forEach((select) => {
+    if (select) select.value = "";
+  });
+  if (productStructuredSearch) productStructuredSearch.value = "1";
+  if (productSortSelect) productSortSelect.value = "recent";
+  productsPage = 1;
+  void loadProducts().catch((error) => console.error("[admin-products] clear filters failed", error));
+});
 if (productFilterVisibility) {
   productFilterVisibility.addEventListener("change", () => {
     updateProductFilters({ visibility: productFilterVisibility.value });
@@ -3494,22 +3590,34 @@ async function loadProducts(options = {}) {
       search: productFilters.query || "",
       filters: {
         category: productFilters.category || "",
+        partType: productFilters.partType || "",
+        deviceBrand: productFilters.deviceBrand || "",
+        modelBase: productFilters.modelBase || "",
+        qualityTier: productFilters.qualityTier || "",
         visibility: productFilters.visibility || "",
         stock: productFilters.stock || "",
+        issue: productFilters.issue || "",
+        structuredSearch: productFilters.structuredSearch || "",
         sort: productFilters.sort || "recent",
       },
     });
     productsTableBody.innerHTML =
-      `<tr><td colspan="15">${productFilters.query ? "Buscando…" : "Cargando productos…"}</td></tr>`;
+      `<tr><td colspan="17">${productFilters.query ? "Buscando…" : "Cargando productos…"}</td></tr>`;
     const query = new URLSearchParams({
       page: String(productsPage),
       pageSize: String(productsPageSize),
       search: productFilters.query || "",
+      structuredSearch: productFilters.structuredSearch || "1",
       category: productFilters.category || "",
+      part_type: productFilters.partType || "",
+      device_brand: productFilters.deviceBrand || "",
+      model_base: productFilters.modelBase || "",
+      quality_tier: productFilters.qualityTier || "",
       visibility: productFilters.visibility || "",
       stockStatus: productFilters.stock || "",
       sort: productFilters.sort || "recent",
     });
+    if (productFilters.issue) query.set(productFilters.issue, "1");
     const res = await apiFetch(`/api/admin/products?${query.toString()}`, {
       headers: getAdminHeaders(),
       signal: adminProductsAbortController.signal,
@@ -3553,6 +3661,7 @@ async function loadProducts(options = {}) {
       Number.isFinite(Number(data.totalPages))
         ? Number(data.totalPages)
         : null;
+    applyAdminFacets(data.facets || {});
     syncProductTaxonomies(productsCache);
     renderProductsTable();
     updateProductsPaginationControls();
@@ -3610,7 +3719,7 @@ async function loadProducts(options = {}) {
     }
     productsLoadErrorMessage = `Error cargando productos: ${err.message || "No se pudieron cargar los productos."}${details}`;
     productsTableBody.innerHTML =
-      `<tr><td colspan="15">${escapeHtml(productsLoadErrorMessage)}</td></tr>`;
+      `<tr><td colspan="17">${escapeHtml(productsLoadErrorMessage)}</td></tr>`;
     updateProductSummary([]);
   }
 }

--- a/nerin_final_updated/scripts/audit-catalog-classification.js
+++ b/nerin_final_updated/scripts/audit-catalog-classification.js
@@ -64,6 +64,21 @@ async function main() {
     const brandCounts = await all(db, "SELECT device_brand AS value, COUNT(*) AS count FROM product_search_index WHERE is_public = 1 AND device_brand != '' GROUP BY device_brand ORDER BY count DESC LIMIT 20");
     const modelCounts = await all(db, "SELECT model_base AS value, COUNT(*) AS count FROM product_search_index WHERE is_public = 1 AND model_base != '' GROUP BY model_base ORDER BY count DESC LIMIT 20");
     const partCounts = await all(db, "SELECT part_type AS value, COUNT(*) AS count FROM product_search_index WHERE is_public = 1 AND part_type != '' GROUP BY part_type ORDER BY count DESC LIMIT 20");
+    const pixelDetected = (await all(db, "SELECT COUNT(*) AS count FROM product_search_index WHERE is_public = 1 AND device_brand = 'Google' AND model_family = 'Pixel'"))[0]?.count || 0;
+    const pixelMissingModel = (await all(db, "SELECT COUNT(*) AS count FROM product_search_index WHERE is_public = 1 AND (normalized_title LIKE '%pixel%' OR search_blob LIKE '%pixel%') AND (model_base = '' OR model_base IS NULL)"))[0]?.count || 0;
+    const topUndetectedBrandTokens = await all(db, `SELECT title, sku FROM product_search_index WHERE is_public = 1 AND (device_brand = '' OR device_brand IS NULL) ORDER BY classification_confidence ASC, title ASC LIMIT 20`);
+    const likelyPartTypeErrors = await all(db, `SELECT product_id, sku, title, part_type, model_base, classification_confidence
+      FROM product_search_index
+      WHERE is_public = 1 AND (
+        (part_type = 'display' AND (search_blob LIKE '%adhesive%' OR search_blob LIKE '%bracket%' OR search_blob LIKE '%lens%'))
+        OR (part_type = 'camera' AND search_blob LIKE '%lens%')
+        OR (part_type = 'component' AND search_blob LIKE '%antenna%')
+      )
+      ORDER BY title ASC LIMIT 30`);
+    const officialBrandErrors = await all(db, `SELECT product_id, sku, title, device_brand, compatible_brand, official_brand
+      FROM product_search_index
+      WHERE is_public = 1 AND is_compatible_for_brand = 1 AND official_brand != ''
+      ORDER BY title ASC LIMIT 30`);
     const examples = await all(db, `SELECT part_type, product_id, sku, title, device_brand, model_base, quality_tier, color, classification_confidence
       FROM product_search_index WHERE is_public = 1 AND part_type != ''
       ORDER BY part_type, classification_confidence DESC LIMIT 120`);
@@ -109,6 +124,11 @@ async function main() {
       commonBrands: topCounts(brandCounts, "value"),
       commonModels: topCounts(modelCounts, "value"),
       commonPartTypes: topCounts(partCounts, "value"),
+      googlePixelDetected: Number(pixelDetected),
+      googlePixelMissingModel: Number(pixelMissingModel),
+      topUndetectedBrandTokens,
+      likelyPartTypeErrors,
+      officialBrandCompatibilityErrors: officialBrandErrors,
       probableErrors: missing.slice(0, 12).map((row) => ({ id: row.product_id, sku: row.sku, title: row.title, confidence: row.classification_confidence })),
       examplesByCategory: examples.slice(0, 30),
       csvExport: path.relative(root, csvPath).replace(/\\/g, "/"),

--- a/nerin_final_updated/scripts/debug-classify-product.js
+++ b/nerin_final_updated/scripts/debug-classify-product.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+"use strict";
+
+const { classifyCatalogProduct, parseCatalogQuery } = require("../backend/utils/catalogClassifier");
+
+const input = process.argv.slice(2).join(" ").trim();
+
+if (!input) {
+  console.error('Uso: node scripts/debug-classify-product.js "Display for Google Pixel 7 Pro Black"');
+  process.exit(1);
+}
+
+const classification = classifyCatalogProduct({
+  id: "debug",
+  sku: "debug",
+  name: input,
+  title: input,
+  description: input,
+  stock: 1,
+  price: 1,
+});
+
+console.log(JSON.stringify({
+  input,
+  classification,
+  queryIntent: parseCatalogQuery(input),
+}, null, 2));

--- a/nerin_final_updated/scripts/test-catalog-intelligence-search.js
+++ b/nerin_final_updated/scripts/test-catalog-intelligence-search.js
@@ -2,7 +2,19 @@
 "use strict";
 
 const assert = require("assert/strict");
+const fs = require("fs");
+const path = require("path");
 const productsSqliteRepo = require("../backend/data/productsSqliteRepo");
+
+const productsPath = path.resolve(__dirname, "../data/products.json");
+const hardeningFixtures = [
+  { id: "test-pixel7-display", sku: "PIX7-DISPLAY", name: "Display Original Black Google Pixel 7 Pro", brand: "Google", model: "Pixel 7 Pro", category: "Pantallas", stock: 4, price_minorista: 90000, image: "/assets/product1.png", visibility: "private" },
+  { id: "test-pixel7-base-display", sku: "PIX7-BASE-DISPLAY", name: "Display Original Black Google Pixel 7", brand: "Google", model: "Pixel 7", category: "Pantallas", stock: 6, price_minorista: 82000, image: "/assets/product1.png", visibility: "private" },
+  { id: "test-pixel6a-battery", sku: "BAT-PIX6A", name: "Battery Compatible for Google Pixel 6a", brand: "for Google", model: "Pixel 6a", category: "Baterias", stock: 8, price_minorista: 35000, image: "/assets/product2.png", visibility: "private" },
+  { id: "test-pixel7-lens", sku: "LENS-PIX7", name: "Camera Lens Google Pixel 7", brand: "Google", model: "Pixel 7", category: "Camaras", stock: 5, price_minorista: 12000, image: "/assets/product2.png", visibility: "private" },
+  { id: "test-unclassified", sku: "MYSTERY-LOW", name: "Universal Small Parts Kit", category: "Varios", stock: 1, price_minorista: 1000, visibility: "private" },
+  { id: "test-display-adhesive", sku: "ADH-IPH16", name: "Display Adhesive Tape for iPhone 16", brand: "for Apple", model: "iPhone 16", category: "Adhesivos", stock: 10, price_minorista: 5000, image: "/assets/product1.png", visibility: "private" },
+];
 
 function titleOf(item) {
   return String(item?.title || item?.name || "");
@@ -15,9 +27,16 @@ async function firstTitle(query, extra = {}) {
 }
 
 async function main() {
-  await productsSqliteRepo.rebuildProductsDbFromJson({ force: true, reason: "catalog_intelligence_search_test" });
+  const originalProductsJson = await fs.promises.readFile(productsPath, "utf8");
+  try {
+    const parsed = JSON.parse(originalProductsJson);
+    const products = Array.isArray(parsed.products) ? parsed.products : Array.isArray(parsed) ? parsed : [];
+    const withoutFixtures = products.filter((product) => !hardeningFixtures.some((fixture) => fixture.id === product.id));
+    const nextPayload = Array.isArray(parsed) ? [...withoutFixtures, ...hardeningFixtures] : { ...parsed, products: [...withoutFixtures, ...hardeningFixtures] };
+    await fs.promises.writeFile(productsPath, JSON.stringify(nextPayload, null, 2), "utf8");
+    await productsSqliteRepo.rebuildProductsDbFromJson({ force: true, reason: "catalog_intelligence_search_test" });
 
-  const pantalla = await firstTitle("pantalla iphone 12");
+    const pantalla = await firstTitle("pantalla iphone 12");
   assert.match(pantalla.title, /iphone/i);
   assert.match(pantalla.title, /12/i);
   assert.equal(pantalla.result.items[0].part_type, "display");
@@ -56,7 +75,24 @@ async function main() {
   assert.ok(frameFilter.items.length > 0, "has_frame=true debe devolver displays con marco en fixtures");
   assert.ok(frameFilter.items.every((item) => item.has_frame === true), "has_frame=true solo devuelve productos con marco");
 
-  const noCrashQueries = [
+    const adminPixel = await productsSqliteRepo.queryAdminProducts({ page: 1, pageSize: 10, search: "pixel 7 display", debugSearch: true });
+    assert.equal(adminPixel.source, "sqlite_search_index_admin", "admin search debe usar product_search_index admin");
+    assert.match(titleOf(adminPixel.items[0]), /pixel 7/i, "admin pixel 7 display debe priorizar Pixel display");
+    assert.equal(adminPixel.items[0].part_type, "display");
+
+    const adminPixelBattery = await productsSqliteRepo.queryAdminProducts({ page: 1, pageSize: 10, search: "google pixel bateria", debugSearch: true });
+    assert.equal(adminPixelBattery.items[0].part_type, "battery", "admin google pixel bateria debe priorizar baterias Pixel");
+
+    const missingModel = await productsSqliteRepo.queryAdminProducts({ page: 1, pageSize: 20, missingModel: "1" });
+    assert.ok(missingModel.items.some((item) => item.sku === "MYSTERY-LOW"), "admin missing_model devuelve productos sin modelo");
+
+    const lowConfidence = await productsSqliteRepo.queryAdminProducts({ page: 1, pageSize: 20, lowConfidence: "1" });
+    assert.ok(lowConfidence.items.some((item) => item.sku === "MYSTERY-LOW"), "admin low_confidence devuelve productos baja confianza");
+
+    const skuExact = await productsSqliteRepo.queryAdminProducts({ page: 1, pageSize: 10, search: "BAT-PIX6A", debugSearch: true });
+    assert.equal(skuExact.items[0].sku, "BAT-PIX6A", "admin SKU exacto prioriza SKU exacto");
+
+    const noCrashQueries = [
     "pin de carga samsung a54",
     "display samsung a15 5g",
     "tapa honor 200",
@@ -65,21 +101,28 @@ async function main() {
     "adhesivo pantalla iphone 16",
     "macbook air 13 2020 display",
   ];
-  for (const query of noCrashQueries) {
-    const result = await productsSqliteRepo.queryProducts({ page: 1, pageSize: 10, search: query, debugSearch: true });
-    assert.ok(result.facets && typeof result.facets === "object", `${query} debe devolver facets`);
-    assert.ok(result.searchDebug?.engine === "product_search_index", `${query} debe devolver debug avanzado`);
-  }
+    for (const query of noCrashQueries) {
+      const result = await productsSqliteRepo.queryProducts({ page: 1, pageSize: 10, search: query, debugSearch: true });
+      assert.ok(result.facets && typeof result.facets === "object", `${query} debe devolver facets`);
+      assert.ok(result.searchDebug?.engine === "product_search_index", `${query} debe devolver debug avanzado`);
+    }
 
-  console.log(JSON.stringify({
-    ok: true,
-    examples: {
-      pantalla_iphone_12: pantalla.result.searchDebug.results.slice(0, 3),
-      bateria_iphone_12: bateria.result.searchDebug.results.slice(0, 3),
-      display_samsung_a16_4g: samsungA16.result.searchDebug.results.slice(0, 3),
-    },
-    facets: pantalla.result.facets,
-  }, null, 2));
+    console.log(JSON.stringify({
+      ok: true,
+      examples: {
+        pantalla_iphone_12: pantalla.result.searchDebug.results.slice(0, 3),
+        bateria_iphone_12: bateria.result.searchDebug.results.slice(0, 3),
+        display_samsung_a16_4g: samsungA16.result.searchDebug.results.slice(0, 3),
+        admin_pixel_7_display: adminPixel.searchDebug.results.slice(0, 3),
+        admin_google_pixel_bateria: adminPixelBattery.searchDebug.results.slice(0, 3),
+      },
+      facets: pantalla.result.facets,
+      adminFacets: adminPixel.facets,
+    }, null, 2));
+  } finally {
+    await fs.promises.writeFile(productsPath, originalProductsJson, "utf8");
+    await productsSqliteRepo.rebuildProductsDbFromJson({ force: true, reason: "catalog_intelligence_search_test_restore" }).catch(() => {});
+  }
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Summary
- Hardened `catalogClassifier` coverage for Google Pixel, Nothing, Asus, Microsoft Surface, tablets, watches, and additional long-tail brands.
- Added finer part types so adhesive/bracket/lens/antenna/etc. do not fall into broad display/camera/component buckets.
- Kept compatible-vs-official brand safety: `for Google Pixel` sets compatible brand without inventing official brand.
- Bumped `CATALOG_MAPPING_VERSION` from 3 to 4 so Render invalidates/rebuilds `product_search_index` with the new classifier.
- Switched admin product search to the same structured `product_search_index` used by shop, with admin scope, facets, debug, exact SKU boost, and audit filters.
- Added admin UI filters/badges for structured classification, confidence, blockers, and clear filters.
- Added classification debug script and admin classification debug endpoint.

## Google Pixel fix
Pixel now classifies as:
- `device_brand = Google`
- `model_family = Pixel`
- `model_base = Pixel 7 Pro`, `Pixel 6a`, `Pixel Fold`, `Pixel Tablet`, etc.
- `model_variant = base | pro | a | pro xl | fold | tablet`

Examples validated:
- `Display Original Black Google Pixel 7 Pro` => display / Google / Pixel 7 Pro / pro
- `Battery Compatible for Google Pixel 6a` => battery / Google compatible / Pixel 6a / a / no official brand

## Admin search
`/api/admin/products` and `/api/admin/products/search` now use `product_search_index` with admin scope. The endpoint returns products, total, admin facets, structured fields, confidence/blockers, and debug scoring with `debug=1`.

Admin filters include:
- `part_type`, `device_brand`, `model_base`, `quality_tier`, `color`, `has_frame`, `stock_status`
- `visibility`, `status`
- `missing_image`, `missing_price`, `low_confidence`, `missing_model`, `missing_brand`, `missing_part_type`

## Validation
- `node --check backend/utils/catalogClassifier.js`
- `node --check backend/data/productsSqliteRepo.js`
- `node --check backend/server.js`
- `node --check frontend/js/admin.js`
- `node --check scripts/audit-catalog-classification.js`
- `node --check scripts/test-catalog-intelligence-search.js`
- `node --check scripts/debug-classify-product.js`
- `npx jest __tests__/backend/catalog-classifier.test.js --runInBand` => 19 passed
- `node scripts/test-catalog-intelligence-search.js` => OK, including admin Pixel/SKU/low-confidence/missing-model checks
- `node scripts/audit-catalog-classification.js` => OK, CSV exported

## Audit output on local fixture
- total/public products: 6
- part type detected: 100%
- brand detected: 100%
- model detected: 100%
- low confidence: 0
- Google Pixel detected: 0 in the tiny local public fixture; Pixel coverage is covered by deterministic classifier/admin-search tests.

## Not touched
- Mercado Pago
- webhooks
- inventory mutation logic
- orders mutation logic
- base prices
- critical checkout flow
- real Andreani integration