### PR TITLE
Fix catalog rebuild timeout and add streaming fallback

### DIFF
--- a/nerin_final_updated/backend/data/productsSqliteRepo.js
+++ b/nerin_final_updated/backend/data/productsSqliteRepo.js
@@ -42,6 +42,11 @@ const TEST_REBUILD_DELAY_MS =
   process.env.NODE_ENV === "test"
     ? Math.max(0, Number(process.env.CATALOG_REBUILD_TEST_DELAY_MS || 0) || 0)
     : 0;
+const DEFAULT_REBUILD_TIMEOUT_MS = IS_PRODUCTION_RUNTIME ? 8 * 60 * 1000 : 2 * 60 * 1000;
+const CATALOG_REBUILD_TIMEOUT_MS = Math.max(
+  1000,
+  Number(process.env.CATALOG_REBUILD_TIMEOUT_MS || DEFAULT_REBUILD_TIMEOUT_MS) || DEFAULT_REBUILD_TIMEOUT_MS,
+);
 const SEARCH_INDEX_INSERT_SQL = `INSERT INTO product_search_index (
   product_id, product_rowid, public_slug, title, normalized_title, sku, mpn, part_number, brand,
   device_brand, compatible_brand, official_brand, is_compatible_for_brand, part_type,
@@ -83,6 +88,7 @@ const catalogState = {
   total: 0,
   processed: 0,
   corruptDetected: false,
+  failed: false,
   lastError: null,
   lastErrorAt: null,
   lastReadyAt: null,
@@ -100,7 +106,7 @@ function shouldAllowAutomaticRebuild() {
 }
 
 function catalogStateSnapshot() {
-  return { ...catalogState, automaticRebuildEnabled: shouldAllowAutomaticRebuild() };
+  return { ...catalogState, automaticRebuildEnabled: shouldAllowAutomaticRebuild(), rebuildTimeoutMs: CATALOG_REBUILD_TIMEOUT_MS };
 }
 
 function updateCatalogProgress(processed, total = catalogState.total) {
@@ -159,13 +165,15 @@ function setCatalogError(error, context = {}) {
     stack: error?.stack || null,
   };
   catalogState.lastErrorAt = new Date().toISOString();
-  catalogState.ready = false;
+  catalogState.ready = Boolean(dbReady);
+  catalogState.failed = true;
   catalogState.corruptDetected = Boolean(isCorrupt);
 }
 
 function clearCatalogError() {
   catalogState.lastError = null;
   catalogState.lastErrorAt = null;
+  catalogState.failed = false;
   catalogState.corruptDetected = false;
 }
 
@@ -2578,6 +2586,55 @@ function createCatalogFailedError(reason = "sqlite_failed", originalError = null
   return error;
 }
 
+
+function createRebuildTimeoutError(reason = "rebuild_timeout") {
+  const error = new Error(`Catalog SQLite rebuild timed out after ${CATALOG_REBUILD_TIMEOUT_MS}ms`);
+  error.code = "CATALOG_REBUILD_TIMEOUT";
+  error.reason = reason;
+  error.catalogState = catalogStateSnapshot();
+  return error;
+}
+
+function markExistingSqliteReady(context = {}) {
+  dbReady = true;
+  catalogState.ready = true;
+  catalogState.initializing = false;
+  catalogState.lastReadyAt = catalogState.lastReadyAt || new Date().toISOString();
+  if (context.reason) catalogState.freshnessReason = context.reason;
+  console.warn("[products-db] using existing sqlite while rebuild is pending/failed", {
+    reason: context.reason || null,
+    productCount: context.productCount || null,
+    publicProductCount: context.publicProductCount || null,
+    dbPath: SQLITE_PATH,
+  });
+}
+
+async function inspectUsableSqlite() {
+  if (!fs.existsSync(SQLITE_PATH)) return { ok: false, reason: "sqlite_missing", productCount: 0, publicProductCount: 0 };
+  try {
+    const integrity = await inspectSqliteSchemaIntegrity();
+    if (!integrity.ok) return { ok: false, reason: integrity.reason, productCount: 0, publicProductCount: 0 };
+    const db = await openDb();
+    await runIntegrityCheck(db);
+    const productRow = await get(db, "SELECT COUNT(*) AS total FROM products");
+    const publicRow = await get(db, "SELECT COUNT(*) AS total FROM products WHERE is_public = 1");
+    const productCount = Number(productRow?.total || 0);
+    const publicProductCount = Number(publicRow?.total || 0);
+    return {
+      ok: productCount > 0,
+      reason: productCount > 0 ? "usable" : "sqlite_empty",
+      productCount,
+      publicProductCount,
+    };
+  } catch (error) {
+    if (isSqliteCorruptionError(error)) {
+      markSqliteCorruption(error, { phase: "inspect_usable_sqlite", reason: "sqlite_corrupt" });
+      return { ok: false, reason: "sqlite_corrupt", productCount: 0, publicProductCount: 0, error };
+    }
+    return { ok: false, reason: "sqlite_unusable", productCount: 0, publicProductCount: 0, error };
+  }
+}
+
 async function rebuildProductsDbFromJson({ force = true, reason = "manual" } = {}) {
   if (rebuildPromise) {
     console.log("[products-db] rebuild already in progress; waiting");
@@ -2587,11 +2644,32 @@ async function rebuildProductsDbFromJson({ force = true, reason = "manual" } = {
     const startedAt = Date.now();
     const activeReason = reason || (force ? "forced" : "unknown");
     catalogState.rebuilding = true;
-    catalogState.initializing = true;
-    catalogState.ready = false;
+    catalogState.initializing = !dbReady;
+    catalogState.ready = Boolean(dbReady);
+    catalogState.failed = false;
     catalogState.startedAt = new Date(startedAt).toISOString();
     catalogState.finishedAt = null;
     catalogState.lastRebuildStartedAt = new Date(startedAt).toISOString();
+    let rebuildTimedOut = false;
+    const timeout = setTimeout(() => {
+      rebuildTimedOut = true;
+      const timeoutError = createRebuildTimeoutError(activeReason);
+      console.error("[products-db] rebuild timeout", {
+        reason: activeReason,
+        timeoutMs: CATALOG_REBUILD_TIMEOUT_MS,
+        dbPath: SQLITE_PATH,
+        dataDir: path.dirname(SQLITE_PATH),
+      });
+      setCatalogError(timeoutError, { phase: "rebuild", reason: activeReason, code: timeoutError.code });
+      catalogState.rebuilding = false;
+      catalogState.initializing = false;
+      catalogState.lastRebuildFinishedAt = new Date().toISOString();
+      catalogState.lastRebuildDurationMs = Date.now() - startedAt;
+      catalogState.finishedAt = catalogState.lastRebuildFinishedAt;
+    }, CATALOG_REBUILD_TIMEOUT_MS);
+    const throwIfTimedOut = () => {
+      if (rebuildTimedOut) throw createRebuildTimeoutError(activeReason);
+    };
     const productsStats = await fsp.stat(PRODUCTS_JSON_PATH);
     const previousManifest = await readManifest();
     updateCatalogProgress(0, Number(previousManifest?.productCount || 0));
@@ -2675,6 +2753,7 @@ async function rebuildProductsDbFromJson({ force = true, reason = "manual" } = {
       await productsStreamRepo.streamProducts({
         filePath: PRODUCTS_JSON_PATH,
         onProduct: async (product) => {
+          throwIfTimedOut();
           const identifier = String(product?.id || product?.sku || product?.code || "").trim();
           const override = identifier ? overrides[identifier] : null;
           const mergedProduct = override ? { ...product, ...override } : product;
@@ -2698,7 +2777,9 @@ async function rebuildProductsDbFromJson({ force = true, reason = "manual" } = {
         },
       });
 
+      throwIfTimedOut();
       await flush();
+      throwIfTimedOut();
 
       if (ftsEnabled) {
         await run(tmpDb, "DELETE FROM products_fts");
@@ -2709,6 +2790,7 @@ async function rebuildProductsDbFromJson({ force = true, reason = "manual" } = {
         );
       }
       const searchIndexCount = await rebuildProductSearchIndex(tmpDb);
+      throwIfTimedOut();
 
       await new Promise((resolve, reject) => {
         tmpDb.close((error) => {
@@ -2762,9 +2844,11 @@ async function rebuildProductsDbFromJson({ force = true, reason = "manual" } = {
       catalogState.lastRebuildDurationMs = durationMs;
       catalogState.finishedAt = catalogState.lastRebuildFinishedAt;
       updateCatalogProgress(count, count);
+      clearTimeout(timeout);
       clearCatalogError();
       return manifest;
     } catch (error) {
+      clearTimeout(timeout);
       console.error(`[products-db] rebuild failed reason=${activeReason}`, error);
       if (isSqliteCorruptionError(error)) {
         markSqliteCorruption(error, { phase: "rebuild", reason: activeReason });
@@ -2919,7 +3003,23 @@ async function ensureProductsDb({ allowRebuild = true } = {}) {
 
   if (reason) {
     console.log(`[products-db] rebuild required reason=${reason}`);
-    if (!allowRebuild) throw createInitializingError(reason);
+    const usableExisting = reason === "sqlite_corrupt" ? { ok: false } : await inspectUsableSqlite();
+    if (usableExisting.ok) {
+      markExistingSqliteReady({ ...usableExisting, reason });
+    }
+    if (!allowRebuild) {
+      if (usableExisting.ok) {
+        return {
+          dbPath: SQLITE_PATH,
+          manifest: await getManifestFromDb(),
+          ftsEnabled,
+          source: "sqlite_stale_usable",
+          ready: true,
+          freshnessReason: reason,
+        };
+      }
+      throw createInitializingError(reason);
+    }
     if (reason === "sqlite_corrupt") {
       await repairCorruptSqlite({ reason });
     } else {
@@ -3160,6 +3260,106 @@ function buildProductSummary(row = {}) {
   };
 }
 
+
+
+function shouldUseStreamingFallback(error) {
+  const code = String(error?.code || "");
+  return code === "CATALOG_INITIALIZING" || code === "CATALOG_SQLITE_FAILED" || code === "CATALOG_REBUILD_TIMEOUT";
+}
+
+function productMatchesFallbackFilters(product = {}, params = {}, { publicOnly = true } = {}) {
+  if (publicOnly && !computePublicationState(product).is_public) return false;
+  const normalizedSearch = normalizeQueryText(params.search || params.q || "");
+  if (normalizedSearch) {
+    const haystack = normalizeQueryText([
+      product.id,
+      product.sku,
+      product.code,
+      product.name,
+      product.title,
+      product.brand,
+      product.model,
+      product.category,
+      product.part_number,
+      product.mpn,
+      product.description,
+    ].filter(Boolean).join(" "));
+    if (!haystack.includes(normalizedSearch)) return false;
+  }
+  const exactFilters = ["category", "brand", "model", "visibility", "status"];
+  for (const key of exactFilters) {
+    const expected = normalizeQueryText(params[key] || "");
+    if (!expected) continue;
+    if (normalizeQueryText(product[key] || "") !== expected) return false;
+  }
+  const stock = normalizeQueryText(params.stock || params.stockStatus || "");
+  const stockValue = toNumber(product.stock ?? product.quantity ?? product.availableStock, 0);
+  if ((stock === "in-stock" || stock === "in") && stockValue <= 0) return false;
+  if ((stock === "out" || stock === "out-of-stock") && stockValue > 0) return false;
+  if (params.priceMax !== null && params.priceMax !== undefined && params.priceMax !== "") {
+    const price = toFiniteNumberOrNull(product.price_minorista ?? product.price ?? product.precio_minorista ?? product.precio_final);
+    if (price !== null && Number.isFinite(Number(params.priceMax)) && price > Number(params.priceMax)) return false;
+  }
+  return true;
+}
+
+async function queryProductsStreamingFallback(params = {}, { adminMode = false } = {}) {
+  const safePage = Math.max(1, Number(params.page) || 1);
+  const safePageSize = Math.max(1, Math.min(100, Number(params.pageSize) || 24));
+  const slugCounts = new Map();
+  let fallbackRow = 0;
+  const result = await productsStreamRepo.getProductsEmergencyPage({
+    page: safePage,
+    pageSize: safePageSize,
+    filePath: PRODUCTS_JSON_PATH,
+    matchItem: (product) => productMatchesFallbackFilters(product, params, { publicOnly: !adminMode }),
+    mapItem: (product) => {
+      fallbackRow += 1;
+      const mapped = mapProductRow(product, { rowNumber: fallbackRow, slugCounts });
+      return buildProductSummary({
+        ...mapped,
+        rowid: fallbackRow,
+        part_type: "",
+        device_brand: mapped.brand || "",
+        compatible_brand: "",
+        official_brand: mapped.brand || "",
+        is_compatible_for_brand: 0,
+        model_family: "",
+        model_base: mapped.model || "",
+        model_variant: "",
+        network_variant: "",
+        quality_tier: "",
+        has_frame: null,
+        color: "",
+        stock_status: Number(mapped.stock || 0) > 0 ? "in_stock" : "out_of_stock",
+        is_stock_real: 0,
+        classification_confidence: null,
+        filters_blob: "{}",
+      });
+    },
+  });
+  const totalItems = Number(result.matchedCount || result.items.length || 0);
+  return {
+    rows: [],
+    items: result.items,
+    page: result.page,
+    pageSize: result.pageSize,
+    totalItems,
+    totalPages: result.hasNextPage ? result.page + 1 : Math.max(1, Math.ceil(totalItems / result.pageSize)),
+    hasNextPage: Boolean(result.hasNextPage),
+    hasPrevPage: Boolean(result.hasPrevPage),
+    source: adminMode ? "streaming_fallback_admin" : "streaming_fallback",
+    search: params.search || undefined,
+    facets: {},
+    searchDebug: undefined,
+    countMs: 0,
+    selectMs: 0,
+    parseItemsMs: 0,
+    totalDurationMs: 0,
+    fallback: true,
+    catalogState: catalogStateSnapshot(),
+  };
+}
 function normalizeFacetValue(value = "") {
   return normalizeCatalogText(value);
 }
@@ -3690,6 +3890,13 @@ async function queryProducts(params = {}) {
       markSqliteCorruption(error, { phase: "query_products", reason: "sqlite_corrupt" });
       await repairCorruptSqlite({ reason: "query_products_corrupt" });
       result = await querySearchIndex({ ...params, isPublicOnly: true });
+    } else if (shouldUseStreamingFallback(error)) {
+      console.warn("[products-sqlite:fallback] public catalog using streaming fallback", {
+        code: error?.code || null,
+        reason: error?.reason || null,
+        message: error?.message || String(error),
+      });
+      result = await queryProductsStreamingFallback(params, { adminMode: false });
     } else {
       throw error;
     }
@@ -3791,6 +3998,13 @@ async function queryAdminProducts(params = {}) {
       markSqliteCorruption(error, { phase: "query_admin_products", reason: "sqlite_corrupt" });
       await repairCorruptSqlite({ reason: "query_admin_products_corrupt" });
       result = await querySearchIndex({ ...params, isPublicOnly: false, adminMode: true });
+    } else if (shouldUseStreamingFallback(error)) {
+      console.warn("[products-sqlite:fallback] admin catalog using streaming fallback", {
+        code: error?.code || null,
+        reason: error?.reason || null,
+        message: error?.message || String(error),
+      });
+      result = await queryProductsStreamingFallback(params, { adminMode: true });
     } else {
       throw error;
     }
@@ -4145,9 +4359,10 @@ async function getCatalogHealth() {
   return {
     source: "sqlite",
     ...paths,
-    ready: Boolean(dbReady && sqliteExists && !catalogState.lastError),
+    ready: Boolean((dbReady || productCount > 0) && sqliteExists),
     initializing: Boolean(catalogState.initializing),
     rebuilding: Boolean(catalogState.rebuilding),
+    failed: Boolean(catalogState.failed || catalogState.lastError),
     progress: Number(catalogState.progress || 0),
     total: Number(catalogState.total || manifest?.productCount || 0),
     processed: Number(catalogState.processed || 0),

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -7830,6 +7830,7 @@ async function requestHandler(req, res) {
         ready: Boolean(health.ready),
         initializing: Boolean(health.initializing),
         rebuilding: Boolean(health.rebuilding),
+        failed: Boolean(health.failed || health.lastError),
         progress: Number(health.progress || 0),
         processed: Number(health.processed || 0),
         total: Number(health.total || health.productCount || 0),
@@ -7839,7 +7840,10 @@ async function requestHandler(req, res) {
         mappingVersion: Number(health.mappingVersion || health.catalogMappingVersion || 0),
         schemaVersion: Number(health.schemaVersion || health.sqliteSchemaVersion || 0),
         productCount: Number(health.productCount || 0),
+        productsCount: Number(health.productCount || 0),
         publicCount: Number(health.publicProductCount || 0),
+        dbPath: health.dbPath || health.sqlitePath || null,
+        dataDir: health.DATA_DIR || null,
         freshnessReason: health.freshnessReason || null,
       }, { "Cache-Control": "no-store" });
     } catch (error) {
@@ -8569,7 +8573,7 @@ async function requestHandler(req, res) {
         ...sqliteData,
         rows: undefined,
         items,
-        source: "sqlite",
+        source: sqliteData.source || "sqlite",
       };
       const durationMs = Date.now() - startedAt;
       console.info("[public-products:respond]", {

--- a/nerin_final_updated/package.json
+++ b/nerin_final_updated/package.json
@@ -21,7 +21,8 @@
     "audit:screens-final": "node scripts/audit-screens-and-adhesives-final.js",
     "check:production-hardening": "node scripts/check-production-hardening.js",
     "check:no-products-full-parse": "node scripts/check-no-products-full-parse.js",
-    "backup:sqlite": "node scripts/backup-sqlite.js"
+    "backup:sqlite": "node scripts/backup-sqlite.js",
+    "test:catalog-rebuild-timeout": "node scripts/test-products-rebuild-timeout-fallback.js"
   },
   "dependencies": {
     "@react-email/components": "^0.5.4",

--- a/nerin_final_updated/scripts/test-products-rebuild-timeout-fallback.js
+++ b/nerin_final_updated/scripts/test-products-rebuild-timeout-fallback.js
@@ -1,0 +1,138 @@
+const fsp = require("fs").promises;
+const http = require("http");
+const os = require("os");
+const path = require("path");
+const { fork } = require("child_process");
+
+const root = path.resolve(__dirname, "..");
+
+function requestJson(port, pathname, timeoutMs = 1500) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { hostname: "127.0.0.1", port, path: pathname, method: "GET", timeout: timeoutMs },
+      (res) => {
+        let body = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => { body += chunk; });
+        res.on("end", () => {
+          let json = null;
+          try { json = body ? JSON.parse(body) : null; } catch {}
+          resolve({ statusCode: res.statusCode, body, json });
+        });
+      },
+    );
+    req.on("timeout", () => req.destroy(new Error(`timeout ${pathname}`)));
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+async function waitFor(port, predicate, deadlineMs = 7000) {
+  const startedAt = Date.now();
+  let last = null;
+  while (Date.now() - startedAt < deadlineMs) {
+    try {
+      last = await requestJson(port, "/api/catalog/status", 1000);
+      if (predicate(last)) return last;
+    } catch (error) {
+      last = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`condition not reached; last=${last?.body || last?.message || JSON.stringify(last)}`);
+}
+
+async function main() {
+  const dataDir = await fsp.mkdtemp(path.join(os.tmpdir(), "nerin-rebuild-timeout-"));
+  const products = Array.from({ length: 40 }, (_, index) => ({
+    id: `timeout-${index + 1}`,
+    sku: `TIMEOUT-${index + 1}`,
+    name: `Producto timeout ${index + 1}`,
+    title: `Producto timeout ${index + 1}`,
+    brand: "Test",
+    category: "pantallas",
+    visibility: "public",
+    status: "active",
+    stock: 3,
+    price: 1000 + index,
+    image: "/assets/test.png",
+  }));
+  await fsp.writeFile(path.join(dataDir, "products.json"), JSON.stringify({ products }, null, 2), "utf8");
+
+  const port = 39000 + Math.floor(Math.random() * 1000);
+  const child = fork(path.join(root, "backend/server.js"), {
+    cwd: root,
+    stdio: ["ignore", "pipe", "pipe", "ipc"],
+    env: {
+      ...process.env,
+      NODE_ENV: "test",
+      DATA_DIR: dataDir,
+      PORT: String(port),
+      CATALOG_REBUILD_TEST_DELAY_MS: "250",
+      CATALOG_REBUILD_TIMEOUT_MS: "1000",
+    },
+  });
+
+  let logs = "";
+  child.stdout.on("data", (chunk) => { logs += chunk.toString(); });
+  child.stderr.on("data", (chunk) => { logs += chunk.toString(); });
+
+  try {
+    await waitFor(port, (res) => res.statusCode === 200, 4000);
+    const failedStatus = await waitFor(
+      port,
+      (res) => res.statusCode === 200 && res.json?.failed && !res.json?.initializing && !res.json?.rebuilding,
+      8000,
+    );
+
+    if (failedStatus.json?.ready) {
+      throw new Error(`expected no sqlite-ready catalog after timed-out rebuild: ${failedStatus.body}`);
+    }
+    if (failedStatus.json?.lastError?.code !== "CATALOG_REBUILD_TIMEOUT") {
+      throw new Error(`expected timeout error state: ${failedStatus.body}`);
+    }
+
+    const productsResponse = await requestJson(port, "/api/products?page=1&pageSize=5", 2500);
+    if (productsResponse.statusCode !== 200) {
+      throw new Error(`/api/products must use fallback, got ${productsResponse.statusCode}: ${productsResponse.body}`);
+    }
+    if (productsResponse.json?.source !== "streaming_fallback") {
+      throw new Error(`expected streaming_fallback source: ${productsResponse.body}`);
+    }
+    if (!Array.isArray(productsResponse.json?.items) || productsResponse.json.items.length === 0) {
+      throw new Error(`expected fallback items: ${productsResponse.body}`);
+    }
+    if (/CATALOG_INITIALIZING/.test(productsResponse.body)) {
+      throw new Error(`public catalog leaked CATALOG_INITIALIZING: ${productsResponse.body}`);
+    }
+    if (!logs.includes("[products-db] rebuild timeout")) {
+      throw new Error("timeout log not found");
+    }
+
+    console.log(JSON.stringify({
+      ok: true,
+      status: {
+        ready: Boolean(failedStatus.json.ready),
+        initializing: Boolean(failedStatus.json.initializing),
+        rebuilding: Boolean(failedStatus.json.rebuilding),
+        failed: Boolean(failedStatus.json.failed),
+        code: failedStatus.json.lastError?.code,
+      },
+      products: {
+        source: productsResponse.json.source,
+        items: productsResponse.json.items.length,
+      },
+    }, null, 2));
+  } finally {
+    if (!child.killed) {
+      child.kill();
+      await new Promise((resolve) => child.once("exit", resolve));
+    }
+    await fsp.rm(dataDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error?.stack || error?.message || error);
+  process.exit(1);
+});

--- a/nerin_final_updated/scripts/test-products-sqlite-corruption-repair.js
+++ b/nerin_final_updated/scripts/test-products-sqlite-corruption-repair.js
@@ -35,7 +35,7 @@ function runNodeEval(code) {
   }
 
   const page = await repo.queryProducts({ page: 1, pageSize: 5 });
-  if (!page || page.source !== 'sqlite' || !Array.isArray(page.items)) {
+  if (!page || !String(page.source || '').startsWith('sqlite') || !Array.isArray(page.items)) {
     throw new Error('[test-corrupt] expected sqlite query response');
   }
 


### PR DESCRIPTION
### Motivation
- Prevent production from getting stuck indefinitely in a SQLite rebuild/initialization state and ensure the public site and admin remain usable during long or failed rebuilds.
- Provide a clear failed state and error code when a rebuild times out or fails, and prefer an existing usable SQLite DB on disk instead of blocking traffic.
- Offer a safe streaming/JSON fallback from `products.json` so product queries still return data when SQLite is unavailable.

### Description
- Add a configurable rebuild timeout (`CATALOG_REBUILD_TIMEOUT_MS`) and create a `CATALOG_REBUILD_TIMEOUT` error, track `catalogState.failed`, and expose `rebuildTimeoutMs` in `catalogStateSnapshot` (changes in `backend/data/productsSqliteRepo.js`).
- Wire a timeout into `rebuildProductsDbFromJson` with periodic `throwIfTimedOut()` checks, clear the timeout on success/failure, and mark errors via `setCatalogError` so `initializing`/`rebuilding` cannot remain true forever.
- Implement `inspectUsableSqlite` and `markExistingSqliteReady` to detect and keep an existing valid SQLite DB marked `ready:true` while a rebuild is pending or failed, and return a usable stale result when rebuild is disallowed.
- Add streaming fallback logic (`shouldUseStreamingFallback`, `queryProductsStreamingFallback`, and product-matching/filtering) and use it in `queryProducts` and `queryAdminProducts` so public/admin requests return `streaming_fallback` results when SQLite is initializing/failed/timed-out.
- Extend catalog health/status to include `failed`, `productsCount`, `dbPath`, and `dataDir`, and ensure `/api/products` preserves `sqliteData.source` or reports `streaming_fallback` when applicable (changes in `backend/server.js`).
- Add a regression script `scripts/test-products-rebuild-timeout-fallback.js` and `package.json` entry `test:catalog-rebuild-timeout` to emulate a stuck rebuild and verify fallback behavior, and adjust the corruption-repair test to accept current sqlite-derived sources.

### Testing
- Performed static checks with `node --check` on modified files and they passed successfully.
- Ran `npm run test:catalog-rebuild-timeout` which simulates a timed-out rebuild and confirmed the catalog moves to `failed` and `/api/products` returns `streaming_fallback`, and the test passed.
- Ran `npm run test:render-startup` (startup non-blocking) to verify background ensure/rebuild behavior and it passed.
- Ran `node scripts/test-products-sqlite-corruption-repair.js` to validate corruption repair still yields a usable SQLite-backed response and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c638cbc648331b50ba70b85ef2c2e)