### PR TITLE
SQLite: configurable DATABASE_PATH, add availability column, disk caching and backup tooling

### DIFF
--- a/nerin_final_updated/backend/data/productsSqliteRepo.js
+++ b/nerin_final_updated/backend/data/productsSqliteRepo.js
@@ -17,16 +17,27 @@ const {
 } = require("../utils/screenProductClassifier");
 
 const PRODUCTS_JSON_PATH = dataPath("products.json");
-const SQLITE_PATH = dataPath("products.sqlite");
+function resolveSqlitePath() {
+  const configured = String(process.env.DATABASE_PATH || "").trim();
+  if (configured) {
+    return path.isAbsolute(configured) ? configured : path.resolve(process.cwd(), configured);
+  }
+  return dataPath("products.sqlite");
+}
+
+const SQLITE_PATH = resolveSqlitePath();
 const MANIFEST_PATH = dataPath("products.manifest.json");
 const OVERRIDES_PATH = dataPath("products.overrides.json");
 const COUNT_CACHE_TTL_MS = 60_000;
-const PRODUCTS_SQLITE_SCHEMA_VERSION = 6;
+const PRODUCTS_SQLITE_SCHEMA_VERSION = 7;
 const CATALOG_MAPPING_VERSION = 5;
 const BULK_PUBLISH_CHUNK_SIZE = 1000;
 const SEARCH_RANK_CANDIDATE_LIMIT = 1200;
 const DEBUG_PRICE_MAPPING =
   String(process.env.DEBUG_PRICE_MAPPING || "").trim().toLowerCase() === "true";
+const IS_PRODUCTION_RUNTIME = process.env.NODE_ENV === "production";
+const CATALOG_AUTO_REBUILD =
+  String(process.env.CATALOG_AUTO_REBUILD || "").trim().toLowerCase() === "true";
 const TEST_REBUILD_DELAY_MS =
   process.env.NODE_ENV === "test"
     ? Math.max(0, Number(process.env.CATALOG_REBUILD_TEST_DELAY_MS || 0) || 0)
@@ -84,8 +95,12 @@ const catalogState = {
   schemaVersion: PRODUCTS_SQLITE_SCHEMA_VERSION,
 };
 
+function shouldAllowAutomaticRebuild() {
+  return !IS_PRODUCTION_RUNTIME || CATALOG_AUTO_REBUILD;
+}
+
 function catalogStateSnapshot() {
-  return { ...catalogState };
+  return { ...catalogState, automaticRebuildEnabled: shouldAllowAutomaticRebuild() };
 }
 
 function updateCatalogProgress(processed, total = catalogState.total) {
@@ -988,7 +1003,10 @@ async function openDb() {
     dbInstance = await new Promise((resolve, reject) => {
       const db = new sqlite3.Database(SQLITE_PATH, (error) => {
         if (error) reject(error);
-        else resolve(db);
+        else {
+          db.serialize();
+          resolve(db);
+        }
       });
     });
     await run(dbInstance, "PRAGMA journal_mode = WAL");
@@ -1041,6 +1059,7 @@ async function createSchema(db) {
       supplier_code TEXT,
       status TEXT,
       visibility TEXT,
+      availability TEXT,
       stock INTEGER,
       price REAL,
       price_minorista REAL,
@@ -1075,9 +1094,13 @@ async function createSchema(db) {
     "CREATE INDEX IF NOT EXISTS idx_products_supplier_code ON products(supplier_code)",
     "CREATE INDEX IF NOT EXISTS idx_products_brand ON products(brand)",
     "CREATE INDEX IF NOT EXISTS idx_products_category ON products(category)",
+    "CREATE INDEX IF NOT EXISTS idx_products_model ON products(model)",
+    "CREATE INDEX IF NOT EXISTS idx_products_availability ON products(availability)",
     "CREATE INDEX IF NOT EXISTS idx_products_is_public ON products(is_public)",
     "CREATE INDEX IF NOT EXISTS idx_products_stock ON products(stock)",
     "CREATE INDEX IF NOT EXISTS idx_products_price ON products(price)",
+    "CREATE INDEX IF NOT EXISTS idx_products_public_category_brand ON products(is_public, category, brand)",
+    "CREATE INDEX IF NOT EXISTS idx_products_public_stock_price ON products(is_public, stock, price)",
     "CREATE INDEX IF NOT EXISTS idx_products_name ON products(name)",
   ];
 
@@ -1141,6 +1164,9 @@ async function createSchema(db) {
     "CREATE INDEX IF NOT EXISTS idx_search_is_stock_real ON product_search_index(is_stock_real)",
     "CREATE INDEX IF NOT EXISTS idx_search_price ON product_search_index(price)",
     "CREATE INDEX IF NOT EXISTS idx_search_is_public ON product_search_index(is_public)",
+    "CREATE INDEX IF NOT EXISTS idx_search_public_model_variant ON product_search_index(is_public, model_base, model_variant, network_variant)",
+    "CREATE INDEX IF NOT EXISTS idx_search_public_brand_part ON product_search_index(is_public, device_brand, compatible_brand, part_type)",
+    "CREATE INDEX IF NOT EXISTS idx_search_public_stock_price ON product_search_index(is_public, stock_status, stock, price)",
   ];
 
   for (const sql of searchIndexSql) {
@@ -1811,6 +1837,7 @@ function mapProductRow(product = {}, options = {}) {
     supplier_code: toNullableText(getField(product, ["supplierCode", "supplier_code", "Supplier Part Number"])),
     status: normalizeQueryText(toNullableText(getField(product, ["status", "estado"]))),
     visibility: normalizeQueryText(toNullableText(getField(product, ["visibility", "visibilidad"]))),
+    availability: normalizeQueryText(toNullableText(getField(product, ["availability", "disponibilidad", "estado_stock", "stock_status"]))),
     stock,
     price: priceFields.price,
     price_minorista: priceFields.price_minorista,
@@ -2206,7 +2233,7 @@ async function updateProductByIdentifier(identifier, patch = {}) {
     db,
     `UPDATE products SET
       id = ?, sku = ?, code = ?, slug = ?, public_slug = ?, image = ?, name = ?, title = ?, brand = ?, model = ?, category = ?,
-      part_number = ?, mpn = ?, ean = ?, gtin = ?, supplier_code = ?, status = ?, visibility = ?,
+      part_number = ?, mpn = ?, ean = ?, gtin = ?, supplier_code = ?, status = ?, visibility = ?, availability = ?,
       stock = ?, price = ?, price_minorista = ?, price_mayorista = ?, precio_minorista = ?, precio_mayorista = ?, precio_final = ?, precio_sin_impuestos = ?, cost = ?, currency = ?, is_public = ?, enabled = ?, deleted = ?, archived = ?, vip_only = ?, wholesale_only = ?, search_text = ?, raw_json = ?
       WHERE rowid = ?`,
     [
@@ -2228,6 +2255,7 @@ async function updateProductByIdentifier(identifier, patch = {}) {
       mapped.supplier_code,
       mapped.status,
       mapped.visibility,
+      mapped.availability,
       mapped.stock,
       mapped.price,
       mapped.price_minorista,
@@ -2524,6 +2552,7 @@ function buildCatalogPathsInfo() {
   return {
     DATA_DIR: path.dirname(SQLITE_PATH),
     dbPath: SQLITE_PATH,
+    databasePathEnv: (process.env.DATABASE_PATH || "").trim() || null,
     productsFilePath: PRODUCTS_JSON_PATH,
     renderDiskMountPath,
     dbExists: fs.existsSync(SQLITE_PATH),
@@ -2583,10 +2612,10 @@ async function rebuildProductsDbFromJson({ force = true, reason = "manual" } = {
       await createSchema(tmpDb);
       const insertSql = `INSERT INTO products (
         id, sku, code, slug, public_slug, image, name, title, brand, model, category,
-        part_number, mpn, ean, gtin, supplier_code, status, visibility,
+        part_number, mpn, ean, gtin, supplier_code, status, visibility, availability,
         stock, price, price_minorista, price_mayorista, precio_minorista, precio_mayorista, precio_final, precio_sin_impuestos, cost, currency, is_public, enabled, deleted, archived, vip_only, wholesale_only,
         search_text, raw_json
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
 
       let count = 0;
       let publicCount = 0;
@@ -2618,6 +2647,7 @@ async function rebuildProductsDbFromJson({ force = true, reason = "manual" } = {
               item.supplier_code,
               item.status,
               item.visibility,
+              item.availability,
               item.stock,
               item.price,
               item.price_minorista,
@@ -2809,6 +2839,9 @@ async function inspectSqliteSchemaIntegrity() {
     if (!columnByName.has("public_slug")) {
       return { ok: false, reason: "public_slug_missing" };
     }
+    if (!columnByName.has("availability")) {
+      return { ok: false, reason: "availability_column_missing" };
+    }
     const priceColumns = [
       "price",
       "price_minorista",
@@ -2910,11 +2943,12 @@ async function ensureProductsDb({ allowRebuild = true } = {}) {
   };
 }
 
-async function ensureProductsDbOnce() {
+async function ensureProductsDbOnce(options = {}) {
   if (dbReady) return { dbPath: SQLITE_PATH, source: "sqlite", ready: true };
   if (dbReadyPromise) return dbReadyPromise;
+  const allowRebuild = options.allowRebuild ?? shouldAllowAutomaticRebuild();
   catalogState.initializing = true;
-  dbReadyPromise = ensureProductsDb({ allowRebuild: true });
+  dbReadyPromise = ensureProductsDb({ allowRebuild });
   try {
     return await dbReadyPromise;
   } catch (error) {
@@ -2935,17 +2969,18 @@ async function ensureProductsDbOnce() {
   }
 }
 
-function ensureProductsDbInBackground(trigger = "request") {
+function ensureProductsDbInBackground(trigger = "request", options = {}) {
   if (dbReady || dbReadyPromise) return;
+  const allowRebuild = options.allowRebuild ?? shouldAllowAutomaticRebuild();
   catalogState.initializing = true;
   catalogState.startedAt = catalogState.startedAt || new Date().toISOString();
-  dbReadyPromise = ensureProductsDb({ allowRebuild: true });
+  dbReadyPromise = ensureProductsDb({ allowRebuild });
   dbReadyPromise
     .then(() => {
-      console.log(`[products-db] background ensure completed trigger=${trigger}`);
+      console.log(`[products-db] background ensure completed trigger=${trigger} allowRebuild=${allowRebuild}`);
     })
     .catch((error) => {
-      console.warn(`[products-db] background ensure failed trigger=${trigger} reason=${error?.message || error}`);
+      console.warn(`[products-db] background ensure failed trigger=${trigger} allowRebuild=${allowRebuild} reason=${error?.message || error}`);
     })
     .finally(() => {
       dbReadyPromise = null;
@@ -2970,7 +3005,9 @@ async function ensureDbReadyForRequest() {
     await ensureProductsDb({ allowRebuild: false });
   } catch (error) {
     if (error?.code === "CATALOG_INITIALIZING") {
-      ensureProductsDbInBackground("request-auto-bootstrap");
+      if (shouldAllowAutomaticRebuild()) {
+        ensureProductsDbInBackground("request-auto-bootstrap", { allowRebuild: true });
+      }
       throw error;
     }
     if (isSqliteCorruptionError(error)) {
@@ -3423,7 +3460,7 @@ async function querySearchIndex(params = {}) {
   await ensureDbReadyForRequest();
   const db = await openDb();
   const safePage = Math.max(1, Number(params.page) || 1);
-  const safePageSize = Math.max(1, Number(params.pageSize) || 24);
+  const safePageSize = Math.max(1, Math.min(100, Number(params.pageSize) || 24));
   const includeFacets = params.includeFacets === true || String(params.includeFacets || "") === "1";
   const offset = (safePage - 1) * safePageSize;
   const whereClause = buildSearchIndexWhere(params);
@@ -3545,7 +3582,7 @@ async function queryBase({
   await ensureDbReadyForRequest();
   const db = await openDb();
   const safePage = Math.max(1, Number(page) || 1);
-  const safePageSize = Math.max(1, Number(pageSize) || 24);
+  const safePageSize = Math.max(1, Math.min(100, Number(pageSize) || 24));
   const offset = (safePage - 1) * safePageSize;
   const normalizedSearch = normalizeQueryText(search);
   const whereClause = buildWhereClause({
@@ -3949,6 +3986,12 @@ async function adjustStockForInventory(identifier, delta, { reason = "inventory"
       [after, JSON.stringify(raw), resolved.row.rowid],
     );
     await run(db, "COMMIT");
+    try {
+      await reindexProduct(resolved.row.rowid, { db });
+      countCache.clear();
+    } catch (reindexError) {
+      console.warn("[products-inventory] reindex after stock adjustment failed", reindexError?.message || reindexError);
+    }
     return {
       source: "sqlite",
       foundBy: resolved.foundBy,
@@ -4687,6 +4730,22 @@ async function getCatalogPriceAudit({ limit = 20 } = {}) {
   };
 }
 
+function closeProductsDbOnShutdown(signal) {
+  closeDbInstance()
+    .then(() => {
+      if (signal) console.log(`[products-db] sqlite connection closed on ${signal}`);
+    })
+    .catch((error) => {
+      console.warn("[products-db] sqlite close failed", error?.message || error);
+    });
+}
+
+if (require.main !== module && !global.__NERIN_PRODUCTS_SQLITE_SHUTDOWN_HOOKS__) {
+  global.__NERIN_PRODUCTS_SQLITE_SHUTDOWN_HOOKS__ = true;
+  process.once("SIGINT", () => closeProductsDbOnShutdown("SIGINT"));
+  process.once("SIGTERM", () => closeProductsDbOnShutdown("SIGTERM"));
+}
+
 function isRebuildInProgress() {
   return Boolean(rebuildPromise);
 }
@@ -4746,6 +4805,7 @@ module.exports = {
   rankRowsBySearchIntent,
   PRODUCTS_SQLITE_SCHEMA_VERSION,
   CATALOG_MAPPING_VERSION,
+  shouldAllowAutomaticRebuild,
   getField,
   isProductPublic,
   mapProductRow,

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -344,6 +344,7 @@ const MAX_JSON_BODY_BYTES = Math.max(16 * 1024, Number(process.env.MAX_JSON_BODY
 const publicProductsCache = new Map();
 const publicSearchCache = new Map();
 const merchantFeedRuntimeCache = new Map();
+const DISK_CACHE_DIR = dataPath("cache");
 let sitemapStockCache = { t: 0, baseUrl: null, xml: null, count: 0 };
 
 function getDetailedAnalyticsTtlMs(range = "7d") {
@@ -1670,11 +1671,22 @@ function buildMetaFeedCsv(products, baseUrl) {
 }
 
 
-function openSqliteReadonly(dbPath) {
-  return new Promise((resolve, reject) => {
-    const dbConn = new sqlite3.Database(dbPath, sqlite3.OPEN_READONLY, (error) => {
+async function openSqliteReadonly(dbPath) {
+  const dbConn = await new Promise((resolve, reject) => {
+    const conn = new sqlite3.Database(dbPath, sqlite3.OPEN_READONLY, (error) => {
       if (error) reject(error);
-      else resolve(dbConn);
+      else resolve(conn);
+    });
+  });
+  await sqliteRun(dbConn, "PRAGMA busy_timeout = 5000");
+  return dbConn;
+}
+
+function sqliteRun(dbConn, sql, params = []) {
+  return new Promise((resolve, reject) => {
+    dbConn.run(sql, params, (error) => {
+      if (error) reject(error);
+      else resolve();
     });
   });
 }
@@ -1705,6 +1717,30 @@ function setCacheEntry(cache, key, value, maxEntries = 120) {
   if (cache.size > maxEntries) {
     const firstKey = cache.keys().next().value;
     if (firstKey) cache.delete(firstKey);
+  }
+}
+
+async function readDiskCacheEntry(namespace, key, ttlMs) {
+  if (!ttlMs) return null;
+  try {
+    const digest = crypto.createHash("sha256").update(String(key || "")).digest("hex");
+    const filePath = path.join(DISK_CACHE_DIR, namespace, `${digest}.cache`);
+    const stat = await fs.promises.stat(filePath);
+    if (Date.now() - stat.mtimeMs > ttlMs) return null;
+    return await fs.promises.readFile(filePath, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+async function writeDiskCacheEntry(namespace, key, body) {
+  try {
+    const digest = crypto.createHash("sha256").update(String(key || "")).digest("hex");
+    const dir = path.join(DISK_CACHE_DIR, namespace);
+    await fs.promises.mkdir(dir, { recursive: true });
+    await fs.promises.writeFile(path.join(dir, `${digest}.cache`), String(body || ""), "utf8");
+  } catch (error) {
+    console.warn("[disk-cache:write-skip]", { namespace, error: error?.message || String(error) });
   }
 }
 
@@ -7617,7 +7653,19 @@ async function buildSitemapResponse(pathname, req) {
 
 async function sendSitemapResponse(req, res, pathname) {
   try {
+    const sitemapCacheKey = `${getPublicBaseUrl(getConfig()) || FALLBACK_BASE_URL}:${pathname}`;
+    const cachedXml = await readDiskCacheEntry("sitemap", sitemapCacheKey, SITEMAP_STOCK_CACHE_MS);
+    if (cachedXml) {
+      res.writeHead(200, {
+        "Content-Type": "application/xml; charset=utf-8",
+        "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+        "X-Cache": "DISK-HIT",
+      });
+      res.end(cachedXml);
+      return;
+    }
     const response = await buildSitemapResponse(pathname, req);
+    if (response.status === 200) await writeDiskCacheEntry("sitemap", sitemapCacheKey, response.body);
     res.writeHead(response.status, {
       "Content-Type": response.contentType,
       "Cache-Control": response.cacheControl || (response.status === 200 ? "public, max-age=3600" : "no-store"),
@@ -8636,7 +8684,7 @@ async function requestHandler(req, res) {
       const { page, pageSize } = parsePaginationParams(parsedUrl.query, {
         page: 1,
         pageSize: 100,
-        maxPageSize: 250,
+        maxPageSize: 100,
       });
       const queryParams = parsedUrl.query || {};
       const startedAt = Date.now();
@@ -14412,13 +14460,14 @@ async function requestHandler(req, res) {
     });
     if (pathname !== "/merchant-feed-debug.json") {
       const cachedFeed = getCacheEntry(merchantFeedRuntimeCache, feedCacheKey, MERCHANT_FEED_CACHE_MS);
-      if (cachedFeed) {
+      const diskCachedFeed = cachedFeed || await readDiskCacheEntry("merchant-feed", feedCacheKey, MERCHANT_FEED_CACHE_MS);
+      if (diskCachedFeed) {
         res.writeHead(200, {
           "Content-Type": "text/tab-separated-values; charset=utf-8",
           "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
-          "X-Cache": "HIT",
+          "X-Cache": cachedFeed ? "HIT" : "DISK-HIT",
         });
-        res.end(cachedFeed);
+        res.end(diskCachedFeed);
         return;
       }
     }
@@ -14527,7 +14576,10 @@ async function requestHandler(req, res) {
       return sendJson(res, 200, audit);
     }
     const feedBody = `${rows.join('\n')}\n`;
-    if (pathname !== "/merchant-feed-debug.json") setCacheEntry(merchantFeedRuntimeCache, feedCacheKey, feedBody, 20);
+    if (pathname !== "/merchant-feed-debug.json") {
+      setCacheEntry(merchantFeedRuntimeCache, feedCacheKey, feedBody, 20);
+      await writeDiskCacheEntry("merchant-feed", feedCacheKey, feedBody);
+    }
     res.writeHead(200, {
       'Content-Type': 'text/tab-separated-values; charset=utf-8',
       'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
@@ -15162,7 +15214,10 @@ if (require.main === module) {
   const server = createServer();
   server.listen(APP_PORT, () => {
     console.log(`Servidor de NERIN corriendo en http://localhost:${APP_PORT}`);
-    console.log(`[products-db] startup background ensure scheduled after listen port=${APP_PORT}`);
-    productsSqliteRepo.ensureProductsDbInBackground("startup-after-listen");
+    const allowStartupRebuild = typeof productsSqliteRepo.shouldAllowAutomaticRebuild === "function"
+      ? productsSqliteRepo.shouldAllowAutomaticRebuild()
+      : process.env.NODE_ENV !== "production";
+    console.log(`[products-db] startup background ensure scheduled after listen port=${APP_PORT} allowRebuild=${allowStartupRebuild}`);
+    productsSqliteRepo.ensureProductsDbInBackground("startup-after-listen", { allowRebuild: allowStartupRebuild });
   });
 }

--- a/nerin_final_updated/docs/RENDER_SQLITE_OPTIMIZATION.md
+++ b/nerin_final_updated/docs/RENDER_SQLITE_OPTIMIZATION.md
@@ -1,0 +1,173 @@
+# Render + SQLite Optimization (sin PostgreSQL pago)
+
+## Objetivo
+
+Mantener NERINParts en Render usando SQLite con Persistent Disk, sin migrar a PostgreSQL pago ni cambiar de hosting. Esta optimización prioriza estabilidad, bajo costo y compatibilidad con checkout, catálogo, stock, pedidos, Mercado Pago y Resend.
+
+## Problemas encontrados
+
+- El catálogo convive con varias fuentes: JSON locales para entidades operativas (`data/*.json`), `products.json` como origen de importación y SQLite/search index para consultas rápidas de productos.
+- Ya existía protección contra parseos completos de `products.json`, pero el SQLite usaba una ruta derivada de `DATA_DIR`; en Render eso puede terminar en almacenamiento efímero si no se configura explícitamente.
+- Los endpoints públicos tenían paginación, pero el límite interno de repositorio no estaba centralizado y admin aceptaba hasta 250 ítems por página.
+- El sitemap ya estaba dividido en índice y páginas parciales; faltaba cache persistente en disco para no regenerar XML pesado en caliente después de reinicios.
+- Merchant feed tenía cache en memoria, pero no cache en disco. Un restart de Render obligaba a regenerar el TSV.
+- Había índices básicos, pero faltaban índices explícitos para `model`, `availability` y combinaciones comunes de búsqueda técnica/modelo/stock/precio.
+- No había script operativo de backup rotativo de SQLite en `/var/data/backups`.
+
+## Archivos modificados
+
+- `backend/data/productsSqliteRepo.js`
+  - Centraliza SQLite con `DATABASE_PATH`.
+  - Mantiene fallback local seguro con `dataPath("products.sqlite")` para desarrollo.
+  - Activa WAL, `synchronous=NORMAL`, `busy_timeout=5000` y serialización de operaciones en la conexión compartida.
+  - Evita reconstrucciones automáticas del catálogo en producción salvo que se habilite explícitamente `CATALOG_AUTO_REBUILD=true`.
+  - Agrega columna `availability` e índices para SKU, slug, brand, model, category, availability, stock, price y combinaciones críticas.
+  - Limita internamente `pageSize` a 100.
+  - Registra cierre de conexión ante `SIGINT`/`SIGTERM`.
+- `backend/server.js`
+  - Reduce el máximo de página admin a 100.
+  - Agrega cache en disco para sitemap y Merchant feed usando el directorio persistente de datos.
+  - Configura `busy_timeout` también para conexiones SQLite readonly auxiliares.
+- `scripts/backup-sqlite.js`
+  - Crea backups seguros con la Online Backup API de SQLite para no copiar archivos WAL/SHM a mano.
+  - Guarda copias rotativas en `/var/data/backups` cuando `DATABASE_PATH=/var/data/nerinparts.sqlite`.
+- `package.json`
+  - Agrega `npm run backup:sqlite`.
+
+## Configuración recomendada en Render
+
+### Root directory
+
+Configurar el servicio con:
+
+```txt
+Root Directory: nerin_final_updated
+```
+
+### Build command
+
+```bash
+npm install
+```
+
+### Start command
+
+```bash
+npm start
+```
+
+El script `start` ejecuta `node backend/server.js` y no debe correr reconstrucciones pesadas, importaciones ni hotfixes en cada arranque. En producción la verificación de SQLite al iniciar se ejecuta con `allowRebuild=false`; si falta o está desactualizado, `/readyz` queda en `503` hasta que se restaure/reconstruya de forma operativa.
+
+### Persistent Disk
+
+Crear un **Persistent Disk** en el servicio de Render:
+
+```txt
+Mount path: /var/data
+```
+
+### Variables de entorno
+
+Configurar:
+
+```txt
+DATABASE_PATH=/var/data/nerinparts.sqlite
+DATA_DIR=/var/data
+```
+
+`DATABASE_PATH` es la fuente de verdad para SQLite. Si no existe, la app usa un fallback local solo para desarrollo; en producción no conviene depender de ese fallback porque puede quedar en disco efímero. `DATA_DIR=/var/data` mantiene JSON operativos, uploads, manifiestos, overrides y caches en el Persistent Disk.
+
+## Health checks recomendados
+
+- Health liviano para Render:
+
+```txt
+/healthz
+```
+
+- Readiness real del catálogo:
+
+```txt
+/readyz
+```
+
+`/healthz` no fuerza lecturas pesadas de catálogo. `/readyz` puede devolver `503` mientras SQLite inicializa o reconstruye.
+
+## Backups
+
+### Crear backup manual
+
+En Render Shell o como Job manual:
+
+```bash
+cd /opt/render/project/src/nerin_final_updated
+DATABASE_PATH=/var/data/nerinparts.sqlite npm run backup:sqlite
+```
+
+Por defecto guarda en:
+
+```txt
+/var/data/backups
+```
+
+El backup no corre automáticamente en `npm start`; se ejecuta solo manualmente o como Job programado externo. Conserva 7 manifiestos/backups por defecto. Se puede cambiar con:
+
+```txt
+SQLITE_BACKUP_KEEP=14
+SQLITE_BACKUP_DIR=/var/data/backups
+```
+
+### Restaurar backup
+
+1. Detener temporalmente el servicio web en Render o evitar tráfico mientras se restaura.
+2. Identificar el backup deseado en `/var/data/backups`, por ejemplo:
+
+```txt
+nerinparts-2026-05-31T12-00-00-000Z.sqlite
+```
+
+3. Copiar el backup al path principal:
+
+```bash
+cp /var/data/backups/nerinparts-YYYY-MM-DDTHH-MM-SS-000Z.sqlite /var/data/nerinparts.sqlite
+```
+
+4. Reiniciar el servicio.
+5. Verificar:
+
+```bash
+curl https://TU-DOMINIO/readyz
+curl https://TU-DOMINIO/api/products?page=1&pageSize=24
+```
+
+## Feed y sitemap
+
+- `sitemap.xml` sigue funcionando como sitemap index.
+- Productos se dividen en `sitemap-products-N.xml`.
+- `sitemap-stock.xml` mantiene cache de stock real.
+- Las respuestas XML se cachean en disco bajo el directorio persistente de datos para evitar recomputar en caliente después de reinicios. Si `DATA_DIR` no apunta a un Persistent Disk, este cache es regenerable y no debe considerarse dato crítico.
+- Merchant feed mantiene campos críticos de Google Merchant Center: `availability`, `availability_date`, `preorder`, landing page y datos derivados usados por JSON-LD.
+- Merchant feed ahora tiene cache en memoria y disco; la cache en disco sobrevive reinicios si `DATA_DIR=/var/data`.
+
+## Riesgos de SQLite en producción
+
+SQLite en Render con Persistent Disk es válido para una tienda chica/mediana con un solo proceso web, pero tiene límites:
+
+- Una sola escritura fuerte a la vez. WAL mejora lectura concurrente, pero no convierte SQLite en un motor multi-writer.
+- No conviene ejecutar múltiples instancias web escribiendo el mismo archivo SQLite.
+- Rebuilds grandes de catálogo pueden consumir CPU/IO; deben hacerse con cuidado y fuera de picos de tráfico.
+- El Persistent Disk debe estar correctamente montado; sin eso, datos críticos pueden perderse en deploys/restarts.
+- Backups son obligatorios. No depender únicamente del archivo principal.
+- No habilitar `CATALOG_AUTO_REBUILD=true` en producción salvo una operación controlada; un rebuild grande puede consumir CPU/IO.
+
+## Cuándo convendría pasar a PostgreSQL en el futuro
+
+Considerar Postgres cuando ocurra una o más de estas condiciones:
+
+- Necesidad de múltiples instancias web escribiendo en paralelo.
+- Volumen alto de pedidos, cambios de stock o administración concurrente.
+- Catálogo muy grande con búsquedas/filtros que ya no respondan bien con SQLite/FTS5.
+- Necesidad de transacciones complejas, auditoría avanzada, roles o replicación.
+- Backups/restores y observabilidad requieren herramientas administradas.
+
+Hasta entonces, SQLite + Persistent Disk + WAL + backups rotativos permite mantener Render sin pagar PostgreSQL.

--- a/nerin_final_updated/package.json
+++ b/nerin_final_updated/package.json
@@ -20,7 +20,8 @@
     "test:admin-bulk-selection-stale": "node scripts/test-admin-bulk-selection-stale.js",
     "audit:screens-final": "node scripts/audit-screens-and-adhesives-final.js",
     "check:production-hardening": "node scripts/check-production-hardening.js",
-    "check:no-products-full-parse": "node scripts/check-no-products-full-parse.js"
+    "check:no-products-full-parse": "node scripts/check-no-products-full-parse.js",
+    "backup:sqlite": "node scripts/backup-sqlite.js"
   },
   "dependencies": {
     "@react-email/components": "^0.5.4",

--- a/nerin_final_updated/scripts/backup-sqlite.js
+++ b/nerin_final_updated/scripts/backup-sqlite.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const fsp = fs.promises;
+const path = require('path');
+const sqlite3 = require('sqlite3');
+const productsRepo = require('../backend/data/productsSqliteRepo');
+
+const DATABASE_PATH = productsRepo.SQLITE_PATH;
+const BACKUP_DIR = process.env.SQLITE_BACKUP_DIR || path.join(path.dirname(DATABASE_PATH), 'backups');
+const KEEP = Math.max(1, Number(process.env.SQLITE_BACKUP_KEEP || 7) || 7);
+
+function openDb(dbPath) {
+  return new Promise((resolve, reject) => {
+    const db = new sqlite3.Database(dbPath, sqlite3.OPEN_READONLY, (error) => (error ? reject(error) : resolve(db)));
+  });
+}
+
+function run(db, sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.run(sql, params, (error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function close(db) {
+  return new Promise((resolve, reject) => db.close((error) => (error ? reject(error) : resolve())));
+}
+
+function backupOnline(db, targetPath) {
+  return new Promise((resolve, reject) => {
+    const backup = db.backup(targetPath, (error) => {
+      backup.finish((finishError) => {
+        if (error || finishError) reject(error || finishError);
+        else resolve();
+      });
+    });
+  });
+}
+
+async function rotateBackups() {
+  const entries = await fsp.readdir(BACKUP_DIR, { withFileTypes: true }).catch(() => []);
+  const manifests = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.manifest.json')) continue;
+    const filePath = path.join(BACKUP_DIR, entry.name);
+    const stat = await fsp.stat(filePath).catch(() => null);
+    if (stat) manifests.push({ filePath, name: entry.name, mtimeMs: stat.mtimeMs });
+  }
+  manifests.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  for (const old of manifests.slice(KEEP)) {
+    const prefix = old.name.replace(/\.manifest\.json$/, '');
+    for (const suffix of ['.sqlite', '.manifest.json']) {
+      await fsp.unlink(path.join(BACKUP_DIR, `${prefix}${suffix}`)).catch(() => {});
+    }
+  }
+}
+
+async function main() {
+  if (!fs.existsSync(DATABASE_PATH)) {
+    throw new Error(`SQLite database not found: ${DATABASE_PATH}`);
+  }
+  await fsp.mkdir(BACKUP_DIR, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const prefix = `nerinparts-${stamp}`;
+  const backupPath = path.join(BACKUP_DIR, `${prefix}.sqlite`);
+  const db = await openDb(DATABASE_PATH);
+  try {
+    await run(db, 'PRAGMA busy_timeout = 5000');
+    await backupOnline(db, backupPath);
+  } finally {
+    await close(db);
+  }
+
+  const manifest = {
+    createdAt: new Date().toISOString(),
+    databasePath: DATABASE_PATH,
+    backupDir: BACKUP_DIR,
+    method: 'sqlite_online_backup_api',
+    files: [path.basename(backupPath)],
+    restore: 'Stop the Render service, copy the .sqlite file back to DATABASE_PATH, then restart.',
+  };
+  await fsp.writeFile(path.join(BACKUP_DIR, `${prefix}.manifest.json`), JSON.stringify(manifest, null, 2), 'utf8');
+  await rotateBackups();
+  console.log(JSON.stringify({ ok: true, ...manifest }, null, 2));
+}
+
+main().catch((error) => {
+  console.error('[backup-sqlite] failed:', error?.message || error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
### Motivation

- Ensure SQLite uses a configurable, persistent path via `DATABASE_PATH` to avoid ephemeral storage on hosts like Render and improve stability.  
- Reduce runtime surprises by disabling automatic heavy rebuilds in production and adding safer startup and background bootstrap behavior.  
- Improve catalog/search performance and survivability by adding `availability` to the schema, extra indexes, disk caches for sitemap/merchant feed and a backup/rotation workflow.  

### Description

- Use a resolved `DATABASE_PATH` (fallback to `data/products.sqlite`) via `resolveSqlitePath()` and expose `SQLITE_PATH` from `productsSqliteRepo.js`.  
- Add `availability` column to `products` schema and related indexes and propagate the field through `mapProductRow`, `createSchema`, inserts/updates, batch import and schema integrity checks; bump `PRODUCTS_SQLITE_SCHEMA_VERSION` to `7`.  
- Add runtime controls for automatic rebuilds: `IS_PRODUCTION_RUNTIME`, `CATALOG_AUTO_REBUILD`, `shouldAllowAutomaticRebuild()` and thread `allowRebuild` into `ensureProductsDbOnce`, `ensureProductsDbInBackground` and startup behavior.  
- Improve DB handling: call `db.serialize()` on open, set pragmas, serialize read-only helper connection with `busy_timeout`, add graceful close on `SIGINT`/`SIGTERM`, and guard reindexing after stock adjustments.  
- Limit page size caps to 100 in query handlers and repository APIs to avoid large requests.  
- Add disk cache helpers `readDiskCacheEntry`/`writeDiskCacheEntry` and use them for sitemap and merchant feed (persisted under `data/cache` or configured `DATA_DIR`).  
- Add offline backup script `scripts/backup-sqlite.js` using SQLite Online Backup API with rotation controlled by `SQLITE_BACKUP_KEEP`/`SQLITE_BACKUP_DIR` and expose `npm run backup:sqlite` in `package.json`.  
- Add operational docs `docs/RENDER_SQLITE_OPTIMIZATION.md` describing Render configuration, persistent disk usage, backup/restore, risks and recommendations.  

### Testing

- Ran the repository automated test suite with `npm test` (Jest) and completion smoke via `npm run test:render-startup` locally, with no failing tests.  
- Executed `npm run backup:sqlite` against a local copy to validate the online backup and rotation logic succeeded.  
- Exercised sitemap and merchant feed code paths to validate disk cache read/write via the new `readDiskCacheEntry`/`writeDiskCacheEntry` helpers in automated startup scripts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ba909aef88331bdda83e8a6a08f3d)