### PR TITLE
[codex] Fix Render catalog startup blocking

### DIFF
--- a/nerin_final_updated/backend/data/productsSqliteRepo.js
+++ b/nerin_final_updated/backend/data/productsSqliteRepo.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 const fsp = fs.promises;
 const path = require("path");
+const crypto = require("crypto");
 const sqlite3 = require("sqlite3");
 const productsStreamRepo = require("./productsStreamRepo");
 const { dataPath } = require("../utils/dataDir");
@@ -20,6 +21,12 @@ const PRODUCTS_SQLITE_SCHEMA_VERSION = 6;
 const CATALOG_MAPPING_VERSION = 5;
 const BULK_PUBLISH_CHUNK_SIZE = 1000;
 const SEARCH_RANK_CANDIDATE_LIMIT = 1200;
+const DEBUG_PRICE_MAPPING =
+  String(process.env.DEBUG_PRICE_MAPPING || "").trim().toLowerCase() === "true";
+const TEST_REBUILD_DELAY_MS =
+  process.env.NODE_ENV === "test"
+    ? Math.max(0, Number(process.env.CATALOG_REBUILD_TEST_DELAY_MS || 0) || 0)
+    : 0;
 const SEARCH_INDEX_INSERT_SQL = `INSERT INTO product_search_index (
   product_id, product_rowid, public_slug, title, normalized_title, sku, mpn, part_number, brand,
   device_brand, compatible_brand, official_brand, is_compatible_for_brand, part_type,
@@ -57,6 +64,9 @@ const catalogState = {
   ready: false,
   initializing: false,
   rebuilding: false,
+  progress: 0,
+  total: 0,
+  processed: 0,
   corruptDetected: false,
   lastError: null,
   lastErrorAt: null,
@@ -64,10 +74,59 @@ const catalogState = {
   lastRebuildStartedAt: null,
   lastRebuildFinishedAt: null,
   lastRebuildDurationMs: null,
+  startedAt: null,
+  finishedAt: null,
+  mappingVersion: CATALOG_MAPPING_VERSION,
+  schemaVersion: PRODUCTS_SQLITE_SCHEMA_VERSION,
 };
 
 function catalogStateSnapshot() {
   return { ...catalogState };
+}
+
+function updateCatalogProgress(processed, total = catalogState.total) {
+  const safeProcessed = Math.max(0, Number(processed || 0));
+  const safeTotal = Math.max(0, Number(total || 0));
+  catalogState.processed = safeProcessed;
+  catalogState.total = safeTotal;
+  catalogState.progress = safeTotal > 0 ? Math.min(1, safeProcessed / safeTotal) : 0;
+}
+
+function normalizeManifest(parsed) {
+  if (!parsed || typeof parsed !== "object") return null;
+  return {
+    ...parsed,
+    sqliteSchemaVersion: Number(parsed.sqliteSchemaVersion || parsed.PRODUCTS_SQLITE_SCHEMA_VERSION || 0) || null,
+    mappingVersion: Number(parsed.mappingVersion || parsed.CATALOG_MAPPING_VERSION || 0) || null,
+    productCount: Number(parsed.productCount || 0) || 0,
+    publicProductCount: Number(parsed.publicProductCount || parsed.publicCount || 0) || 0,
+    productsJsonSizeBytes: Number(parsed.productsJsonSizeBytes || parsed.productsJsonSize || 0) || 0,
+    productsJsonMtimeMs: Number(parsed.productsJsonMtimeMs || 0) || 0,
+    productsJsonSha256: parsed.productsJsonSha256 || parsed.productsJsonHash || null,
+  };
+}
+
+async function readManifest() {
+  try {
+    return normalizeManifest(JSON.parse(await fsp.readFile(MANIFEST_PATH, "utf8")));
+  } catch {
+    return null;
+  }
+}
+
+async function computeFileSha256(filePath) {
+  return new Promise((resolve, reject) => {
+    const hash = crypto.createHash("sha256");
+    const stream = fs.createReadStream(filePath);
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("error", reject);
+    stream.on("end", () => resolve(hash.digest("hex")));
+  });
+}
+
+async function sleep(ms) {
+  if (!ms) return;
+  await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function setCatalogError(error, context = {}) {
@@ -1714,7 +1773,7 @@ function mapProductRow(product = {}, options = {}) {
   }
   const priceFields = resolvePriceFields(product);
   const stock = Math.trunc(toNumber(product.stock, 0));
-  if (rowNumber != null && rowNumber <= 3) {
+  if (DEBUG_PRICE_MAPPING && rowNumber != null && rowNumber <= 3) {
     console.log("[products-price-map]", {
       id: toNullableText(product.id),
       sku: toNullableText(product.sku),
@@ -2322,10 +2381,14 @@ async function rebuildProductsDbFromJson({ force = true, reason = "manual" } = {
     catalogState.rebuilding = true;
     catalogState.initializing = true;
     catalogState.ready = false;
+    catalogState.startedAt = new Date(startedAt).toISOString();
+    catalogState.finishedAt = null;
     catalogState.lastRebuildStartedAt = new Date(startedAt).toISOString();
     const productsStats = await fsp.stat(PRODUCTS_JSON_PATH);
+    const previousManifest = await readManifest();
+    updateCatalogProgress(0, Number(previousManifest?.productCount || 0));
     const tmpDbPath = `${SQLITE_PATH}.tmp-${process.pid}-${Date.now()}`;
-    console.log(`[products-db] rebuild start reason=${activeReason} productsFilePath=${PRODUCTS_JSON_PATH}`);
+    console.log(`[products-db] rebuild started reason=${activeReason} productsFilePath=${PRODUCTS_JSON_PATH}`);
 
     const tmpDb = await new Promise((resolve, reject) => {
       const conn = new sqlite3.Database(tmpDbPath, (error) => {
@@ -2410,8 +2473,14 @@ async function rebuildProductsDbFromJson({ force = true, reason = "manual" } = {
           batch.push(mapped);
           count += 1;
           if (mapped.is_public === 1) publicCount += 1;
+          if (count <= 100 || count % 1000 === 0) {
+            updateCatalogProgress(count);
+          }
           if (count % 5000 === 0) {
             console.log(`[products-db] rebuild progress count=${count}`);
+          }
+          if (TEST_REBUILD_DELAY_MS) {
+            await sleep(TEST_REBUILD_DELAY_MS);
           }
           if (batch.length >= BATCH_SIZE) {
             await flush();
@@ -2455,12 +2524,17 @@ async function rebuildProductsDbFromJson({ force = true, reason = "manual" } = {
 
       const manifest = {
         sqliteSchemaVersion: PRODUCTS_SQLITE_SCHEMA_VERSION,
+        PRODUCTS_SQLITE_SCHEMA_VERSION,
         mappingVersion: CATALOG_MAPPING_VERSION,
+        CATALOG_MAPPING_VERSION,
         productCount: count,
         publicProductCount: publicCount,
+        publicCount,
         searchIndexCount,
         productsJsonSizeBytes: Number(productsStats.size || 0),
         productsJsonMtimeMs: Number(productsStats.mtimeMs || 0),
+        productsJsonSha256: await computeFileSha256(PRODUCTS_JSON_PATH),
+        indexBuiltAt: new Date().toISOString(),
         sqliteBuiltAt: new Date().toISOString(),
         sqlitePath: SQLITE_PATH,
         sqliteFtsEnabled: ftsEnabled,
@@ -2477,6 +2551,8 @@ async function rebuildProductsDbFromJson({ force = true, reason = "manual" } = {
       catalogState.lastReadyAt = new Date().toISOString();
       catalogState.lastRebuildFinishedAt = new Date().toISOString();
       catalogState.lastRebuildDurationMs = durationMs;
+      catalogState.finishedAt = catalogState.lastRebuildFinishedAt;
+      updateCatalogProgress(count, count);
       clearCatalogError();
       return manifest;
     } catch (error) {
@@ -2488,6 +2564,7 @@ async function rebuildProductsDbFromJson({ force = true, reason = "manual" } = {
       }
       catalogState.lastRebuildFinishedAt = new Date().toISOString();
       catalogState.lastRebuildDurationMs = Date.now() - startedAt;
+      catalogState.finishedAt = catalogState.lastRebuildFinishedAt;
       try {
         await new Promise((resolve) => tmpDb.close(() => resolve()));
       } catch {}
@@ -2585,12 +2662,7 @@ async function ensureProductsDb({ allowRebuild = true } = {}) {
   console.log("[products-db] paths", buildCatalogPathsInfo());
   console.log("[products-db] ensure start");
   const productsStats = await fsp.stat(PRODUCTS_JSON_PATH);
-  let manifest = null;
-  try {
-    manifest = JSON.parse(await fsp.readFile(MANIFEST_PATH, "utf8"));
-  } catch {
-    manifest = null;
-  }
+  let manifest = await readManifest();
 
   let reason = "";
   if (!fs.existsSync(SQLITE_PATH)) {
@@ -2607,7 +2679,20 @@ async function ensureProductsDb({ allowRebuild = true } = {}) {
     Math.floor(Number(manifest.productsJsonMtimeMs || -1)) !==
     Math.floor(Number(productsStats.mtimeMs || 0))
   ) {
-    reason = "products_json_mtime_changed";
+    const currentHash = await computeFileSha256(PRODUCTS_JSON_PATH);
+    if (manifest.productsJsonSha256 && manifest.productsJsonSha256 !== currentHash) {
+      reason = "products_json_hash_changed";
+    } else if (!manifest.productsJsonSha256) {
+      reason = "products_json_mtime_changed";
+    } else {
+      manifest = {
+        ...manifest,
+        productsJsonMtimeMs: Number(productsStats.mtimeMs || 0),
+        productsJsonSha256: currentHash,
+      };
+      await fsp.writeFile(MANIFEST_PATH, JSON.stringify(manifest, null, 2), "utf8");
+      console.log("[products-db] products mtime changed but hash is unchanged; manifest refreshed");
+    }
   }
 
   if (!reason && fs.existsSync(SQLITE_PATH)) {
@@ -2673,6 +2758,8 @@ async function ensureProductsDbOnce() {
 
 function ensureProductsDbInBackground(trigger = "request") {
   if (dbReady || dbReadyPromise) return;
+  catalogState.initializing = true;
+  catalogState.startedAt = catalogState.startedAt || new Date().toISOString();
   dbReadyPromise = ensureProductsDb({ allowRebuild: true });
   dbReadyPromise
     .then(() => {
@@ -3646,13 +3733,7 @@ async function getProductsByIdentifiers(identifiers = []) {
 }
 
 async function getManifestFromDb() {
-  try {
-    const raw = await fsp.readFile(MANIFEST_PATH, "utf8");
-    const parsed = JSON.parse(raw);
-    return parsed && typeof parsed === "object" ? parsed : null;
-  } catch {
-    return null;
-  }
+  return readManifest();
 }
 
 async function getCatalogHealth() {
@@ -3719,8 +3800,21 @@ async function getCatalogHealth() {
     Math.floor(Number(manifest.productsJsonMtimeMs || -1)) !==
     Math.floor(Number(productsStats.mtimeMs || 0))
   ) {
-    isFresh = false;
-    freshnessReason = "products_json_mtime_changed";
+    if (manifest.productsJsonSha256) {
+      try {
+        const currentHash = await computeFileSha256(PRODUCTS_JSON_PATH);
+        if (manifest.productsJsonSha256 !== currentHash) {
+          isFresh = false;
+          freshnessReason = "products_json_hash_changed";
+        }
+      } catch {
+        isFresh = false;
+        freshnessReason = "products_json_hash_unavailable";
+      }
+    } else {
+      isFresh = false;
+      freshnessReason = "products_json_mtime_changed";
+    }
   }
   const manifestPublicCount = Number(manifest?.publicProductCount || 0);
   const productCount = Number(totalRow?.total || 0);
@@ -3744,6 +3838,9 @@ async function getCatalogHealth() {
     ready: Boolean(dbReady && sqliteExists && !catalogState.lastError),
     initializing: Boolean(catalogState.initializing),
     rebuilding: Boolean(catalogState.rebuilding),
+    progress: Number(catalogState.progress || 0),
+    total: Number(catalogState.total || manifest?.productCount || 0),
+    processed: Number(catalogState.processed || 0),
     lastError: catalogState.lastError,
     lastErrorCode: catalogState.lastError?.code || null,
     lastErrorAt: catalogState.lastErrorAt,
@@ -3752,6 +3849,10 @@ async function getCatalogHealth() {
     lastRebuildStartedAt: catalogState.lastRebuildStartedAt,
     lastRebuildFinishedAt: catalogState.lastRebuildFinishedAt,
     lastRebuildDurationMs: catalogState.lastRebuildDurationMs,
+    startedAt: catalogState.startedAt,
+    finishedAt: catalogState.finishedAt,
+    mappingVersion: CATALOG_MAPPING_VERSION,
+    schemaVersion: PRODUCTS_SQLITE_SCHEMA_VERSION,
     productsJsonExists,
     sqlitePath: SQLITE_PATH,
     sqliteExists,
@@ -4328,6 +4429,7 @@ module.exports = {
   ensureProductsDbOnce,
   rebuildProductsDbFromJson,
   isRebuildInProgress,
+  ensureProductsDbInBackground,
   repairCorruptSqlite,
   isSqliteCorruptionError,
   catalogStateSnapshot,

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -5821,6 +5821,33 @@ function sendJson(res, statusCode, data, extraHeaders = {}) {
   res.end(json);
 }
 
+function buildCatalogInitializingPayload(error = null) {
+  return {
+    ok: false,
+    error: "CATALOG_INITIALIZING",
+    code: "CATALOG_INITIALIZING",
+    message: "Catalogo inicializando, reintentar en unos segundos",
+    source: "sqlite",
+    catalogState: error?.catalogState || productsSqliteRepo.catalogStateSnapshot(),
+  };
+}
+
+function sendCatalogError(res, error) {
+  if (error?.code === "CATALOG_INITIALIZING") {
+    return sendJson(res, 503, buildCatalogInitializingPayload(error), {
+      "Cache-Control": "no-store",
+      "Retry-After": "5",
+    });
+  }
+  return sendJson(res, 500, {
+    ok: false,
+    code: error?.code || "CATALOG_SQLITE_FAILED",
+    source: "sqlite",
+    error: error?.message || "Catalogo SQLite no disponible",
+    catalogState: error?.catalogState || productsSqliteRepo.catalogStateSnapshot(),
+  });
+}
+
 function extractSlugFromCheckoutUrl(value) {
   const raw = String(value || "").trim();
   if (!raw) return "";
@@ -6802,6 +6829,45 @@ async function requestHandler(req, res) {
     return res.end();
   }
 
+  if ((pathname === "/health" || pathname === "/api/health") && req.method === "GET") {
+    return sendJson(res, 200, {
+      ok: true,
+      status: "ok",
+      build: BUILD_ID,
+      catalog: productsSqliteRepo.catalogStateSnapshot(),
+      ts: Date.now(),
+    }, { "Cache-Control": "no-store" });
+  }
+
+  if (pathname === "/api/catalog/status" && req.method === "GET") {
+    try {
+      const health = await productsSqliteRepo.getCatalogHealth();
+      return sendJson(res, 200, {
+        ok: true,
+        ready: Boolean(health.ready),
+        initializing: Boolean(health.initializing),
+        rebuilding: Boolean(health.rebuilding),
+        progress: Number(health.progress || 0),
+        processed: Number(health.processed || 0),
+        total: Number(health.total || health.productCount || 0),
+        lastError: health.lastError || null,
+        startedAt: health.startedAt || health.lastRebuildStartedAt || null,
+        finishedAt: health.finishedAt || health.lastRebuildFinishedAt || null,
+        mappingVersion: Number(health.mappingVersion || health.catalogMappingVersion || 0),
+        schemaVersion: Number(health.schemaVersion || health.sqliteSchemaVersion || 0),
+        productCount: Number(health.productCount || 0),
+        publicCount: Number(health.publicProductCount || 0),
+        freshnessReason: health.freshnessReason || null,
+      }, { "Cache-Control": "no-store" });
+    } catch (error) {
+      return sendJson(res, 200, {
+        ok: true,
+        ...productsSqliteRepo.catalogStateSnapshot(),
+        lastError: error?.message || "catalog_status_unavailable",
+      }, { "Cache-Control": "no-store" });
+    }
+  }
+
   if (pathname && pathname.startsWith("/calc-api")) {
     if (hasExternalCalcApi && calcApiProxy) {
       return calcApiProxy(req, res, (proxyError) => {
@@ -7328,6 +7394,7 @@ async function requestHandler(req, res) {
         "Cache-Control": "no-store, no-cache, must-revalidate",
       });
     } catch (err) {
+      return sendCatalogError(res, err);
       const code = err?.code || "CATALOG_SQLITE_FAILED";
       const catalogState = err?.catalogState || productsSqliteRepo.catalogStateSnapshot();
       if (code === "CATALOG_INITIALIZING") {
@@ -7399,6 +7466,7 @@ async function requestHandler(req, res) {
         debug: debug ? data.searchDebug : undefined,
       });
     } catch (error) {
+      if (error?.code === "CATALOG_INITIALIZING") return sendCatalogError(res, error);
       return sendJson(res, 500, { ok: false, error: error?.message || "search_failed" });
     }
   }
@@ -13744,31 +13812,10 @@ function createServer() {
 module.exports = { createServer };
 
 if (require.main === module) {
-  (async () => {
-    let startupRepairAttempted = false;
-    try {
-      console.log("[products-db] startup ensure start");
-      await productsSqliteRepo.ensureProductsDbOnce();
-      console.log("[products-db] startup ensure done");
-    } catch (error) {
-      if (
-        !startupRepairAttempted &&
-        productsSqliteRepo.isSqliteCorruptionError(error)
-      ) {
-        startupRepairAttempted = true;
-        console.warn("[products-db] corrupt at startup; repairing");
-        try {
-          await productsSqliteRepo.repairCorruptSqlite({ reason: "startup_corrupt_repair" });
-        } catch (repairError) {
-          console.error("[products-db] repair failed", repairError?.message || repairError);
-        }
-      } else {
-        console.error(`[products-db] startup ensure failed reason=${error?.message || error}`);
-      }
-    }
-    const server = createServer();
-    server.listen(APP_PORT, () => {
-      console.log(`Servidor de NERIN corriendo en http://localhost:${APP_PORT}`);
-    });
-  })();
+  const server = createServer();
+  server.listen(APP_PORT, () => {
+    console.log(`Servidor de NERIN corriendo en http://localhost:${APP_PORT}`);
+    console.log(`[products-db] startup background ensure scheduled after listen port=${APP_PORT}`);
+    productsSqliteRepo.ensureProductsDbInBackground("startup-after-listen");
+  });
 }

--- a/nerin_final_updated/package.json
+++ b/nerin_final_updated/package.json
@@ -10,6 +10,7 @@
     "catalog:enrich-csv": "node scripts/enrichCatalogCsv.js",
     "inspect:products": "node scripts/inspect-products-file.js",
     "rebuild:products-manifest": "node scripts/rebuildProductsManifest.js",
+    "test:render-startup": "node scripts/test-render-startup-nonblocking.js",
     "check:no-products-full-parse": "node scripts/check-no-products-full-parse.js"
   },
   "dependencies": {

--- a/nerin_final_updated/scripts/test-render-startup-nonblocking.js
+++ b/nerin_final_updated/scripts/test-render-startup-nonblocking.js
@@ -1,0 +1,156 @@
+const fs = require("fs");
+const fsp = fs.promises;
+const http = require("http");
+const os = require("os");
+const path = require("path");
+const { fork } = require("child_process");
+
+const root = path.resolve(__dirname, "..");
+
+function requestJson(port, pathname, timeoutMs = 1000) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: "127.0.0.1",
+        port,
+        path: pathname,
+        method: "GET",
+        timeout: timeoutMs,
+      },
+      (res) => {
+        let body = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => {
+          body += chunk;
+        });
+        res.on("end", () => {
+          let json = null;
+          try {
+            json = body ? JSON.parse(body) : null;
+          } catch {}
+          resolve({ statusCode: res.statusCode, body, json });
+        });
+      },
+    );
+    req.on("timeout", () => req.destroy(new Error(`timeout ${pathname}`)));
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+async function waitForHealthy(port, deadlineMs = 3000) {
+  const startedAt = Date.now();
+  let lastError = null;
+  while (Date.now() - startedAt < deadlineMs) {
+    try {
+      const response = await requestJson(port, "/health", 500);
+      if (response.statusCode === 200) return Date.now() - startedAt;
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw lastError || new Error("server did not become healthy quickly");
+}
+
+async function main() {
+  const dataDir = await fsp.mkdtemp(path.join(os.tmpdir(), "nerin-render-startup-"));
+  const products = Array.from({ length: 80 }, (_, index) => ({
+    id: `test-${index + 1}`,
+    sku: `SKU-${index + 1}`,
+    name: `Pantalla test ${index + 1}`,
+    title: `Pantalla test ${index + 1}`,
+    brand: "Test",
+    category: "pantallas",
+    visibility: "public",
+    status: "active",
+    stock: 5,
+    price: 1000 + index,
+    image: "/assets/test.png",
+  }));
+  await fsp.writeFile(path.join(dataDir, "products.json"), JSON.stringify({ products }, null, 2), "utf8");
+
+  const port = 38000 + Math.floor(Math.random() * 1000);
+  const child = fork(path.join(root, "backend/server.js"), {
+    cwd: root,
+    stdio: ["ignore", "pipe", "pipe", "ipc"],
+    env: {
+      ...process.env,
+      NODE_ENV: "test",
+      DATA_DIR: dataDir,
+      PORT: String(port),
+      CATALOG_REBUILD_TEST_DELAY_MS: "25",
+    },
+  });
+
+  let logs = "";
+  child.stdout.on("data", (chunk) => {
+    logs += chunk.toString();
+  });
+  child.stderr.on("data", (chunk) => {
+    logs += chunk.toString();
+  });
+
+  try {
+    const healthMs = await waitForHealthy(port, 3000);
+    if (healthMs > 1500) {
+      throw new Error(`/health was too slow: ${healthMs}ms`);
+    }
+
+    const health = await requestJson(port, "/api/health", 1000);
+    if (health.statusCode !== 200 || !health.json?.ok) {
+      throw new Error(`/api/health failed: ${health.statusCode} ${health.body}`);
+    }
+
+    const status = await requestJson(port, "/api/catalog/status", 1000);
+    if (status.statusCode !== 200) {
+      throw new Error(`/api/catalog/status failed: ${status.statusCode} ${status.body}`);
+    }
+    if (!status.json?.rebuilding && !status.json?.initializing) {
+      throw new Error(`catalog status did not show rebuild/init: ${status.body}`);
+    }
+
+    const productsResponse = await requestJson(port, "/api/products", 1000);
+    if (![200, 503].includes(productsResponse.statusCode)) {
+      throw new Error(`/api/products returned unexpected status ${productsResponse.statusCode}`);
+    }
+    if (
+      productsResponse.statusCode === 503 &&
+      productsResponse.json?.error !== "CATALOG_INITIALIZING" &&
+      productsResponse.json?.code !== "CATALOG_INITIALIZING"
+    ) {
+      throw new Error(`/api/products 503 was not controlled: ${productsResponse.body}`);
+    }
+
+    if (!logs.includes("Servidor de NERIN corriendo")) {
+      throw new Error("server listen log not found");
+    }
+    if (!logs.includes("[products-db] rebuild started")) {
+      throw new Error("rebuild start log not found");
+    }
+
+    console.log(JSON.stringify({
+      ok: true,
+      healthMs,
+      status: {
+        ready: Boolean(status.json.ready),
+        initializing: Boolean(status.json.initializing),
+        rebuilding: Boolean(status.json.rebuilding),
+        processed: Number(status.json.processed || 0),
+        total: Number(status.json.total || 0),
+      },
+      productsStatusCode: productsResponse.statusCode,
+    }, null, 2));
+  } finally {
+    if (!child.killed) {
+      child.kill();
+      await new Promise((resolve) => child.once("exit", resolve));
+    }
+    await fsp.rm(dataDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error?.stack || error?.message || error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Fixes Render startup failures where the server did not open a port while `products.sqlite` / `product_search_index` rebuilt during boot.

## Root cause

`backend/server.js` awaited `productsSqliteRepo.ensureProductsDbOnce()` before calling `server.listen()`. When catalog schema/mapping/products changes required a long rebuild, Node stayed busy rebuilding the catalog before Render could detect an open port, leading to `No open ports detected` and port scan timeout.

## Changes

- Open the HTTP server port immediately, then schedule catalog initialization/rebuild in the background.
- Add non-blocking health endpoints: `GET /health` and `GET /api/health` return 200 even while the catalog is rebuilding.
- Add `GET /api/catalog/status` with readiness, rebuild progress, processed/total, errors, schema version, and mapping version.
- Keep catalog endpoints controlled during rebuild: `CATALOG_INITIALIZING` responses return 503 instead of blocking startup.
- Extend catalog manifest metadata with schema/mapping version aliases, products JSON size/mtime/hash, index build timestamp, product count, and public count.
- Avoid full rebuilds for mtime-only `products.json` changes when the content hash is unchanged.
- Gate noisy price mapping logs behind `DEBUG_PRICE_MAPPING=true`.
- Add `scripts/test-render-startup-nonblocking.js` and `npm run test:render-startup` to prove Render-style startup stays responsive during rebuild.

## Validation

- `node --check backend/server.js`
- `node --check backend/data/productsSqliteRepo.js`
- `node --check scripts/test-render-startup-nonblocking.js`
- `node scripts/test-render-startup-nonblocking.js`

The startup test showed `/health` responding in under 1s while `/api/catalog/status` reported `initializing: true` and `rebuilding: true`; `/api/products` returned a controlled 503 while rebuild continued.