### PR TITLE
Publish real display and screen adhesive products safely with dedicated Merchant feeds

### DIFF
--- a/nerin_final_updated/backend/data/productsSqliteRepo.js
+++ b/nerin_final_updated/backend/data/productsSqliteRepo.js
@@ -11,6 +11,10 @@ const {
   normalizeText: normalizeCatalogText,
   parseCatalogQuery,
 } = require("../utils/catalogClassifier");
+const {
+  isRealScreenProduct,
+  isScreenAdhesiveProduct,
+} = require("../utils/screenProductClassifier");
 
 const PRODUCTS_JSON_PATH = dataPath("products.json");
 const SQLITE_PATH = dataPath("products.sqlite");
@@ -3112,6 +3116,10 @@ function scoreSearchIndexRow(row = {}, intent = {}) {
   const rowNetwork = normalizeFacetValue(row.network_variant || "");
   const queryNetwork = normalizeFacetValue(intent.network_variant || "");
   const queryText = normalizeFacetValue(intent.normalized_query || intent.original_query || "");
+  const adhesiveIntent = /\b(adhesivo|adhesive|gasket|seal|junta|cinta|tape)\b/.test(queryText) && /\b(pantalla|display|screen|lcd|oled|pixel|iphone|galaxy)\b/.test(queryText);
+  const displayIntent = !adhesiveIntent && /\b(pantalla|display|screen|modulo|modulo|lcd|oled|amoled)\b/.test(queryText);
+  const screenClass = isRealScreenProduct(row);
+  const adhesiveClass = isScreenAdhesiveProduct(row);
   const identifiers = [row.sku, row.mpn, row.part_number, row.product_id, row.public_slug, row.id, row.code].map(normalizeFacetValue).filter(Boolean);
   if (queryText && identifiers.includes(queryText)) addStructuredReason(entry, "SKU/MPN/slug exacto", 2600);
   if (intent.model_code && blob.includes(normalizeFacetValue(intent.model_code))) addStructuredReason(entry, "SKU/MPN/model code exacto", 800);
@@ -3131,6 +3139,14 @@ function scoreSearchIndexRow(row = {}, intent = {}) {
   if (intent.part_type) {
     if (row.part_type === intent.part_type) addStructuredReason(entry, `tipo exacto ${intent.part_type}`, 2200);
     else if (row.part_type) addStructuredReason(entry, `tipo incorrecto ${row.part_type}`, -2200);
+  }
+  if (adhesiveIntent) {
+    if (adhesiveClass.isScreenAdhesive) addStructuredReason(entry, "intencion adhesivo de pantalla", 3200);
+    if (screenClass.isScreen) addStructuredReason(entry, "pantalla real debajo de adhesivo", -1800);
+  } else if (displayIntent) {
+    if (screenClass.isScreen) addStructuredReason(entry, "intencion pantalla real", 3200);
+    if (adhesiveClass.isScreenAdhesive) addStructuredReason(entry, "adhesivo debajo de pantalla", -2400);
+    if (screenClass.excludedAsAccessory) addStructuredReason(entry, `accesorio excluido ${screenClass.excludeReason}`, -2600);
   }
   if (intent.device_brand) {
     if (normalizeFacetValue(row.device_brand) === normalizeFacetValue(intent.device_brand) || normalizeFacetValue(row.compatible_brand) === normalizeFacetValue(intent.device_brand)) {

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -76,6 +76,7 @@ const {
 } = require("./utils/reviewValidation");
 const { importStockXlsxFile } = require("./services/stockXlsxImport");
 const { buildMockAndreaniQuote } = require("./services/andreaniService");
+const finalScreenPublication = require("./services/screenPublicationService");
 const productsStreamRepo = require("./data/productsStreamRepo");
 const productsSqliteRepo = require("./data/productsSqliteRepo");
 const catalogInventoryRepo = require("./data/catalogInventoryRepo");
@@ -7380,6 +7381,70 @@ async function requestHandler(req, res) {
     }
   }
 
+  if (pathname === "/api/admin/screens/audit" && req.method === "GET") {
+    if (!requireAdmin(req, res)) return;
+    try {
+      const result = await finalScreenPublication.previewPublication("screen", parsedUrl.query || {});
+      return sendJson(res, 200, result);
+    } catch (error) {
+      return sendJson(res, 500, { ok: false, error: error?.message || "screen_audit_failed" });
+    }
+  }
+
+  if (pathname === "/api/admin/screens/publish-preview" && req.method === "POST") {
+    if (!requireAdmin(req, res)) return;
+    await parseBody(req);
+    try {
+      const result = await finalScreenPublication.previewPublication("screen", req.body || {});
+      return sendJson(res, 200, result);
+    } catch (error) {
+      return sendJson(res, 500, { ok: false, error: error?.message || "screen_preview_failed" });
+    }
+  }
+
+  if (pathname === "/api/admin/screens/publish" && req.method === "POST") {
+    if (!requireAdmin(req, res)) return;
+    await parseBody(req);
+    try {
+      const result = await finalScreenPublication.publishEligible("screen", req.body || {});
+      return sendJson(res, 200, result);
+    } catch (error) {
+      return sendJson(res, error?.statusCode || 500, { ok: false, error: error?.message || "screen_publish_failed" });
+    }
+  }
+
+  if (pathname === "/api/admin/screen-adhesives/audit" && req.method === "GET") {
+    if (!requireAdmin(req, res)) return;
+    try {
+      const result = await finalScreenPublication.previewPublication("screen_adhesive", parsedUrl.query || {});
+      return sendJson(res, 200, result);
+    } catch (error) {
+      return sendJson(res, 500, { ok: false, error: error?.message || "screen_adhesive_audit_failed" });
+    }
+  }
+
+  if (pathname === "/api/admin/screen-adhesives/publish-preview" && req.method === "POST") {
+    if (!requireAdmin(req, res)) return;
+    await parseBody(req);
+    try {
+      const result = await finalScreenPublication.previewPublication("screen_adhesive", req.body || {});
+      return sendJson(res, 200, result);
+    } catch (error) {
+      return sendJson(res, 500, { ok: false, error: error?.message || "screen_adhesive_preview_failed" });
+    }
+  }
+
+  if (pathname === "/api/admin/screen-adhesives/publish" && req.method === "POST") {
+    if (!requireAdmin(req, res)) return;
+    await parseBody(req);
+    try {
+      const result = await finalScreenPublication.publishEligible("screen_adhesive", req.body || {});
+      return sendJson(res, 200, result);
+    } catch (error) {
+      return sendJson(res, error?.statusCode || 500, { ok: false, error: error?.message || "screen_adhesive_publish_failed" });
+    }
+  }
+
   if (pathname === "/api/test-email" && req.method === "GET") {
     const requestUrl = new URL(req.url, "http://localhost");
     const to = requestUrl.searchParams.get("to") || "tuemail@ejemplo.com";
@@ -13318,6 +13383,25 @@ async function requestHandler(req, res) {
     return;
   }
 
+  if ((pathname === "/api/merchant/screens-feed.csv" || pathname === "/google-merchant-screens-feed.csv" || pathname === "/api/merchant/screen-adhesives-feed.csv" || pathname === "/google-merchant-screen-adhesives-feed.csv") && req.method === "GET") {
+    try {
+      const type = pathname.includes("adhesive") ? "screen_adhesive" : "screen";
+      const payload = await finalScreenPublication.buildFeed(type, {
+        baseUrl: getPublicBaseUrl(getConfig()) || "https://nerinparts.com.ar",
+        limit: Math.max(1, Number(parsedUrl.query?.limit || 100000) || 100000),
+      });
+      res.writeHead(200, {
+        "Content-Type": "text/csv; charset=utf-8",
+        "Cache-Control": "public, max-age=1800",
+      });
+      res.end(payload.csv);
+      return;
+    } catch (error) {
+      console.error("[merchant-screen-feed] error", error?.message || error);
+      return sendJson(res, 500, { ok: false, error: "No se pudo generar feed Merchant dedicado" });
+    }
+  }
+
 
   if ((pathname === "/merchant-feed.tsv" || pathname === "/merchant-feed-sample.tsv" || pathname === "/merchant-feed-debug.json") && req.method === "GET") {
     const startedAt = Date.now();
@@ -13518,6 +13602,40 @@ async function requestHandler(req, res) {
       refreshedAt: new Date().toISOString(),
     });
     return;
+  }
+
+  if (pathname === "/adhesivos-de-pantalla" && req.method === "GET") {
+    try {
+      const feed = await finalScreenPublication.buildFeed("screen_adhesive", {
+        baseUrl: getPublicBaseUrl(getConfig()) || "https://nerinparts.com.ar",
+        limit: 48,
+      });
+      const items = feed.entries.slice(0, 48);
+      const itemList = {
+        "@context": "https://schema.org",
+        "@type": "ItemList",
+        itemListElement: items.map((item, index) => ({
+          "@type": "ListItem",
+          position: index + 1,
+          url: item.link,
+          name: item.title,
+        })),
+      };
+      const cards = items.map((item) => `
+        <article class="product-card">
+          <a href="${esc(item.link)}"><img src="${esc(item.image_link)}" alt="${esc(item.title)}" loading="lazy"></a>
+          <h2><a href="${esc(item.link)}">${esc(item.title)}</a></h2>
+          <p>${esc(item.price)}</p>
+        </article>
+      `).join("");
+      const html = `<!doctype html><html lang="es-AR"><head><meta charset="utf-8"><title>Adhesivos de pantalla para celulares | NERIN Parts</title><meta name="description" content="Adhesivos, gaskets y cintas para instalación de pantallas en Samsung, iPhone, Motorola, Xiaomi, Honor, Huawei, Google Pixel y más."><link rel="canonical" href="${esc((getPublicBaseUrl(getConfig()) || BASE_URL).replace(/\/+$/, ""))}/adhesivos-de-pantalla"><script type="application/ld+json">${safeJsonForScript(itemList)}</script></head><body><main><nav><a href="/shop.html?part_type=display_adhesive">Ver en catálogo</a></nav><h1>Adhesivos de pantalla para celulares</h1><p>Adhesivos, gaskets y cintas para instalación de pantallas en Samsung, iPhone, Motorola, Xiaomi, Honor, Huawei, Google Pixel y más. Repuestos para técnicos y laboratorios, con soporte para verificar compatibilidad.</p><section class="product-grid">${cards || '<p>No hay adhesivos de pantalla publicados en este momento.</p>'}</section></main></body></html>`;
+      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=600" });
+      res.end(html);
+      return;
+    } catch (error) {
+      console.error("[screen-adhesives-page] error", error?.message || error);
+      return sendJson(res, 500, { ok: false, error: "No se pudo cargar adhesivos de pantalla" });
+    }
   }
 
   if ((pathname === "/sitemap.xml" || pathname === "/sitemap-static.xml" || /^\/sitemap-products-\d+\.xml$/.test(pathname)) && req.method === "GET") {

--- a/nerin_final_updated/backend/services/screenPublicationService.js
+++ b/nerin_final_updated/backend/services/screenPublicationService.js
@@ -1,0 +1,476 @@
+const fs = require("fs");
+const fsp = fs.promises;
+const path = require("path");
+const sqlite3 = require("sqlite3");
+const productsSqliteRepo = require("../data/productsSqliteRepo");
+const { dataPath } = require("../utils/dataDir");
+const {
+  isRealScreenProduct,
+  isScreenAdhesiveProduct,
+  normalizeClassifierText,
+} = require("../utils/screenProductClassifier");
+const {
+  resolveProductAvailability,
+  getPublicPriceValue,
+} = require("../utils/productAvailability");
+const {
+  normalizeMerchantImageUrl,
+} = require("../utils/merchantFeed");
+
+const DEFAULT_BASE_URL = "https://nerinparts.com.ar";
+const GOOGLE_CATEGORY = "Electrónica > Comunicaciones > Telefonía > Accesorios para móviles";
+const VALID_AVAILABILITY = new Set(["in_stock", "preorder", "backorder", "out_of_stock"]);
+
+function dbAll(db, sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.all(sql, params, (error, rows) => (error ? reject(error) : resolve(rows || [])));
+  });
+}
+
+function dbGet(db, sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.get(sql, params, (error, row) => (error ? reject(error) : resolve(row || null)));
+  });
+}
+
+function openReadonly(dbPath) {
+  return new Promise((resolve, reject) => {
+    const db = new sqlite3.Database(dbPath, sqlite3.OPEN_READONLY, (error) => (error ? reject(error) : resolve(db)));
+  });
+}
+
+function closeDb(db) {
+  return new Promise((resolve) => db.close(() => resolve()));
+}
+
+function parseRaw(row = {}) {
+  try {
+    return row.raw_json ? JSON.parse(row.raw_json) : {};
+  } catch {
+    return {};
+  }
+}
+
+function mergeRow(row = {}) {
+  const raw = parseRaw(row);
+  return { ...raw, ...row, raw_json: row.raw_json };
+}
+
+function firstText(values = []) {
+  for (const value of values) {
+    const text = String(value || "").trim();
+    if (text) return text;
+  }
+  return "";
+}
+
+function boolish(value) {
+  return value === true || value === 1 || ["1", "true", "yes", "si", "sí"].includes(String(value || "").toLowerCase());
+}
+
+function optionEnabled(value, fallback = true) {
+  if (value === undefined || value === null || value === "") return fallback;
+  if (value === false || value === 0) return false;
+  return !["0", "false", "no", "off"].includes(String(value).toLowerCase());
+}
+
+function publicationBucket(product = {}) {
+  const state = productsSqliteRepo.computePublicationState(product);
+  return state.admin_visibility_bucket || (state.is_public ? "public" : "not_public");
+}
+
+function getIdentifier(product = {}) {
+  return firstText([product.id, product.sku, product.code, product.public_slug, product.publicSlug, product.slug, product.mpn, product.part_number, product.rowid]);
+}
+
+function getTitle(product = {}) {
+  return firstText([product.title, product.name, product.description, product.model]);
+}
+
+function getSlug(product = {}) {
+  return firstText([product.public_slug, product.publicSlug, product.slug]);
+}
+
+function getImage(product = {}) {
+  const images = Array.isArray(product.images) ? product.images : [];
+  return firstText([product.image, product.image_url, product.thumbnail, ...images]);
+}
+
+function hasPrice(product = {}) {
+  const price = getPublicPriceValue(product);
+  return Number.isFinite(price) && price > 0;
+}
+
+function hasImage(product = {}) {
+  return Boolean(getImage(product));
+}
+
+function availability(product = {}) {
+  return resolveProductAvailability(product);
+}
+
+function isRemoteOrderable(product = {}) {
+  const av = availability(product);
+  return av.merchantAvailability === "preorder" || av.merchantAvailability === "backorder";
+}
+
+function isStockReal(product = {}) {
+  const av = availability(product);
+  return av.merchantAvailability === "in_stock" && Number(product.stock || 0) > 0;
+}
+
+function hasAvailabilityDateIfNeeded(product = {}) {
+  const av = availability(product);
+  if (av.merchantAvailability !== "preorder" && av.merchantAvailability !== "backorder") return true;
+  return Boolean(av.availabilityDateFeed || av.availabilityStarts || product.availability_date || product.preorder_date);
+}
+
+function baseEligibility(product, classification, type) {
+  const blockers = [];
+  const warnings = [];
+  const state = productsSqliteRepo.computePublicationState(product);
+  const bucket = state.admin_visibility_bucket;
+  const priceOk = hasPrice(product);
+  const imageOk = hasImage(product);
+  const titleOk = Boolean(getTitle(product));
+  const slugOk = Boolean(getSlug(product) || state.public_slug);
+  const modelOk = Boolean(classification.modelBase);
+  const brandOk = Boolean(classification.deviceBrand);
+  const confidenceOk = Number(classification.confidence || 0) >= 0.55;
+  const av = availability(product);
+
+  if (state.public_blockers?.includes("deleted")) blockers.push("deleted");
+  if (state.public_blockers?.includes("archived")) blockers.push("archived");
+  if (state.public_blockers?.includes("draft")) blockers.push("draft");
+  if (state.public_blockers?.includes("disabled")) blockers.push("disabledNotOrderable");
+  if (!titleOk) blockers.push("missingTitle");
+  if (!priceOk) blockers.push("missingPrice");
+  if (!imageOk) blockers.push("missingImage");
+  if (!slugOk) blockers.push("missingSlug");
+  if (!modelOk && !brandOk && !confidenceOk) blockers.push("lowClassificationConfidence");
+  if (!isStockReal(product) && !isRemoteOrderable(product)) blockers.push("outOfStockNotOrderable");
+  if (!hasAvailabilityDateIfNeeded(product)) blockers.push("merchantAvailabilityDateMissing");
+  if (!VALID_AVAILABILITY.has(av.merchantAvailability || "")) blockers.push("merchantAvailabilityInvalid");
+
+  const merchantReady = blockers.filter((b) => /^missing|merchant|outOfStock|lowClassification/.test(b)).length === 0;
+  const indexReady = Boolean(product.product_rowid || product.rowid);
+  const publishable = blockers.length === 0;
+  return {
+    eligible: publishable,
+    publishable,
+    blockers,
+    warnings,
+    publicationState: state,
+    merchantReadiness: {
+      ready: merchantReady,
+      availability: av.merchantAvailability || "",
+      availability_date: av.availabilityDateFeed || "",
+      price: getPublicPriceValue(product),
+      hasImage: imageOk,
+      link: getSlug(product) ? `/p/${encodeURIComponent(getSlug(product))}` : "",
+    },
+    indexReadiness: { ready: indexReady, product_rowid: product.product_rowid || product.rowid || null },
+    bucket,
+    type,
+  };
+}
+
+function computeScreenPublicationEligibility(product = {}) {
+  const screenClassification = isRealScreenProduct(product);
+  const base = baseEligibility(product, screenClassification, "screen");
+  if (!screenClassification.isScreen) base.blockers.unshift(screenClassification.excludedAsAccessory ? "likelyAccessory" : "notRealScreen");
+  if (screenClassification.excludedAsAccessory && !base.blockers.includes("likelyAccessory")) base.blockers.unshift("likelyAccessory");
+  base.eligible = base.publishable = base.blockers.length === 0;
+  return { ...base, screenClassification };
+}
+
+function computeScreenAdhesivePublicationEligibility(product = {}) {
+  const adhesiveClassification = isScreenAdhesiveProduct(product);
+  const base = baseEligibility(product, adhesiveClassification, "screen_adhesive");
+  if (!adhesiveClassification.isScreenAdhesive) base.blockers.unshift(adhesiveClassification.excludedReason || "notScreenAdhesive");
+  base.eligible = base.publishable = base.blockers.length === 0;
+  return { ...base, adhesiveClassification };
+}
+
+function matchesFilters(item, filters = {}, type = "screen") {
+  const cls = type === "screen" ? item.screenClassification : item.adhesiveClassification;
+  const brand = normalizeClassifierText(filters.brand || "");
+  const model = normalizeClassifierText(filters.model || "");
+  const stockMode = String(filters.stockMode || "all");
+  const bucket = publicationBucket(item.product);
+  if (brand && normalizeClassifierText(cls.deviceBrand) !== brand) return false;
+  if (model && !normalizeClassifierText(cls.modelBase).includes(model)) return false;
+  if (type === "screen" && filters.qualityTier && normalizeClassifierText(cls.qualityTier) !== normalizeClassifierText(filters.qualityTier)) return false;
+  if (type !== "screen" && filters.adhesiveType && normalizeClassifierText(cls.adhesiveType) !== normalizeClassifierText(filters.adhesiveType)) return false;
+  if (!optionEnabled(filters.includePrivate, true) && bucket === "private") return false;
+  if (!optionEnabled(filters.includeHidden, true) && bucket === "hidden") return false;
+  if (!optionEnabled(filters.includeRemoteOrderable, true) && isRemoteOrderable(item.product)) return false;
+  if (optionEnabled(filters.onlyWithImage, false) && !hasImage(item.product)) return false;
+  if (optionEnabled(filters.onlyWithPrice, false) && !hasPrice(item.product)) return false;
+  if (stockMode === "stock_real" && !isStockReal(item.product)) return false;
+  if (stockMode === "remote_orderable" && !isRemoteOrderable(item.product)) return false;
+  return true;
+}
+
+function counterAdd(map, key) {
+  const safe = key || "unknown";
+  map[safe] = (map[safe] || 0) + 1;
+}
+
+function sampleItem(item) {
+  const cls = item.screenClassification || item.adhesiveClassification || {};
+  return {
+    id: item.product.id || item.product.sku || item.product.rowid,
+    sku: item.product.sku || "",
+    title: getTitle(item.product),
+    public_slug: getSlug(item.product),
+    brand: cls.deviceBrand || "",
+    model: cls.modelBase || "",
+    qualityTier: cls.qualityTier || "",
+    adhesiveType: cls.adhesiveType || "",
+    blockers: item.blockers || [],
+    warnings: item.warnings || [],
+  };
+}
+
+async function loadRows({ limit = 100000 } = {}) {
+  await productsSqliteRepo.ensureProductsDbOnce();
+  const db = await openReadonly(productsSqliteRepo.SQLITE_PATH);
+  try {
+    const rows = await dbAll(
+      db,
+      `SELECT p.rowid, p.*, si.product_rowid, si.part_type, si.device_brand, si.compatible_brand, si.model_base, si.quality_tier, si.has_frame, si.stock_status, si.is_stock_real, si.classification_confidence, si.search_blob
+       FROM products p
+       LEFT JOIN product_search_index si ON si.product_rowid = p.rowid
+       ORDER BY p.rowid ASC
+       LIMIT ?`,
+      [Math.max(1, Number(limit) || 100000)],
+    );
+    return rows;
+  } finally {
+    await closeDb(db);
+  }
+}
+
+function analyzeRows(rows, filters = {}, type = "screen") {
+  const summary = {
+    ok: true,
+    totalProducts: rows.length,
+    blockedCount: 0,
+    warningCount: 0,
+    byBrand: {},
+    byQualityTier: {},
+    byAdhesiveType: {},
+    byStockStatus: {},
+    byPublicationState: {},
+    blockersBreakdown: {},
+    eligibleSamples: [],
+    blockedSamples: [],
+    accessoryExcludedSamples: [],
+    excludedSamples: [],
+    items: [],
+  };
+  for (const row of rows) {
+    const product = mergeRow(row);
+    const eligibility = type === "screen" ? computeScreenPublicationEligibility(product) : computeScreenAdhesivePublicationEligibility(product);
+    const cls = type === "screen" ? eligibility.screenClassification : eligibility.adhesiveClassification;
+    const detected = type === "screen" ? cls.isScreen || cls.excludedAsAccessory : cls.isScreenAdhesive || cls.excludedReason;
+    if (!detected) continue;
+    const item = { ...eligibility, product };
+    if (!matchesFilters(item, filters, type)) continue;
+    summary.items.push(item);
+    counterAdd(summary.byBrand, cls.deviceBrand || "otros");
+    counterAdd(summary.byStockStatus, isStockReal(product) ? "stock_real" : isRemoteOrderable(product) ? "a_pedido" : "no_vendible");
+    counterAdd(summary.byPublicationState, publicationBucket(product));
+    if (type === "screen") counterAdd(summary.byQualityTier, cls.qualityTier || "unknown");
+    else counterAdd(summary.byAdhesiveType, cls.adhesiveType || "adhesive");
+    if (item.warnings.length) summary.warningCount += 1;
+    if (item.blockers.length) {
+      summary.blockedCount += 1;
+      for (const blocker of item.blockers) counterAdd(summary.blockersBreakdown, blocker);
+      if (summary.blockedSamples.length < 20) summary.blockedSamples.push(sampleItem(item));
+    } else if (summary.eligibleSamples.length < 20) {
+      summary.eligibleSamples.push(sampleItem(item));
+    }
+    if (type === "screen" && cls.excludedAsAccessory && summary.accessoryExcludedSamples.length < 20) summary.accessoryExcludedSamples.push(sampleItem(item));
+    if (type !== "screen" && cls.excludedReason && summary.excludedSamples.length < 20) summary.excludedSamples.push(sampleItem(item));
+  }
+  const publicCurrent = summary.items.filter((i) => {
+    const realType = type === "screen" ? i.screenClassification.isScreen : i.adhesiveClassification.isScreenAdhesive;
+    return realType && (Number(i.product.is_public) === 1 || boolish(i.product.is_public));
+  }).length;
+  const eligible = summary.items.filter((i) => i.eligible);
+  if (type === "screen") {
+    summary.totalScreensDetected = summary.items.filter((i) => i.screenClassification.isScreen).length;
+    summary.publicScreensCurrent = publicCurrent;
+    summary.privateScreensEligible = eligible.filter((i) => i.bucket === "private").length;
+    summary.hiddenScreensEligible = eligible.filter((i) => i.bucket === "hidden").length;
+    summary.remoteScreensEligible = eligible.filter((i) => isRemoteOrderable(i.product)).length;
+    summary.stockRealScreensEligible = eligible.filter((i) => isStockReal(i.product)).length;
+  } else {
+    summary.totalScreenAdhesivesDetected = summary.items.filter((i) => i.adhesiveClassification.isScreenAdhesive).length;
+    summary.publicScreenAdhesivesCurrent = publicCurrent;
+    summary.privateScreenAdhesivesEligible = eligible.filter((i) => i.bucket === "private").length;
+    summary.hiddenScreenAdhesivesEligible = eligible.filter((i) => i.bucket === "hidden").length;
+    summary.remoteScreenAdhesivesEligible = eligible.filter((i) => isRemoteOrderable(i.product)).length;
+    summary.stockRealScreenAdhesivesEligible = eligible.filter((i) => isStockReal(i.product)).length;
+  }
+  return summary;
+}
+
+async function previewPublication(type, filters = {}) {
+  const rows = await loadRows({ limit: filters.limit || 100000 });
+  const summary = analyzeRows(rows, filters, type);
+  delete summary.items;
+  return summary;
+}
+
+async function publishEligible(type, filters = {}) {
+  const confirm = type === "screen" ? filters.confirmScreenBulkPublish : filters.confirmScreenAdhesiveBulkPublish;
+  if (!confirm) {
+    const error = new Error(type === "screen" ? "confirmScreenBulkPublish requerido" : "confirmScreenAdhesiveBulkPublish requerido");
+    error.statusCode = 400;
+    throw error;
+  }
+  const rows = await loadRows({ limit: filters.limit || 100000 });
+  const summary = analyzeRows(rows, filters, type);
+  const eligible = summary.items.filter((i) => i.eligible);
+  const result = { ok: true, attemptedCount: eligible.length, updatedCount: 0, verifiedPublicCount: 0, failedCount: 0, samplePublished: [], sampleFailed: [] };
+  for (const item of eligible) {
+    const identifier = getIdentifier(item.product);
+    try {
+      const publication = await productsSqliteRepo.setProductVisibility(identifier, "public", { reason: type === "screen" ? "final_screen_publish" : "final_screen_adhesive_publish" });
+      await productsSqliteRepo.reindexProduct(identifier);
+      const debug = await productsSqliteRepo.debugPublicationByIdentifier(identifier);
+      const verified = Boolean(debug?.appearsInPublicApi || publication?.publicApiVisible || publication?.after?.is_public);
+      if (verified) {
+        result.updatedCount += 1;
+        result.verifiedPublicCount += 1;
+        if (result.samplePublished.length < 15) result.samplePublished.push(sampleItem(item));
+      } else {
+        result.failedCount += 1;
+        if (result.sampleFailed.length < 15) result.sampleFailed.push({ ...sampleItem(item), reason: "postVerificationFailed" });
+      }
+    } catch (error) {
+      result.failedCount += 1;
+      if (result.sampleFailed.length < 15) result.sampleFailed.push({ ...sampleItem(item), reason: error?.message || "publishFailed" });
+    }
+  }
+  return result;
+}
+
+function labelBrand(brand) {
+  return normalizeClassifierText(brand || "otros").replace(/^apple$/, "iphone") || "otros";
+}
+
+function priority(item) {
+  const cls = item.screenClassification || item.adhesiveClassification || {};
+  if (isStockReal(item.product) && hasImage(item.product) && hasPrice(item.product) && cls.deviceBrand && cls.modelBase) return "priority_high";
+  if (isRemoteOrderable(item.product) && cls.deviceBrand && cls.modelBase) return "priority_medium";
+  return "priority_low";
+}
+
+function feedEntry(item, type, baseUrl = DEFAULT_BASE_URL) {
+  const product = item.product;
+  const cls = item.screenClassification || item.adhesiveClassification || {};
+  const slug = getSlug(product);
+  const image = normalizeMerchantImageUrl(getImage(product), baseUrl);
+  const price = getPublicPriceValue(product);
+  const av = availability(product);
+  if (!slug || !image.valid || !Number.isFinite(price) || price <= 0 || !VALID_AVAILABILITY.has(av.merchantAvailability || "")) return null;
+  if ((av.merchantAvailability === "preorder" || av.merchantAvailability === "backorder") && !av.availabilityDateFeed) return null;
+  const brand = labelBrand(cls.deviceBrand || product.brand);
+  const quality = type === "screen" ? (cls.qualityTier || "compatible") : cls.adhesiveType || "adhesive";
+  const model = cls.modelBase || product.model || "";
+  const stockLabel = isStockReal(product) ? "stock_real" : "a_pedido";
+  const title = type === "screen"
+    ? `${/original|service_pack/.test(quality) ? "Pantalla" : "Pantalla compatible"} ${model || getTitle(product)} ${quality.replace(/_/g, " ")}`.trim()
+    : `${quality === "gasket" ? "Gasket" : quality === "seal" ? "Seal" : quality === "tape" ? "Display Adhesive Tape" : "Adhesivo de pantalla"} para ${model || getTitle(product)}`.trim();
+  return {
+    id: firstText([product.sku, product.id, product.mpn, product.rowid]),
+    title,
+    description: type === "screen"
+      ? `Pantalla/modulo para ${model || "celular"}. Repuesto ${quality.replace(/_/g, " ")}. Verifica compatibilidad antes de comprar. Factura A/B y soporte tecnico.`
+      : `Adhesivo/cinta/gasket para instalacion de pantalla en ${model || "celular"}. Verifica compatibilidad antes de comprar. Factura A/B y soporte tecnico.`,
+    link: `${baseUrl.replace(/\/+$/, "")}/p/${encodeURIComponent(slug)}`,
+    image_link: image.normalized,
+    additional_image_link: "",
+    availability: av.merchantAvailability,
+    availability_date: av.merchantAvailability === "preorder" || av.merchantAvailability === "backorder" ? av.availabilityDateFeed : "",
+    price: `${price.toFixed(2)} ARS`,
+    condition: "new",
+    brand: brand === "iphone" ? "Apple" : brand,
+    mpn: firstText([product.mpn, product.part_number, product.sku]),
+    identifier_exists: firstText([product.mpn, product.part_number]) ? "yes" : "no",
+    google_product_category: GOOGLE_CATEGORY,
+    product_type: type === "screen"
+      ? `Pantallas celulares > ${brand} > ${model || "otros"} > ${quality}`
+      : `Adhesivos de pantalla > ${brand} > ${model || "otros"} > ${quality}`,
+    custom_label_0: type === "screen" ? "screens" : "screen_adhesives",
+    custom_label_1: stockLabel,
+    custom_label_2: quality,
+    custom_label_3: brand,
+    custom_label_4: priority(item),
+  };
+}
+
+async function buildFeed(type, options = {}) {
+  const rows = await loadRows({ limit: options.limit || 100000 });
+  const summary = analyzeRows(rows, {}, type);
+  const entries = summary.items
+    .filter((item) => Number(item.product.is_public) === 1 || boolish(item.product.is_public))
+    .filter((item) => item.eligible || item.blockers.every((b) => b === "not_public_visibility"))
+    .map((item) => feedEntry(item, type, options.baseUrl || DEFAULT_BASE_URL))
+    .filter(Boolean);
+  const headers = ["id","title","description","link","image_link","additional_image_link","availability","availability_date","price","condition","brand","mpn","identifier_exists","google_product_category","product_type","custom_label_0","custom_label_1","custom_label_2","custom_label_3","custom_label_4"];
+  const csv = [headers.join(",")].concat(entries.map((entry) => headers.map((h) => csvCell(entry[h])).join(","))).join("\n") + "\n";
+  return { entries, csv };
+}
+
+function csvCell(value) {
+  const text = String(value ?? "");
+  return /[",\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+}
+
+async function writeAuditCsv() {
+  const rows = await loadRows({ limit: 100000 });
+  const screens = analyzeRows(rows, {}, "screen");
+  const adhesives = analyzeRows(rows, {}, "screen_adhesive");
+  const exportDir = path.join(path.dirname(dataPath("x")), "..", "exports");
+  await fsp.mkdir(exportDir, { recursive: true });
+  const screenHeaders = ["id","sku","title","public_slug","visibility","is_public","part_type","device_brand","model_base","quality_tier","stock_status","price","has_image","availability","availability_date","eligible","merchantReady","custom_label_0","custom_label_1","custom_label_2","custom_label_3","custom_label_4","blockers","warnings"];
+  const adhesiveHeaders = ["id","sku","title","public_slug","visibility","is_public","part_type","adhesive_context","device_brand","model_base","adhesive_type","stock_status","price","has_image","availability","availability_date","eligible","merchantReady","custom_label_0","custom_label_1","custom_label_2","custom_label_3","custom_label_4","blockers","warnings"];
+  await fsp.writeFile(path.join(exportDir, "screens-final-audit.csv"), toAuditCsv(screens.items, "screen", screenHeaders), "utf8");
+  await fsp.writeFile(path.join(exportDir, "screen-adhesives-final-audit.csv"), toAuditCsv(adhesives.items, "screen_adhesive", adhesiveHeaders), "utf8");
+  return { screens, adhesives, exportDir };
+}
+
+function toAuditCsv(items, type, headers) {
+  return [headers.join(",")].concat(items.map((item) => {
+    const p = item.product;
+    const cls = item.screenClassification || item.adhesiveClassification || {};
+    const av = availability(p);
+    const entry = feedEntry(item, type, DEFAULT_BASE_URL) || {};
+    const values = {
+      id: p.id || p.rowid, sku: p.sku || "", title: getTitle(p), public_slug: getSlug(p), visibility: p.visibility || "", is_public: p.is_public || 0,
+      part_type: type === "screen" ? "display" : "display_adhesive", adhesive_context: type === "screen_adhesive" ? "display" : "",
+      device_brand: cls.deviceBrand || "", model_base: cls.modelBase || "", quality_tier: cls.qualityTier || "", adhesive_type: cls.adhesiveType || "",
+      stock_status: isStockReal(p) ? "stock_real" : isRemoteOrderable(p) ? "a_pedido" : "out_of_stock", price: getPublicPriceValue(p) || "", has_image: hasImage(p),
+      availability: av.merchantAvailability || "", availability_date: av.availabilityDateFeed || "", eligible: item.eligible, merchantReady: item.merchantReadiness?.ready,
+      custom_label_0: entry.custom_label_0 || "", custom_label_1: entry.custom_label_1 || "", custom_label_2: entry.custom_label_2 || "", custom_label_3: entry.custom_label_3 || "", custom_label_4: entry.custom_label_4 || "",
+      blockers: (item.blockers || []).join("|"), warnings: (item.warnings || []).join("|"),
+    };
+    return headers.map((h) => csvCell(values[h])).join(",");
+  })).join("\n") + "\n";
+}
+
+module.exports = {
+  computeScreenPublicationEligibility,
+  computeScreenAdhesivePublicationEligibility,
+  previewPublication,
+  publishEligible,
+  buildFeed,
+  writeAuditCsv,
+  analyzeRows,
+  feedEntry,
+};

--- a/nerin_final_updated/backend/utils/screenProductClassifier.js
+++ b/nerin_final_updated/backend/utils/screenProductClassifier.js
@@ -1,0 +1,279 @@
+const BRAND_ALIASES = [
+  ["google_pixel", /\b(pixel|google pixel)\b/i],
+  ["samsung", /\b(samsung|galaxy|sm-[a-z]\d+)/i],
+  ["iphone", /\b(apple|iphone)\b/i],
+  ["motorola", /\b(motorola|moto\s)/i],
+  ["xiaomi", /\b(xiaomi|redmi|poco)\b/i],
+  ["honor", /\bhonor\b/i],
+  ["huawei", /\bhuawei\b/i],
+  ["oneplus", /\boneplus\b/i],
+  ["oppo", /\boppo\b/i],
+  ["realme", /\brealme\b/i],
+];
+
+const SCREEN_TERMS = [
+  /\bpart[_\s-]?type\s*[:=]?\s*display\b/i,
+  /\b(display|screen|lcd|oled|amoled|super\s+amoled|pantalla|modulo|m[oó]dulo)\b/i,
+  /\b(display|pantalla|modulo|m[oó]dulo)\s+(incl|excl|with|without|con|sin)\s+(frame|marco)\b/i,
+  /\b(service\s*pack|original|compatible|hard\s*oled|soft\s*oled|incell|refurb(?:ished)?|pulled|jk).{0,24}\b(display|pantalla|modulo|m[oó]dulo)\b/i,
+  /\brepair\s+kit\s+display\b/i,
+];
+
+const SCREEN_ACCESSORY_BLOCKERS = [
+  ["display_adhesive", /\b(display|screen|lcd|oled|pantalla).{0,24}(adhesive|adhesivo|tape|cinta|sticker|gasket|seal|junta)\b/i],
+  ["adhesive_display", /\b(adhesive|adhesivo|tape|cinta|sticker|gasket|seal|junta).{0,24}(display|screen|lcd|oled|pantalla)\b/i],
+  ["bracket_display", /\bbracket.{0,20}(display|screen|pantalla|frame|marco)\b|\b(display|screen|pantalla|frame|marco).{0,20}bracket\b|\bsoporte\s+(?:de\s+)?(?:display|pantalla|marco)\b/i],
+  ["screen_protector", /\b(screen\s+protector|protector\s+de\s+pantalla|tempered\s+glass|vidrio\s+templado|hydrogel|film)\b/i],
+  ["case_cover", /\b(case|coverz|magsafe\s+case|funda|carcasa\s+protectora|snap)\b/i],
+  ["sim_tray", /\b(sim\s+tray|keyset\s+simcard\s+tray|bandeja\s+sim)\b/i],
+  ["antenna", /\b(antenna|antena|gps\s+antenna)\b/i],
+  ["camera_lens", /\b(camera\s+lens|camera\s+glass|lente\s+c[aá]mara|cristal\s+c[aá]mara)\b/i],
+  ["back_cover", /\b(back\s+glass|rear\s+cover|back\s+cover|battery\s+cover|tapa\s+trasera|vidrio\s+trasero)\b/i],
+  ["battery", /\b(battery|bateria|bater[ií]a)\b/i],
+  ["charging", /\b(dock\s+connector|charging\s+board|usb\s+board|pin\s+de\s+carga|placa\s+de\s+carga)\b/i],
+  ["audio", /\b(speaker|earpiece|microphone|parlante|auricular|micr[oó]fono)\b/i],
+  ["small_part", /\b(vibrator|sensor|button|flex\s+cable|flex)\b/i],
+];
+
+const ADHESIVE_TERMS = [
+  /\b(display|screen|lcd|oled|pantalla).{0,32}(adhesive|adhesivo|tape|cinta|sticker|gasket|seal|junta)\b/i,
+  /\b(adhesive|adhesivo|tape|cinta|sticker|gasket|seal|junta).{0,32}(display|screen|lcd|oled|pantalla)\b/i,
+  /\brepair\s+kit\s+adhesive\b/i,
+];
+
+const NON_SCREEN_ADHESIVE_BLOCKERS = [
+  ["battery_adhesive", /\b(battery|bateria|bater[ií]a).{0,24}(adhesive|adhesivo|tape|cinta)\b|\b(adhesive|adhesivo|tape|cinta).{0,24}(battery|bateria|bater[ií]a)\b/i],
+  ["back_cover_adhesive", /\b(back|rear|battery)\s+cover.{0,24}(adhesive|tape)\b|\b(tapa|vidrio)\s+trasera.{0,24}(adhesivo|cinta)\b/i],
+  ["camera_adhesive", /\b(camera|lens|c[aá]mara|lente).{0,24}(adhesive|adhesivo|tape|cinta)\b/i],
+  ["audio_adhesive", /\b(speaker|microphone|parlante|micr[oó]fono).{0,24}(adhesive|adhesivo|tape|cinta)\b/i],
+];
+
+const QUALITY_PATTERNS = [
+  ["service_pack", /\bservice\s*pack\b/i],
+  ["hard_oled", /\bhard\s*oled\b/i],
+  ["soft_oled", /\bsoft\s*oled\b|soft\s+factory\b/i],
+  ["amoled", /\bamoled|super\s+amoled\b/i],
+  ["lcd", /\blcd\b/i],
+  ["incell", /\bincell|in-cell\b/i],
+  ["refurbished", /\brefurb(?:ished)?\b/i],
+  ["pulled_a", /\bpulled\s*a\b/i],
+  ["pulled_b", /\bpulled\s*b\b/i],
+  ["pulled_c", /\bpulled\s*c\b/i],
+  ["pulled", /\bpulled\b/i],
+  ["jk", /\bjk\b/i],
+  ["original", /\boriginal\b/i],
+  ["compatible", /\bcompatible|compat\b/i],
+  ["high_quality", /\bhigh\s+quality|alta\s+calidad\b/i],
+];
+
+function norm(value) {
+  return String(value || "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function textOf(product = {}) {
+  let raw = {};
+  if (product.raw_json && typeof product.raw_json === "string") {
+    try {
+      raw = JSON.parse(product.raw_json);
+    } catch {
+      raw = {};
+    }
+  }
+  return [
+    product.part_type,
+    product.category,
+    product.title,
+    product.name,
+    product.description,
+    product.short_description,
+    product.sku,
+    product.mpn,
+    product.part_number,
+    product.brand,
+    product.model,
+    product.device_brand,
+    product.model_base,
+    raw.part_type,
+    raw.category,
+    raw.title,
+    raw.name,
+    raw.description,
+    raw.short_description,
+    raw.sku,
+    raw.mpn,
+    raw.part_number,
+    raw.brand,
+    raw.model,
+    raw.device_brand,
+    raw.model_base,
+  ].filter(Boolean).join(" ");
+}
+
+function detectBrand(text, product = {}) {
+  const existing = norm(product.device_brand || product.compatible_brand || product.brand || "");
+  if (existing) {
+    if (/apple|iphone/.test(existing)) return "iphone";
+    if (/google|pixel/.test(existing)) return "google_pixel";
+    return existing.replace(/[^a-z0-9]+/g, "_").replace(/^_|_$/g, "") || "otros";
+  }
+  for (const [brand, pattern] of BRAND_ALIASES) {
+    if (pattern.test(text)) return brand;
+  }
+  return "";
+}
+
+function detectModel(text, product = {}) {
+  const existing = norm(product.model_base || product.model || "");
+  if (existing) return existing;
+  const patterns = [
+    /\biphone\s+\d{1,2}(?:\s+(?:pro\s+max|pro|plus|mini|air))?/i,
+    /\bgalaxy\s+[a-z]\d{1,3}(?:\s*5g|\s*4g)?(?:\s+plus|\s+ultra)?/i,
+    /\b(?:redmi\s+note|redmi|poco|pixel|honor|huawei|moto)\s+[a-z0-9 ]{1,20}/i,
+    /\bsm-[a-z]\d{3,}[a-z]?\b/i,
+  ];
+  for (const pattern of patterns) {
+    const match = text.match(pattern);
+    if (match) return norm(match[0]);
+  }
+  return "";
+}
+
+function detectQuality(text, product = {}) {
+  const existing = norm(product.quality_tier || "");
+  if (existing) return existing;
+  for (const [quality, pattern] of QUALITY_PATTERNS) {
+    if (pattern.test(text)) return quality;
+  }
+  return "";
+}
+
+function detectAdhesiveType(text) {
+  if (/\bgasket|junta\b/i.test(text)) return "gasket";
+  if (/\bseal|sello\b/i.test(text)) return "seal";
+  if (/\btape|cinta\b/i.test(text)) return "tape";
+  if (/\bsticker\b/i.test(text)) return "sticker";
+  return "adhesive";
+}
+
+function hasFrame(text, product = {}) {
+  if (product.has_frame === true || Number(product.has_frame) === 1) return true;
+  if (product.has_frame === false || Number(product.has_frame) === 0) return false;
+  if (/\b(with|incl|con)\s+(frame|marco)\b|\b(con\s+marco)\b/i.test(text)) return true;
+  if (/\b(without|excl|sin)\s+(frame|marco)\b|\b(sin\s+marco)\b/i.test(text)) return false;
+  return null;
+}
+
+function isRealScreenProduct(product = {}) {
+  const text = textOf(product);
+  const normalized = norm(text);
+  const reasons = [];
+  const blockers = [];
+  let excludedAsAccessory = false;
+  let excludeReason = "";
+
+  const adhesive = isScreenAdhesiveProduct(product);
+  if (adhesive.isScreenAdhesive) {
+    excludedAsAccessory = true;
+    excludeReason = "display_adhesive";
+    blockers.push("likelyAccessory");
+  }
+  for (const [reason, pattern] of SCREEN_ACCESSORY_BLOCKERS) {
+    if (pattern.test(text)) {
+      excludedAsAccessory = true;
+      excludeReason = excludeReason || reason;
+      blockers.push(reason);
+      break;
+    }
+  }
+
+  let confidence = 0;
+  if (norm(product.part_type) === "display") {
+    confidence += 0.55;
+    reasons.push("part_type_display");
+  }
+  for (const pattern of SCREEN_TERMS) {
+    if (pattern.test(text)) {
+      confidence += 0.18;
+      reasons.push(`term:${String(pattern).slice(1, 24)}`);
+    }
+  }
+  if (/\brepair\s+kit\s+display\b/i.test(text)) confidence += 0.15;
+  if (detectModel(text, product)) confidence += 0.1;
+  if (detectBrand(text, product)) confidence += 0.08;
+  confidence = Math.min(0.99, confidence);
+  const isScreen = confidence >= 0.35 && !excludedAsAccessory;
+  if (!isScreen && !excludedAsAccessory) blockers.push("notRealScreen");
+  return {
+    isScreen,
+    confidence,
+    screenType: hasFrame(text, product) === true ? "display_with_frame" : hasFrame(text, product) === false ? "display_without_frame" : "display",
+    qualityTier: detectQuality(text, product),
+    hasFrame: hasFrame(text, product),
+    deviceBrand: detectBrand(text, product),
+    modelBase: detectModel(text, product),
+    reasons,
+    blockers,
+    excludedAsAccessory,
+    excludeReason,
+  };
+}
+
+function isScreenAdhesiveProduct(product = {}) {
+  const text = textOf(product);
+  const reasons = [];
+  const blockers = [];
+  let excludedReason = "";
+  for (const [reason, pattern] of NON_SCREEN_ADHESIVE_BLOCKERS) {
+    if (pattern.test(text)) {
+      excludedReason = reason;
+      blockers.push(reason);
+      break;
+    }
+  }
+  let confidence = 0;
+  if (norm(product.part_type) === "display_adhesive") {
+    confidence += 0.6;
+    reasons.push("part_type_display_adhesive");
+  }
+  if (norm(product.adhesive_context) === "display") {
+    confidence += 0.3;
+    reasons.push("adhesive_context_display");
+  }
+  for (const pattern of ADHESIVE_TERMS) {
+    if (pattern.test(text)) {
+      confidence += 0.25;
+      reasons.push(`term:${String(pattern).slice(1, 24)}`);
+    }
+  }
+  const modelBase = detectModel(text, product);
+  if (modelBase) confidence += 0.08;
+  const adhesiveType = detectAdhesiveType(text);
+  if (!modelBase && /\b(universal|generic|generico|gen[eé]rico)\b/i.test(text)) {
+    excludedReason = excludedReason || "genericAdhesiveWithoutModel";
+    blockers.push("genericAdhesiveWithoutModel");
+  }
+  confidence = Math.min(0.99, confidence);
+  const isScreenAdhesive = confidence >= 0.3 && !excludedReason;
+  if (!isScreenAdhesive && !excludedReason) blockers.push("notScreenAdhesive");
+  return {
+    isScreenAdhesive,
+    confidence,
+    adhesiveType,
+    deviceBrand: detectBrand(text, product),
+    modelBase,
+    reasons,
+    blockers,
+    excludedReason,
+  };
+}
+
+module.exports = {
+  isRealScreenProduct,
+  isScreenAdhesiveProduct,
+  normalizeClassifierText: norm,
+};

--- a/nerin_final_updated/frontend/admin.html
+++ b/nerin_final_updated/frontend/admin.html
@@ -560,6 +560,54 @@
             <div id="bulkPublishSummary" role="status" aria-live="polite"></div>
             <div id="bulkPublishDetails" class="bulk-publish-details"></div>
           </section>
+          <section class="bulk-publish-panel" aria-labelledby="finalScreensPublisherTitle">
+            <header class="bulk-publish-header">
+              <h4 id="finalScreensPublisherTitle">Publicador final de pantallas y adhesivos de pantalla</h4>
+              <p>PublicaciÃ³n manual y separada. No mezcla pantallas con adhesivos, brackets, fundas ni protectores.</p>
+            </header>
+            <div class="bulk-publish-card">
+              <h5>Pantallas / mÃ³dulos</h5>
+              <div class="bulk-publish-filters-grid">
+                <label class="bulk-publish-field">Marca<input id="screenPubBrand" type="text" /></label>
+                <label class="bulk-publish-field">Modelo<input id="screenPubModel" type="text" /></label>
+                <label class="bulk-publish-field">Calidad<input id="screenPubQuality" type="text" /></label>
+                <label class="bulk-publish-field">Stock<select id="screenPubStock"><option value="all">Todas</option><option value="stock_real">Stock real</option><option value="remote_orderable">A pedido</option></select></label>
+                <label class="bulk-publish-field">LÃ­mite<input id="screenPubLimit" type="number" value="10000" min="1" max="50000" /></label>
+              </div>
+              <label><input id="screenPubOnlyImage" type="checkbox" checked /> Solo con imagen</label>
+              <label><input id="screenPubOnlyPrice" type="checkbox" checked /> Solo con precio</label>
+              <label><input id="screenPubIncludePrivate" type="checkbox" checked /> Incluir privadas</label>
+              <label><input id="screenPubIncludeHidden" type="checkbox" checked /> Incluir ocultas</label>
+              <label><input id="screenPubIncludeRemote" type="checkbox" checked /> Incluir a pedido</label>
+              <div class="bulk-publish-actions">
+                <button id="screenAuditBtn" class="button secondary">Auditar pantallas</button>
+                <button id="screenPreviewBtn" class="button secondary">Simular publicaciÃ³n de pantallas</button>
+                <button id="screenPublishBtn" class="button">Publicar pantallas elegibles</button>
+              </div>
+            </div>
+            <div class="bulk-publish-card">
+              <h5>Adhesivos de pantalla</h5>
+              <div class="bulk-publish-filters-grid">
+                <label class="bulk-publish-field">Marca<input id="adhPubBrand" type="text" /></label>
+                <label class="bulk-publish-field">Modelo<input id="adhPubModel" type="text" /></label>
+                <label class="bulk-publish-field">Tipo<input id="adhPubType" type="text" /></label>
+                <label class="bulk-publish-field">Stock<select id="adhPubStock"><option value="all">Todas</option><option value="stock_real">Stock real</option><option value="remote_orderable">A pedido</option></select></label>
+                <label class="bulk-publish-field">LÃ­mite<input id="adhPubLimit" type="number" value="10000" min="1" max="50000" /></label>
+              </div>
+              <label><input id="adhPubOnlyImage" type="checkbox" checked /> Solo con imagen</label>
+              <label><input id="adhPubOnlyPrice" type="checkbox" checked /> Solo con precio</label>
+              <label><input id="adhPubIncludePrivate" type="checkbox" checked /> Incluir privadas</label>
+              <label><input id="adhPubIncludeHidden" type="checkbox" checked /> Incluir ocultas</label>
+              <label><input id="adhPubIncludeRemote" type="checkbox" checked /> Incluir a pedido</label>
+              <div class="bulk-publish-actions">
+                <button id="adhAuditBtn" class="button secondary">Auditar adhesivos de pantalla</button>
+                <button id="adhPreviewBtn" class="button secondary">Simular publicaciÃ³n de adhesivos</button>
+                <button id="adhPublishBtn" class="button">Publicar adhesivos elegibles</button>
+              </div>
+            </div>
+            <div id="finalScreensPublisherStatus" class="bulk-publish-status" role="status" aria-live="polite"></div>
+            <div id="finalScreensPublisherSummary" class="bulk-publish-details"></div>
+          </section>
           <div class="bulk-actions">
             <select id="bulkActionSelect">
               <option value="">Acción masiva…</option>

--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -4060,6 +4060,81 @@ if (bulkPublishRunBtn) {
     }
   });
 }
+
+const finalScreensPublisherStatus = document.getElementById("finalScreensPublisherStatus");
+const finalScreensPublisherSummary = document.getElementById("finalScreensPublisherSummary");
+
+function finalPublisherFilters(kind) {
+  const isScreen = kind === "screen";
+  return {
+    brand: document.getElementById(isScreen ? "screenPubBrand" : "adhPubBrand")?.value?.trim() || "",
+    model: document.getElementById(isScreen ? "screenPubModel" : "adhPubModel")?.value?.trim() || "",
+    qualityTier: isScreen ? document.getElementById("screenPubQuality")?.value?.trim() || "" : undefined,
+    adhesiveType: !isScreen ? document.getElementById("adhPubType")?.value?.trim() || "" : undefined,
+    stockMode: document.getElementById(isScreen ? "screenPubStock" : "adhPubStock")?.value || "all",
+    onlyWithImage: Boolean(document.getElementById(isScreen ? "screenPubOnlyImage" : "adhPubOnlyImage")?.checked),
+    onlyWithPrice: Boolean(document.getElementById(isScreen ? "screenPubOnlyPrice" : "adhPubOnlyPrice")?.checked),
+    includePrivate: Boolean(document.getElementById(isScreen ? "screenPubIncludePrivate" : "adhPubIncludePrivate")?.checked),
+    includeHidden: Boolean(document.getElementById(isScreen ? "screenPubIncludeHidden" : "adhPubIncludeHidden")?.checked),
+    includeRemoteOrderable: Boolean(document.getElementById(isScreen ? "screenPubIncludeRemote" : "adhPubIncludeRemote")?.checked),
+    limit: Number(document.getElementById(isScreen ? "screenPubLimit" : "adhPubLimit")?.value || 10000) || 10000,
+  };
+}
+
+function setFinalPublisherStatus(message) {
+  if (finalScreensPublisherStatus) finalScreensPublisherStatus.textContent = message || "";
+}
+
+function renderFinalPublisherSummary(data = {}, kind = "screen") {
+  if (!finalScreensPublisherSummary) return;
+  const isScreen = kind === "screen";
+  const rows = isScreen
+    ? [["Pantallas publicas actuales", data.publicScreensCurrent], ["Pantallas privadas elegibles", data.privateScreensEligible], ["Pantallas ocultas elegibles", data.hiddenScreensEligible], ["Pantallas stock real elegibles", data.stockRealScreensEligible], ["Pantallas a pedido elegibles", data.remoteScreensEligible]]
+    : [["Adhesivos publicos actuales", data.publicScreenAdhesivesCurrent], ["Adhesivos privados elegibles", data.privateScreenAdhesivesEligible], ["Adhesivos ocultos elegibles", data.hiddenScreenAdhesivesEligible], ["Adhesivos stock real elegibles", data.stockRealScreenAdhesivesEligible], ["Adhesivos a pedido elegibles", data.remoteScreenAdhesivesEligible]];
+  rows.push(["Bloqueados por imagen", data.blockersBreakdown?.missingImage || 0]);
+  rows.push(["Bloqueados por precio", data.blockersBreakdown?.missingPrice || 0]);
+  rows.push(["Bloqueados Merchant", Object.entries(data.blockersBreakdown || {}).filter(([k]) => k.startsWith("merchant")).reduce((s, [, v]) => s + Number(v || 0), 0)]);
+  rows.push([isScreen ? "Excluidos por accesorio" : "Excluidos por no ser de pantalla", isScreen ? (data.accessoryExcludedSamples || []).length : (data.excludedSamples || []).length]);
+  finalScreensPublisherSummary.innerHTML = `<div class="bulk-publish-summary-grid">${rows.map(([label, value]) => `<article><strong>${escapeHtml(String(value ?? 0))}</strong><span>${escapeHtml(label)}</span></article>`).join("")}</div><p><a href="/pantallas-en-stock" target="_blank">/pantallas-en-stock</a> · <a href="/adhesivos-de-pantalla" target="_blank">/adhesivos-de-pantalla</a> · <a href="/api/merchant/screens-feed.csv" target="_blank">feed pantallas</a> · <a href="/api/merchant/screen-adhesives-feed.csv" target="_blank">feed adhesivos</a></p>`;
+}
+
+async function runFinalPublisher(kind, action) {
+  const isScreen = kind === "screen";
+  const base = isScreen ? "/api/admin/screens" : "/api/admin/screen-adhesives";
+  const filters = finalPublisherFilters(kind);
+  setFinalPublisherStatus("Procesando...");
+  try {
+    let data;
+    if (action === "audit") {
+      const params = new URLSearchParams(Object.entries(filters).filter(([, v]) => v !== undefined && v !== ""));
+      const res = await apiFetch(`${base}/audit?${params.toString()}`);
+      data = await res.json();
+    } else {
+      const body = action === "publish" ? { ...filters, [isScreen ? "confirmScreenBulkPublish" : "confirmScreenAdhesiveBulkPublish"]: true } : filters;
+      if (action === "publish") {
+        const ok = confirm(isScreen
+          ? "Vas a publicar pantallas reales elegibles. No se publicaran adhesivos, brackets, fundas, protectores ni productos sin precio/imagen."
+          : "Vas a publicar adhesivos de pantalla elegibles. No se publicaran adhesivos de bateria, tapas, camaras ni cintas genericas sin modelo.");
+        if (!ok) return;
+      }
+      const res = await apiFetch(`${base}/${action === "publish" ? "publish" : "publish-preview"}`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
+      data = await res.json();
+    }
+    if (!data.ok) throw new Error(data.error || "No se pudo completar");
+    setFinalPublisherStatus(action === "publish" ? `Actualizados ${data.updatedCount || 0}, verificados ${data.verifiedPublicCount || 0}, fallidos ${data.failedCount || 0}` : "Listo.");
+    renderFinalPublisherSummary(data, kind);
+  } catch (error) {
+    setFinalPublisherStatus(error?.message || "No se pudo completar la operacion");
+  }
+}
+
+document.getElementById("screenAuditBtn")?.addEventListener("click", () => runFinalPublisher("screen", "audit"));
+document.getElementById("screenPreviewBtn")?.addEventListener("click", () => runFinalPublisher("screen", "preview"));
+document.getElementById("screenPublishBtn")?.addEventListener("click", () => runFinalPublisher("screen", "publish"));
+document.getElementById("adhAuditBtn")?.addEventListener("click", () => runFinalPublisher("adhesive", "audit"));
+document.getElementById("adhPreviewBtn")?.addEventListener("click", () => runFinalPublisher("adhesive", "preview"));
+document.getElementById("adhPublishBtn")?.addEventListener("click", () => runFinalPublisher("adhesive", "publish"));
+
 async function deleteProduct(id) {
   if (!confirm("¿Estás seguro de eliminar este producto?")) return;
   const resp = await apiFetch(`/api/products/${id}`, { method: "DELETE" });

--- a/nerin_final_updated/package.json
+++ b/nerin_final_updated/package.json
@@ -12,6 +12,8 @@
     "rebuild:products-manifest": "node scripts/rebuildProductsManifest.js",
     "test:render-startup": "node scripts/test-render-startup-nonblocking.js",
     "test:analytics-memory": "node scripts/test-analytics-memory-safety.js",
+    "test:screens-final": "node scripts/test-screens-and-adhesives-final.js",
+    "audit:screens-final": "node scripts/audit-screens-and-adhesives-final.js",
     "check:no-products-full-parse": "node scripts/check-no-products-full-parse.js"
   },
   "dependencies": {

--- a/nerin_final_updated/scripts/audit-screens-and-adhesives-final.js
+++ b/nerin_final_updated/scripts/audit-screens-and-adhesives-final.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+"use strict";
+
+const {
+  writeAuditCsv,
+  buildFeed,
+} = require("../backend/services/screenPublicationService");
+
+function countBlockers(summary, names) {
+  return names.reduce((total, name) => total + Number(summary.blockersBreakdown?.[name] || 0), 0);
+}
+
+function topEntries(map = {}, limit = 10) {
+  return Object.entries(map)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([key, value]) => `${key}:${value}`)
+    .join(", ");
+}
+
+function printSamples(title, samples = [], limit = 15) {
+  console.log(`\n${title}`);
+  const list = samples.slice(0, limit);
+  if (!list.length) {
+    console.log("- none");
+    return;
+  }
+  for (const item of list) {
+    const why = item.blockers?.length ? ` | blockers=${item.blockers.join("|")}` : "";
+    console.log(`- ${item.sku || item.id || "sin-id"} | ${item.title || "sin-titulo"}${why}`);
+  }
+}
+
+async function main() {
+  const { screens, adhesives, exportDir } = await writeAuditCsv();
+  const screensFeed = await buildFeed("screen", { limit: 100000 });
+  const adhesivesFeed = await buildFeed("screen_adhesive", { limit: 100000 });
+
+  const screenEligible = screens.items.filter((item) => item.eligible);
+  const adhesiveEligible = adhesives.items.filter((item) => item.eligible);
+
+  const screenAccessoryBlocked = countBlockers(screens, ["likelyAccessory", "display_adhesive", "adhesive_display", "bracket_display", "screen_protector", "case_cover"]);
+  const adhesiveNotScreenBlocked = countBlockers(adhesives, ["notScreenAdhesive", "genericAdhesiveWithoutModel", "battery_adhesive", "back_cover_adhesive", "camera_adhesive", "audio_adhesive"]);
+
+  console.log("NERIN final screens and screen adhesives audit");
+  console.log(`exportsDir=${exportDir}`);
+  console.log(`total productos=${screens.totalProducts}`);
+  console.log(`pantallas detectadas totales=${screens.totalScreensDetected || 0}`);
+  console.log(`pantallas publicas actuales=${screens.publicScreensCurrent || 0}`);
+  console.log(`pantallas privadas elegibles=${screens.privateScreensEligible || 0}`);
+  console.log(`pantallas ocultas elegibles=${screens.hiddenScreensEligible || 0}`);
+  console.log(`pantallas stock real elegibles=${screens.stockRealScreensEligible || 0}`);
+  console.log(`pantallas a pedido elegibles=${screens.remoteScreensEligible || 0}`);
+  console.log(`pantallas bloqueadas por imagen=${screens.blockersBreakdown?.missingImage || 0}`);
+  console.log(`pantallas bloqueadas por precio=${screens.blockersBreakdown?.missingPrice || 0}`);
+  console.log(`pantallas bloqueadas por Merchant=${countBlockers(screens, ["merchantAvailabilityDateMissing", "merchantAvailabilityInvalid", "outOfStockNotOrderable", "lowClassificationConfidence"])}`);
+  console.log(`pantallas bloqueadas por accesorio=${screenAccessoryBlocked}`);
+  console.log(`adhesivos de pantalla detectados totales=${adhesives.totalScreenAdhesivesDetected || 0}`);
+  console.log(`adhesivos de pantalla publicos actuales=${adhesives.publicScreenAdhesivesCurrent || 0}`);
+  console.log(`adhesivos privados elegibles=${adhesives.privateScreenAdhesivesEligible || 0}`);
+  console.log(`adhesivos ocultos elegibles=${adhesives.hiddenScreenAdhesivesEligible || 0}`);
+  console.log(`adhesivos stock real elegibles=${adhesives.stockRealScreenAdhesivesEligible || 0}`);
+  console.log(`adhesivos a pedido elegibles=${adhesives.remoteScreenAdhesivesEligible || 0}`);
+  console.log(`adhesivos bloqueados por imagen=${adhesives.blockersBreakdown?.missingImage || 0}`);
+  console.log(`adhesivos bloqueados por precio=${adhesives.blockersBreakdown?.missingPrice || 0}`);
+  console.log(`adhesivos bloqueados por Merchant=${countBlockers(adhesives, ["merchantAvailabilityDateMissing", "merchantAvailabilityInvalid", "outOfStockNotOrderable", "lowClassificationConfidence"])}`);
+  console.log(`adhesivos bloqueados por no ser de pantalla=${adhesiveNotScreenBlocked}`);
+  console.log(`top marcas con pantallas pendientes=${topEntries(screens.byBrand)}`);
+  console.log(`top marcas con adhesivos pendientes=${topEntries(adhesives.byBrand)}`);
+  console.log(`top calidades de pantallas=${topEntries(screens.byQualityTier)}`);
+  console.log(`total screens feed ready=${screensFeed.entries.length}`);
+  console.log(`total screen adhesives feed ready=${adhesivesFeed.entries.length}`);
+  console.log(`total screens feed blocked=${Math.max(0, screens.totalScreensDetected - screensFeed.entries.length)}`);
+  console.log(`total screen adhesives feed blocked=${Math.max(0, adhesives.totalScreenAdhesivesDetected - adhesivesFeed.entries.length)}`);
+
+  printSamples("top 15 pantallas candidatas a publicar", screenEligible.map((item) => ({
+    ...(item.screenClassification || {}),
+    id: item.product.id || item.product.rowid,
+    sku: item.product.sku || "",
+    title: item.product.title || item.product.name || "",
+  })));
+  printSamples("top 15 pantallas bloqueadas", screens.blockedSamples, 15);
+  printSamples("top 15 adhesivos candidatos a publicar", adhesiveEligible.map((item) => ({
+    ...(item.adhesiveClassification || {}),
+    id: item.product.id || item.product.rowid,
+    sku: item.product.sku || "",
+    title: item.product.title || item.product.name || "",
+  })));
+  printSamples("top 15 adhesivos bloqueados", adhesives.blockedSamples, 15);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/nerin_final_updated/scripts/test-screens-and-adhesives-final.js
+++ b/nerin_final_updated/scripts/test-screens-and-adhesives-final.js
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const assert = require("assert");
+const {
+  isRealScreenProduct,
+  isScreenAdhesiveProduct,
+} = require("../backend/utils/screenProductClassifier");
+const {
+  computeScreenPublicationEligibility,
+  computeScreenAdhesivePublicationEligibility,
+  feedEntry,
+} = require("../backend/services/screenPublicationService");
+
+const ROOT = path.join(__dirname, "..");
+
+function product(title, overrides = {}) {
+  return {
+    id: title.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, ""),
+    sku: title.toUpperCase().replace(/[^A-Z0-9]+/g, "-").slice(0, 48),
+    title,
+    name: title,
+    public_slug: title.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, ""),
+    image: "https://example.com/image.jpg",
+    price: 10000,
+    stock: 2,
+    is_public: 0,
+    visibility: "private",
+    rowid: Math.floor(Math.random() * 100000),
+    product_rowid: 1,
+    ...overrides,
+  };
+}
+
+function assertMany(name, cases, fn) {
+  for (const value of cases) {
+    assert.strictEqual(fn(product(value)), true, `${name} should be true: ${value}`);
+  }
+}
+
+function assertManyFalse(name, cases, fn) {
+  for (const value of cases) {
+    assert.strictEqual(fn(product(value)), false, `${name} should be false: ${value}`);
+  }
+}
+
+function testClassifiers() {
+  assertMany("screen", [
+    "Display Original Black Samsung Galaxy A15 SM-A155",
+    "Display Incl Frame Original Green Honor 9X Lite",
+    "Display JK Compatible Hard OLED for iPhone 15 Pro",
+    "Modulo Samsung A15 5G Original Con Marco Service Pack GH82-33638A",
+    "Repair Kit Display Galaxy S24 Plus SM-S926",
+    "Display Excl Frame Refurb Redmi Note 10S",
+    "Display Soft Factory STD for iPhone 11 Pro Max",
+    "Pantalla Samsung Galaxy A16 4G Original Negra con Marco AMOLED",
+  ], (p) => isRealScreenProduct(p).isScreen);
+
+  assertManyFalse("screen", [
+    "Display Adhesive Tape 30 pcs Original Apple iPhone 16",
+    "Bracket Display Galaxy XCover6 Pro",
+    "Coverz MagSafe Compatible Black Apple iPhone 17",
+    "Back Glass Black iPhone 14 Plus",
+    "SIM Tray Original Black Titanium iPhone 15 Pro",
+    "GPS Antenna Compatible iPhone 17 Air",
+    "Camera Lens iPhone 12",
+    "Dock Connector iPhone 14 Plus",
+  ], (p) => isRealScreenProduct(p).isScreen);
+
+  assertMany("screen adhesive", [
+    "Display Adhesive Tape 30 pcs Original Apple iPhone 16",
+    "Adhesive Tape for Samsung Galaxy A15 Display",
+    "LCD Adhesive for iPhone 12",
+    "Display Gasket for iPhone 13 Pro",
+    "Screen Seal for Google Pixel 7 Pro",
+    "Cinta adhesiva de pantalla Samsung A54",
+  ], (p) => isScreenAdhesiveProduct(p).isScreenAdhesive);
+
+  assertManyFalse("screen adhesive", [
+    "Battery Adhesive iPhone 12",
+    "Back Cover Adhesive Samsung A54",
+    "Rear Cover Adhesive Huawei P30",
+    "Camera Lens Adhesive iPhone 14",
+    "Universal Adhesive Tape sin modelo ni destino claro",
+  ], (p) => isScreenAdhesiveProduct(p).isScreenAdhesive);
+}
+
+function testPublicationEligibility() {
+  assert.strictEqual(computeScreenPublicationEligibility(product("Display Samsung Galaxy A15 Original")).eligible, true, "private eligible screen");
+  assert.strictEqual(computeScreenPublicationEligibility(product("Display iPhone 12 Hard OLED", { visibility: "hidden" })).eligible, true, "hidden eligible screen");
+  assert(computeScreenPublicationEligibility(product("Display Samsung Galaxy A15", { image: "" })).blockers.includes("missingImage"), "screen missing image blocked");
+  assert(computeScreenPublicationEligibility(product("Display Samsung Galaxy A15", { price: 0 })).blockers.includes("missingPrice"), "screen missing price blocked");
+  assert(computeScreenPublicationEligibility(product("Display Samsung Galaxy A15", { stock: 0, remote_stock: 0 })).blockers.includes("outOfStockNotOrderable"), "screen not orderable blocked");
+  assert(computeScreenPublicationEligibility(product("Display Adhesive Tape 30 pcs Original Apple iPhone 16")).blockers.includes("likelyAccessory"), "display adhesive not screen");
+  assert(computeScreenPublicationEligibility(product("Bracket Display Galaxy XCover6 Pro")).blockers.includes("likelyAccessory"), "bracket display not screen");
+  assert(computeScreenPublicationEligibility(product("Coverz MagSafe Compatible Black Apple iPhone 17")).blockers.includes("likelyAccessory"), "case not screen");
+
+  assert.strictEqual(computeScreenAdhesivePublicationEligibility(product("Display Adhesive Tape for iPhone 12")).eligible, true, "private eligible screen adhesive");
+  assert(computeScreenAdhesivePublicationEligibility(product("Battery Adhesive iPhone 12")).blockers.includes("battery_adhesive"), "battery adhesive blocked");
+  assert(computeScreenAdhesivePublicationEligibility(product("Universal Adhesive Tape sin modelo ni destino claro")).blockers.includes("genericAdhesiveWithoutModel"), "generic adhesive blocked");
+}
+
+function testMerchantFeeds() {
+  const screen = computeScreenPublicationEligibility(product("Display Samsung Galaxy A15 Original", { is_public: 1 }));
+  const adhesive = computeScreenAdhesivePublicationEligibility(product("Display Adhesive Tape for iPhone 12", { is_public: 1 }));
+  const screenEntry = feedEntry({ ...screen, product: product("Display Samsung Galaxy A15 Original", { is_public: 1 }) }, "screen", "https://nerinparts.com.ar");
+  const adhesiveEntry = feedEntry({ ...adhesive, product: product("Display Adhesive Tape for iPhone 12", { is_public: 1 }) }, "screen_adhesive", "https://nerinparts.com.ar");
+
+  assert(screenEntry, "screen feed entry created");
+  assert(adhesiveEntry, "adhesive feed entry created");
+  assert.strictEqual(screenEntry.custom_label_0, "screens", "screen custom label");
+  assert.strictEqual(adhesiveEntry.custom_label_0, "screen_adhesives", "adhesive custom label");
+  assert(!/adhesivo|adhesive|gasket/i.test(screenEntry.title), "screen title is not adhesive");
+  assert(!/^pantalla\b/i.test(adhesiveEntry.title), "adhesive title is not screen");
+  assert.strictEqual(screenEntry.availability, "in_stock", "screen in stock");
+  assert.strictEqual(screenEntry.availability_date, "", "in stock has no availability date");
+  assert.notStrictEqual(screenEntry.identifier_exists, "yes", "no invented gtin/mpn");
+  assert(!/original/i.test(feedEntry({ ...computeScreenPublicationEligibility(product("Display compatible for iPhone 12 Hard OLED", { is_public: 1 })), product: product("Display compatible for iPhone 12 Hard OLED", { is_public: 1 }) }, "screen").title), "compatible is not titled as original");
+}
+
+function testSearchAndRoutesContracts() {
+  const repoSource = fs.readFileSync(path.join(ROOT, "backend", "data", "productsSqliteRepo.js"), "utf8");
+  assert(repoSource.includes("adhesiveIntent"), "search scoring has adhesive intent");
+  assert(repoSource.includes("displayIntent"), "search scoring has display intent");
+  assert(repoSource.includes("isRealScreenProduct"), "search scoring uses screen classifier");
+  assert(repoSource.includes("isScreenAdhesiveProduct"), "search scoring uses adhesive classifier");
+
+  const serverSource = fs.readFileSync(path.join(ROOT, "backend", "server.js"), "utf8");
+  assert(serverSource.includes("/api/admin/screens/audit"), "screen audit endpoint exists");
+  assert(serverSource.includes("/api/admin/screen-adhesives/audit"), "adhesive audit endpoint exists");
+  assert(serverSource.includes("/api/merchant/screens-feed.csv"), "screens feed exists");
+  assert(serverSource.includes("/api/merchant/screen-adhesives-feed.csv"), "adhesive feed exists");
+  assert(serverSource.includes("/adhesivos-de-pantalla"), "screen adhesives page exists");
+  const serviceSource = fs.readFileSync(path.join(ROOT, "backend", "services", "screenPublicationService.js"), "utf8");
+  assert(serviceSource.includes("confirmScreenBulkPublish"), "screen publish confirmation required");
+  assert(serviceSource.includes("confirmScreenAdhesiveBulkPublish"), "adhesive publish confirmation required");
+}
+
+testClassifiers();
+testPublicationEligibility();
+testMerchantFeeds();
+testSearchAndRoutesContracts();
+
+console.log("screens and screen adhesives final tests passed");


### PR DESCRIPTION
## Summary

- Adds final classifiers for real screen/display products and screen adhesive products, explicitly separating display adhesives, brackets, protectors, cases, batteries, audio parts, cameras, back covers, and generic adhesives from real screens.
- Adds safe admin audit, preview, and confirmed publish endpoints for screens and screen adhesives, using the existing publication/reindex flow and counting success only after public visibility verification.
- Adds dedicated Merchant CSV feeds for screens and screen adhesives, plus a lightweight `/adhesivos-de-pantalla` page and admin UI block.
- Adds search ranking intent boosts so display queries favor real screens and adhesive/gasket queries favor screen adhesives.
- Adds final audit and test scripts for the screens/adhesives publication workflow.

## Root cause / commercial need

The catalog publication logic did not have a dedicated final pass for real screens versus screen adhesives. Accessories could be mixed into screen-like searches or audits, while real private/hidden display products needed a safe, manual publication path with preview, verification, Merchant labels, and separate feeds.

## Safety boundaries

This PR does not touch Mercado Pago, webhooks, inventory/stock discount logic, order mutations, base pricing, critical checkout, real Andreani, startup/render, heavy analytics, or public bulk publication logic outside the dedicated screens/adhesives block.

## Validation

- `node --check backend/server.js`
- `node --check backend/data/productsSqliteRepo.js`
- `node --check backend/utils/screenProductClassifier.js`
- `node --check backend/services/screenPublicationService.js`
- `node --check frontend/js/admin.js`
- `node --check scripts/audit-screens-and-adhesives-final.js`
- `node --check scripts/test-screens-and-adhesives-final.js`
- `node scripts/test-screens-and-adhesives-final.js`
- `node scripts/audit-screens-and-adhesives-final.js`
- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json valid')"`

## Local audit snapshot

Local sample data contains 6 products:

- Screens detected: 4
- Public screens current: 4
- Screen stock-real eligible: 4
- Screen remote-order eligible: 0
- Screen blocked by image: 0
- Screen blocked by price: 0
- Screen blocked by Merchant: 0
- Screen blocked as accessory: 2
- Screen adhesives detected: 0
- Screen adhesives public current: 0
- Screen adhesives eligible: 0
- Screens feed ready: 4
- Screen adhesives feed ready: 0

Dedicated feed URLs:

- `/api/merchant/screens-feed.csv`
- `/api/merchant/screen-adhesives-feed.csv`