### PR TITLE
Improve admin bulk visibility performance

### DIFF
--- a/nerin_final_updated/package.json
+++ b/nerin_final_updated/package.json
@@ -4,7 +4,7 @@
   "description": "Sistema ERP + E‑commerce para NERIN Repuestos",
   "main": "backend/index.js",
   "scripts": {
-    "start": "node scripts/applyCodexSeoBulkPatch.js && node scripts/applySitemapHotfix.js && node --max-old-space-size=512 -r ./backend/utils/preloadProductAvailability.js backend/server.js",
+    "start": "node scripts/applyCodexSeoBulkPatch.js && node scripts/applySitemapHotfix.js && node scripts/applyAdminBulkPerfPatch.js && node --max-old-space-size=512 -r ./backend/utils/preloadProductAvailability.js backend/server.js",
     "test": "jest",
     "validate:meta-feed": "node scripts/validate-meta-feed.js",
     "catalog:enrich-csv": "node scripts/enrichCatalogCsv.js",

--- a/nerin_final_updated/scripts/applyAdminBulkPerfPatch.js
+++ b/nerin_final_updated/scripts/applyAdminBulkPerfPatch.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const target = path.join(root, 'backend/server.js');
+let text = fs.readFileSync(target, 'utf8');
+const before = text;
+
+text = text.replace(
+  '        reindex: payload.reindex !== false,',
+  '        reindex: false,',
+);
+
+text = text.replace(
+  '      rebuildsFullCatalog: false,',
+  '      rebuildsFullCatalog: false,\n      cacheInvalidation: "once_per_batch",\n      duplicateReindexSuppressed: true,',
+);
+
+if (text !== before) {
+  fs.writeFileSync(target, text, 'utf8');
+  console.log('[admin-bulk-perf-patch] updated backend/server.js');
+} else {
+  console.log('[admin-bulk-perf-patch] already applied');
+}


### PR DESCRIPTION
## Resumen

Mejora quirurgica para que el publicador masivo de visibilidad sea mas rapido sin cambiar la logica comercial.

## Cambio principal

- Agrega `scripts/applyAdminBulkPerfPatch.js`.
- Lo conecta al `npm start` de Render.
- El patch cambia el endpoint `/api/admin/products/bulk-visibility` para pasar `reindex: false` al batch.

## Por que mejora

Hoy el flujo ya funciona, pero es lento porque cada producto se reindexa dentro de `setProductVisibility/updateProductByIdentifier` y despues el batch puede volver a reindexarlo. Este patch elimina ese segundo reindex, manteniendo la publicacion actual.

## Alcance

No toca:
- Mercado Pago
- checkout
- orders
- stock
- Andreani
- precios
- importacion

## Validacion esperada

Al publicar 100 productos:
- debe seguir funcionando igual
- debe tardar menos
- debe evitar reindex duplicado
- debe seguir invalidando cache al final con `admin_bulk_visibility`

## Archivos

- `nerin_final_updated/scripts/applyAdminBulkPerfPatch.js`
- `nerin_final_updated/package.json`