### PR TITLE
Replace screen publisher with fast admin bulk visibility action

### DIFF
--- a/nerin_final_updated/backend/data/productsSqliteRepo.js
+++ b/nerin_final_updated/backend/data/productsSqliteRepo.js
@@ -2322,6 +2322,120 @@ async function setProductVisibility(identifier, nextVisibility, options = {}) {
   };
 }
 
+async function runWithConcurrency(items, limit, worker) {
+  const results = new Array(items.length);
+  let index = 0;
+  const workerCount = Math.min(Math.max(1, Number(limit) || 1), items.length || 1);
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (index < items.length) {
+        const currentIndex = index;
+        index += 1;
+        results[currentIndex] = await worker(items[currentIndex], currentIndex);
+      }
+    }),
+  );
+  return results;
+}
+
+async function setProductsVisibilityBatch(identifiers = [], visibility, options = {}) {
+  const startedAt = Date.now();
+  const uniqueIdentifiers = Array.from(
+    new Set(
+      (Array.isArray(identifiers) ? identifiers : [])
+        .map((identifier) => String(identifier || "").trim())
+        .filter(Boolean),
+    ),
+  );
+  const nextVisibility = normalizeQueryText(visibility || "");
+  const allowedVisibility = new Set(["public", "private", "hidden"]);
+  if (!allowedVisibility.has(nextVisibility)) {
+    const error = new Error("visibility debe ser public, private o hidden");
+    error.code = "INVALID_VISIBILITY";
+    throw error;
+  }
+  const maxBatchSize = Number(options.maxBatchSize || 200);
+  if (uniqueIdentifiers.length > maxBatchSize) {
+    const error = new Error(`El lote supera el maximo de ${maxBatchSize} productos`);
+    error.code = "BULK_VISIBILITY_TOO_LARGE";
+    throw error;
+  }
+  console.info("[admin-bulk-visibility:start]", {
+    requestedCount: uniqueIdentifiers.length,
+    visibility: nextVisibility,
+    reindex: options.reindex !== false,
+  });
+  const sampleUpdated = [];
+  const sampleFailed = [];
+  let updatedCount = 0;
+  let failedCount = 0;
+  await runWithConcurrency(uniqueIdentifiers, options.concurrency || 5, async (identifier) => {
+    const itemStartedAt = Date.now();
+    try {
+      const result = await setProductVisibility(identifier, nextVisibility, {
+        reason: options.reason || "admin_bulk_visibility",
+      });
+      if (!result?.ok) {
+        throw new Error("Producto no encontrado");
+      }
+      let reindexResult = null;
+      if (options.reindex !== false) {
+        reindexResult = await reindexProduct(identifier);
+      }
+      updatedCount += 1;
+      if (sampleUpdated.length < 20) {
+        sampleUpdated.push({
+          identifier,
+          title: result?.debug?.sqlite?.title || result?.debug?.sqlite?.name || result?.debug?.product?.title || null,
+          before: result.before || null,
+          after: result.after || null,
+          reindexed: Boolean(reindexResult?.indexUpdated || result.indexUpdated),
+        });
+      }
+      console.info("[admin-bulk-visibility:item]", {
+        identifier,
+        ok: true,
+        visibility: nextVisibility,
+        durationMs: Date.now() - itemStartedAt,
+      });
+      return result;
+    } catch (error) {
+      failedCount += 1;
+      if (sampleFailed.length < 20) {
+        sampleFailed.push({
+          identifier,
+          error: error?.message || "No se pudo actualizar el producto",
+        });
+      }
+      console.info("[admin-bulk-visibility:item]", {
+        identifier,
+        ok: false,
+        error: error?.message || "bulk_visibility_item_failed",
+        durationMs: Date.now() - itemStartedAt,
+      });
+      return null;
+    }
+  });
+  const durationMs = Date.now() - startedAt;
+  console.info("[admin-bulk-visibility:end]", {
+    requestedCount: uniqueIdentifiers.length,
+    updatedCount,
+    failedCount,
+    visibility: nextVisibility,
+    durationMs,
+  });
+  return {
+    ok: true,
+    requestedCount: uniqueIdentifiers.length,
+    updatedCount,
+    failedCount,
+    visibility: nextVisibility,
+    sampleUpdated,
+    sampleFailed,
+    durationMs,
+  };
+}
+
 async function loadProductOverrides() {
   try {
     return JSON.parse(await fsp.readFile(OVERRIDES_PATH, "utf8")) || {};
@@ -4477,6 +4591,7 @@ module.exports = {
   computePublicationState,
   computeProductPublicState,
   setProductVisibility,
+  setProductsVisibilityBatch,
   reindexProduct,
   updateProductByIdentifier,
   normalizeProductForPublic,

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -2790,7 +2790,7 @@ function requireAdminJson(req, res, options = {}) {
 }
 
 function screenPublisherDisabled(res) {
-  return sendApiError(res, 503, "SCREEN_PUBLISHER_DISABLED", "Publicador desactivado temporalmente para proteger produccion");
+  return sendApiError(res, 503, "DISABLED", "Publicador especifico desactivado. Usar accion masiva normal.");
 }
 
 function normalizeScreenPublisherType(value) {
@@ -7695,6 +7695,56 @@ async function requestHandler(req, res) {
       }
     });
     return;
+  }
+
+  if (pathname === "/api/admin/products/bulk-visibility/health" && req.method === "GET") {
+    if (!requireAdminJson(req, res)) return;
+    return sendApiJson(res, 200, {
+      ok: true,
+      routeReady: true,
+      hasBatchFunction: typeof productsSqliteRepo.setProductsVisibilityBatch === "function",
+      maxBatchSize: 200,
+      reindexMode: "per-product",
+      rebuildsFullCatalog: false,
+    });
+  }
+
+  if (pathname === "/api/admin/products/bulk-visibility" && req.method === "POST") {
+    if (!requireAdminJson(req, res)) return;
+    await parseBody(req);
+    try {
+      const payload = req.body && typeof req.body === "object" ? req.body : {};
+      const identifiers = Array.isArray(payload.identifiers) ? payload.identifiers : [];
+      const visibility = String(payload.visibility || "").trim().toLowerCase();
+      if (identifiers.length === 0) {
+        return sendApiError(res, 400, "BULK_VISIBILITY_EMPTY", "Selecciona al menos un producto.");
+      }
+      if (identifiers.length > 200) {
+        return sendApiError(res, 400, "BULK_VISIBILITY_TOO_LARGE", "La accion masiva permite hasta 200 productos por request.", {
+          requestedCount: identifiers.length,
+          maxBatchSize: 200,
+        });
+      }
+      if (!["public", "private", "hidden"].includes(visibility)) {
+        return sendApiError(res, 400, "INVALID_VISIBILITY", "visibility debe ser public, private o hidden.");
+      }
+      const result = await productsSqliteRepo.setProductsVisibilityBatch(identifiers, visibility, {
+        reindex: payload.reindex !== false,
+        maxBatchSize: 200,
+        concurrency: 5,
+        reason: "admin_bulk_visibility",
+      });
+      invalidateCatalogCaches("admin_bulk_visibility");
+      return sendApiJson(res, 200, result);
+    } catch (error) {
+      if (error?.code === "INVALID_VISIBILITY") {
+        return sendApiError(res, 400, "INVALID_VISIBILITY", error.message);
+      }
+      if (error?.code === "BULK_VISIBILITY_TOO_LARGE") {
+        return sendApiError(res, 400, "BULK_VISIBILITY_TOO_LARGE", error.message);
+      }
+      return sendApiError(res, 500, "BULK_VISIBILITY_FAILED", error?.message || "No se pudo actualizar la visibilidad en lote.");
+    }
   }
 
   const adminProductReindexMatch = pathname.match(/^\/api\/admin\/products\/([^/]+)\/reindex$/);

--- a/nerin_final_updated/frontend/admin.html
+++ b/nerin_final_updated/frontend/admin.html
@@ -560,61 +560,13 @@
             <div id="bulkPublishSummary" role="status" aria-live="polite"></div>
             <div id="bulkPublishDetails" class="bulk-publish-details"></div>
           </section>
-          <section class="bulk-publish-panel" aria-labelledby="finalScreensPublisherTitle">
-            <header class="bulk-publish-header">
-              <h4 id="finalScreensPublisherTitle">Publicador final de pantallas y adhesivos de pantalla</h4>
-              <p>PublicaciÃ³n manual y separada. No mezcla pantallas con adhesivos, brackets, fundas ni protectores.</p>
-            </header>
-            <div class="bulk-publish-card">
-              <h5>Pantallas / mÃ³dulos</h5>
-              <div class="bulk-publish-filters-grid">
-                <label class="bulk-publish-field">Marca<input id="screenPubBrand" type="text" /></label>
-                <label class="bulk-publish-field">Modelo<input id="screenPubModel" type="text" /></label>
-                <label class="bulk-publish-field">Calidad<input id="screenPubQuality" type="text" /></label>
-                <label class="bulk-publish-field">Stock<select id="screenPubStock"><option value="all">Todas</option><option value="stock_real">Stock real</option><option value="remote_orderable">A pedido</option></select></label>
-                <label class="bulk-publish-field">LÃ­mite<input id="screenPubLimit" type="number" value="10000" min="1" max="50000" /></label>
-              </div>
-              <label><input id="screenPubOnlyImage" type="checkbox" checked /> Solo con imagen</label>
-              <label><input id="screenPubOnlyPrice" type="checkbox" checked /> Solo con precio</label>
-              <label><input id="screenPubIncludePrivate" type="checkbox" checked /> Incluir privadas</label>
-              <label><input id="screenPubIncludeHidden" type="checkbox" checked /> Incluir ocultas</label>
-              <label><input id="screenPubIncludeRemote" type="checkbox" checked /> Incluir a pedido</label>
-              <div class="bulk-publish-actions">
-                <button id="screenAuditBtn" class="button secondary">Auditar pantallas</button>
-                <button id="screenPreviewBtn" class="button secondary">Simular publicaciÃ³n de pantallas</button>
-                <button id="screenPublishBtn" class="button">Publicar pantallas elegibles</button>
-              </div>
-            </div>
-            <div class="bulk-publish-card">
-              <h5>Adhesivos de pantalla</h5>
-              <div class="bulk-publish-filters-grid">
-                <label class="bulk-publish-field">Marca<input id="adhPubBrand" type="text" /></label>
-                <label class="bulk-publish-field">Modelo<input id="adhPubModel" type="text" /></label>
-                <label class="bulk-publish-field">Tipo<input id="adhPubType" type="text" /></label>
-                <label class="bulk-publish-field">Stock<select id="adhPubStock"><option value="all">Todas</option><option value="stock_real">Stock real</option><option value="remote_orderable">A pedido</option></select></label>
-                <label class="bulk-publish-field">LÃ­mite<input id="adhPubLimit" type="number" value="10000" min="1" max="50000" /></label>
-              </div>
-              <label><input id="adhPubOnlyImage" type="checkbox" checked /> Solo con imagen</label>
-              <label><input id="adhPubOnlyPrice" type="checkbox" checked /> Solo con precio</label>
-              <label><input id="adhPubIncludePrivate" type="checkbox" checked /> Incluir privadas</label>
-              <label><input id="adhPubIncludeHidden" type="checkbox" checked /> Incluir ocultas</label>
-              <label><input id="adhPubIncludeRemote" type="checkbox" checked /> Incluir a pedido</label>
-              <div class="bulk-publish-actions">
-                <button id="adhAuditBtn" class="button secondary">Auditar adhesivos de pantalla</button>
-                <button id="adhPreviewBtn" class="button secondary">Simular publicaciÃ³n de adhesivos</button>
-                <button id="adhPublishBtn" class="button">Publicar adhesivos elegibles</button>
-              </div>
-            </div>
-            <div id="finalScreensPublisherStatus" class="bulk-publish-status" role="status" aria-live="polite"></div>
-            <div id="finalScreensPublisherSummary" class="bulk-publish-details"></div>
-          </section>
           <div class="bulk-actions">
             <select id="bulkActionSelect">
               <option value="">Acción masiva…</option>
               <option value="delete">Eliminar</option>
               <option value="vis-public">Hacer público</option>
               <option value="vis-private">Hacer privado</option>
-              <option value="vis-draft">Marcar borrador</option>
+              <option value="vis-hidden">Ocultar</option>
               <option value="price-inc">Aumentar precios %</option>
               <option value="price-dec">Disminuir precios %</option>
             </select>

--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -3821,78 +3821,122 @@ if (bulkSelect && bulkValueInput) {
   });
 }
 
+async function fetchAdminJson(url, options = {}) {
+  const response = await apiFetch(url, {
+    ...options,
+    headers: {
+      Accept: "application/json",
+      ...(options.headers || {}),
+      ...getAdminHeaders(),
+    },
+  });
+  const contentType = response.headers.get("content-type") || "";
+  const text = await response.text();
+  const preview = text.slice(0, 300).replace(/\s+/g, " ");
+  if (!contentType.includes("application/json")) {
+    throw new Error(`El endpoint ${url} devolvio ${response.status} ${contentType || "sin content-type"} en vez de JSON. Preview: ${preview}`);
+  }
+  let data = {};
+  try {
+    data = text ? JSON.parse(text) : {};
+  } catch (error) {
+    throw new Error(`Respuesta JSON invalida de ${url}: ${error.message}`);
+  }
+  if (!response.ok) {
+    throw new Error(data.message || data.error || `Error HTTP ${response.status}`);
+  }
+  return data;
+}
+
+function getSelectedProductIdentifiers() {
+  return Array.from(document.querySelectorAll(".select-product:checked"))
+    .map((cb) => {
+      const row = cb.closest("tr");
+      return row?.dataset?.adminIdentifier || row?.dataset?.id || "";
+    })
+    .map((identifier) => String(identifier || "").trim())
+    .filter(Boolean);
+}
+
+function setBulkActionBusy(isBusy) {
+  if (applyBulkBtn) {
+    applyBulkBtn.disabled = isBusy;
+    applyBulkBtn.textContent = isBusy ? "Aplicando..." : "Aplicar";
+  }
+}
+
+async function applyBulkVisibilityAction(visibility, identifiers) {
+  const label = visibility === "public" ? "Publicando" : visibility === "private" ? "Pasando a privado" : "Ocultando";
+  setBulkActionBusy(true);
+  if (window.showToast) showToast(`${label} ${identifiers.length} productos...`);
+  const data = await fetchAdminJson("/api/admin/products/bulk-visibility", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ identifiers, visibility, reindex: true }),
+  });
+  const message = `${visibility === "public" ? "Publicados" : "Actualizados"} ${data.updatedCount || 0}/${data.requestedCount || identifiers.length} productos. Fallaron ${data.failedCount || 0}.`;
+  if (window.showToast) showToast(message);
+  if (data.failedCount && Array.isArray(data.sampleFailed)) {
+    console.warn("[admin-bulk-visibility:failed]", data.sampleFailed);
+    alert(`${message}\n\nFallos:\n${data.sampleFailed.map((item) => `${item.identifier}: ${item.error}`).join("\n")}`);
+  }
+  document.querySelectorAll(".select-product:checked").forEach((cb) => {
+    cb.checked = false;
+  });
+  if (selectAllCheckbox) selectAllCheckbox.checked = false;
+  await loadProducts();
+}
+
 if (applyBulkBtn && bulkSelect) {
   applyBulkBtn.addEventListener("click", async () => {
     const action = bulkSelect.value;
-  const selected = Array.from(
-    document.querySelectorAll(".select-product:checked"),
-  ).map((cb) => cb.closest("tr").dataset.id);
-  if (selected.length === 0) {
-    alert("Seleccione productos");
-    return;
-  }
-  if (action === "delete") {
-    if (!confirm("¿Eliminar productos seleccionados?")) return;
-    for (const id of selected) {
-      await apiFetch(`/api/products/${id}`, { method: "DELETE" });
-    }
-  } else if (action.startsWith("vis-")) {
-    const vis = action.split("-")[1];
-    for (const id of selected) {
-      const row = document.querySelector(`tr[data-id="${id}"]`);
-      const identifier = row?.dataset?.adminIdentifier || id;
-      const endpoint = `/api/products/${encodeURIComponent(String(identifier))}`;
-      const payload = { visibility: vis };
-      console.info("[admin-visibility-update]", {
-        identifier,
-        previousVisibility: row ? String((productsCache.find((item) => String(item.id) === String(id)) || {}).visibility || "") : "",
-        nextVisibility: vis,
-        endpoint,
-        payload,
-      });
-      const response = await apiFetch(endpoint, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-      });
-      const data = await response.json().catch(() => ({}));
-      console.info("[admin-visibility-update-result]", {
-        status: response.status,
-        enabled: data?.product?.enabled,
-        visibility: data?.product?.visibility,
-        is_public: data?.product?.is_public,
-        source: data?.source,
-      });
-      const computedIsPublic = data?.debugPublication?.computed?.isPublic;
-      const computedReason = data?.debugPublication?.computed?.reason;
-      if (!response.ok || (vis === "public" && (response.status === 409 || computedIsPublic === false))) {
-        throw new Error(data.error || `No se pudo publicar el producto (reason: ${computedReason || "unknown"}).`);
-      }
-    }
-  } else if (action.startsWith("price")) {
-    const pct = parseFloat(bulkValueInput.value);
-    if (isNaN(pct)) {
-      alert("Ingrese un porcentaje válido");
+    const selected = getSelectedProductIdentifiers();
+    if (selected.length === 0) {
+      alert("Seleccione productos");
       return;
     }
-    for (const id of selected) {
-      const row = document.querySelector(`tr[data-id='${id}']`);
-      const minorInput = row.querySelector("input[data-field='price_minorista']");
-      const mayorInput = row.querySelector("input[data-field='price_mayorista']");
-      const factor = action === "price-inc" ? 1 + pct / 100 : 1 - pct / 100;
-      const newMinor = Math.round(parseFloat(minorInput.value) * factor);
-      const newMayor = Math.round(parseFloat(mayorInput.value) * factor);
-      await apiFetch(`/api/products/${id}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          price_minorista: newMinor,
-          price_mayorista: newMayor,
-        }),
-      });
+    try {
+      setBulkActionBusy(true);
+      if (action === "delete") {
+        if (!confirm("Eliminar productos seleccionados?")) return;
+        for (const id of selected) {
+          await apiFetch(`/api/products/${encodeURIComponent(String(id))}`, { method: "DELETE" });
+        }
+        await loadProducts();
+      } else if (action.startsWith("vis-")) {
+        const vis = action.split("-")[1];
+        await applyBulkVisibilityAction(vis, selected);
+      } else if (action.startsWith("price")) {
+        const pct = parseFloat(bulkValueInput.value);
+        if (isNaN(pct)) {
+          alert("Ingrese un porcentaje valido");
+          return;
+        }
+        const selectedRows = Array.from(document.querySelectorAll(".select-product:checked")).map((cb) => cb.closest("tr"));
+        for (const id of selected) {
+          const row = selectedRows.find((candidate) => candidate?.dataset?.adminIdentifier === id || candidate?.dataset?.id === id);
+          const minorInput = row?.querySelector("input[data-field='price_minorista']");
+          const mayorInput = row?.querySelector("input[data-field='price_mayorista']");
+          const factor = action === "price-inc" ? 1 + pct / 100 : 1 - pct / 100;
+          const newMinor = Math.round(parseFloat(minorInput?.value || 0) * factor);
+          const newMayor = Math.round(parseFloat(mayorInput?.value || 0) * factor);
+          await apiFetch(`/api/products/${encodeURIComponent(String(id))}`, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              price_minorista: newMinor,
+              price_mayorista: newMayor,
+            }),
+          });
+        }
+        await loadProducts();
+      }
+    } catch (error) {
+      console.error("[admin-bulk-action:error]", error);
+      alert(error?.message || "No se pudo aplicar la accion masiva");
+    } finally {
+      setBulkActionBusy(false);
     }
-  }
-  loadProducts();
   });
 }
 
@@ -4061,132 +4105,7 @@ if (bulkPublishRunBtn) {
   });
 }
 
-const finalScreensPublisherStatus = document.getElementById("finalScreensPublisherStatus");
-const finalScreensPublisherSummary = document.getElementById("finalScreensPublisherSummary");
 
-function finalPublisherFilters(kind) {
-  const isScreen = kind === "screen";
-  return {
-    brand: document.getElementById(isScreen ? "screenPubBrand" : "adhPubBrand")?.value?.trim() || "",
-    model: document.getElementById(isScreen ? "screenPubModel" : "adhPubModel")?.value?.trim() || "",
-    qualityTier: isScreen ? document.getElementById("screenPubQuality")?.value?.trim() || "" : undefined,
-    adhesiveType: !isScreen ? document.getElementById("adhPubType")?.value?.trim() || "" : undefined,
-    stockMode: document.getElementById(isScreen ? "screenPubStock" : "adhPubStock")?.value || "all",
-    onlyWithImage: Boolean(document.getElementById(isScreen ? "screenPubOnlyImage" : "adhPubOnlyImage")?.checked),
-    onlyWithPrice: Boolean(document.getElementById(isScreen ? "screenPubOnlyPrice" : "adhPubOnlyPrice")?.checked),
-    includePrivate: Boolean(document.getElementById(isScreen ? "screenPubIncludePrivate" : "adhPubIncludePrivate")?.checked),
-    includeHidden: Boolean(document.getElementById(isScreen ? "screenPubIncludeHidden" : "adhPubIncludeHidden")?.checked),
-    includeRemoteOrderable: Boolean(document.getElementById(isScreen ? "screenPubIncludeRemote" : "adhPubIncludeRemote")?.checked),
-    limit: Number(document.getElementById(isScreen ? "screenPubLimit" : "adhPubLimit")?.value || 10000) || 10000,
-  };
-}
-
-function setFinalPublisherStatus(message) {
-  if (finalScreensPublisherStatus) finalScreensPublisherStatus.textContent = message || "";
-}
-
-function renderFinalPublisherSummary(data = {}, kind = "screen") {
-  if (!finalScreensPublisherSummary) return;
-  const isScreen = kind === "screen";
-  const rows = isScreen
-    ? [["Pantallas publicas actuales", data.publicScreensCurrent], ["Pantallas privadas elegibles", data.privateScreensEligible], ["Pantallas ocultas elegibles", data.hiddenScreensEligible], ["Pantallas stock real elegibles", data.stockRealScreensEligible], ["Pantallas a pedido elegibles", data.remoteScreensEligible]]
-    : [["Adhesivos publicos actuales", data.publicScreenAdhesivesCurrent], ["Adhesivos privados elegibles", data.privateScreenAdhesivesEligible], ["Adhesivos ocultos elegibles", data.hiddenScreenAdhesivesEligible], ["Adhesivos stock real elegibles", data.stockRealScreenAdhesivesEligible], ["Adhesivos a pedido elegibles", data.remoteScreenAdhesivesEligible]];
-  rows.push(["Bloqueados por imagen", data.blockersBreakdown?.missingImage || 0]);
-  rows.push(["Bloqueados por precio", data.blockersBreakdown?.missingPrice || 0]);
-  rows.push(["Bloqueados Merchant", Object.entries(data.blockersBreakdown || {}).filter(([k]) => k.startsWith("merchant")).reduce((s, [, v]) => s + Number(v || 0), 0)]);
-  rows.push([isScreen ? "Excluidos por accesorio" : "Excluidos por no ser de pantalla", isScreen ? (data.accessoryExcludedSamples || []).length : (data.excludedSamples || []).length]);
-  finalScreensPublisherSummary.innerHTML = `<div class="bulk-publish-summary-grid">${rows.map(([label, value]) => `<article><strong>${escapeHtml(String(value ?? 0))}</strong><span>${escapeHtml(label)}</span></article>`).join("")}</div><p><a href="/pantallas-en-stock" target="_blank">/pantallas-en-stock</a> · <a href="/adhesivos-de-pantalla" target="_blank">/adhesivos-de-pantalla</a> · <a href="/api/merchant/screens-feed.csv" target="_blank">feed pantallas</a> · <a href="/api/merchant/screen-adhesives-feed.csv" target="_blank">feed adhesivos</a></p>`;
-}
-
-async function fetchAdminJson(url, options = {}) {
-  const response = await apiFetch(url, {
-    ...options,
-    headers: {
-      Accept: "application/json",
-      ...(options.headers || {}),
-      ...getAdminHeaders(),
-    },
-  });
-  const contentType = response.headers.get("content-type") || "";
-  const text = await response.text();
-  const preview = text.slice(0, 300).replace(/\s+/g, " ");
-  console.info("[screen-admin-request]", {
-    url,
-    method: options.method || "GET",
-    status: response.status,
-    contentType,
-    preview,
-  });
-  if (!contentType.includes("application/json")) {
-    throw new Error(`El endpoint ${url} devolvio ${response.status} ${contentType || "sin content-type"} en vez de JSON. Preview: ${preview}`);
-  }
-  let data = {};
-  try {
-    data = text ? JSON.parse(text) : {};
-  } catch (error) {
-    throw new Error(`Respuesta JSON invalida de ${url}: ${error.message}`);
-  }
-  if (!response.ok) {
-    throw new Error(data.message || data.error || `Error HTTP ${response.status}`);
-  }
-  return data;
-}
-
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-async function waitScreenPublisherJob(base, jobId, kind) {
-  for (let attempt = 0; attempt < 80; attempt += 1) {
-    const data = await fetchAdminJson(`${base}/jobs/${encodeURIComponent(jobId)}`);
-    const job = data.job || {};
-    setFinalPublisherStatus(`Job ${job.status || "running"}: escaneados ${job.scannedRows || 0}, elegibles ${job.eligibleCount || 0}, bloqueados ${job.blockedCount || 0}`);
-    if (job.status === "done") {
-      return data.result || job;
-    }
-    if (job.status === "failed") {
-      throw new Error(job.error || "El job del publicador fallo");
-    }
-    await sleep(2500);
-  }
-  throw new Error("El job sigue corriendo. Volve a consultar el estado en unos segundos.");
-}
-
-async function runFinalPublisher(kind, action) {
-  const isScreen = kind === "screen";
-  const base = isScreen ? "/api/admin/screens" : "/api/admin/screen-adhesives";
-  const filters = finalPublisherFilters(kind);
-  setFinalPublisherStatus("Procesando...");
-  try {
-    let data;
-    if (action === "audit" || action === "preview") {
-      const started = await fetchAdminJson(`${base}/audit-job`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(filters) });
-      data = await waitScreenPublisherJob(base, started.jobId, kind);
-    } else {
-      const body = { ...filters, [isScreen ? "confirmScreenBulkPublish" : "confirmScreenAdhesiveBulkPublish"]: true };
-      if (action === "publish") {
-        const ok = confirm(isScreen
-          ? "Vas a publicar pantallas reales elegibles. No se publicaran adhesivos, brackets, fundas, protectores ni productos sin precio/imagen."
-          : "Vas a publicar adhesivos de pantalla elegibles. No se publicaran adhesivos de bateria, tapas, camaras ni cintas genericas sin modelo.");
-        if (!ok) return;
-      }
-      const started = await fetchAdminJson(`${base}/publish-job`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
-      data = await waitScreenPublisherJob(base, started.jobId, kind);
-    }
-    if (!data.ok) throw new Error(data.error || "No se pudo completar");
-    setFinalPublisherStatus(action === "publish" ? `Actualizados ${data.updatedCount || 0}, verificados ${data.verifiedPublicCount || 0}, fallidos ${data.failedCount || 0}` : "Listo.");
-    renderFinalPublisherSummary(data, kind);
-  } catch (error) {
-    setFinalPublisherStatus(error?.message || "No se pudo completar la operacion");
-  }
-}
-
-document.getElementById("screenAuditBtn")?.addEventListener("click", () => runFinalPublisher("screen", "audit"));
-document.getElementById("screenPreviewBtn")?.addEventListener("click", () => runFinalPublisher("screen", "preview"));
-document.getElementById("screenPublishBtn")?.addEventListener("click", () => runFinalPublisher("screen", "publish"));
-document.getElementById("adhAuditBtn")?.addEventListener("click", () => runFinalPublisher("adhesive", "audit"));
-document.getElementById("adhPreviewBtn")?.addEventListener("click", () => runFinalPublisher("adhesive", "preview"));
-document.getElementById("adhPublishBtn")?.addEventListener("click", () => runFinalPublisher("adhesive", "publish"));
 
 async function deleteProduct(id) {
   if (!confirm("¿Estás seguro de eliminar este producto?")) return;

--- a/nerin_final_updated/package.json
+++ b/nerin_final_updated/package.json
@@ -16,6 +16,7 @@
     "test:screen-publisher-production": "node scripts/test-screen-publisher-production.js",
     "test:screen-publisher-routes": "node scripts/test-screen-publisher-routes.js",
     "test:screen-publisher-stability": "node scripts/test-screen-publisher-stability.js",
+    "test:admin-bulk-visibility": "node scripts/test-admin-bulk-visibility.js",
     "audit:screens-final": "node scripts/audit-screens-and-adhesives-final.js",
     "check:no-products-full-parse": "node scripts/check-no-products-full-parse.js"
   },

--- a/nerin_final_updated/scripts/test-admin-bulk-visibility.js
+++ b/nerin_final_updated/scripts/test-admin-bulk-visibility.js
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("assert");
+const fs = require("fs");
+const fsp = fs.promises;
+const os = require("os");
+const path = require("path");
+
+const rootDir = path.join(__dirname, "..");
+const sourceDataDir = path.join(rootDir, "data");
+const tempDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "nerin-bulk-visibility-"));
+
+for (const fileName of ["products.json", "products.sqlite", "products.manifest.json"]) {
+  const source = path.join(sourceDataDir, fileName);
+  if (fs.existsSync(source)) {
+    fs.copyFileSync(source, path.join(tempDataDir, fileName));
+  }
+}
+
+process.env.DATA_DIR = tempDataDir;
+process.env.SCREEN_PUBLISHER_ENABLED = "false";
+
+const { createServer } = require("../backend/server");
+const productsSqliteRepo = require("../backend/data/productsSqliteRepo");
+
+const ADMIN_TOKEN = Buffer.from("admin@nerin.com:test").toString("base64");
+
+async function listen(server) {
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve(`http://127.0.0.1:${server.address().port}`));
+  });
+}
+
+async function close(server) {
+  return new Promise((resolve) => server.close(resolve));
+}
+
+async function requestJson(baseUrl, pathName, options = {}) {
+  const response = await fetch(`${baseUrl}${pathName}`, {
+    ...options,
+    headers: { Accept: "application/json", ...(options.headers || {}) },
+  });
+  const contentType = response.headers.get("content-type") || "";
+  const text = await response.text();
+  const preview = text.slice(0, 300).replace(/\s+/g, " ");
+  assert(contentType.includes("application/json"), `${pathName} returned ${response.status} ${contentType}: ${preview}`);
+  assert(!preview.startsWith("<!DOCTYPE"), `${pathName} returned HTML`);
+  return { response, data: text ? JSON.parse(text) : {}, preview };
+}
+
+function readSource(relativePath) {
+  return fs.readFileSync(path.join(rootDir, relativePath), "utf8");
+}
+
+function functionBody(source, name) {
+  const start = source.indexOf(`async function ${name}`);
+  assert(start >= 0, `${name} debe existir`);
+  const brace = source.indexOf("{", start);
+  let depth = 0;
+  for (let i = brace; i < source.length; i += 1) {
+    if (source[i] === "{") depth += 1;
+    if (source[i] === "}") depth -= 1;
+    if (depth === 0) return source.slice(brace, i + 1);
+  }
+  throw new Error(`No se pudo leer el cuerpo de ${name}`);
+}
+
+(async () => {
+  await productsSqliteRepo.ensureProductsDb();
+  const adminPage = await productsSqliteRepo.queryAdminProducts({ page: 1, pageSize: 40 });
+  const samples = (adminPage.items || [])
+    .map((product) => product.sku || product.code || product.id || product.publicSlug)
+    .filter(Boolean)
+    .slice(0, 4);
+  assert(samples.length >= 4, "Se necesitan al menos 4 productos fixture");
+
+  const server = createServer();
+  const baseUrl = await listen(server);
+  const auth = { Authorization: `Bearer ${ADMIN_TOKEN}` };
+  try {
+    const health = await requestJson(baseUrl, "/api/admin/products/bulk-visibility/health", { headers: auth });
+    assert.strictEqual(health.response.status, 200, "bulk health status");
+    assert.strictEqual(health.data.ok, true, "bulk health ok");
+    assert.strictEqual(health.data.rebuildsFullCatalog, false, "bulk health no rebuild");
+
+    const empty = await requestJson(baseUrl, "/api/admin/products/bulk-visibility", {
+      method: "POST",
+      headers: { ...auth, "Content-Type": "application/json" },
+      body: JSON.stringify({ identifiers: [], visibility: "public" }),
+    });
+    assert.strictEqual(empty.response.status, 400, "empty identifiers status");
+    assert.strictEqual(empty.data.error, "BULK_VISIBILITY_EMPTY", "empty identifiers code");
+
+    const invalid = await requestJson(baseUrl, "/api/admin/products/bulk-visibility", {
+      method: "POST",
+      headers: { ...auth, "Content-Type": "application/json" },
+      body: JSON.stringify({ identifiers: samples.slice(0, 1), visibility: "draft" }),
+    });
+    assert.strictEqual(invalid.response.status, 400, "invalid visibility status");
+    assert.strictEqual(invalid.data.error, "INVALID_VISIBILITY", "invalid visibility code");
+
+    await requestJson(baseUrl, "/api/admin/products/bulk-visibility", {
+      method: "POST",
+      headers: { ...auth, "Content-Type": "application/json" },
+      body: JSON.stringify({ identifiers: samples.slice(0, 3), visibility: "private", reindex: true }),
+    });
+
+    const publish = await requestJson(baseUrl, "/api/admin/products/bulk-visibility", {
+      method: "POST",
+      headers: { ...auth, "Content-Type": "application/json" },
+      body: JSON.stringify({ identifiers: samples.slice(0, 3), visibility: "public", reindex: true }),
+    });
+    assert.strictEqual(publish.response.status, 200, "publish status");
+    assert.strictEqual(publish.data.requestedCount, 3, "requested count");
+    assert.strictEqual(publish.data.updatedCount, 3, "updated count");
+    assert.strictEqual(publish.data.failedCount, 0, "failed count");
+    assert(Array.isArray(publish.data.sampleUpdated), "sampleUpdated array");
+    assert(Array.isArray(publish.data.sampleFailed), "sampleFailed array");
+
+    for (const identifier of samples.slice(0, 3)) {
+      const debug = await productsSqliteRepo.debugPublicationByIdentifier(identifier);
+      assert(debug?.found === true, `debug exists for ${identifier}`);
+      assert(debug.computePublicationState?.is_public === true || debug.computed?.isPublic === true, `${identifier} debe quedar publico`);
+      assert(debug.index?.found === true, `${identifier} debe estar reindexado`);
+    }
+
+    const partial = await requestJson(baseUrl, "/api/admin/products/bulk-visibility", {
+      method: "POST",
+      headers: { ...auth, "Content-Type": "application/json" },
+      body: JSON.stringify({ identifiers: [samples[0], "missing-bulk-visibility-fixture", samples[1]], visibility: "hidden", reindex: true }),
+    });
+    assert.strictEqual(partial.response.status, 200, "partial status");
+    assert.strictEqual(partial.data.updatedCount, 2, "partial updated count");
+    assert.strictEqual(partial.data.failedCount, 1, "partial failed count");
+    assert(partial.data.sampleFailed.some((item) => item.identifier === "missing-bulk-visibility-fixture"), "partial failure sample");
+
+    const screenDisabled = await requestJson(baseUrl, "/api/admin/screens/audit", { headers: auth });
+    assert.strictEqual(screenDisabled.response.status, 503, "screen publisher disabled status");
+    assert.strictEqual(screenDisabled.data.error, "DISABLED", "screen publisher disabled code");
+  } finally {
+    await close(server);
+    try {
+      await fsp.rm(tempDataDir, { recursive: true, force: true });
+    } catch {}
+  }
+
+  const repoSource = readSource("backend/data/productsSqliteRepo.js");
+  const batchBody = functionBody(repoSource, "setProductsVisibilityBatch");
+  assert(!/rebuildProductsDb|rebuildProductsDbFromJson|ensureProductsDb\s*\(/.test(batchBody), "batch no debe hacer rebuild completo");
+  assert(repoSource.includes("reindexProduct(identifier)"), "batch debe reindexar por producto");
+
+  const serverSource = readSource("backend/server.js");
+  assert(serverSource.includes("/api/admin/products/bulk-visibility"), "server debe exponer bulk-visibility");
+
+  const adminSource = readSource("frontend/js/admin.js");
+  assert(adminSource.includes("/api/admin/products/bulk-visibility"), "frontend debe llamar al endpoint batch");
+  assert(!/screenAuditBtn|screenPreviewBtn|screenPublishBtn|adhAuditBtn|adhPreviewBtn|adhPublishBtn/.test(adminSource), "frontend no debe mantener botones del publicador viejo");
+  assert(!/for\s*\(\s*const\s+id\s+of\s+selected\s*\)[\s\S]{0,700}visibility/.test(adminSource), "frontend no debe hacer PATCH por producto para visibilidad");
+
+  const htmlSource = readSource("frontend/admin.html");
+  assert(!htmlSource.includes("Publicador final de pantallas"), "admin no debe mostrar el publicador viejo");
+  assert(htmlSource.includes('value="vis-hidden"'), "admin debe incluir accion Ocultar");
+
+  console.log("admin bulk visibility tests passed", { samples: samples.slice(0, 3) });
+})().catch(async (error) => {
+  try {
+    await fsp.rm(tempDataDir, { recursive: true, force: true });
+  } catch {}
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/nerin_final_updated/scripts/test-screen-publisher-production.js
+++ b/nerin_final_updated/scripts/test-screen-publisher-production.js
@@ -65,7 +65,8 @@ function assertSourceContracts() {
   assert(server.includes("outputLimit: 48"), "/adhesivos-de-pantalla must use outputLimit");
   assert(!server.includes("limit: 48,"), "/adhesivos-de-pantalla must not scan only 48 products");
   assert(admin.includes("async function fetchAdminJson"), "frontend fetchAdminJson helper missing");
-  assert(admin.includes("[screen-admin-request]"), "frontend request diagnostic log missing");
+  assert(admin.includes("/api/admin/products/bulk-visibility"), "frontend must use normal bulk visibility endpoint");
+  assert(!/screenAuditBtn|screenPreviewBtn|screenPublishBtn|adhAuditBtn|adhPreviewBtn|adhPublishBtn/.test(admin), "admin must not wire the retired screen publisher buttons");
   assert(!packageJson.includes("applyScreenPublisherHotfix.js"), "runtime hotfix must be removed from package.json");
 }
 
@@ -86,7 +87,7 @@ async function assertEndpointContracts() {
     const authHeaders = { Authorization: `Bearer ${ADMIN_TOKEN}` };
     const screensAudit = await requestJson(baseUrl, "/api/admin/screens/audit", { headers: authHeaders });
     assert.strictEqual(screensAudit.response.status, 503, "screens audit should be disabled by default");
-    assert.strictEqual(screensAudit.data.error, "SCREEN_PUBLISHER_DISABLED", "screens audit disabled code");
+    assert.strictEqual(screensAudit.data.error, "DISABLED", "screens audit disabled code");
 
     const preview = await requestJson(baseUrl, "/api/admin/screens/publish-preview", {
       method: "POST",
@@ -94,7 +95,7 @@ async function assertEndpointContracts() {
       body: JSON.stringify({ onlyWithImage: true, onlyWithPrice: true }),
     });
     assert.strictEqual(preview.response.status, 503, "screens preview should be disabled by default");
-    assert.strictEqual(preview.data.error, "SCREEN_PUBLISHER_DISABLED", "screens preview disabled code");
+    assert.strictEqual(preview.data.error, "DISABLED", "screens preview disabled code");
 
     const publishNoConfirm = await requestJson(baseUrl, "/api/admin/screens/publish", {
       method: "POST",
@@ -106,7 +107,7 @@ async function assertEndpointContracts() {
 
     const adhesivesAudit = await requestJson(baseUrl, "/api/admin/screen-adhesives/audit", { headers: authHeaders });
     assert.strictEqual(adhesivesAudit.response.status, 503, "adhesives audit should be disabled by default");
-    assert.strictEqual(adhesivesAudit.data.error, "SCREEN_PUBLISHER_DISABLED", "adhesives audit disabled code");
+    assert.strictEqual(adhesivesAudit.data.error, "DISABLED", "adhesives audit disabled code");
   } finally {
     await close(server);
   }

--- a/nerin_final_updated/scripts/test-screen-publisher-routes.js
+++ b/nerin_final_updated/scripts/test-screen-publisher-routes.js
@@ -51,11 +51,11 @@ async function request(baseUrl, pathName, options = {}) {
 
     const screensAudit = await request(baseUrl, "/api/admin/screens/audit", { headers: auth });
     assert.strictEqual(screensAudit.response.status, 503, "screens audit disabled status");
-    assert.strictEqual(screensAudit.data.error, "SCREEN_PUBLISHER_DISABLED", "screens audit disabled code");
+    assert.strictEqual(screensAudit.data.error, "DISABLED", "screens audit disabled code");
 
     const adhesivesAudit = await request(baseUrl, "/api/admin/screen-adhesives/audit", { headers: auth });
     assert.strictEqual(adhesivesAudit.response.status, 503, "adhesives audit disabled status");
-    assert.strictEqual(adhesivesAudit.data.error, "SCREEN_PUBLISHER_DISABLED", "adhesives audit disabled code");
+    assert.strictEqual(adhesivesAudit.data.error, "DISABLED", "adhesives audit disabled code");
 
     const preview = await request(baseUrl, "/api/admin/screens/publish-preview", {
       method: "POST",
@@ -63,7 +63,7 @@ async function request(baseUrl, pathName, options = {}) {
       body: JSON.stringify({ onlyWithImage: true }),
     });
     assert.strictEqual(preview.response.status, 503, "preview disabled status");
-    assert.strictEqual(preview.data.error, "SCREEN_PUBLISHER_DISABLED", "preview disabled code");
+    assert.strictEqual(preview.data.error, "DISABLED", "preview disabled code");
   } finally {
     await close(server);
   }


### PR DESCRIPTION
## Causa raiz
El publicador especifico de pantallas/adhesivos era un flujo pesado y fragil para el admin: podia devolver HTML donde el frontend esperaba JSON y no era el camino que necesitabas para publicar productos seleccionados.

## Solucion
- Se quita el bloque visible del publicador final de pantallas/adhesivos del admin.
- Las rutas especificas del publicador quedan desactivadas con JSON `DISABLED`, nunca HTML.
- Se agrega `POST /api/admin/products/bulk-visibility` para publicar/privatizar/ocultar hasta 200 productos en una sola request.
- El backend usa la logica unificada `setProductVisibility`, recalcula estado publico y reindexa producto por producto sin rebuild completo.
- El boton normal `Aplicar` ahora usa el endpoint batch para `Hacer publico`, `Hacer privado` y `Ocultar`, deshabilitando el boton mientras corre y recargando la tabla una sola vez.

## Performance
1 request para hasta 200 productos, concurrencia limitada en backend, reindex puntual por producto, invalidacion de cache al final del lote y sin reconstruccion completa del catalogo.

## Validacion
- `node --check backend/server.js`
- `node --check backend/data/productsSqliteRepo.js`
- `node --check frontend/js/admin.js`
- `node --check scripts/test-admin-bulk-visibility.js`
- `node scripts/test-admin-bulk-visibility.js`
- `node scripts/test-screen-publisher-routes.js`
- `node scripts/test-screen-publisher-production.js`