### PR TITLE
Fix stale admin selection and fast bulk visibility updates

### DIFF
--- a/nerin_final_updated/backend/data/productsSqliteRepo.js
+++ b/nerin_final_updated/backend/data/productsSqliteRepo.js
@@ -2338,6 +2338,23 @@ async function runWithConcurrency(items, limit, worker) {
   return results;
 }
 
+function getPublicationStateFromDebug(debug = {}) {
+  return debug?.computePublicationState || debug?.computed || debug?.publicationState || {};
+}
+
+function getStateVisibility(state = {}) {
+  return normalizeQueryText(state.visibility || state.status || state.admin_visibility_bucket || "");
+}
+
+function stateMatchesVisibility(state = {}, visibility = "") {
+  const target = normalizeQueryText(visibility || "");
+  if (target === "public") return state.is_public === true || state.isPublic === true;
+  const stateVisibility = getStateVisibility(state);
+  if (target === "private") return stateVisibility === "private" && state.is_public !== true;
+  if (target === "hidden") return stateVisibility === "hidden" && state.is_public !== true;
+  return false;
+}
+
 async function setProductsVisibilityBatch(identifiers = [], visibility, options = {}) {
   const startedAt = Date.now();
   const uniqueIdentifiers = Array.from(
@@ -2366,12 +2383,20 @@ async function setProductsVisibilityBatch(identifiers = [], visibility, options 
     reindex: options.reindex !== false,
   });
   const sampleUpdated = [];
+  const sampleAlreadyInTargetState = [];
   const sampleFailed = [];
   let updatedCount = 0;
+  let alreadyInTargetStateCount = 0;
   let failedCount = 0;
   await runWithConcurrency(uniqueIdentifiers, options.concurrency || 5, async (identifier) => {
     const itemStartedAt = Date.now();
     try {
+      const beforeDebug = await debugPublicationByIdentifier(identifier);
+      if (!beforeDebug?.found) {
+        throw new Error("Producto no encontrado");
+      }
+      const beforeState = getPublicationStateFromDebug(beforeDebug);
+      const beforeMatchesTarget = stateMatchesVisibility(beforeState, nextVisibility);
       const result = await setProductVisibility(identifier, nextVisibility, {
         reason: options.reason || "admin_bulk_visibility",
       });
@@ -2382,20 +2407,48 @@ async function setProductsVisibilityBatch(identifiers = [], visibility, options 
       if (options.reindex !== false) {
         reindexResult = await reindexProduct(identifier);
       }
-      updatedCount += 1;
-      if (sampleUpdated.length < 20) {
-        sampleUpdated.push({
-          identifier,
-          title: result?.debug?.sqlite?.title || result?.debug?.sqlite?.name || result?.debug?.product?.title || null,
-          before: result.before || null,
-          after: result.after || null,
-          reindexed: Boolean(reindexResult?.indexUpdated || result.indexUpdated),
-        });
+      const afterDebug = await debugPublicationByIdentifier(identifier);
+      const afterState = getPublicationStateFromDebug(afterDebug);
+      const afterMatchesTarget = stateMatchesVisibility(afterState, nextVisibility);
+      const changed = !beforeMatchesTarget && afterMatchesTarget;
+      if (!afterMatchesTarget) {
+        const error = new Error("postVerificationFailed");
+        error.beforeState = beforeState;
+        error.afterState = afterState;
+        throw error;
+      }
+      const sample = {
+        identifier,
+        title: beforeDebug?.sqlite?.title || beforeDebug?.sqlite?.name || result?.debug?.sqlite?.title || result?.debug?.sqlite?.name || null,
+        before: {
+          visibility: beforeState.visibility || null,
+          status: beforeState.status || null,
+          is_public: beforeState.is_public === true,
+        },
+        after: {
+          visibility: afterState.visibility || null,
+          status: afterState.status || null,
+          is_public: afterState.is_public === true,
+        },
+        reindexed: Boolean(reindexResult?.indexUpdated || result.indexUpdated),
+      };
+      let itemResult = "updated";
+      if (beforeMatchesTarget) {
+        alreadyInTargetStateCount += 1;
+        itemResult = "already";
+        if (sampleAlreadyInTargetState.length < 20) sampleAlreadyInTargetState.push(sample);
+      } else {
+        updatedCount += 1;
+        if (sampleUpdated.length < 20) sampleUpdated.push(sample);
       }
       console.info("[admin-bulk-visibility:item]", {
         identifier,
-        ok: true,
-        visibility: nextVisibility,
+        beforeIsPublic: beforeState.is_public === true,
+        afterIsPublic: afterState.is_public === true,
+        beforeVisibility: beforeState.visibility || null,
+        afterVisibility: afterState.visibility || null,
+        changed,
+        result: itemResult,
         durationMs: Date.now() - itemStartedAt,
       });
       return result;
@@ -2409,7 +2462,12 @@ async function setProductsVisibilityBatch(identifiers = [], visibility, options 
       }
       console.info("[admin-bulk-visibility:item]", {
         identifier,
-        ok: false,
+        beforeIsPublic: error?.beforeState?.is_public === true,
+        afterIsPublic: error?.afterState?.is_public === true,
+        beforeVisibility: error?.beforeState?.visibility || null,
+        afterVisibility: error?.afterState?.visibility || null,
+        changed: false,
+        result: "failed",
         error: error?.message || "bulk_visibility_item_failed",
         durationMs: Date.now() - itemStartedAt,
       });
@@ -2420,6 +2478,7 @@ async function setProductsVisibilityBatch(identifiers = [], visibility, options 
   console.info("[admin-bulk-visibility:end]", {
     requestedCount: uniqueIdentifiers.length,
     updatedCount,
+    alreadyInTargetStateCount,
     failedCount,
     visibility: nextVisibility,
     durationMs,
@@ -2428,9 +2487,11 @@ async function setProductsVisibilityBatch(identifiers = [], visibility, options 
     ok: true,
     requestedCount: uniqueIdentifiers.length,
     updatedCount,
+    alreadyInTargetStateCount,
     failedCount,
     visibility: nextVisibility,
     sampleUpdated,
+    sampleAlreadyInTargetState,
     sampleFailed,
     durationMs,
   };

--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -1832,6 +1832,7 @@ let productsLoadErrorMessage = "";
 let adminProductsAbortController = null;
 let adminProductsRequestSeq = 0;
 let adminProductsFacets = {};
+const selectedProductMap = new Map();
 
 let isApplyingAutoSeo = false;
 let isApplyingAutoTags = false;
@@ -2116,14 +2117,78 @@ function updateProductSummary(filtered) {
     </div>`;
 }
 
+function isAdminProductPublic(product = {}) {
+  return product.is_public === true || product.isPublic === true || String(product.visibility || "").toLowerCase() === "public";
+}
+
+function getProductSelectionMeta(product = {}, rowIndex = 0) {
+  const identifier = resolveProductAdminIdentifier(product);
+  return {
+    identifier,
+    title: product.title || product.name || "",
+    visibility: product.visibility || "",
+    is_public: isAdminProductPublic(product),
+    status: product.status || "",
+    rowIndex,
+  };
+}
+
+function getRowSelectionMeta(row) {
+  if (!row) return null;
+  const identifier = String(row.dataset.adminIdentifier || row.dataset.id || "").trim();
+  if (!identifier) return null;
+  return {
+    identifier,
+    title: row.dataset.title || "",
+    visibility: row.dataset.visibility || "",
+    is_public: row.dataset.isPublic === "true",
+    status: row.dataset.status || "",
+    rowIndex: Number(row.dataset.rowIndex || 0) || 0,
+  };
+}
+
+function updateSelectedProductsCounter() {
+  if (applyBulkBtn) {
+    applyBulkBtn.dataset.selectedCount = String(selectedProductMap.size);
+  }
+}
+
+function clearProductSelection(reason = "reset") {
+  selectedProductMap.clear();
+  document.querySelectorAll(".select-product").forEach((cb) => {
+    cb.checked = false;
+  });
+  if (selectAllCheckbox) selectAllCheckbox.checked = false;
+  updateSelectedProductsCounter();
+  console.info("[admin-products-selection:clear]", { reason });
+}
+
+function syncProductSelectionFromCheckbox(checkbox) {
+  const meta = getRowSelectionMeta(checkbox?.closest?.("tr"));
+  if (!meta) return;
+  if (checkbox.checked) {
+    selectedProductMap.set(meta.identifier, meta);
+  } else {
+    selectedProductMap.delete(meta.identifier);
+  }
+  updateSelectedProductsCounter();
+}
+
 function buildProductRow(product) {
   const tr = document.createElement("tr");
   const productId = product && product.id != null ? String(product.id) : "";
   const adminIdentifier = resolveProductAdminIdentifier(product);
+  const rowIndex = productsCache.findIndex((item) => item === product);
+  const selectionMeta = getProductSelectionMeta(product, rowIndex);
   const safeIdAttr = escapeHtml(productId);
   tr.dataset.id = productId;
   tr.dataset.productId = productId;
   tr.dataset.adminIdentifier = adminIdentifier;
+  tr.dataset.title = selectionMeta.title;
+  tr.dataset.visibility = selectionMeta.visibility;
+  tr.dataset.isPublic = String(selectionMeta.is_public);
+  tr.dataset.status = selectionMeta.status;
+  tr.dataset.rowIndex = String(selectionMeta.rowIndex);
   let stockBadge = "";
   if (isOutOfStock(product)) {
     stockBadge = '<span class="badge">Sin stock</span>';
@@ -2278,6 +2343,7 @@ function highlightProductRow(targetId) {
 }
 
 function updateProductFilters(patch) {
+  clearProductSelection("filters_changed");
   productFilters = {
     ...productFilters,
     ...patch,
@@ -2312,6 +2378,7 @@ if (productFilterCategory) {
   });
 });
 productClearFilters?.addEventListener("click", () => {
+  clearProductSelection("filters_cleared");
   productFilters = {
     query: "",
     category: "",
@@ -2352,6 +2419,7 @@ if (productSortSelect) {
 }
 if (adminProductsPageSize) {
   adminProductsPageSize.addEventListener("change", () => {
+    clearProductSelection("page_size_changed");
     productsPageSize = Number(adminProductsPageSize.value || 100);
     productsPage = 1;
     void loadProducts().catch((error) => {
@@ -2366,6 +2434,7 @@ if (adminProductsPrevPage) {
       hasPrevPage: productsHasPrevPage,
     });
     if (!productsHasPrevPage || productsPage <= 1) return;
+    clearProductSelection("page_changed");
     productsPage -= 1;
     void loadProducts().catch((error) => {
       console.error("[admin-products] prev page failed", error);
@@ -2379,6 +2448,7 @@ if (adminProductsNextPage) {
       hasNextPage: productsHasNextPage,
     });
     if (!productsHasNextPage) return;
+    clearProductSelection("page_changed");
     productsPage += 1;
     void loadProducts().catch((error) => {
       console.error("[admin-products] next page failed", error);
@@ -3577,6 +3647,7 @@ function updateProductsPaginationControls() {
 
 async function loadProducts(options = {}) {
   if (!productsTableBody) return;
+  clearProductSelection("loadProducts");
   const { highlightId } = options;
   const requestSeq = ++adminProductsRequestSeq;
   if (adminProductsAbortController) {
@@ -3809,7 +3880,22 @@ if (selectAllCheckbox) {
     const checked = selectAllCheckbox.checked;
     document
       .querySelectorAll(".select-product")
-      .forEach((cb) => (cb.checked = checked));
+      .forEach((cb) => {
+        cb.checked = checked;
+        syncProductSelectionFromCheckbox(cb);
+      });
+  });
+}
+
+if (productsTableBody) {
+  productsTableBody.addEventListener("change", (event) => {
+    const checkbox = event.target;
+    if (!checkbox?.classList?.contains("select-product")) return;
+    syncProductSelectionFromCheckbox(checkbox);
+    if (selectAllCheckbox) {
+      const checkboxes = Array.from(document.querySelectorAll(".select-product"));
+      selectAllCheckbox.checked = checkboxes.length > 0 && checkboxes.every((cb) => cb.checked);
+    }
   });
 }
 
@@ -3849,13 +3935,34 @@ async function fetchAdminJson(url, options = {}) {
 }
 
 function getSelectedProductIdentifiers() {
-  return Array.from(document.querySelectorAll(".select-product:checked"))
+  const visibleSelection = Array.from(document.querySelectorAll(".select-product:checked"))
     .map((cb) => {
-      const row = cb.closest("tr");
-      return row?.dataset?.adminIdentifier || row?.dataset?.id || "";
+      const meta = getRowSelectionMeta(cb.closest("tr"));
+      if (meta) selectedProductMap.set(meta.identifier, meta);
+      return meta?.identifier || "";
     })
     .map((identifier) => String(identifier || "").trim())
     .filter(Boolean);
+  const visibleSet = new Set(visibleSelection);
+  Array.from(selectedProductMap.keys()).forEach((identifier) => {
+    if (!visibleSet.has(identifier)) selectedProductMap.delete(identifier);
+  });
+  updateSelectedProductsCounter();
+  return visibleSelection;
+}
+
+function getSelectedProductEntries() {
+  getSelectedProductIdentifiers();
+  return Array.from(selectedProductMap.values());
+}
+
+function getCurrentProductViewState() {
+  return {
+    filters: { ...productFilters },
+    currentSearch: productFilters.query || "",
+    currentPage: productsPage,
+    pageSize: productsPageSize,
+  };
 }
 
 function setBulkActionBusy(isBusy) {
@@ -3869,16 +3976,35 @@ async function applyBulkVisibilityAction(visibility, identifiers) {
   const label = visibility === "public" ? "Publicando" : visibility === "private" ? "Pasando a privado" : "Ocultando";
   setBulkActionBusy(true);
   if (window.showToast) showToast(`${label} ${identifiers.length} productos...`);
-  const data = await fetchAdminJson("/api/admin/products/bulk-visibility", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ identifiers, visibility, reindex: true }),
-  });
-  const message = `${visibility === "public" ? "Publicados" : "Actualizados"} ${data.updatedCount || 0}/${data.requestedCount || identifiers.length} productos. Fallaron ${data.failedCount || 0}.`;
+  const chunks = [];
+  for (let index = 0; index < identifiers.length; index += 200) {
+    chunks.push(identifiers.slice(index, index + 200));
+  }
+  const aggregate = {
+    requestedCount: identifiers.length,
+    updatedCount: 0,
+    alreadyInTargetStateCount: 0,
+    failedCount: 0,
+    sampleFailed: [],
+  };
+  for (let index = 0; index < chunks.length; index += 1) {
+    if (window.showToast && chunks.length > 1) showToast(`${label} tanda ${index + 1}/${chunks.length}...`);
+    const data = await fetchAdminJson("/api/admin/products/bulk-visibility", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ identifiers: chunks[index], visibility, reindex: true }),
+    });
+    aggregate.updatedCount += Number(data.updatedCount || 0);
+    aggregate.alreadyInTargetStateCount += Number(data.alreadyInTargetStateCount || 0);
+    aggregate.failedCount += Number(data.failedCount || 0);
+    aggregate.sampleFailed.push(...(Array.isArray(data.sampleFailed) ? data.sampleFailed : []));
+  }
+  const already = Number(aggregate.alreadyInTargetStateCount || 0);
+  const message = `${visibility === "public" ? "Publicados" : "Actualizados"} ${aggregate.updatedCount || 0} productos. ${already} ya estaban en ese estado. Fallaron ${aggregate.failedCount || 0}.`;
   if (window.showToast) showToast(message);
-  if (data.failedCount && Array.isArray(data.sampleFailed)) {
-    console.warn("[admin-bulk-visibility:failed]", data.sampleFailed);
-    alert(`${message}\n\nFallos:\n${data.sampleFailed.map((item) => `${item.identifier}: ${item.error}`).join("\n")}`);
+  if (aggregate.failedCount && Array.isArray(aggregate.sampleFailed)) {
+    console.warn("[admin-bulk-visibility:failed]", aggregate.sampleFailed);
+    alert(`${message}\n\nFallos:\n${aggregate.sampleFailed.slice(0, 20).map((item) => `${item.identifier}: ${item.error}`).join("\n")}`);
   }
   document.querySelectorAll(".select-product:checked").forEach((cb) => {
     cb.checked = false;
@@ -3890,7 +4016,16 @@ async function applyBulkVisibilityAction(visibility, identifiers) {
 if (applyBulkBtn && bulkSelect) {
   applyBulkBtn.addEventListener("click", async () => {
     const action = bulkSelect.value;
-    const selected = getSelectedProductIdentifiers();
+    const selectedEntries = getSelectedProductEntries();
+    const selected = selectedEntries.map((entry) => entry.identifier);
+    console.info("[admin-bulk-action:selection]", {
+      action,
+      selectedCount: selected.length,
+      selectedSample: selectedEntries.slice(0, 10),
+      currentFilters: { ...productFilters },
+      currentSearch: productFilters.query || "",
+      currentPage: productsPage,
+    });
     if (selected.length === 0) {
       alert("Seleccione productos");
       return;
@@ -3905,6 +4040,10 @@ if (applyBulkBtn && bulkSelect) {
         await loadProducts();
       } else if (action.startsWith("vis-")) {
         const vis = action.split("-")[1];
+        if (vis === "public" && selectedEntries.length > 0 && selectedEntries.every((entry) => entry.is_public === true || entry.visibility === "public")) {
+          alert("Los productos seleccionados ya figuran publicos. Recarga la tabla.");
+          return;
+        }
         await applyBulkVisibilityAction(vis, selected);
       } else if (action.startsWith("price")) {
         const pct = parseFloat(bulkValueInput.value);

--- a/nerin_final_updated/package.json
+++ b/nerin_final_updated/package.json
@@ -17,6 +17,7 @@
     "test:screen-publisher-routes": "node scripts/test-screen-publisher-routes.js",
     "test:screen-publisher-stability": "node scripts/test-screen-publisher-stability.js",
     "test:admin-bulk-visibility": "node scripts/test-admin-bulk-visibility.js",
+    "test:admin-bulk-selection-stale": "node scripts/test-admin-bulk-selection-stale.js",
     "audit:screens-final": "node scripts/audit-screens-and-adhesives-final.js",
     "check:no-products-full-parse": "node scripts/check-no-products-full-parse.js"
   },

--- a/nerin_final_updated/scripts/test-admin-bulk-selection-stale.js
+++ b/nerin_final_updated/scripts/test-admin-bulk-selection-stale.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
+
+const rootDir = path.join(__dirname, "..");
+const adminSource = fs.readFileSync(path.join(rootDir, "frontend", "js", "admin.js"), "utf8");
+
+function bodyOf(functionName) {
+  let start = adminSource.indexOf(`function ${functionName}`);
+  if (start < 0) start = adminSource.indexOf(`async function ${functionName}`);
+  assert(start >= 0, `${functionName} debe existir`);
+  const signatureEnd = adminSource.indexOf(") {", start);
+  const brace = signatureEnd >= 0 ? signatureEnd + 2 : adminSource.indexOf("{", start);
+  let depth = 0;
+  for (let index = brace; index < adminSource.length; index += 1) {
+    if (adminSource[index] === "{") depth += 1;
+    if (adminSource[index] === "}") depth -= 1;
+    if (depth === 0) return adminSource.slice(brace, index + 1);
+  }
+  throw new Error(`No se pudo leer ${functionName}`);
+}
+
+const loadProductsBody = bodyOf("loadProducts");
+const updateFiltersBody = bodyOf("updateProductFilters");
+const getSelectedBody = bodyOf("getSelectedProductIdentifiers");
+const applyVisibilityBody = bodyOf("applyBulkVisibilityAction");
+
+assert(adminSource.includes("const selectedProductMap = new Map()"), "debe existir selectedProductMap");
+assert(adminSource.includes("function clearProductSelection"), "debe existir clearProductSelection");
+assert(loadProductsBody.includes('clearProductSelection("loadProducts")'), "loadProducts debe limpiar seleccion stale");
+assert(updateFiltersBody.includes('clearProductSelection("filters_changed")'), "cambios de filtro deben limpiar seleccion");
+assert(adminSource.includes('clearProductSelection("page_changed")'), "cambios de pagina deben limpiar seleccion");
+assert(adminSource.includes('clearProductSelection("page_size_changed")'), "cambios de pageSize deben limpiar seleccion");
+assert(adminSource.includes('clearProductSelection("filters_cleared")'), "limpiar filtros debe limpiar seleccion");
+
+assert(getSelectedBody.includes('document.querySelectorAll(".select-product:checked")'), "payload debe salir de checkboxes visibles actuales");
+assert(getSelectedBody.includes("getRowSelectionMeta"), "seleccion debe usar metadata de la fila visible");
+assert(getSelectedBody.includes("selectedProductMap.delete"), "seleccion stale debe eliminarse del map");
+assert(adminSource.includes("[admin-bulk-action:selection]"), "debe loguear muestra de seleccion");
+assert(adminSource.includes("selectedSample: selectedEntries.slice(0, 10)"), "log debe incluir sample con metadata");
+assert(adminSource.includes("selectedEntries.every"), "debe detectar seleccion ya publica antes de publicar");
+
+assert(applyVisibilityBody.includes("/api/admin/products/bulk-visibility"), "visibilidad debe usar endpoint batch");
+assert(applyVisibilityBody.includes("identifiers.slice(index, index + 200)"), "mas de 200 seleccionados debe enviarse en chunks");
+assert(!/apiFetch\(`\/api\/products\/\$\{[^`]+`[\s\S]{0,220}visibility/.test(adminSource), "hacer publico no debe hacer PATCH producto por producto");
+
+console.log("admin bulk stale selection source tests passed");

--- a/nerin_final_updated/scripts/test-admin-bulk-visibility.js
+++ b/nerin_final_updated/scripts/test-admin-bulk-visibility.js
@@ -114,8 +114,10 @@ function functionBody(source, name) {
     assert.strictEqual(publish.response.status, 200, "publish status");
     assert.strictEqual(publish.data.requestedCount, 3, "requested count");
     assert.strictEqual(publish.data.updatedCount, 3, "updated count");
+    assert.strictEqual(publish.data.alreadyInTargetStateCount, 0, "already count after private to public");
     assert.strictEqual(publish.data.failedCount, 0, "failed count");
     assert(Array.isArray(publish.data.sampleUpdated), "sampleUpdated array");
+    assert(Array.isArray(publish.data.sampleAlreadyInTargetState), "sampleAlreadyInTargetState array");
     assert(Array.isArray(publish.data.sampleFailed), "sampleFailed array");
 
     for (const identifier of samples.slice(0, 3)) {
@@ -124,6 +126,17 @@ function functionBody(source, name) {
       assert(debug.computePublicationState?.is_public === true || debug.computed?.isPublic === true, `${identifier} debe quedar publico`);
       assert(debug.index?.found === true, `${identifier} debe estar reindexado`);
     }
+
+    const publishAgain = await requestJson(baseUrl, "/api/admin/products/bulk-visibility", {
+      method: "POST",
+      headers: { ...auth, "Content-Type": "application/json" },
+      body: JSON.stringify({ identifiers: samples.slice(0, 3), visibility: "public", reindex: true }),
+    });
+    assert.strictEqual(publishAgain.response.status, 200, "publish again status");
+    assert.strictEqual(publishAgain.data.updatedCount, 0, "already public must not count as updated");
+    assert.strictEqual(publishAgain.data.alreadyInTargetStateCount, 3, "already public count");
+    assert.strictEqual(publishAgain.data.failedCount, 0, "publish again failed count");
+    assert(publishAgain.data.sampleAlreadyInTargetState.length > 0, "already sample");
 
     const partial = await requestJson(baseUrl, "/api/admin/products/bulk-visibility", {
       method: "POST",
@@ -149,14 +162,20 @@ function functionBody(source, name) {
   const batchBody = functionBody(repoSource, "setProductsVisibilityBatch");
   assert(!/rebuildProductsDb|rebuildProductsDbFromJson|ensureProductsDb\s*\(/.test(batchBody), "batch no debe hacer rebuild completo");
   assert(repoSource.includes("reindexProduct(identifier)"), "batch debe reindexar por producto");
+  assert(repoSource.includes("alreadyInTargetStateCount"), "batch debe separar ya-en-estado-destino");
+  assert(repoSource.includes("postVerificationFailed"), "batch debe verificar estado despues de publicar");
 
   const serverSource = readSource("backend/server.js");
   assert(serverSource.includes("/api/admin/products/bulk-visibility"), "server debe exponer bulk-visibility");
+  assert(!/admin-bulk-visibility[\s\S]{0,1200}rebuildProductsDb/.test(serverSource), "endpoint batch no debe disparar rebuild");
 
   const adminSource = readSource("frontend/js/admin.js");
   assert(adminSource.includes("/api/admin/products/bulk-visibility"), "frontend debe llamar al endpoint batch");
+  assert(adminSource.includes("[admin-bulk-action:selection]"), "frontend debe loguear seleccion visible");
+  assert(adminSource.includes("selectedProductMap"), "frontend debe guardar metadata de seleccion");
+  assert(adminSource.includes("clearProductSelection(\"loadProducts\")"), "loadProducts debe limpiar seleccion stale");
   assert(!/screenAuditBtn|screenPreviewBtn|screenPublishBtn|adhAuditBtn|adhPreviewBtn|adhPublishBtn/.test(adminSource), "frontend no debe mantener botones del publicador viejo");
-  assert(!/for\s*\(\s*const\s+id\s+of\s+selected\s*\)[\s\S]{0,700}visibility/.test(adminSource), "frontend no debe hacer PATCH por producto para visibilidad");
+  assert(!/body:\s*JSON\.stringify\(\{\s*visibility:/m.test(adminSource), "frontend no debe mandar visibility en PATCH individual");
 
   const htmlSource = readSource("frontend/admin.html");
   assert(!htmlSource.includes("Publicador final de pantallas"), "admin no debe mostrar el publicador viejo");


### PR DESCRIPTION
## Causa raiz
La accion masiva podia operar con seleccion stale/IDs viejos al cambiar filtros, busqueda o pagina. Eso permitia mandar al batch productos que ya estaban publicos aunque la vista actual estuviera filtrada por privados.

## Solucion
- La seleccion del admin ahora vive en `selectedProductMap` con metadata minima de la fila visible: identifier, title, visibility, is_public, status y rowIndex.
- `loadProducts`, cambios de filtros, busqueda, sort, pagina y pageSize limpian la seleccion anterior.
- El payload de accion masiva se arma desde checkboxes visibles actuales y loguea `[admin-bulk-action:selection]` con muestra de metadata.
- `Hacer publico` avisa si toda la seleccion ya figura publica, senal clara de vista stale.
- El endpoint batch conserva una request por lote y permite chunks de hasta 200 desde frontend.
- `setProductsVisibilityBatch` ahora separa `updatedCount`, `alreadyInTargetStateCount` y `failedCount`, con samples separados y verificacion post-publicacion.

## Validacion
- `node --check backend/server.js`
- `node --check backend/data/productsSqliteRepo.js`
- `node --check frontend/js/admin.js`
- `node --check scripts/test-admin-bulk-visibility.js`
- `node --check scripts/test-admin-bulk-selection-stale.js`
- `node scripts/test-admin-bulk-selection-stale.js`
- `node scripts/test-admin-bulk-visibility.js`

## Logs esperados despues
- Para privados seleccionados: `[admin-bulk-visibility:end] updatedCount: cercano al requestedCount, alreadyInTargetStateCount: 0`.
- Si algun producto ya estaba publico: cuenta en `alreadyInTargetStateCount`, no en `updatedCount`.