### PR TITLE
Stabilize screen publisher and prevent admin scans from crashing production

### DIFF
--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -277,6 +277,19 @@ const ANALYTICS_DETAILED_TIMEOUT_MS = Math.max(
   Number.parseInt(process.env.ANALYTICS_DETAILED_TIMEOUT_MS || "5000", 10) || 5000,
 );
 const ANALYTICS_CATALOG_SNAPSHOT_TTL_MS = 10 * 60 * 1000;
+const SCREEN_PUBLISHER_ENABLED = parseBooleanEnv("SCREEN_PUBLISHER_ENABLED", false);
+const SCREEN_PUBLISHER_SCAN_LIMIT_DEFAULT = Math.max(1, Number(process.env.SCREEN_PUBLISHER_SCAN_LIMIT_DEFAULT || 5000) || 5000);
+const SCREEN_PUBLISHER_SCAN_LIMIT_MAX = Math.max(SCREEN_PUBLISHER_SCAN_LIMIT_DEFAULT, Number(process.env.SCREEN_PUBLISHER_SCAN_LIMIT_MAX || 60000) || 60000);
+const SCREEN_PUBLISHER_JOB_CHUNK_SIZE = Math.max(100, Number(process.env.SCREEN_PUBLISHER_CHUNK_SIZE || 1000) || 1000);
+const SCREEN_PUBLISHER_AUDIT_CACHE_MS = 5 * 60 * 1000;
+const SCREEN_PUBLISHER_HEAP_ABORT_BYTES = Math.max(64 * 1024 * 1024, Number(process.env.SCREEN_PUBLISHER_HEAP_ABORT_BYTES || 420 * 1024 * 1024) || 420 * 1024 * 1024);
+const screenPublisherJobs = new Map();
+const screenPublisherAuditCache = new Map();
+const screenPublisherLocks = { screen: null, screen_adhesive: null };
+let lastScreenPublisherJob = null;
+const PRODUCT_DETAIL_CACHE_TTL_MS = Math.max(60_000, Number(process.env.PRODUCT_DETAIL_CACHE_TTL_MS || 5 * 60 * 1000) || 5 * 60 * 1000);
+const PRODUCT_DETAIL_CACHE_MAX = Math.max(50, Number(process.env.PRODUCT_DETAIL_CACHE_MAX || 500) || 500);
+const productDetailCache = new Map();
 
 function getDetailedAnalyticsTtlMs(range = "7d") {
   if (range === "today") return 60_000;
@@ -1901,14 +1914,42 @@ function buildShopCard(product, siteBase) {
   `;
 }
 
-function renderShopListing(products, siteBase) {
+function renderShopListing(products, siteBase, totalCount = null) {
   const valid = Array.isArray(products)
     ? products.filter((p) => p && isProductPublic(p))
     : [];
   const cards = valid.slice(0, 30).map((p) => buildShopCard(p, siteBase)).join("");
-  const count = valid.length;
-  const summary = count === 1 ? "producto disponible." : "productos listados.";
-  return { cards, count, summary };
+  const numericTotal = Number(totalCount);
+  const count = Number.isFinite(numericTotal) && numericTotal >= valid.length ? numericTotal : valid.length;
+  const summary = count === 1 ? "producto disponible." : "productos disponibles.";
+  return { cards, count, summary, products: valid.slice(0, 30) };
+}
+
+function filterShopProductsForSsr(products = [], { search = "", category = "", brand = "" } = {}) {
+  const cleanSearch = compactText(search).toLowerCase();
+  const cleanCategory = compactText(category).toLowerCase();
+  const cleanBrand = compactText(brand).toLowerCase();
+  return (Array.isArray(products) ? products : [])
+    .filter((product) => product && isProductPublic(product))
+    .filter((product) => {
+      if (cleanCategory && compactText(product?.category || product?.categoria).toLowerCase() !== cleanCategory) return false;
+      if (cleanBrand && compactText(product?.brand || product?.marca).toLowerCase() !== cleanBrand) return false;
+      if (!cleanSearch) return true;
+      const haystack = [
+        product?.name,
+        product?.title,
+        product?.sku,
+        product?.code,
+        product?.brand,
+        product?.category,
+        product?.model,
+        product?.description,
+        product?.short_description,
+      ]
+        .map((value) => compactText(value).toLowerCase())
+        .join(" ");
+      return haystack.includes(cleanSearch);
+    });
 }
 
 function parseSqliteProductRow(row = {}) {
@@ -2718,8 +2759,14 @@ function requireAdmin(req, res, options = {}) {
   return true;
 }
 
+function sendApiJson(res, status, payload) {
+  res.statusCode = status;
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.end(JSON.stringify(payload));
+}
+
 function sendApiError(res, status, code, message, extra = {}) {
-  return sendJson(res, status, {
+  return sendApiJson(res, status, {
     ok: false,
     error: code,
     message,
@@ -2740,6 +2787,192 @@ function requireAdminJson(req, res, options = {}) {
     return false;
   }
   return true;
+}
+
+function screenPublisherDisabled(res) {
+  return sendApiError(res, 503, "SCREEN_PUBLISHER_DISABLED", "Publicador desactivado temporalmente para proteger produccion");
+}
+
+function normalizeScreenPublisherType(value) {
+  return value === "screen_adhesive" || value === "adhesive" ? "screen_adhesive" : "screen";
+}
+
+function clampScreenPublisherScanLimit(value) {
+  return Math.min(SCREEN_PUBLISHER_SCAN_LIMIT_MAX, Math.max(1, Number(value || SCREEN_PUBLISHER_SCAN_LIMIT_DEFAULT) || SCREEN_PUBLISHER_SCAN_LIMIT_DEFAULT));
+}
+
+function screenPublisherJobSnapshot(job) {
+  if (!job) return null;
+  return {
+    id: job.id,
+    type: job.type,
+    mode: job.mode,
+    status: job.status,
+    scannedRows: job.scannedRows || 0,
+    detectedCount: job.detectedCount || 0,
+    eligibleCount: job.eligibleCount || 0,
+    blockedCount: job.blockedCount || 0,
+    updatedCount: job.updatedCount || 0,
+    verifiedPublicCount: job.verifiedPublicCount || 0,
+    failedCount: job.failedCount || 0,
+    startedAt: job.startedAt || null,
+    finishedAt: job.finishedAt || null,
+    error: job.error || "",
+    samples: job.samples || {},
+    memoryUsage: job.memoryUsage || {},
+  };
+}
+
+function screenPublisherCacheKey(type, filters = {}) {
+  const copy = { ...filters };
+  delete copy.confirmScreenBulkPublish;
+  delete copy.confirmScreenAdhesiveBulkPublish;
+  return `${type}:${JSON.stringify(copy)}`;
+}
+
+function logScreenPublisherMemory(label, job) {
+  const memoryUsage = getMemoryUsageSnapshot();
+  console.info("[screen-publisher:memory]", { label, jobId: job?.id || null, memoryUsage });
+  if (job) job.memoryUsage = { ...(job.memoryUsage || {}), [label]: memoryUsage };
+  if (memoryUsage.heapUsed > SCREEN_PUBLISHER_HEAP_ABORT_BYTES) {
+    const error = new Error("SCREEN_PUBLISHER_MEMORY_SOFT_LIMIT");
+    error.code = "SCREEN_PUBLISHER_MEMORY_SOFT_LIMIT";
+    throw error;
+  }
+  return memoryUsage;
+}
+
+async function runScreenPublisherAuditJob(job) {
+  const cacheKey = screenPublisherCacheKey(job.type, job.filters);
+  const cached = screenPublisherAuditCache.get(cacheKey);
+  if (cached && Date.now() - cached.at < SCREEN_PUBLISHER_AUDIT_CACHE_MS) {
+    Object.assign(job, cached.result, { status: "done", cached: true, finishedAt: new Date().toISOString() });
+    return;
+  }
+  const scanLimit = clampScreenPublisherScanLimit(job.filters.scanLimit || job.filters.maxScanRows || job.filters.limit);
+  const rows = [];
+  let offset = 0;
+  const started = Date.now();
+  while (rows.length < scanLimit && Date.now() - started < 30_000) {
+    logScreenPublisherMemory("chunk-start", job);
+    const chunk = await finalScreenPublication.loadRows({
+      type: job.type,
+      scanLimit: Math.min(SCREEN_PUBLISHER_JOB_CHUNK_SIZE, scanLimit - rows.length),
+      offset,
+    });
+    rows.push(...chunk);
+    offset += chunk.length;
+    job.scannedRows = rows.length;
+    if (chunk.length < SCREEN_PUBLISHER_JOB_CHUNK_SIZE) break;
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  const summary = finalScreenPublication.analyzeRows(rows, job.filters, job.type);
+  job.scannedRows = summary.scannedRows || rows.length;
+  job.detectedCount = job.type === "screen" ? summary.totalScreensDetected || 0 : summary.totalScreenAdhesivesDetected || 0;
+  job.eligibleCount = summary.eligibleCount || 0;
+  job.blockedCount = summary.blockedCount || 0;
+  job.samples = {
+    eligible: summary.eligibleSamples || [],
+    blocked: summary.blockedSamples || [],
+    excluded: job.type === "screen" ? summary.accessoryExcludedSamples || [] : summary.excludedSamples || [],
+  };
+  job.result = { ...summary };
+  delete job.result.items;
+  screenPublisherAuditCache.set(cacheKey, { at: Date.now(), result: screenPublisherJobSnapshot(job) });
+}
+
+async function runScreenPublisherPublishJob(job) {
+  const filters = { ...job.filters };
+  if (job.type === "screen") filters.confirmScreenBulkPublish = true;
+  else filters.confirmScreenAdhesiveBulkPublish = true;
+  filters.scanLimit = clampScreenPublisherScanLimit(filters.scanLimit || filters.maxScanRows || filters.limit);
+  const result = await finalScreenPublication.publishEligible(job.type, filters);
+  job.scannedRows = result.scannedRows || filters.scanLimit;
+  job.eligibleCount = result.eligibleCount || result.attemptedCount || 0;
+  job.blockedCount = result.blockedCount || 0;
+  job.updatedCount = result.updatedCount || 0;
+  job.verifiedPublicCount = result.verifiedPublicCount || 0;
+  job.failedCount = result.failedCount || 0;
+  job.samples = {
+    published: result.samplePublished || [],
+    failed: result.sampleFailed || [],
+  };
+  job.result = result;
+}
+
+function startScreenPublisherJob(type, mode, filters = {}) {
+  const normalizedType = normalizeScreenPublisherType(type);
+  if (screenPublisherLocks[normalizedType]) {
+    return { alreadyRunning: true, jobId: screenPublisherLocks[normalizedType] };
+  }
+  const id = `${normalizedType}-${mode}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const job = {
+    id,
+    type: normalizedType,
+    mode,
+    status: "queued",
+    filters: { ...(filters || {}) },
+    scannedRows: 0,
+    detectedCount: 0,
+    eligibleCount: 0,
+    blockedCount: 0,
+    updatedCount: 0,
+    verifiedPublicCount: 0,
+    failedCount: 0,
+    startedAt: null,
+    finishedAt: null,
+    error: "",
+    samples: {},
+    memoryUsage: {},
+  };
+  screenPublisherJobs.set(id, job);
+  screenPublisherLocks[normalizedType] = id;
+  lastScreenPublisherJob = id;
+  setImmediate(async () => {
+    job.status = "running";
+    job.startedAt = new Date().toISOString();
+    try {
+      logScreenPublisherMemory("start", job);
+      if (mode === "audit") await runScreenPublisherAuditJob(job);
+      else await runScreenPublisherPublishJob(job);
+      logScreenPublisherMemory("end", job);
+      job.status = "done";
+    } catch (error) {
+      job.status = "failed";
+      job.error = error?.code || error?.message || "SCREEN_PUBLISHER_JOB_FAILED";
+      console.error("[screen-publisher:job-failed]", { id: job.id, type: job.type, mode: job.mode, error: job.error });
+    } finally {
+      job.finishedAt = new Date().toISOString();
+      if (screenPublisherLocks[normalizedType] === id) screenPublisherLocks[normalizedType] = null;
+    }
+  });
+  return { job };
+}
+
+function isLikelyCrawler(req) {
+  const ua = String(req.headers?.["user-agent"] || "").toLowerCase();
+  return /bot|crawl|spider|slurp|bingpreview|facebookexternalhit|whatsapp|telegram|preview|headless|lighthouse/.test(ua);
+}
+
+function getProductDetailCache(key) {
+  const cached = productDetailCache.get(key);
+  if (!cached) return null;
+  if (Date.now() - cached.at > PRODUCT_DETAIL_CACHE_TTL_MS) {
+    productDetailCache.delete(key);
+    return null;
+  }
+  productDetailCache.delete(key);
+  productDetailCache.set(key, cached);
+  return cached.html;
+}
+
+function setProductDetailCache(key, html) {
+  productDetailCache.set(key, { at: Date.now(), html });
+  while (productDetailCache.size > PRODUCT_DETAIL_CACHE_MAX) {
+    const first = productDetailCache.keys().next().value;
+    if (!first) break;
+    productDetailCache.delete(first);
+  }
 }
 
 function parseSvixSignatures(headerValue) {
@@ -7139,6 +7372,16 @@ async function requestHandler(req, res) {
     }, { "Cache-Control": "no-store" });
   }
 
+  if (pathname === "/api/system/health-light" && req.method === "GET") {
+    return sendApiJson(res, 200, {
+      ok: true,
+      uptime: process.uptime(),
+      memoryUsage: getMemoryUsageSnapshot(),
+      catalogReady: Boolean(productsSqliteRepo.catalogStateSnapshot()?.ready),
+      timestamp: new Date().toISOString(),
+    });
+  }
+
   if (pathname === "/api/catalog/status" && req.method === "GET") {
     try {
       const health = await productsSqliteRepo.getCatalogHealth();
@@ -7591,8 +7834,9 @@ async function requestHandler(req, res) {
     } catch (error) {
       warnings.push(`No se pudo leer package.json: ${error?.message || error}`);
     }
-    return sendJson(res, 200, {
+    return sendApiJson(res, 200, {
       ok: true,
+      enabled: SCREEN_PUBLISHER_ENABLED,
       routesReady: true,
       serviceLoaded: Boolean(finalScreenPublication),
       hasPreviewPublication: typeof finalScreenPublication.previewPublication === "function",
@@ -7601,15 +7845,19 @@ async function requestHandler(req, res) {
       canUseComputePublicationState: typeof productsSqliteRepo.computePublicationState === "function",
       canUseSearchIndex: typeof productsSqliteRepo.ensureProductsDbOnce === "function",
       startHotfixRemoved,
+      jobRunning: { screen: screenPublisherLocks.screen, screen_adhesive: screenPublisherLocks.screen_adhesive },
+      lastJob: screenPublisherJobSnapshot(screenPublisherJobs.get(lastScreenPublisherJob)),
+      memoryUsage: getMemoryUsageSnapshot(),
       warnings,
     });
   }
 
   if (pathname === "/api/admin/screens/audit" && req.method === "GET") {
     if (!requireAdminJson(req, res)) return;
+    if (!SCREEN_PUBLISHER_ENABLED) return screenPublisherDisabled(res);
     try {
       const result = await finalScreenPublication.previewPublication("screen", parsedUrl.query || {});
-      return sendJson(res, 200, result);
+      return sendApiJson(res, 200, result);
     } catch (error) {
       return sendApiError(res, 500, "SCREEN_AUDIT_FAILED", "No se pudo auditar pantallas.", { detail: error?.message || "screen_audit_failed" });
     }
@@ -7617,10 +7865,11 @@ async function requestHandler(req, res) {
 
   if (pathname === "/api/admin/screens/publish-preview" && req.method === "POST") {
     if (!requireAdminJson(req, res)) return;
+    if (!SCREEN_PUBLISHER_ENABLED) return screenPublisherDisabled(res);
     await parseBody(req);
     try {
       const result = await finalScreenPublication.previewPublication("screen", req.body || {});
-      return sendJson(res, 200, result);
+      return sendApiJson(res, 200, result);
     } catch (error) {
       return sendApiError(res, 500, "SCREEN_PREVIEW_FAILED", "No se pudo simular publicacion de pantallas.", { detail: error?.message || "screen_preview_failed" });
     }
@@ -7628,20 +7877,48 @@ async function requestHandler(req, res) {
 
   if (pathname === "/api/admin/screens/publish" && req.method === "POST") {
     if (!requireAdminJson(req, res)) return;
+    if (!SCREEN_PUBLISHER_ENABLED) return screenPublisherDisabled(res);
     await parseBody(req);
     try {
       const result = await finalScreenPublication.publishEligible("screen", req.body || {});
-      return sendJson(res, 200, result);
+      return sendApiJson(res, 200, result);
     } catch (error) {
       return sendApiError(res, error?.statusCode || 500, "SCREEN_PUBLISH_FAILED", error?.message || "No se pudo publicar pantallas.");
     }
   }
 
+  if (pathname === "/api/admin/screens/audit-job" && req.method === "POST") {
+    if (!requireAdminJson(req, res)) return;
+    if (!SCREEN_PUBLISHER_ENABLED) return screenPublisherDisabled(res);
+    await parseBody(req);
+    const started = startScreenPublisherJob("screen", "audit", req.body || {});
+    if (started.alreadyRunning) return sendApiError(res, 423, "SCREEN_PUBLISHER_JOB_RUNNING", "Ya hay un job de pantallas corriendo.", { jobId: started.jobId });
+    return sendApiJson(res, 202, { ok: true, job: screenPublisherJobSnapshot(started.job), jobId: started.job.id });
+  }
+
+  if (pathname === "/api/admin/screens/publish-job" && req.method === "POST") {
+    if (!requireAdminJson(req, res)) return;
+    if (!SCREEN_PUBLISHER_ENABLED) return screenPublisherDisabled(res);
+    await parseBody(req);
+    const started = startScreenPublisherJob("screen", "publish", req.body || {});
+    if (started.alreadyRunning) return sendApiError(res, 423, "SCREEN_PUBLISHER_JOB_RUNNING", "Ya hay un job de pantallas corriendo.", { jobId: started.jobId });
+    return sendApiJson(res, 202, { ok: true, job: screenPublisherJobSnapshot(started.job), jobId: started.job.id });
+  }
+
+  const screenJobMatch = pathname.match(/^\/api\/admin\/screens\/jobs\/([^/]+)$/);
+  if (screenJobMatch && req.method === "GET") {
+    if (!requireAdminJson(req, res)) return;
+    const job = screenPublisherJobs.get(decodeURIComponent(screenJobMatch[1] || ""));
+    if (!job || job.type !== "screen") return sendApiError(res, 404, "SCREEN_PUBLISHER_JOB_NOT_FOUND", "Job de pantallas no encontrado.");
+    return sendApiJson(res, 200, { ok: true, job: screenPublisherJobSnapshot(job), result: job.result || null });
+  }
+
   if (pathname === "/api/admin/screen-adhesives/audit" && req.method === "GET") {
     if (!requireAdminJson(req, res)) return;
+    if (!SCREEN_PUBLISHER_ENABLED) return screenPublisherDisabled(res);
     try {
       const result = await finalScreenPublication.previewPublication("screen_adhesive", parsedUrl.query || {});
-      return sendJson(res, 200, result);
+      return sendApiJson(res, 200, result);
     } catch (error) {
       return sendApiError(res, 500, "SCREEN_ADHESIVE_AUDIT_FAILED", "No se pudo auditar adhesivos de pantalla.", { detail: error?.message || "screen_adhesive_audit_failed" });
     }
@@ -7649,10 +7926,11 @@ async function requestHandler(req, res) {
 
   if (pathname === "/api/admin/screen-adhesives/publish-preview" && req.method === "POST") {
     if (!requireAdminJson(req, res)) return;
+    if (!SCREEN_PUBLISHER_ENABLED) return screenPublisherDisabled(res);
     await parseBody(req);
     try {
       const result = await finalScreenPublication.previewPublication("screen_adhesive", req.body || {});
-      return sendJson(res, 200, result);
+      return sendApiJson(res, 200, result);
     } catch (error) {
       return sendApiError(res, 500, "SCREEN_ADHESIVE_PREVIEW_FAILED", "No se pudo simular publicacion de adhesivos de pantalla.", { detail: error?.message || "screen_adhesive_preview_failed" });
     }
@@ -7660,13 +7938,40 @@ async function requestHandler(req, res) {
 
   if (pathname === "/api/admin/screen-adhesives/publish" && req.method === "POST") {
     if (!requireAdminJson(req, res)) return;
+    if (!SCREEN_PUBLISHER_ENABLED) return screenPublisherDisabled(res);
     await parseBody(req);
     try {
       const result = await finalScreenPublication.publishEligible("screen_adhesive", req.body || {});
-      return sendJson(res, 200, result);
+      return sendApiJson(res, 200, result);
     } catch (error) {
       return sendApiError(res, error?.statusCode || 500, "SCREEN_ADHESIVE_PUBLISH_FAILED", error?.message || "No se pudo publicar adhesivos de pantalla.");
     }
+  }
+
+  if (pathname === "/api/admin/screen-adhesives/audit-job" && req.method === "POST") {
+    if (!requireAdminJson(req, res)) return;
+    if (!SCREEN_PUBLISHER_ENABLED) return screenPublisherDisabled(res);
+    await parseBody(req);
+    const started = startScreenPublisherJob("screen_adhesive", "audit", req.body || {});
+    if (started.alreadyRunning) return sendApiError(res, 423, "SCREEN_PUBLISHER_JOB_RUNNING", "Ya hay un job de adhesivos corriendo.", { jobId: started.jobId });
+    return sendApiJson(res, 202, { ok: true, job: screenPublisherJobSnapshot(started.job), jobId: started.job.id });
+  }
+
+  if (pathname === "/api/admin/screen-adhesives/publish-job" && req.method === "POST") {
+    if (!requireAdminJson(req, res)) return;
+    if (!SCREEN_PUBLISHER_ENABLED) return screenPublisherDisabled(res);
+    await parseBody(req);
+    const started = startScreenPublisherJob("screen_adhesive", "publish", req.body || {});
+    if (started.alreadyRunning) return sendApiError(res, 423, "SCREEN_PUBLISHER_JOB_RUNNING", "Ya hay un job de adhesivos corriendo.", { jobId: started.jobId });
+    return sendApiJson(res, 202, { ok: true, job: screenPublisherJobSnapshot(started.job), jobId: started.job.id });
+  }
+
+  const adhesiveJobMatch = pathname.match(/^\/api\/admin\/screen-adhesives\/jobs\/([^/]+)$/);
+  if (adhesiveJobMatch && req.method === "GET") {
+    if (!requireAdminJson(req, res)) return;
+    const job = screenPublisherJobs.get(decodeURIComponent(adhesiveJobMatch[1] || ""));
+    if (!job || job.type !== "screen_adhesive") return sendApiError(res, 404, "SCREEN_PUBLISHER_JOB_NOT_FOUND", "Job de adhesivos no encontrado.");
+    return sendApiJson(res, 200, { ok: true, job: screenPublisherJobSnapshot(job), result: job.result || null });
   }
 
   if (pathname.startsWith("/api/admin/screens/") || pathname.startsWith("/api/admin/screen-adhesives/")) {
@@ -14041,6 +14346,14 @@ async function requestHandler(req, res) {
       res.end(html);
       return;
     }
+    const detailCacheKey = `product:${slug}`;
+    const cachedProductHtml = getProductDetailCache(detailCacheKey);
+    if (cachedProductHtml) {
+      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "X-Product-Detail-Cache": "hit" });
+      res.end(cachedProductHtml);
+      return;
+    }
+    const productDetailIsCrawler = isLikelyCrawler(req);
     let source = "sqlite";
     let foundBy = "none";
     let product = null;
@@ -14069,7 +14382,9 @@ async function requestHandler(req, res) {
       res.end(html);
       return;
     }
-    console.log(`[product-detail:found] identifier=${slug} source=${source} foundBy=${foundBy}`);
+    if (process.env.DEBUG_PRODUCT_DETAIL === "true") {
+      console.log(`[product-detail:found] identifier=${slug} source=${source} foundBy=${foundBy} crawler=${productDetailIsCrawler}`);
+    }
     const name = product.name || "";
     const productSeo = generateProductSeo(product);
     const desc =
@@ -14229,12 +14544,13 @@ async function requestHandler(req, res) {
     const infoHtml = renderProductInfoSsr(product, siteBase) + (debugMerchant ? renderMerchantDebugSsr(product, { canonical, imageLink: primaryImage || "" }) : "") + seoDebugHtml;
     const hydratedBody = injectProductContent(templateBody, galleryHtml, infoHtml);
     const html = `<!DOCTYPE html><html lang="es-AR"><head>${head}</head>${hydratedBody}</html>`;
+    setProductDetailCache(detailCacheKey, html);
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
     res.end(html);
     return;
   }
 
-  // SSR del catálogo
+  // SSR del catalogo
   if (
     (pathname === "/shop.html" || pathname === "/shop" || pathname === "/shop/") &&
     req.method === "GET"
@@ -14242,24 +14558,58 @@ async function requestHandler(req, res) {
     const seoConfig = getConfig();
     const siteBase = getPublicBaseUrl(seoConfig);
     const { head: templateHead, body: templateBody } = getShopTemplateParts();
-    const listing =
-      '<p class="description">Cargando catálogo…</p>';
-    const summary = "Mostrando productos";
-    const hydratedHead = replaceBasePlaceholders(templateHead, siteBase);
+    const search = compactText(String(parsedUrl.query?.search || ""));
+    const category = compactText(String(parsedUrl.query?.category || parsedUrl.query?.categoria || ""));
+    const brand = compactText(String(parsedUrl.query?.brand || parsedUrl.query?.marca || ""));
+    const sort = compactText(String(parsedUrl.query?.sort || ""));
+    let queryResult = null;
+    try {
+      queryResult = await productsSqliteRepo.queryProducts({
+        page: 1,
+        pageSize: 30,
+        search,
+        category,
+        brand,
+        sort,
+      });
+    } catch (error) {
+      console.warn("[shop-ssr:query-failed]", error?.message || error);
+      try {
+        const fallbackProducts = filterShopProductsForSsr(await loadProducts(), { search, category, brand });
+        queryResult = {
+          items: fallbackProducts.slice(0, 30),
+          totalItems: fallbackProducts.length,
+        };
+      } catch (fallbackError) {
+        console.warn("[shop-ssr:fallback-failed]", fallbackError?.message || fallbackError);
+      }
+    }
+    const rendered = renderShopListing(queryResult?.items || [], siteBase, queryResult?.totalItems);
+    const listing = rendered.cards || '<p class="description">Cargando catalogo...</p>';
+    const summary = rendered.summary || "Mostrando productos";
+    const seo = buildShopSeoState({
+      siteBase,
+      search,
+      category,
+      brand,
+      count: rendered.count,
+      products: rendered.products,
+    });
+    const hydratedHead = applyShopSeoHead(replaceBasePlaceholders(templateHead, siteBase), seo);
     let hydratedBody = replaceBasePlaceholders(templateBody, siteBase);
     hydratedBody = hydratedBody.replace(
       /<div\s+id=\"productGrid\"[^>]*>\s*<\/div>/i,
-      `<div id="productGrid" class="product-grid premium-grid" role="list">${listing}</div>`,
+      '<div id="productGrid" class="product-grid premium-grid" role="list">' + listing + '</div>',
     );
     hydratedBody = hydratedBody.replace(
       /<span\s+id=\"resultCount\">[^<]*<\/span>/i,
-      `<span id="resultCount">0</span>`,
+      '<span id="resultCount">' + esc(String(rendered.count || 0)) + '</span>',
     );
     hydratedBody = hydratedBody.replace(
       /<p>\s*<span\s+id=\"resultCount\">[^<]*<\/span>[^<]*<\/p>/i,
-      `<p><span id="resultCount">0</span> ${esc(summary)}</p>`,
+      '<p><span id="resultCount">' + esc(String(rendered.count || 0)) + '</span> ' + esc(summary) + '</p>',
     );
-    const html = `<!doctype html><html lang="es"><head>${hydratedHead}</head>${hydratedBody}</html>`;
+    const html = '<!doctype html><html lang="es"><head>' + hydratedHead + '</head>' + hydratedBody + '</html>';
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
     res.end(html);
     return;

--- a/nerin_final_updated/backend/services/screenPublicationService.js
+++ b/nerin_final_updated/backend/services/screenPublicationService.js
@@ -20,7 +20,14 @@ const {
 const DEFAULT_BASE_URL = "https://nerinparts.com.ar";
 const GOOGLE_CATEGORY = "Electrónica > Comunicaciones > Telefonía > Accesorios para móviles";
 const VALID_AVAILABILITY = new Set(["in_stock", "preorder", "backorder", "out_of_stock"]);
-const DEFAULT_SCAN_LIMIT = 250000;
+const DEFAULT_SCAN_LIMIT = Math.max(1, Number(process.env.SCREEN_PUBLISHER_SCAN_LIMIT_DEFAULT || 5000) || 5000);
+const MAX_SCAN_LIMIT = Math.max(DEFAULT_SCAN_LIMIT, Number(process.env.SCREEN_PUBLISHER_SCAN_LIMIT_MAX || 60000) || 60000);
+const JOB_CHUNK_SIZE = Math.max(100, Number(process.env.SCREEN_PUBLISHER_CHUNK_SIZE || 1000) || 1000);
+const CLI_SCAN_LIMIT = 250000;
+
+function clampScanLimit(value, fallback = DEFAULT_SCAN_LIMIT) {
+  return Math.min(MAX_SCAN_LIMIT, Math.max(1, Number(value || fallback) || fallback));
+}
 
 function dbAll(db, sql, params = []) {
   return new Promise((resolve, reject) => {
@@ -238,18 +245,56 @@ function sampleItem(item) {
   };
 }
 
-async function loadRows({ limit = DEFAULT_SCAN_LIMIT, scanLimit } = {}) {
+function candidateWhere(type = "screen") {
+  if (type === "screen_adhesive") {
+    return `(
+      (lower(si.search_blob) LIKE '%adhesive%' OR lower(si.search_blob) LIKE '%adhesivo%' OR lower(si.search_blob) LIKE '%tape%' OR lower(si.search_blob) LIKE '%cinta%' OR lower(si.search_blob) LIKE '%gasket%' OR lower(si.search_blob) LIKE '%seal%' OR lower(si.search_blob) LIKE '%junta%')
+      AND (lower(si.search_blob) LIKE '%display%' OR lower(si.search_blob) LIKE '%screen%' OR lower(si.search_blob) LIKE '%pantalla%' OR lower(si.search_blob) LIKE '%lcd%' OR lower(si.search_blob) LIKE '%oled%')
+      AND lower(si.search_blob) NOT LIKE '%battery%'
+      AND lower(si.search_blob) NOT LIKE '%bateria%'
+      AND lower(si.search_blob) NOT LIKE '%back cover%'
+      AND lower(si.search_blob) NOT LIKE '%rear cover%'
+      AND lower(si.search_blob) NOT LIKE '%camera%'
+    )`;
+  }
+  return `(
+    si.part_type = 'display'
+    OR lower(si.search_blob) LIKE '%display%'
+    OR lower(si.search_blob) LIKE '%pantalla%'
+    OR lower(si.search_blob) LIKE '%screen%'
+    OR lower(si.search_blob) LIKE '%lcd%'
+    OR lower(si.search_blob) LIKE '%oled%'
+    OR lower(si.search_blob) LIKE '%amoled%'
+  ) AND lower(si.search_blob) NOT LIKE '%adhesive%'
+    AND lower(si.search_blob) NOT LIKE '%adhesivo%'
+    AND lower(si.search_blob) NOT LIKE '%bracket%'
+    AND lower(si.search_blob) NOT LIKE '%protector%'
+    AND lower(si.search_blob) NOT LIKE '%case%'
+    AND lower(si.search_blob) NOT LIKE '%coverz%'
+    AND lower(si.search_blob) NOT LIKE '%snap%'
+    AND lower(si.search_blob) NOT LIKE '%back glass%'
+    AND lower(si.search_blob) NOT LIKE '%rear cover%'
+    AND lower(si.search_blob) NOT LIKE '%sim tray%'
+    AND lower(si.search_blob) NOT LIKE '%antenna%'
+    AND lower(si.search_blob) NOT LIKE '%camera lens%'
+    AND lower(si.search_blob) NOT LIKE '%battery%'`;
+}
+
+async function loadRows({ limit = DEFAULT_SCAN_LIMIT, scanLimit, offset = 0, type = "screen", fullScan = false } = {}) {
   await productsSqliteRepo.ensureProductsDbOnce();
   const db = await openReadonly(productsSqliteRepo.SQLITE_PATH);
   try {
+    const effectiveLimit = fullScan ? Math.max(1, Number(scanLimit || limit) || CLI_SCAN_LIMIT) : clampScanLimit(scanLimit || limit);
+    const where = fullScan ? "1=1" : candidateWhere(type);
     const rows = await dbAll(
       db,
       `SELECT p.rowid, p.*, si.product_rowid, si.part_type, si.device_brand, si.compatible_brand, si.model_base, si.quality_tier, si.has_frame, si.stock_status, si.is_stock_real, si.classification_confidence, si.search_blob
        FROM products p
        LEFT JOIN product_search_index si ON si.product_rowid = p.rowid
+       WHERE ${where}
        ORDER BY p.rowid ASC
-       LIMIT ?`,
-      [Math.max(1, Number(scanLimit || limit) || DEFAULT_SCAN_LIMIT)],
+       LIMIT ? OFFSET ?`,
+      [effectiveLimit, Math.max(0, Number(offset) || 0)],
     );
     return rows;
   } finally {
@@ -327,7 +372,7 @@ function analyzeRows(rows, filters = {}, type = "screen") {
 
 async function previewPublication(type, filters = {}) {
   const startedAt = Date.now();
-  const rows = await loadRows({ scanLimit: filters.scanLimit || filters.maxScanRows || DEFAULT_SCAN_LIMIT });
+  const rows = await loadRows({ scanLimit: filters.scanLimit || filters.maxScanRows || DEFAULT_SCAN_LIMIT, type });
   const summary = analyzeRows(rows, filters, type);
   delete summary.items;
   summary.durationMs = Date.now() - startedAt;
@@ -343,7 +388,7 @@ async function publishEligible(type, filters = {}) {
     throw error;
   }
   const startedAt = Date.now();
-  const rows = await loadRows({ scanLimit: filters.scanLimit || filters.maxScanRows || DEFAULT_SCAN_LIMIT });
+  const rows = await loadRows({ scanLimit: filters.scanLimit || filters.maxScanRows || DEFAULT_SCAN_LIMIT, type });
   const summary = analyzeRows(rows, filters, type);
   const eligible = summary.items.filter((i) => i.eligible);
   const result = { ok: true, attemptedCount: eligible.length, eligibleCount: eligible.length, blockedCount: summary.blockedCount || 0, warningCount: summary.warningCount || 0, updatedCount: 0, verifiedPublicCount: 0, failedCount: 0, samplePublished: [], sampleFailed: [], blockersBreakdown: summary.blockersBreakdown || {} };
@@ -430,7 +475,7 @@ function feedEntry(item, type, baseUrl = DEFAULT_BASE_URL) {
 async function buildFeed(type, options = {}) {
   const startedAt = Date.now();
   const outputLimit = Math.max(1, Number(options.outputLimit || options.limit || 100000) || 100000);
-  const rows = await loadRows({ scanLimit: options.scanLimit || options.maxScanRows || DEFAULT_SCAN_LIMIT });
+  const rows = await loadRows({ scanLimit: options.scanLimit || options.maxScanRows || DEFAULT_SCAN_LIMIT, type });
   const summary = analyzeRows(rows, {}, type);
   const entries = summary.items
     .filter((item) => type === "screen" ? item.screenClassification?.isScreen : item.adhesiveClassification?.isScreenAdhesive)
@@ -451,7 +496,7 @@ function csvCell(value) {
 }
 
 async function writeAuditCsv() {
-  const rows = await loadRows({ limit: 100000 });
+  const rows = await loadRows({ limit: CLI_SCAN_LIMIT, fullScan: true });
   const screens = analyzeRows(rows, {}, "screen");
   const adhesives = analyzeRows(rows, {}, "screen_adhesive");
   const exportDir = path.join(path.dirname(dataPath("x")), "..", "exports");
@@ -492,4 +537,8 @@ module.exports = {
   analyzeRows,
   feedEntry,
   isPublicProduct,
+  loadRows,
+  DEFAULT_SCAN_LIMIT,
+  MAX_SCAN_LIMIT,
+  JOB_CHUNK_SIZE,
 };

--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -4132,6 +4132,26 @@ async function fetchAdminJson(url, options = {}) {
   return data;
 }
 
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitScreenPublisherJob(base, jobId, kind) {
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    const data = await fetchAdminJson(`${base}/jobs/${encodeURIComponent(jobId)}`);
+    const job = data.job || {};
+    setFinalPublisherStatus(`Job ${job.status || "running"}: escaneados ${job.scannedRows || 0}, elegibles ${job.eligibleCount || 0}, bloqueados ${job.blockedCount || 0}`);
+    if (job.status === "done") {
+      return data.result || job;
+    }
+    if (job.status === "failed") {
+      throw new Error(job.error || "El job del publicador fallo");
+    }
+    await sleep(2500);
+  }
+  throw new Error("El job sigue corriendo. Volve a consultar el estado en unos segundos.");
+}
+
 async function runFinalPublisher(kind, action) {
   const isScreen = kind === "screen";
   const base = isScreen ? "/api/admin/screens" : "/api/admin/screen-adhesives";
@@ -4139,18 +4159,19 @@ async function runFinalPublisher(kind, action) {
   setFinalPublisherStatus("Procesando...");
   try {
     let data;
-    if (action === "audit") {
-      const params = new URLSearchParams(Object.entries(filters).filter(([, v]) => v !== undefined && v !== ""));
-      data = await fetchAdminJson(`${base}/audit?${params.toString()}`);
+    if (action === "audit" || action === "preview") {
+      const started = await fetchAdminJson(`${base}/audit-job`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(filters) });
+      data = await waitScreenPublisherJob(base, started.jobId, kind);
     } else {
-      const body = action === "publish" ? { ...filters, [isScreen ? "confirmScreenBulkPublish" : "confirmScreenAdhesiveBulkPublish"]: true } : filters;
+      const body = { ...filters, [isScreen ? "confirmScreenBulkPublish" : "confirmScreenAdhesiveBulkPublish"]: true };
       if (action === "publish") {
         const ok = confirm(isScreen
           ? "Vas a publicar pantallas reales elegibles. No se publicaran adhesivos, brackets, fundas, protectores ni productos sin precio/imagen."
           : "Vas a publicar adhesivos de pantalla elegibles. No se publicaran adhesivos de bateria, tapas, camaras ni cintas genericas sin modelo.");
         if (!ok) return;
       }
-      data = await fetchAdminJson(`${base}/${action === "publish" ? "publish" : "publish-preview"}`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
+      const started = await fetchAdminJson(`${base}/publish-job`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
+      data = await waitScreenPublisherJob(base, started.jobId, kind);
     }
     if (!data.ok) throw new Error(data.error || "No se pudo completar");
     setFinalPublisherStatus(action === "publish" ? `Actualizados ${data.updatedCount || 0}, verificados ${data.verifiedPublicCount || 0}, fallidos ${data.failedCount || 0}` : "Listo.");

--- a/nerin_final_updated/package.json
+++ b/nerin_final_updated/package.json
@@ -14,6 +14,8 @@
     "test:analytics-memory": "node scripts/test-analytics-memory-safety.js",
     "test:screens-final": "node scripts/test-screens-and-adhesives-final.js",
     "test:screen-publisher-production": "node scripts/test-screen-publisher-production.js",
+    "test:screen-publisher-routes": "node scripts/test-screen-publisher-routes.js",
+    "test:screen-publisher-stability": "node scripts/test-screen-publisher-stability.js",
     "audit:screens-final": "node scripts/audit-screens-and-adhesives-final.js",
     "check:no-products-full-parse": "node scripts/check-no-products-full-parse.js"
   },

--- a/nerin_final_updated/scripts/test-screen-publisher-production.js
+++ b/nerin_final_updated/scripts/test-screen-publisher-production.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 "use strict";
 
+process.env.SCREEN_PUBLISHER_ENABLED = "false";
+
 const fs = require("fs");
 const path = require("path");
 const assert = require("assert");
@@ -45,7 +47,7 @@ function assertSourceContracts() {
   const admin = fs.readFileSync(path.join(ROOT, "frontend", "js", "admin.js"), "utf8");
   const packageJson = fs.readFileSync(path.join(ROOT, "package.json"), "utf8");
 
-  assert(service.includes("const DEFAULT_SCAN_LIMIT = 250000"), "DEFAULT_SCAN_LIMIT must be permanent");
+  assert(service.includes("SCREEN_PUBLISHER_SCAN_LIMIT_DEFAULT || 5000"), "DEFAULT_SCAN_LIMIT must default to 5000");
   assert(service.includes("function isPublicProduct(product = {})"), "isPublicProduct helper missing");
   assert(service.includes("computePublicationState(product).is_public"), "isPublicProduct must use computePublicationState");
   assert(!/Number\([^)\n]*is_public/.test(service), "service must not use Number(raw is_public)");
@@ -83,28 +85,28 @@ async function assertEndpointContracts() {
 
     const authHeaders = { Authorization: `Bearer ${ADMIN_TOKEN}` };
     const screensAudit = await requestJson(baseUrl, "/api/admin/screens/audit", { headers: authHeaders });
-    assert.strictEqual(screensAudit.response.status, 200, "screens audit with auth should be 200 JSON");
-    assert.strictEqual(screensAudit.data.ok, true, "screens audit ok");
+    assert.strictEqual(screensAudit.response.status, 503, "screens audit should be disabled by default");
+    assert.strictEqual(screensAudit.data.error, "SCREEN_PUBLISHER_DISABLED", "screens audit disabled code");
 
     const preview = await requestJson(baseUrl, "/api/admin/screens/publish-preview", {
       method: "POST",
       headers: { ...authHeaders, "Content-Type": "application/json" },
       body: JSON.stringify({ onlyWithImage: true, onlyWithPrice: true }),
     });
-    assert.strictEqual(preview.response.status, 200, "screens preview should be 200 JSON");
-    assert.strictEqual(preview.data.ok, true, "screens preview ok");
+    assert.strictEqual(preview.response.status, 503, "screens preview should be disabled by default");
+    assert.strictEqual(preview.data.error, "SCREEN_PUBLISHER_DISABLED", "screens preview disabled code");
 
     const publishNoConfirm = await requestJson(baseUrl, "/api/admin/screens/publish", {
       method: "POST",
       headers: { ...authHeaders, "Content-Type": "application/json" },
       body: JSON.stringify({ onlyWithImage: true }),
     });
-    assert.strictEqual(publishNoConfirm.response.status, 400, "screens publish without confirm should be 400 JSON");
+    assert.strictEqual(publishNoConfirm.response.status, 503, "screens publish should be disabled before confirm");
     assert.strictEqual(publishNoConfirm.data.ok, false, "screens publish without confirm ok=false");
 
     const adhesivesAudit = await requestJson(baseUrl, "/api/admin/screen-adhesives/audit", { headers: authHeaders });
-    assert.strictEqual(adhesivesAudit.response.status, 200, "adhesives audit with auth should be 200 JSON");
-    assert.strictEqual(adhesivesAudit.data.ok, true, "adhesives audit ok");
+    assert.strictEqual(adhesivesAudit.response.status, 503, "adhesives audit should be disabled by default");
+    assert.strictEqual(adhesivesAudit.data.error, "SCREEN_PUBLISHER_DISABLED", "adhesives audit disabled code");
   } finally {
     await close(server);
   }

--- a/nerin_final_updated/scripts/test-screen-publisher-routes.js
+++ b/nerin_final_updated/scripts/test-screen-publisher-routes.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+"use strict";
+
+process.env.SCREEN_PUBLISHER_ENABLED = "false";
+process.env.DATA_DIR = process.env.DATA_DIR || require("path").join(__dirname, "..", "data");
+
+const assert = require("assert");
+const { createServer } = require("../backend/server");
+
+const ADMIN_TOKEN = Buffer.from("admin@nerin.com:test").toString("base64");
+
+async function listen(server) {
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve(`http://127.0.0.1:${server.address().port}`));
+  });
+}
+
+async function close(server) {
+  return new Promise((resolve) => server.close(resolve));
+}
+
+async function request(baseUrl, pathName, options = {}) {
+  const response = await fetch(`${baseUrl}${pathName}`, {
+    ...options,
+    headers: { Accept: "application/json", ...(options.headers || {}) },
+  });
+  const contentType = response.headers.get("content-type") || "";
+  const text = await response.text();
+  const preview = text.slice(0, 300).replace(/\s+/g, " ");
+  assert(contentType.includes("application/json"), `${pathName} returned ${response.status} ${contentType}: ${preview}`);
+  assert(!preview.startsWith("<!DOCTYPE"), `${pathName} returned HTML`);
+  return { response, data: text ? JSON.parse(text) : {}, preview };
+}
+
+(async () => {
+  const server = createServer();
+  const baseUrl = await listen(server);
+  const auth = { Authorization: `Bearer ${ADMIN_TOKEN}` };
+  try {
+    const light = await request(baseUrl, "/api/system/health-light");
+    assert.strictEqual(light.response.status, 200, "health-light status");
+    assert.strictEqual(light.data.ok, true, "health-light ok");
+
+    const health = await request(baseUrl, "/api/admin/screens/publisher-health");
+    assert.strictEqual(health.response.status, 200, "publisher health status");
+    assert.strictEqual(health.data.enabled, false, "publisher disabled by default");
+
+    const unauth = await request(baseUrl, "/api/admin/screens/audit");
+    assert.strictEqual(unauth.response.status, 401, "unauth screens audit status");
+    assert.strictEqual(unauth.data.error, "UNAUTHORIZED", "unauth screens audit code");
+
+    const screensAudit = await request(baseUrl, "/api/admin/screens/audit", { headers: auth });
+    assert.strictEqual(screensAudit.response.status, 503, "screens audit disabled status");
+    assert.strictEqual(screensAudit.data.error, "SCREEN_PUBLISHER_DISABLED", "screens audit disabled code");
+
+    const adhesivesAudit = await request(baseUrl, "/api/admin/screen-adhesives/audit", { headers: auth });
+    assert.strictEqual(adhesivesAudit.response.status, 503, "adhesives audit disabled status");
+    assert.strictEqual(adhesivesAudit.data.error, "SCREEN_PUBLISHER_DISABLED", "adhesives audit disabled code");
+
+    const preview = await request(baseUrl, "/api/admin/screens/publish-preview", {
+      method: "POST",
+      headers: { ...auth, "Content-Type": "application/json" },
+      body: JSON.stringify({ onlyWithImage: true }),
+    });
+    assert.strictEqual(preview.response.status, 503, "preview disabled status");
+    assert.strictEqual(preview.data.error, "SCREEN_PUBLISHER_DISABLED", "preview disabled code");
+  } finally {
+    await close(server);
+  }
+  console.log("screen publisher route tests passed");
+})().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/nerin_final_updated/scripts/test-screen-publisher-stability.js
+++ b/nerin_final_updated/scripts/test-screen-publisher-stability.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+"use strict";
+
+process.env.SCREEN_PUBLISHER_ENABLED = "true";
+process.env.SCREEN_PUBLISHER_SCAN_LIMIT_DEFAULT = "5";
+process.env.SCREEN_PUBLISHER_SCAN_LIMIT_MAX = "10";
+process.env.SCREEN_PUBLISHER_CHUNK_SIZE = "2";
+process.env.DATA_DIR = process.env.DATA_DIR || require("path").join(__dirname, "..", "data");
+
+const fs = require("fs");
+const path = require("path");
+const assert = require("assert");
+const { createServer } = require("../backend/server");
+
+const ROOT = path.join(__dirname, "..");
+const ADMIN_TOKEN = Buffer.from("admin@nerin.com:test").toString("base64");
+
+async function listen(server) {
+  return new Promise((resolve) => server.listen(0, "127.0.0.1", () => resolve(`http://127.0.0.1:${server.address().port}`)));
+}
+
+async function close(server) {
+  return new Promise((resolve) => server.close(resolve));
+}
+
+async function requestJson(baseUrl, pathName, options = {}) {
+  const response = await fetch(`${baseUrl}${pathName}`, {
+    ...options,
+    headers: { Accept: "application/json", ...(options.headers || {}) },
+  });
+  const contentType = response.headers.get("content-type") || "";
+  const text = await response.text();
+  const preview = text.slice(0, 300).replace(/\s+/g, " ");
+  assert(contentType.includes("application/json"), `${pathName} returned ${response.status} ${contentType}: ${preview}`);
+  assert(!preview.startsWith("<!DOCTYPE"), `${pathName} returned HTML`);
+  return { response, data: text ? JSON.parse(text) : {} };
+}
+
+async function waitJob(baseUrl, jobId, auth) {
+  for (let i = 0; i < 40; i += 1) {
+    const result = await requestJson(baseUrl, `/api/admin/screens/jobs/${encodeURIComponent(jobId)}`, { headers: auth });
+    const status = result.data.job?.status;
+    if (status === "done" || status === "failed") return result.data;
+    await new Promise((resolve) => setTimeout(resolve, 150));
+  }
+  throw new Error("job did not finish");
+}
+
+function assertSourceContracts() {
+  const service = fs.readFileSync(path.join(ROOT, "backend", "services", "screenPublicationService.js"), "utf8");
+  const server = fs.readFileSync(path.join(ROOT, "backend", "server.js"), "utf8");
+  const admin = fs.readFileSync(path.join(ROOT, "frontend", "js", "admin.js"), "utf8");
+  const packageJson = fs.readFileSync(path.join(ROOT, "package.json"), "utf8");
+
+  assert(!packageJson.includes("applyScreenPublisherHotfix.js"), "start must not run screen publisher hotfix");
+  assert(service.includes("SCREEN_PUBLISHER_SCAN_LIMIT_DEFAULT || 5000"), "interactive scan default must be 5000");
+  assert(service.includes("SCREEN_PUBLISHER_SCAN_LIMIT_MAX || 60000"), "interactive scan max must be 60000");
+  assert(service.includes("candidateWhere(type"), "loadRows must prefilter candidates in SQLite");
+  assert(service.includes("LIMIT ? OFFSET ?"), "loadRows must support chunk/cursor paging");
+  assert(service.includes(".filter((item) => isPublicProduct(item.product))"), "buildFeed must use computed public state");
+  assert(service.indexOf(".filter((item) => isPublicProduct(item.product))") < service.indexOf(".slice(0, outputLimit)"), "buildFeed must apply outputLimit at the end");
+  assert(!/Number\([^)\n]*is_public/.test(service), "service must not use raw Number(is_public)");
+  assert(!/boolish\([^)\n]*is_public/.test(service), "service must not use raw boolish(is_public)");
+
+  assert(server.includes("SCREEN_PUBLISHER_ENABLED"), "server must have publisher feature flag");
+  assert(server.includes("startScreenPublisherJob"), "server must start publisher jobs");
+  assert(server.includes("screenPublisherLocks"), "server must lock publisher jobs");
+  assert(server.includes("[screen-publisher:memory]"), "server must log memory for publisher jobs");
+  assert(server.includes("/api/system/health-light"), "health-light endpoint missing");
+  assert(server.includes("DEBUG_PRODUCT_DETAIL"), "product detail found logs must be debug-gated");
+  assert(server.includes("productDetailCache"), "product detail cache missing");
+  assert(server.includes("productsSqliteRepo.getProductByPublicSlugOrAnyIdentifier"), "product detail must use SQLite first");
+  assert(server.includes("ANALYTICS_DETAILED_ENABLED") && server.includes("!IS_PRODUCTION"), "analytics detailed must be disabled by default in production");
+  assert(server.includes("ANALYTICS_CATALOG_SNAPSHOT_ENABLED") && server.includes("!IS_PRODUCTION"), "analytics snapshot must be disabled by default in production");
+
+  assert(admin.includes("/audit-job"), "admin must start audit jobs");
+  assert(admin.includes("/publish-job"), "admin must start publish jobs");
+  assert(admin.includes("/jobs/"), "admin must poll jobs");
+  assert(admin.includes("fetchAdminJson"), "admin must use robust JSON helper");
+}
+
+(async () => {
+  assertSourceContracts();
+  const server = createServer();
+  const baseUrl = await listen(server);
+  const auth = { Authorization: `Bearer ${ADMIN_TOKEN}` };
+  try {
+    const health = await requestJson(baseUrl, "/api/admin/screens/publisher-health");
+    assert.strictEqual(health.data.enabled, true, "publisher should be enabled in this test");
+
+    const start = await requestJson(baseUrl, "/api/admin/screens/audit-job", {
+      method: "POST",
+      headers: { ...auth, "Content-Type": "application/json" },
+      body: JSON.stringify({ scanLimit: 5 }),
+    });
+    assert.strictEqual(start.response.status, 202, "audit job should return immediately");
+    assert(start.data.jobId, "audit job id missing");
+    const done = await waitJob(baseUrl, start.data.jobId, auth);
+    assert.strictEqual(done.job.status, "done", "job must finish successfully");
+    assert(Number(done.job.scannedRows || 0) <= 10, "job must respect scan max");
+  } finally {
+    await close(server);
+  }
+  console.log("screen publisher stability tests passed");
+})().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

- Keeps the screen/screen-adhesive publisher disabled by default with `SCREEN_PUBLISHER_ENABLED=false` unless explicitly enabled.
- Adds JSON-only disabled/auth/error behavior for publisher routes, plus `/api/system/health-light`.
- Moves admin publisher actions to background jobs: `audit-job`, `publish-job`, and `jobs/:jobId` polling for screens and screen adhesives.
- Adds job lock, 5-minute audit cache, chunked candidate loading, memory logging, and a heap soft abort.
- Reduces interactive scan defaults to `SCREEN_PUBLISHER_SCAN_LIMIT_DEFAULT=5000` and max `SCREEN_PUBLISHER_SCAN_LIMIT_MAX=60000`.
- Prefilters publisher candidates in SQLite/search index instead of loading all products first.
- Gates `[product-detail:found]` logs behind `DEBUG_PRODUCT_DETAIL=true` and adds an LRU-ish product detail HTML cache.
- Keeps analytics detailed/catalog snapshot disabled by default in production.

## Root cause

The admin could still receive HTML while expecting JSON, causing `Unexpected token '<'`. Separately, the screen publisher paths could run large synchronous scans from normal admin requests, and product detail traffic from crawlers was producing noisy per-product logs while repeatedly doing detail rendering work.

## Solution

- Publisher is safe-off by default and returns JSON `{ ok:false, error:"SCREEN_PUBLISHER_DISABLED" }` when disabled.
- Admin buttons now start short background jobs and poll every few seconds instead of holding a long request open.
- Jobs use locks, cache, chunked SQLite-prefiltered candidate reads, memory logs, and soft memory aborts.
- Product detail SSR uses SQLite first, caches rendered detail HTML, and suppresses found logs unless debug is enabled.
- `health-light` responds quickly without touching heavy catalog work.

## Validation

- `node --check backend/server.js`
- `node --check backend/services/screenPublicationService.js`
- `node --check frontend/js/admin.js`
- `node --check scripts/test-screen-publisher-routes.js`
- `node --check scripts/test-screen-publisher-stability.js`
- `node scripts/test-screen-publisher-routes.js`
- `node scripts/test-screen-publisher-stability.js`
- `node scripts/test-screen-publisher-production.js`
- `node scripts/test-screens-and-adhesives-final.js`
- `DATA_DIR=./data node scripts/audit-screens-and-adhesives-final.js`

Manual `npm start` validation on `PORT=11988`:

- `/api/system/health-light` -> `200 application/json; charset=utf-8`, no doctype
- `/api/admin/screens/publisher-health` -> `200 application/json; charset=utf-8`, `enabled:false`, no doctype
- `/api/admin/screens/audit` -> `401 application/json; charset=utf-8`, no doctype
- `/api/admin/screen-adhesives/audit` -> `401 application/json; charset=utf-8`, no doctype

Local audit snapshot:

- Screens detected: 4
- Public screens current: 4
- Screens feed ready: 4
- Screen adhesives detected: 0
- Screen adhesives feed ready: 0
- Accessory-blocked screen-like products: 2

## Safety boundaries

No Mercado Pago, webhooks, inventory, stock discount, orders, base prices, checkout, Andreani, or purchase flow logic was touched.