### PR TITLE
Harden sitemap generation for large catalogs

### DIFF
--- a/nerin_final_updated/__tests__/backend/seo-endpoints.test.js
+++ b/nerin_final_updated/__tests__/backend/seo-endpoints.test.js
@@ -18,7 +18,9 @@ describe('SEO endpoints', () => {
       products: [
         {
           id: '1',
+          title: 'Pantalla iPhone 12',
           slug: 'pantalla-iphone-12',
+          public_slug: 'pantalla-iphone-12',
           visibility: 'public',
           vip_only: false,
           updated_at: '2024-01-10T00:00:00.000Z',
@@ -56,12 +58,24 @@ describe('SEO endpoints', () => {
     expect(res.text).toContain('Disallow: /admin');
   });
 
-  test('sitemap.xml lista páginas principales y productos públicos', async () => {
+  test('sitemap.xml expone índice y sitemaps paginados sin mezclar URLs', async () => {
     const res = await request(server).get('/sitemap.xml');
     expect(res.status).toBe(200);
     expect(res.headers['content-type']).toMatch(/application\/xml/);
-    expect(res.text).toContain('<loc>https://nerinparts.example/</loc>');
-    expect(res.text).toContain('<loc>https://nerinparts.example/shop.html</loc>');
-    expect(res.text).toContain('<loc>https://nerinparts.example/p/pantalla-iphone-12</loc>');
+    expect(res.text).toContain('<sitemapindex');
+    expect(res.text).toContain('<loc>https://nerinparts.example/sitemap-static.xml</loc>');
+    expect(res.text).toContain('<loc>https://nerinparts.example/sitemap-products-1.xml</loc>');
+    expect(res.text).not.toContain('<loc>https://nerinparts.example/p/pantalla-iphone-12</loc>');
+  });
+
+  test('sitemap-static.xml y sitemap-products paginado listan sus URLs', async () => {
+    const staticRes = await request(server).get('/sitemap-static.xml');
+    expect(staticRes.status).toBe(200);
+    expect(staticRes.text).toContain('<loc>https://nerinparts.example/</loc>');
+    expect(staticRes.text).toContain('<loc>https://nerinparts.example/shop.html</loc>');
+
+    const productsRes = await request(server).get('/sitemap-products-1.xml');
+    expect(productsRes.status).toBe(200);
+    expect(productsRes.text).toContain('<loc>https://nerinparts.example/p/pantalla-iphone-12</loc>');
   });
 });

--- a/nerin_final_updated/backend/data/productsSqliteRepo.js
+++ b/nerin_final_updated/backend/data/productsSqliteRepo.js
@@ -3669,6 +3669,79 @@ async function queryProducts(params = {}) {
   return result;
 }
 
+async function getPublicSitemapStats() {
+  const startedAt = Date.now();
+  try {
+    await ensureDbReadyForRequest();
+    const db = await openDb();
+    const countStartedAt = Date.now();
+    const row = await get(
+      db,
+      `SELECT
+        COUNT(*) AS totalPublicProducts,
+        SUM(CASE WHEN public_slug IS NOT NULL AND trim(public_slug) != '' THEN 1 ELSE 0 END) AS indexableProducts,
+        SUM(CASE WHEN public_slug IS NULL OR trim(public_slug) = '' THEN 1 ELSE 0 END) AS missingSlugProducts
+       FROM product_search_index
+       WHERE is_public = 1`,
+    );
+    const countMs = Date.now() - countStartedAt;
+    return {
+      totalPublicProducts: Number(row?.totalPublicProducts || 0),
+      indexableProducts: Number(row?.indexableProducts || 0),
+      missingSlugProducts: Number(row?.missingSlugProducts || 0),
+      countMs,
+      totalDurationMs: Date.now() - startedAt,
+      source: "sqlite_search_index",
+    };
+  } catch (error) {
+    if (!isSqliteCorruptionError(error)) throw error;
+    markSqliteCorruption(error, { phase: "sitemap_stats", reason: "sqlite_corrupt" });
+    await repairCorruptSqlite({ reason: "sitemap_stats_corrupt" });
+    return getPublicSitemapStats();
+  }
+}
+
+async function listPublicSitemapProducts({ page = 1, pageSize = 2500 } = {}) {
+  const startedAt = Date.now();
+  try {
+    await ensureDbReadyForRequest();
+    const db = await openDb();
+    const safePage = Math.max(1, Number(page) || 1);
+    const safePageSize = Math.max(1, Math.min(5000, Number(pageSize) || 2500));
+    const offset = (safePage - 1) * safePageSize;
+    const selectStartedAt = Date.now();
+    const rows = await all(
+      db,
+      `SELECT product_rowid, product_id, public_slug, updated_at
+       FROM product_search_index
+       WHERE is_public = 1
+         AND public_slug IS NOT NULL
+         AND trim(public_slug) != ''
+       ORDER BY product_rowid ASC
+       LIMIT ? OFFSET ?`,
+      [safePageSize, offset],
+    );
+    const selectMs = Date.now() - selectStartedAt;
+    return {
+      rows,
+      page: safePage,
+      pageSize: safePageSize,
+      offset,
+      limit: safePageSize,
+      count: rows.length,
+      selectMs,
+      totalDurationMs: Date.now() - startedAt,
+      source: "sqlite_search_index",
+    };
+  } catch (error) {
+    if (!isSqliteCorruptionError(error)) throw error;
+    markSqliteCorruption(error, { phase: "sitemap_products", reason: "sqlite_corrupt" });
+    await repairCorruptSqlite({ reason: "sitemap_products_corrupt" });
+    return listPublicSitemapProducts({ page, pageSize });
+  }
+}
+
+
 async function queryAdminProducts(params = {}) {
   let result;
   try {
@@ -4627,6 +4700,8 @@ module.exports = {
   setCatalogError,
   clearCatalogError,
   queryProducts,
+  getPublicSitemapStats,
+  listPublicSitemapProducts,
   queryAdminProducts,
   getProductBySlug,
   getProductById,

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -254,6 +254,52 @@ const analyticsLiveCache = { at: 0, value: null };
 let analyticsDetailedRunning = false;
 let analyticsCatalogSnapshotCache = null;
 
+const SITEMAP_PRODUCTS_PAGE_SIZE = Math.max(1, Math.min(5000, Number(process.env.SITEMAP_PRODUCTS_PAGE_SIZE || 2500) || 2500));
+const SITEMAP_DIAGNOSTIC_TOKEN = String(process.env.SITEMAP_DIAGNOSTIC_TOKEN || "").trim();
+let processLifecycleHandlersRegistered = false;
+
+
+function logLifecycleEvent(eventType, error = null) {
+  const payload = {
+    event: eventType,
+    timestamp: new Date().toISOString(),
+    memory: getMemoryUsageSnapshot(),
+  };
+  if (error) {
+    payload.error = {
+      message: String(error?.message || error),
+      stack: error?.stack || null,
+      reason: error?.reason || null,
+      promise: eventType === "unhandledRejection" ? true : undefined,
+    };
+  }
+  console.error("[process:lifecycle]", payload);
+}
+
+function registerProcessLifecycleHandlers() {
+  if (processLifecycleHandlersRegistered) return;
+  processLifecycleHandlersRegistered = true;
+  process.on("uncaughtException", (error) => {
+    logLifecycleEvent("uncaughtException", error);
+  });
+  process.on("unhandledRejection", (reason) => {
+    logLifecycleEvent("unhandledRejection", reason);
+  });
+  process.on("SIGTERM", () => {
+    logLifecycleEvent("SIGTERM");
+    process.exit(0);
+  });
+  process.on("SIGINT", () => {
+    logLifecycleEvent("SIGINT");
+    process.exit(0);
+  });
+  process.on("exit", (code) => {
+    logLifecycleEvent("exit", { message: `process exit code=${code}` });
+  });
+}
+
+registerProcessLifecycleHandlers();
+
 function parseBooleanEnv(name, defaultValue = false) {
   const raw = process.env[name];
   if (raw === undefined || raw === null || String(raw).trim() === "") return defaultValue;
@@ -300,12 +346,9 @@ function getDetailedAnalyticsTtlMs(range = "7d") {
 
 function getMemoryUsageSnapshot() {
   const mem = process.memoryUsage();
-  return {
-    rss: mem.rss,
-    heapUsed: mem.heapUsed,
-    heapTotal: mem.heapTotal,
-    external: mem.external,
-  };
+  return Object.fromEntries(
+    Object.entries(mem).map(([key, value]) => [key, Number(value || 0)]),
+  );
 }
 
 function logAnalyticsMemory(stage) {
@@ -7239,104 +7282,269 @@ function serveStatic(filePath, res, headers = {}) {
 }
 
 // Crear servidor HTTP
+function sitemapLog(stage, details = {}) {
+  console.log("[sitemap]", {
+    stage,
+    timestamp: new Date().toISOString(),
+    memory: getMemoryUsageSnapshot(),
+    ...details,
+  });
+}
+
+function buildStaticSitemapEntries(base, generatedAt) {
+  return ["/", "/shop.html", "/shop", "/contact.html", "/garantia.html"].map((pathSegment) => ({
+    loc: absoluteUrl(pathSegment, base),
+    lastmod: generatedAt,
+    changefreq: pathSegment === "/" || pathSegment === "/shop.html" || pathSegment === "/shop" ? "daily" : "monthly",
+    priority: pathSegment === "/" ? "1.0" : pathSegment === "/shop.html" || pathSegment === "/shop" ? "0.9" : "0.5",
+  }));
+}
+
+async function getSitemapContext(req) {
+  const cfg = getConfig();
+  const siteBase = getPublicBaseUrl(cfg);
+  const base = normalizeBaseUrl(siteBase) || FALLBACK_BASE_URL;
+  const generatedAt = toIsoString(new Date());
+  const organicStartedAt = Date.now();
+  let organicEntries = [];
+  if (typeof buildOrganicSitemapEntries === "function") {
+    try {
+      organicEntries = await buildOrganicSitemapEntries(base, generatedAt);
+    } catch (organicError) {
+      console.warn("[sitemap:organic-skip]", organicError?.message || organicError);
+    }
+  }
+  const organicMs = Date.now() - organicStartedAt;
+  const staticEntries = [...buildStaticSitemapEntries(base, generatedAt), ...organicEntries];
+  return {
+    base,
+    generatedAt,
+    staticEntries,
+    organicCount: organicEntries.length,
+    organicMs,
+    requestId: `${Date.now().toString(36)}-${crypto.randomBytes(3).toString("hex")}`,
+    pathname: url.parse(req.url, true).pathname,
+  };
+}
+
+function buildProductSitemapEntries(rows = [], base, generatedAt, requestId) {
+  const entries = [];
+  let skippedMissingSlug = 0;
+  let skippedInvalid = 0;
+  for (const row of rows) {
+    try {
+      const slug = String(row?.public_slug || "").trim();
+      if (!slug) {
+        skippedMissingSlug += 1;
+        console.warn("[sitemap:product-skip]", { requestId, reason: "missing_slug", productId: row?.product_id || null, rowid: row?.product_rowid || null });
+        continue;
+      }
+      entries.push({
+        loc: absoluteUrl("/p/" + encodeURIComponent(slug), base),
+        lastmod: toIsoString(row?.updated_at) || generatedAt,
+        changefreq: "weekly",
+        priority: "0.8",
+      });
+    } catch (entryError) {
+      skippedInvalid += 1;
+      console.warn("[sitemap:product-skip]", { requestId, reason: "invalid_product", error: entryError?.message || String(entryError) });
+    }
+  }
+  return { entries, skippedMissingSlug, skippedInvalid };
+}
+
+async function buildSitemapResponse(pathname, req) {
+  const startedAt = Date.now();
+  const memoryBefore = getMemoryUsageSnapshot();
+  const context = await getSitemapContext(req);
+  sitemapLog("request:start", {
+    requestId: context.requestId,
+    path: pathname,
+    pageSize: SITEMAP_PRODUCTS_PAGE_SIZE,
+    memoryBefore,
+  });
+
+  const statsStartedAt = Date.now();
+  const stats = await productsSqliteRepo.getPublicSitemapStats();
+  const statsMs = Date.now() - statsStartedAt;
+  const publicCount = Number(stats.indexableProducts || 0);
+  const totalPublicProducts = Number(stats.totalPublicProducts || 0);
+  const missingSlugProducts = Number(stats.missingSlugProducts || 0);
+  const totalProductPages = Math.max(1, Math.ceil(publicCount / SITEMAP_PRODUCTS_PAGE_SIZE));
+  sitemapLog("products:count", {
+    requestId: context.requestId,
+    publicCount,
+    totalPublicProducts,
+    missingSlugProducts,
+    generatedProductPages: totalProductPages,
+    countMs: stats.countMs,
+    queryMs: statsMs,
+    organicCount: context.organicCount,
+    organicMs: context.organicMs,
+  });
+  if (missingSlugProducts > 0) {
+    console.warn("[sitemap:missing-slug]", { requestId: context.requestId, missingSlugProducts, action: "omitted" });
+  }
+
+  if (pathname === "/sitemap-static.xml") {
+    const xml = buildSitemapPartXml(context.base, context.staticEntries);
+    sitemapLog("request:success", {
+      requestId: context.requestId,
+      path: pathname,
+      staticCount: context.staticEntries.length,
+      durationMs: Date.now() - startedAt,
+      memoryAfter: getMemoryUsageSnapshot(),
+    });
+    return { status: 200, contentType: "application/xml; charset=utf-8", body: xml };
+  }
+
+  if (pathname === "/sitemap.xml") {
+    const paths = ["/sitemap-static.xml"];
+    for (let i = 1; i <= totalProductPages; i += 1) paths.push(`/sitemap-products-${i}.xml`);
+    const xml = buildSitemapIndexXml(context.base, paths);
+    sitemapLog("index:success", {
+      requestId: context.requestId,
+      indexCount: paths.length,
+      productPages: totalProductPages,
+      pageSize: SITEMAP_PRODUCTS_PAGE_SIZE,
+      durationMs: Date.now() - startedAt,
+      memoryAfter: getMemoryUsageSnapshot(),
+    });
+    return { status: 200, contentType: "application/xml; charset=utf-8", body: xml };
+  }
+
+  const match = pathname.match(/^\/sitemap-products-(\d+)\.xml$/);
+  const page = Number(match?.[1] || 0);
+  if (!Number.isInteger(page) || page < 1 || page > totalProductPages) {
+    sitemapLog("products:not_found", { requestId: context.requestId, page, totalProductPages, durationMs: Date.now() - startedAt });
+    return { status: 404, contentType: "text/plain; charset=utf-8", body: "Not found" };
+  }
+
+  const offset = (page - 1) * SITEMAP_PRODUCTS_PAGE_SIZE;
+  sitemapLog("products:page:start", {
+    requestId: context.requestId,
+    page,
+    pageSize: SITEMAP_PRODUCTS_PAGE_SIZE,
+    offset,
+    limit: SITEMAP_PRODUCTS_PAGE_SIZE,
+  });
+  const pageQueryStartedAt = Date.now();
+  const productPage = await productsSqliteRepo.listPublicSitemapProducts({ page, pageSize: SITEMAP_PRODUCTS_PAGE_SIZE });
+  const pageQueryMs = Date.now() - pageQueryStartedAt;
+  sitemapLog("products:page:query_done", {
+    requestId: context.requestId,
+    page,
+    pageSize: productPage.pageSize,
+    offset: productPage.offset,
+    limit: productPage.limit,
+    rows: productPage.count,
+    selectMs: productPage.selectMs,
+    queryMs: pageQueryMs,
+  });
+  const built = buildProductSitemapEntries(productPage.rows, context.base, context.generatedAt, context.requestId);
+  const xml = buildSitemapPartXml(context.base, built.entries);
+  sitemapLog("request:success", {
+    requestId: context.requestId,
+    path: pathname,
+    page,
+    pageSize: productPage.pageSize,
+    offset: productPage.offset,
+    limit: productPage.limit,
+    urlCount: built.entries.length,
+    skippedMissingSlug: built.skippedMissingSlug,
+    skippedInvalid: built.skippedInvalid,
+    durationMs: Date.now() - startedAt,
+    memoryAfter: getMemoryUsageSnapshot(),
+  });
+  return { status: 200, contentType: "application/xml; charset=utf-8", body: xml };
+}
+
+async function sendSitemapResponse(req, res, pathname) {
+  try {
+    const response = await buildSitemapResponse(pathname, req);
+    res.writeHead(response.status, {
+      "Content-Type": response.contentType,
+      "Cache-Control": response.status === 200 ? "public, max-age=3600" : "no-store",
+    });
+    res.end(response.body);
+  } catch (error) {
+    console.error("[sitemap:error]", {
+      timestamp: new Date().toISOString(),
+      error: error?.stack || error?.message || error,
+      memory: getMemoryUsageSnapshot(),
+    });
+    res.writeHead(500, { "Content-Type": "application/xml; charset=utf-8", "Cache-Control": "no-store" });
+    res.end('<?xml version="1.0" encoding="UTF-8"?><error>Sitemap temporarily unavailable</error>');
+  }
+}
+
+function isSitemapPath(pathname) {
+  return pathname === "/sitemap.xml" || pathname === "/sitemap-static.xml" || /^\/sitemap-products-\d+\.xml$/.test(pathname);
+}
+
+function isSitemapDiagnosticAllowed(req) {
+  if (!IS_PRODUCTION) return true;
+  if (!SITEMAP_DIAGNOSTIC_TOKEN) return false;
+  const provided = req.headers["x-sitemap-diagnostic-token"] || url.parse(req.url, true).query?.token;
+  return String(provided || "") === SITEMAP_DIAGNOSTIC_TOKEN;
+}
+
+async function sendSitemapDiagnostics(req, res) {
+  if (!isSitemapDiagnosticAllowed(req)) {
+    return sendJson(res, 404, { ok: false, error: "Not found" });
+  }
+  const startedAt = Date.now();
+  const before = getMemoryUsageSnapshot();
+  try {
+    const context = await getSitemapContext(req);
+    const stats = await productsSqliteRepo.getPublicSitemapStats();
+    const productPages = Math.max(1, Math.ceil(Number(stats.indexableProducts || 0) / SITEMAP_PRODUCTS_PAGE_SIZE));
+    const requestedPage = Math.max(1, Math.min(productPages, Number(url.parse(req.url, true).query?.page || 1) || 1));
+    const pageStartedAt = Date.now();
+    const productPage = await productsSqliteRepo.listPublicSitemapProducts({ page: requestedPage, pageSize: SITEMAP_PRODUCTS_PAGE_SIZE });
+    const productPageMs = Date.now() - pageStartedAt;
+    const sample = buildProductSitemapEntries(productPage.rows.slice(0, 5), context.base, context.generatedAt, context.requestId);
+    const after = getMemoryUsageSnapshot();
+    return sendJson(res, 200, {
+      ok: true,
+      generatedAt: new Date().toISOString(),
+      sitemapIndex: "/sitemap.xml",
+      staticSitemap: "/sitemap-static.xml",
+      productSitemaps: Array.from({ length: productPages }, (_, idx) => `/sitemap-products-${idx + 1}.xml`),
+      pageSize: SITEMAP_PRODUCTS_PAGE_SIZE,
+      stats,
+      probePage: {
+        page: productPage.page,
+        offset: productPage.offset,
+        limit: productPage.limit,
+        rows: productPage.count,
+        queryMs: productPageMs,
+        selectMs: productPage.selectMs,
+        sampleUrls: sample.entries.map((entry) => entry.loc),
+      },
+      timings: {
+        organicMs: context.organicMs,
+        totalMs: Date.now() - startedAt,
+      },
+      memory: { before, after },
+    });
+  } catch (error) {
+    console.error("[sitemap:diagnostics:error]", error?.stack || error?.message || error);
+    return sendJson(res, 500, { ok: false, error: error?.message || "diagnostics_failed", memory: { before, after: getMemoryUsageSnapshot() } });
+  }
+}
+
+// Crear servidor HTTP
 async function requestHandler(req, res) {
-  // [sitemap-hotfix-large-catalog]
-  // Intercepta sitemaps antes del handler historico para evitar cargar products.json completo en memoria.
-  // Mantener este handler simple: no ejecutar SEO, no generar contenido, no evaluar cada producto con funciones pesadas.
   const __sitemapParsedUrl = url.parse(req.url, true);
   const __sitemapPathname = __sitemapParsedUrl.pathname;
-  if (
-    (__sitemapPathname === "/sitemap.xml" ||
-      __sitemapPathname === "/sitemap-static.xml" ||
-      /^\/sitemap-products-\d+\.xml$/.test(__sitemapPathname)) &&
-    req.method === "GET"
-  ) {
-    try {
-      const cfg = getConfig();
-      const siteBase = getPublicBaseUrl(cfg);
-      const base = normalizeBaseUrl(siteBase) || FALLBACK_BASE_URL;
-      const generatedAt = toIsoString(new Date());
-      const pageSize = 45000;
-      const baseStaticEntries = ["/", "/shop.html", "/shop", "/contact.html", "/garantia.html"].map((pathSegment) => ({
-        loc: absoluteUrl(pathSegment, base),
-        lastmod: generatedAt,
-        changefreq: pathSegment === "/" || pathSegment === "/shop.html" || pathSegment === "/shop" ? "daily" : "monthly",
-        priority: pathSegment === "/" ? "1.0" : pathSegment === "/shop.html" || pathSegment === "/shop" ? "0.9" : "0.5",
-      }));
-      let organicEntries = [];
-      if (typeof buildOrganicSitemapEntries === "function") {
-        try {
-          organicEntries = await buildOrganicSitemapEntries(base, generatedAt);
-        } catch (organicError) {
-          console.warn("[sitemap:organic-skip]", organicError?.message || organicError);
-        }
-      }
-      const staticEntries = [...baseStaticEntries, ...organicEntries];
-      const toProductEntry = (product) => {
-        try {
-          const slug = product?.publicSlug || product?.public_slug || product?.slug;
-          if (!slug) return null;
-          return {
-            loc: absoluteUrl("/p/" + encodeURIComponent(String(slug)), base),
-            lastmod: generatedAt,
-            changefreq: "weekly",
-            priority: "0.8",
-          };
-        } catch (entryError) {
-          console.warn("[sitemap:product-skip]", entryError?.message || entryError);
-          return null;
-        }
-      };
-      const firstPage = await productsSqliteRepo.queryProducts({ page: 1, pageSize: 1 });
-      const publicCount = Number(firstPage?.totalItems || firstPage?.total || firstPage?.count || firstPage?.items?.length || 0);
-      const totalParts = Math.max(1, Math.ceil(publicCount / pageSize));
-
-      if (__sitemapPathname === "/sitemap-static.xml") {
-        console.log("[sitemap] static count=" + staticEntries.length);
-        const xml = buildSitemapPartXml(base, staticEntries);
-        res.writeHead(200, { "Content-Type": "application/xml; charset=utf-8", "Cache-Control": "public, max-age=3600" });
-        res.end(xml);
-        return;
-      }
-
-      if (__sitemapPathname === "/sitemap.xml") {
-        console.log("[sitemap] index count=" + publicCount);
-        if (publicCount > pageSize) {
-          const paths = ["/sitemap-static.xml"];
-          for (let i = 1; i <= totalParts; i += 1) paths.push("/sitemap-products-" + i + ".xml");
-          const xml = buildSitemapIndexXml(base, paths);
-          res.writeHead(200, { "Content-Type": "application/xml; charset=utf-8", "Cache-Control": "public, max-age=3600" });
-          res.end(xml);
-          return;
-        }
-        const page = await productsSqliteRepo.queryProducts({ page: 1, pageSize });
-        const productEntries = (page?.items || []).map(toProductEntry).filter(Boolean);
-        const xml = buildSitemapPartXml(base, [...staticEntries, ...productEntries]);
-        res.writeHead(200, { "Content-Type": "application/xml; charset=utf-8", "Cache-Control": "public, max-age=3600" });
-        res.end(xml);
-        return;
-      }
-
-      const match = __sitemapPathname.match(/^\/sitemap-products-(\d+)\.xml$/);
-      const part = Number(match?.[1] || 0);
-      if (!Number.isInteger(part) || part < 1 || part > totalParts) {
-        res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
-        res.end("Not found");
-        return;
-      }
-      const page = await productsSqliteRepo.queryProducts({ page: part, pageSize });
-      const productEntries = (page?.items || []).map(toProductEntry).filter(Boolean);
-      console.log("[sitemap] products part=" + part + " limit=" + pageSize + " count=" + productEntries.length);
-      const xml = buildSitemapPartXml(base, productEntries);
-      res.writeHead(200, { "Content-Type": "application/xml; charset=utf-8", "Cache-Control": "public, max-age=3600" });
-      res.end(xml);
-      return;
-    } catch (error) {
-      console.error("[sitemap:error]", error?.stack || error?.message || error);
-      res.writeHead(500, { "Content-Type": "application/xml; charset=utf-8", "Cache-Control": "no-store" });
-      res.end('<?xml version="1.0" encoding="UTF-8"?><error>Sitemap temporarily unavailable</error>');
-      return;
-    }
+  if (isSitemapPath(__sitemapPathname) && req.method === "GET") {
+    await sendSitemapResponse(req, res, __sitemapPathname);
+    return;
+  }
+  if (__sitemapPathname === "/internal/sitemap-diagnostics" && req.method === "GET") {
+    await sendSitemapDiagnostics(req, res);
+    return;
   }
   const parsedUrl = url.parse(req.url, true);
   const pathname = parsedUrl.pathname;
@@ -14221,44 +14429,8 @@ async function requestHandler(req, res) {
     }
   }
 
-  if ((pathname === "/sitemap.xml" || pathname === "/sitemap-static.xml" || /^\/sitemap-products-\d+\.xml$/.test(pathname)) && req.method === "GET") {
-    const cfg = getConfig();
-    const siteBase = getPublicBaseUrl(cfg);
-    const products = loadSmallCatalogProducts({ filePath: PRODUCTS_FILE_PATH });
-    const plan = buildSitemapPlan(siteBase, products);
-    const organicEntries = await buildOrganicSitemapEntries(plan.siteBase, toIsoString(new Date()));
-    plan.staticEntries = [...plan.staticEntries, ...organicEntries];
-    const productCount = plan.productEntries.length;
-    const needsIndex = productCount > 45000;
-    if (pathname === "/sitemap.xml") {
-      const xml = needsIndex
-        ? buildSitemapIndexXml(plan.siteBase, [
-            "/sitemap-static.xml",
-            ...plan.productSitemaps.map((_, idx) => `/sitemap-products-${idx + 1}.xml`),
-          ])
-        : buildSitemapPartXml(plan.siteBase, [...plan.staticEntries, ...plan.productEntries]);
-      res.writeHead(200, { "Content-Type": "application/xml; charset=utf-8", "Cache-Control": "public, max-age=3600" });
-      res.end(xml);
-      return;
-    }
-    if (pathname === "/sitemap-static.xml") {
-      const xml = buildSitemapPartXml(plan.siteBase, plan.staticEntries);
-      res.writeHead(200, { "Content-Type": "application/xml; charset=utf-8", "Cache-Control": "public, max-age=3600" });
-      res.end(xml);
-      return;
-    }
-    const m = pathname.match(/^\/sitemap-products-(\d+)\.xml$/);
-    const idx = Number(m?.[1] || 0) - 1;
-    if (idx < 0 || idx >= plan.productSitemaps.length) {
-      res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
-      res.end("Not found");
-      return;
-    }
-    const xml = buildSitemapPartXml(plan.siteBase, plan.productSitemaps[idx]);
-    res.writeHead(200, { "Content-Type": "application/xml; charset=utf-8", "Cache-Control": "public, max-age=3600" });
-    res.end(xml);
-    return;
-  }
+  // Los sitemaps se atienden al inicio del requestHandler con buildSitemapResponse().
+  // Mantener este punto sin carga de products.json para evitar parseos completos del catálogo.
 
   const organicPageConfig = getOrganicSeoPageConfig(pathname);
   if (organicPageConfig && req.method === "GET") {

--- a/nerin_final_updated/scripts/applySitemapHotfix.js
+++ b/nerin_final_updated/scripts/applySitemapHotfix.js
@@ -8,7 +8,7 @@ const flag = "[sitemap-hotfix-large-catalog]";
 
 let text = fs.readFileSync(serverPath, "utf8");
 
-if (text.includes(flag)) {
+if (text.includes("async function buildSitemapResponse") || text.includes(flag)) {
   console.log("[sitemap-hotfix] already applied");
   process.exit(0);
 }

--- a/nerin_final_updated/scripts/check-no-products-full-parse.js
+++ b/nerin_final_updated/scripts/check-no-products-full-parse.js
@@ -20,6 +20,14 @@ function assertNoPatternInBlock({ content, blockName, startPattern, endPattern, 
   });
 }
 
+
+function sliceRouteBlock(content, start) {
+  const tail = content.slice(start);
+  const matches = [...tail.matchAll(/\n  if\s*\(/g)].filter((match) => match.index > 0);
+  const next = matches.length ? matches[0].index : -1;
+  return next > 0 ? tail.slice(0, next) : tail;
+}
+
 function walk(dirPath) {
   const entries = fs.readdirSync(dirPath, { withFileTypes: true });
   for (const entry of entries) {
@@ -78,10 +86,7 @@ if (fs.existsSync(SERVER_PATH)) {
 
   const analyticsRouteStart = serverContent.indexOf('if (pathname === "/api/analytics/detailed"');
   if (analyticsRouteStart >= 0) {
-    const analyticsRouteTail = serverContent.slice(analyticsRouteStart);
-    const nextRouteIdx = analyticsRouteTail.indexOf("\n  if (pathname === ");
-    const analyticsRouteBlock =
-      nextRouteIdx > 0 ? analyticsRouteTail.slice(0, nextRouteIdx) : analyticsRouteTail;
+    const analyticsRouteBlock = sliceRouteBlock(serverContent, analyticsRouteStart);
     if (/\bgetProducts\s*\(/.test(analyticsRouteBlock)) {
       RULE_VIOLATIONS.push("/api/analytics/detailed: no debe usar getProducts()");
     }
@@ -98,9 +103,7 @@ if (fs.existsSync(SERVER_PATH)) {
   for (const entry of forbiddenPublicRoutes) {
     const start = serverContent.indexOf(entry.marker);
     if (start < 0) continue;
-    const tail = serverContent.slice(start);
-    const nextRouteIdx = tail.indexOf("\n  if (pathname === ");
-    const block = nextRouteIdx > 0 ? tail.slice(0, nextRouteIdx) : tail;
+    const block = sliceRouteBlock(serverContent, start);
     if (/\bloadProducts\s*\(/.test(block)) {
       RULE_VIOLATIONS.push(`${entry.route}: no debe usar loadProducts()`);
     }


### PR DESCRIPTION
### Motivation
- Prevent server crashes during sitemap generation by removing any code path that parses the full `products.json` into memory and instead rely on SQLite-backed, paginated queries. 
- Add clear observability and lifecycle handlers so crashes or OOM events are logged with memory/stack context.

### Description
- Replace the old sitemap handler that could load the whole catalog with a lightweight early-intercept handler using SQLite pagination and limits; sitemap index now points to `/sitemap-static.xml` and `/sitemap-products-N.xml` only. (modified: `backend/server.js`).
- Add two SQLite helpers in `productsSqliteRepo`: `getPublicSitemapStats()` and `listPublicSitemapProducts({ page, pageSize })` which count indexable products and return paginated rows (no full catalog parse). (modified: `backend/data/productsSqliteRepo.js`).
- Add detailed sitemap logging (start/end, counts, pages, offset/limit, query durations, memory snapshots, skipped/missing slugs) and a protected diagnostics route at `/internal/sitemap-diagnostics` (configurable via `SITEMAP_DIAGNOSTIC_TOKEN`). (modified: `backend/server.js`).
- Register global process lifecycle handlers for `uncaughtException`, `unhandledRejection`, `SIGTERM`, `SIGINT`, and `exit` that log timestamp, memory and error stacks. (modified: `backend/server.js`).
- Enforce safe page sizes and caps (`SITEMAP_PRODUCTS_PAGE_SIZE` default `2500`, hard cap `5000`) and never create huge in-memory arrays when building sitemaps. (modified: `backend/server.js`, `backend/data/productsSqliteRepo.js`).
- Update helper scripts and checks to avoid reapplying the hotfix and to robustly detect forbidden full-parse patterns; update the sitemap hotfix script and the static analysis script. (modified: `scripts/applySitemapHotfix.js`, `scripts/check-no-products-full-parse.js`).
- Update SEO tests to assert sitemap is an index and that product URLs are provided only by paginated product sitemap parts. (modified: `__tests__/backend/seo-endpoints.test.js`).

### Testing
- Code syntax checks: `node --check backend/server.js` and `node --check backend/data/productsSqliteRepo.js` both succeeded. 
- Static checks: `npm run check:no-products-full-parse` completed with no violations after changes. 
- Hotfix script: `node scripts/applySitemapHotfix.js` executed and detected the fix already applied (ok). 
- Unit/integration tests: `npm test -- --runInBand __tests__/backend/seo-endpoints.test.js` ran and all tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19d847f7808331a3d4f06c9b92a6f6)