### PR TITLE
Optimizar consultas SQLite de admin/products

### DIFF
--- a/nerin_final_updated/backend/data/productsSqliteRepo.js
+++ b/nerin_final_updated/backend/data/productsSqliteRepo.js
@@ -33,6 +33,8 @@ const PRODUCTS_SQLITE_SCHEMA_VERSION = 7;
 const CATALOG_MAPPING_VERSION = 5;
 const BULK_PUBLISH_CHUNK_SIZE = 1000;
 const SEARCH_RANK_CANDIDATE_LIMIT = 1200;
+const ENABLE_SQLITE_QUERY_PLAN =
+  String(process.env.CATALOG_SQLITE_EXPLAIN || "").trim().toLowerCase() === "true";
 const DEBUG_PRICE_MAPPING =
   String(process.env.DEBUG_PRICE_MAPPING || "").trim().toLowerCase() === "true";
 const IS_PRODUCTION_RUNTIME = process.env.NODE_ENV === "production";
@@ -78,6 +80,8 @@ let ftsEnabled = false;
 let dbReadyPromise = null;
 let dbReady = false;
 let rebuildPromise = null;
+let sqliteOptimizePromise = null;
+let sqliteMaintenancePromise = null;
 const countCache = new Map();
 const SQLITE_CORRUPT_CODE = "CATALOG_SQLITE_CORRUPT";
 const catalogState = {
@@ -188,6 +192,9 @@ function markSqliteCorruption(error, context = {}) {
 }
 
 async function closeDbInstance() {
+  if (sqliteMaintenancePromise) {
+    await sqliteMaintenancePromise.catch(() => {});
+  }
   if (!dbInstance) return;
   await new Promise((resolve) => dbInstance.close(() => resolve()));
   dbInstance = null;
@@ -1045,6 +1052,16 @@ async function detectFtsAvailability(db) {
   }
 }
 
+async function ensureTableColumns(db, tableName, columnDefinitions = {}) {
+  const columns = await all(db, `PRAGMA table_info(${tableName})`);
+  const existing = new Set(columns.map((column) => String(column.name || "").toLowerCase()));
+  for (const [name, definition] of Object.entries(columnDefinitions)) {
+    if (existing.has(String(name).toLowerCase())) continue;
+    await run(db, `ALTER TABLE ${tableName} ADD COLUMN ${name} ${definition}`);
+    existing.add(String(name).toLowerCase());
+  }
+}
+
 async function createSchema(db) {
   await run(
     db,
@@ -1088,6 +1105,45 @@ async function createSchema(db) {
       raw_json TEXT
     )`,
   );
+  await ensureTableColumns(db, "products", {
+    id: "TEXT",
+    sku: "TEXT",
+    code: "TEXT",
+    slug: "TEXT",
+    public_slug: "TEXT",
+    image: "TEXT",
+    name: "TEXT",
+    title: "TEXT",
+    brand: "TEXT",
+    model: "TEXT",
+    category: "TEXT",
+    part_number: "TEXT",
+    mpn: "TEXT",
+    ean: "TEXT",
+    gtin: "TEXT",
+    supplier_code: "TEXT",
+    status: "TEXT",
+    visibility: "TEXT",
+    availability: "TEXT",
+    stock: "INTEGER",
+    price: "REAL",
+    price_minorista: "REAL",
+    price_mayorista: "REAL",
+    precio_minorista: "REAL",
+    precio_mayorista: "REAL",
+    precio_final: "REAL",
+    precio_sin_impuestos: "REAL",
+    cost: "REAL",
+    currency: "TEXT",
+    is_public: "INTEGER",
+    enabled: "INTEGER",
+    deleted: "INTEGER",
+    archived: "INTEGER",
+    vip_only: "INTEGER",
+    wholesale_only: "INTEGER",
+    search_text: "TEXT",
+    raw_json: "TEXT",
+  });
 
   const indexSql = [
     "CREATE INDEX IF NOT EXISTS idx_products_id ON products(id)",
@@ -1104,6 +1160,11 @@ async function createSchema(db) {
     "CREATE INDEX IF NOT EXISTS idx_products_category ON products(category)",
     "CREATE INDEX IF NOT EXISTS idx_products_model ON products(model)",
     "CREATE INDEX IF NOT EXISTS idx_products_availability ON products(availability)",
+    "CREATE INDEX IF NOT EXISTS idx_products_visibility_nocase ON products(visibility COLLATE NOCASE)",
+    "CREATE INDEX IF NOT EXISTS idx_products_status_nocase ON products(status COLLATE NOCASE)",
+    "CREATE INDEX IF NOT EXISTS idx_products_category_nocase ON products(category COLLATE NOCASE)",
+    "CREATE INDEX IF NOT EXISTS idx_products_brand_nocase ON products(brand COLLATE NOCASE)",
+    "CREATE INDEX IF NOT EXISTS idx_products_model_nocase ON products(model COLLATE NOCASE)",
     "CREATE INDEX IF NOT EXISTS idx_products_is_public ON products(is_public)",
     "CREATE INDEX IF NOT EXISTS idx_products_stock ON products(stock)",
     "CREATE INDEX IF NOT EXISTS idx_products_price ON products(price)",
@@ -1153,6 +1214,40 @@ async function createSchema(db) {
       updated_at TEXT
     )`,
   );
+  await ensureTableColumns(db, "product_search_index", {
+    product_id: "TEXT",
+    product_rowid: "INTEGER",
+    public_slug: "TEXT",
+    title: "TEXT",
+    normalized_title: "TEXT",
+    sku: "TEXT",
+    mpn: "TEXT",
+    part_number: "TEXT",
+    brand: "TEXT",
+    device_brand: "TEXT",
+    compatible_brand: "TEXT",
+    official_brand: "TEXT",
+    is_compatible_for_brand: "INTEGER",
+    part_type: "TEXT",
+    model_family: "TEXT",
+    model_base: "TEXT",
+    model_generation: "TEXT",
+    model_variant: "TEXT",
+    network_variant: "TEXT",
+    quality_tier: "TEXT",
+    has_frame: "INTEGER",
+    color: "TEXT",
+    stock: "INTEGER",
+    stock_status: "TEXT",
+    is_stock_real: "INTEGER",
+    price: "REAL",
+    has_image: "INTEGER",
+    is_public: "INTEGER",
+    classification_confidence: "REAL",
+    search_blob: "TEXT",
+    filters_blob: "TEXT",
+    updated_at: "TEXT",
+  });
 
   const searchIndexSql = [
     "CREATE INDEX IF NOT EXISTS idx_search_product_id ON product_search_index(product_id)",
@@ -1172,6 +1267,17 @@ async function createSchema(db) {
     "CREATE INDEX IF NOT EXISTS idx_search_is_stock_real ON product_search_index(is_stock_real)",
     "CREATE INDEX IF NOT EXISTS idx_search_price ON product_search_index(price)",
     "CREATE INDEX IF NOT EXISTS idx_search_is_public ON product_search_index(is_public)",
+    "CREATE INDEX IF NOT EXISTS idx_search_recent ON product_search_index(product_rowid DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_search_public_recent ON product_search_index(is_public, product_rowid DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_search_part_recent ON product_search_index(part_type, product_rowid DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_search_brand_recent ON product_search_index(device_brand, product_rowid DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_search_compatible_brand_recent ON product_search_index(compatible_brand, product_rowid DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_search_model_recent ON product_search_index(model_base, product_rowid DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_search_stock_recent ON product_search_index(stock_status, product_rowid DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_search_stock_real_recent ON product_search_index(is_stock_real, product_rowid DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_search_quality_recent ON product_search_index(quality_tier, product_rowid DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_search_title_nocase ON product_search_index(title COLLATE NOCASE)",
+    "CREATE INDEX IF NOT EXISTS idx_search_normalized_title_nocase ON product_search_index(normalized_title COLLATE NOCASE)",
     "CREATE INDEX IF NOT EXISTS idx_search_public_model_variant ON product_search_index(is_public, model_base, model_variant, network_variant)",
     "CREATE INDEX IF NOT EXISTS idx_search_public_brand_part ON product_search_index(is_public, device_brand, compatible_brand, part_type)",
     "CREATE INDEX IF NOT EXISTS idx_search_public_stock_price ON product_search_index(is_public, stock_status, stock, price)",
@@ -1182,6 +1288,35 @@ async function createSchema(db) {
   }
 
   await detectFtsAvailability(db);
+}
+
+function optimizeSqlitePlannerOnce(db) {
+  if (sqliteOptimizePromise) return sqliteOptimizePromise;
+  sqliteOptimizePromise = (async () => {
+    try {
+      await run(db, "PRAGMA optimize");
+    } catch (error) {
+      console.warn("[products-db] pragma optimize skipped", error?.message || error);
+    }
+  })();
+  return sqliteOptimizePromise;
+}
+
+function ensureSqlitePerformanceMaintenanceInBackground(trigger = "unknown") {
+  if (sqliteMaintenancePromise) return sqliteMaintenancePromise;
+  sqliteMaintenancePromise = (async () => {
+    try {
+      const db = await openDb();
+      await createSchema(db);
+      await optimizeSqlitePlannerOnce(db);
+      console.log(`[products-db] performance maintenance completed trigger=${trigger}`);
+    } catch (error) {
+      console.warn(`[products-db] performance maintenance skipped trigger=${trigger}`, error?.message || error);
+    } finally {
+      sqliteMaintenancePromise = null;
+    }
+  })();
+  return sqliteMaintenancePromise;
 }
 
 function computePublicationState(product = {}) {
@@ -3063,6 +3198,7 @@ async function ensureProductsDb({ allowRebuild = true } = {}) {
     const usableExisting = reason === "sqlite_corrupt" ? { ok: false } : await inspectUsableSqlite();
     if (usableExisting.ok) {
       markExistingSqliteReady({ ...usableExisting, reason });
+      ensureSqlitePerformanceMaintenanceInBackground(`legacy-ready-${reason}`);
       return {
         dbPath: SQLITE_PATH,
         manifest: await getManifestFromDb(),
@@ -3093,6 +3229,7 @@ async function ensureProductsDb({ allowRebuild = true } = {}) {
 
   const db = await openDb();
   await createSchema(db);
+  await optimizeSqlitePlannerOnce(db);
   dbReady = true;
   catalogState.ready = true;
   catalogState.lastReadyAt = new Date().toISOString();
@@ -3322,6 +3459,60 @@ function buildProductSummary(row = {}) {
   };
 }
 
+function buildAdminProductListSummary(row = {}) {
+  const publicSlug = firstText([row.public_slug, row.slug]) || "";
+  const fallbackId = String(row.id || row.sku || row.code || row.product_id || "producto");
+  const price = toFiniteNumberOrNull(row.price_minorista) ?? toFiniteNumberOrNull(row.price);
+  return {
+    id: firstText([row.id, row.product_id]) || "",
+    sku: firstText([row.sku]) || "",
+    code: firstText([row.code]) || "",
+    name: firstText([row.name, row.title]) || "Producto",
+    title: firstText([row.title, row.name]) || "Producto",
+    brand: row.brand || row.device_brand || "",
+    model: row.model || row.model_base || "",
+    category: row.category || "",
+    part_type: row.part_type || "",
+    visibility: row.visibility || (Number(row.is_public || 0) === 1 ? "public" : ""),
+    status: row.status || "",
+    stock: Math.trunc(toNumber(row.stock, 0)),
+    price,
+    price_minorista: toFiniteNumberOrNull(row.price_minorista) ?? price,
+    price_mayorista: toFiniteNumberOrNull(row.price_mayorista),
+    image: row.image || "",
+    thumbnail: row.image || "",
+    publicSlug,
+    public_slug: publicSlug,
+    slug: firstText([row.slug, publicSlug]) || "",
+    url: `/p/${encodeURIComponent(publicSlug || fallbackId)}`,
+    source: "sqlite_admin_projection",
+    device_brand: row.device_brand || "",
+    model_base: row.model_base || row.model || "",
+    quality_tier: row.quality_tier || "",
+    stock_status: row.stock_status || "",
+    is_stock_real: Boolean(row.is_stock_real),
+    is_public: Number(row.is_public || 0) === 1,
+    classification_confidence: toFiniteNumberOrNull(row.classification_confidence),
+    classification_blockers: [],
+    classification_reasons: [],
+    updatedAt: row.updated_at || "",
+    updated_at: row.updated_at || "",
+  };
+}
+
+async function explainQueryPlan(db, sql, params = []) {
+  try {
+    const rows = await all(db, `EXPLAIN QUERY PLAN ${sql}`, params);
+    return rows.map((row) => ({
+      id: row.id,
+      parent: row.parent,
+      detail: row.detail || Object.values(row).join(" "),
+    }));
+  } catch (error) {
+    return [{ error: error?.message || String(error) }];
+  }
+}
+
 
 
 function shouldUseStreamingFallback(error) {
@@ -3439,6 +3630,22 @@ function adminVisibilityBucketSql() {
   END`;
 }
 
+function adminVisibilityBucketWhere(bucket) {
+  const normalized = normalizeFacetValue(bucket || "");
+  if (normalized === "public") return { sql: "si.is_public = 1", params: [] };
+  if (normalized === "not_public") return { sql: "si.is_public != 1", params: [] };
+  const bucketSql = "si.is_public != 1";
+  const pVisibility = "p.visibility COLLATE NOCASE";
+  const pStatus = "p.status COLLATE NOCASE";
+  if (normalized === "private") return { sql: `${bucketSql} AND (${pVisibility} = 'private' OR ${pStatus} = 'private')`, params: [] };
+  if (normalized === "hidden") return { sql: `${bucketSql} AND (${pVisibility} = 'hidden' OR ${pStatus} = 'hidden')`, params: [] };
+  if (normalized === "draft") return { sql: `${bucketSql} AND (${pVisibility} = 'draft' OR ${pStatus} = 'draft')`, params: [] };
+  if (normalized === "archived") return { sql: `${bucketSql} AND (${pVisibility} = 'archived' OR ${pStatus} = 'archived' OR COALESCE(p.archived, 0) = 1)`, params: [] };
+  if (normalized === "deleted") return { sql: `${bucketSql} AND (${pVisibility} = 'deleted' OR ${pStatus} = 'deleted' OR COALESCE(p.deleted, 0) = 1)`, params: [] };
+  if (normalized === "disabled") return { sql: `${bucketSql} AND (${pVisibility} = 'disabled' OR ${pStatus} = 'disabled' OR COALESCE(p.enabled, 1) = 0)`, params: [] };
+  return null;
+}
+
 function buildSearchIndexWhere({
   search = "",
   isPublicOnly = false,
@@ -3469,22 +3676,18 @@ function buildSearchIndexWhere({
   if (isPublicOnly) where.push("si.is_public = 1");
   const requestedVisibility = normalizeFacetValue(visibility || "");
   if (requestedVisibility) {
-    if (requestedVisibility === "public") where.push("si.is_public = 1");
-    else if (requestedVisibility === "private") where.push(`si.is_public != 1 AND (${adminVisibilityBucketSql()}) = 'private'`);
-    else if (requestedVisibility === "hidden") where.push(`si.is_public != 1 AND (${adminVisibilityBucketSql()}) = 'hidden'`);
-    else if (requestedVisibility === "draft") where.push(`si.is_public != 1 AND (${adminVisibilityBucketSql()}) = 'draft'`);
-    else if (requestedVisibility === "disabled") where.push(`si.is_public != 1 AND (${adminVisibilityBucketSql()}) = 'disabled'`);
-    else if (requestedVisibility === "archived") where.push(`si.is_public != 1 AND (${adminVisibilityBucketSql()}) = 'archived'`);
-    else if (requestedVisibility === "deleted") where.push(`si.is_public != 1 AND (${adminVisibilityBucketSql()}) = 'deleted'`);
-    else if (requestedVisibility === "not_public") where.push("si.is_public != 1");
-    else if (requestedVisibility !== "all") {
-      where.push("lower(p.visibility) = lower(?)");
+    const visibilityWhere = adminVisibilityBucketWhere(requestedVisibility);
+    if (visibilityWhere) {
+      where.push(visibilityWhere.sql);
+      params.push(...visibilityWhere.params);
+    } else if (requestedVisibility !== "all") {
+      where.push("p.visibility COLLATE NOCASE = ?");
       params.push(requestedVisibility);
     }
   }
   const requestedStatus = normalizeFacetValue(status || "");
   if (requestedStatus) {
-    where.push("lower(p.status) = lower(?)");
+    where.push("p.status COLLATE NOCASE = ?");
     params.push(requestedStatus);
   }
   if (String(missingImage) === "1" || String(missingImage) === "true") where.push("si.has_image = 0");
@@ -3504,18 +3707,18 @@ function buildSearchIndexWhere({
       where.push("si.part_type = ?");
       params.push(requestedCategory);
     } else {
-      where.push("lower(p.category) = lower(?)");
+      where.push("p.category COLLATE NOCASE = ?");
       params.push(category);
     }
   }
   const requestedBrand = normalizeFacetValue(deviceBrand || brand || "");
   if (requestedBrand) {
-    where.push("(lower(si.device_brand) = lower(?) OR lower(si.compatible_brand) = lower(?))");
+    where.push("(si.device_brand = ? OR si.compatible_brand = ?)");
     params.push(requestedBrand, requestedBrand);
   }
   const requestedModel = normalizeFacetValue(modelBase || model || "");
   if (requestedModel) {
-    where.push("lower(si.model_base) = lower(?)");
+    where.push("si.model_base = ?");
     params.push(requestedModel);
   }
   const requestedQuality = normalizeFacetValue(qualityTier || "");
@@ -3719,11 +3922,13 @@ async function buildSearchFacets(db, whereClause, options = {}) {
 }
 
 async function querySearchIndex(params = {}) {
+  const totalStartedAt = Date.now();
   await ensureDbReadyForRequest();
   const db = await openDb();
   const safePage = Math.max(1, Number(params.page) || 1);
   const safePageSize = Math.max(1, Math.min(100, Number(params.pageSize) || 24));
   const includeFacets = params.includeFacets === true || String(params.includeFacets || "") === "1";
+  const includeQueryPlan = ENABLE_SQLITE_QUERY_PLAN || params.debugSearch === true || params.debugQueryPlan === true || String(params.debugQueryPlan || "") === "1";
   const offset = (safePage - 1) * safePageSize;
   const whereClause = buildSearchIndexWhere(params);
   const countStartedAt = Date.now();
@@ -3743,27 +3948,96 @@ async function querySearchIndex(params = {}) {
     params.sort === "name_asc" ? "si.title ASC" :
     params.sort === "stock_real" ? "si.is_stock_real DESC, si.title ASC" :
     "si.is_stock_real DESC, si.classification_confidence DESC, si.title ASC";
-  const candidates = await all(
-    db,
-    `SELECT si.*, p.rowid, p.id, p.code, p.slug, p.image, p.name, p.category, p.status, p.visibility, p.price_minorista, p.price_mayorista, p.precio_minorista, p.precio_mayorista, p.precio_final, p.precio_sin_impuestos, p.cost, p.currency, p.raw_json
+  const selectColumns = [
+    "si.product_id",
+    "si.product_rowid",
+    "si.public_slug",
+    "si.title",
+    "si.normalized_title",
+    "si.sku",
+    "si.mpn",
+    "si.part_number",
+    "si.brand",
+    "si.device_brand",
+    "si.compatible_brand",
+    "si.official_brand",
+    "si.is_compatible_for_brand",
+    "si.part_type",
+    "si.model_family",
+    "si.model_base",
+    "si.model_generation",
+    "si.model_variant",
+    "si.network_variant",
+    "si.quality_tier",
+    "si.has_frame",
+    "si.color",
+    "si.stock",
+    "si.stock_status",
+    "si.is_stock_real",
+    "si.price",
+    "si.has_image",
+    "si.is_public",
+    "si.classification_confidence",
+    "si.updated_at",
+    "p.rowid",
+    "p.id",
+    "p.code",
+    "p.slug",
+    "p.image",
+    "p.name",
+    "p.category",
+    "p.status",
+    "p.visibility",
+    "p.price_minorista",
+    "p.price_mayorista",
+    "p.precio_minorista",
+    "p.precio_mayorista",
+    "p.precio_final",
+    "p.precio_sin_impuestos",
+    "p.cost",
+    "p.currency",
+  ];
+  if (hasSearch || params.debugSearch) selectColumns.push("si.search_blob");
+  if (!params.adminMode) selectColumns.push("si.filters_blob");
+  const selectSql = `SELECT ${selectColumns.join(", ")}
      FROM product_search_index si
      JOIN products p ON p.rowid = si.product_rowid
      ${whereClause.sql}
      ORDER BY ${orderBy}
-     LIMIT ? OFFSET ?`,
-    [...whereClause.params, candidateLimit, candidateOffset],
+     LIMIT ? OFFSET ?`;
+  const selectParams = [...whereClause.params, candidateLimit, candidateOffset];
+  const candidates = await all(
+    db,
+    selectSql,
+    selectParams,
   );
-  let ranked = candidates.map((row, index) => ({ row, index, ...scoreSearchIndexRow(row, whereClause.intent) }));
+  let ranked = hasSearch
+    ? candidates.map((row, index) => ({ row, index, ...scoreSearchIndexRow(row, whereClause.intent) }))
+    : candidates.map((row, index) => ({ row, index, score: 0, reasons: [] }));
   if (hasSearch && (!params.sort || String(params.sort) === "relevance")) {
     ranked.sort((a, b) => b.score - a.score || Number(b.row.is_stock_real || 0) - Number(a.row.is_stock_real || 0) || a.index - b.index);
   }
   const pageEntries = hasSearch ? ranked.slice(offset, offset + safePageSize) : ranked;
   const rows = pageEntries.map((entry) => entry.row);
-  const items = rows.map((row) => buildProductSummary(row));
-  const facets = includeFacets || params.adminMode
+  const selectMs = Date.now() - selectStartedAt;
+  const mapStartedAt = Date.now();
+  const items = rows.map((row) => params.adminMode ? buildAdminProductListSummary(row) : buildProductSummary(row));
+  const mapMs = Date.now() - mapStartedAt;
+  const facetStartedAt = Date.now();
+  const facets = includeFacets
     ? await buildSearchFacets(db, whereClause, { adminMode: Boolean(params.adminMode) })
     : {};
-  const selectMs = Date.now() - selectStartedAt;
+  const facetMs = Date.now() - facetStartedAt;
+  const queryPlan = includeQueryPlan
+    ? {
+        count: await explainQueryPlan(
+          db,
+          `SELECT COUNT(*) AS totalItems FROM product_search_index si JOIN products p ON p.rowid = si.product_rowid ${whereClause.sql}`,
+          whereClause.params,
+        ),
+        select: await explainQueryPlan(db, selectSql, selectParams),
+      }
+    : undefined;
   const searchDebug = params.debugSearch ? {
     engine: params.adminMode ? "product_search_index_admin" : "product_search_index",
     queryOriginal: params.search || "",
@@ -3804,6 +4078,7 @@ async function querySearchIndex(params = {}) {
         is_stock_real: Boolean(entry.row.is_stock_real),
       },
     })),
+    queryPlan,
   } : undefined;
   const totalPages = Math.max(1, Math.ceil(totalItems / safePageSize));
   return {
@@ -3819,10 +4094,13 @@ async function querySearchIndex(params = {}) {
     search: params.search || undefined,
     facets,
     searchDebug,
+    queryPlan: params.debugSearch ? undefined : queryPlan,
     countMs,
     selectMs,
-    parseItemsMs: 0,
-    totalDurationMs: countMs + selectMs,
+    mapMs,
+    facetMs,
+    parseItemsMs: mapMs,
+    totalDurationMs: Date.now() - totalStartedAt,
   };
 }
 
@@ -3972,7 +4250,8 @@ async function queryProducts(params = {}) {
     rows: result.rows.length,
     countMs: result.countMs,
     selectMs: result.selectMs,
-    parseItemsMs: result.parseItemsMs,
+    mapMs: result.mapMs ?? result.parseItemsMs,
+    facetMs: result.facetMs,
     totalDurationMs: result.totalDurationMs,
   });
   return result;
@@ -4080,7 +4359,8 @@ async function queryAdminProducts(params = {}) {
     rows: result.rows.length,
     countMs: result.countMs,
     selectMs: result.selectMs,
-    parseItemsMs: result.parseItemsMs,
+    mapMs: result.mapMs ?? result.parseItemsMs,
+    facetMs: result.facetMs,
     totalDurationMs: result.totalDurationMs,
   });
   return result;

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -8692,7 +8692,7 @@ async function requestHandler(req, res) {
     try {
       const { page, pageSize } = parsePaginationParams(parsedUrl.query, {
         page: 1,
-        pageSize: 100,
+        pageSize: 50,
         maxPageSize: 100,
       });
       const queryParams = parsedUrl.query || {};
@@ -8739,6 +8739,8 @@ async function requestHandler(req, res) {
         missingBrand: queryParams.missing_brand || queryParams.missingBrand || "",
         missingPartType: queryParams.missing_part_type || queryParams.missingPartType || "",
         debugSearch: queryParams.debug === "1" || queryParams.debugSearch === "1",
+        debugQueryPlan: queryParams.queryPlan === "1" || queryParams.debugQueryPlan === "1",
+        includeFacets: queryParams.includeFacets === "1" || queryParams.facets === "1",
         sort: queryParams.sort || "",
       });
       const responsePayload = {

--- a/nerin_final_updated/frontend/admin.html
+++ b/nerin_final_updated/frontend/admin.html
@@ -474,9 +474,8 @@
           <div style="display:flex;align-items:center;gap:8px;">
             <label for="adminProductsPageSize">Por página</label>
             <select id="adminProductsPageSize">
-              <option value="50">50</option>
-              <option value="100" selected>100</option>
-              <option value="250">250</option>
+              <option value="50" selected>50</option>
+              <option value="100">100</option>
             </select>
             <button id="adminProductsPrevPage" class="button secondary" type="button">Página anterior</button>
             <span id="adminProductsPageInfo">Página 1 · total no calculado · 0 productos en esta página</span>

--- a/nerin_final_updated/frontend/js/admin.js
+++ b/nerin_final_updated/frontend/js/admin.js
@@ -1823,7 +1823,7 @@ let productFilters = {
   sort: "recent",
 };
 let productsPage = 1;
-let productsPageSize = Number(adminProductsPageSize?.value || 100);
+let productsPageSize = Number(adminProductsPageSize?.value || 50);
 let productsHasNextPage = false;
 let productsHasPrevPage = false;
 let productsTotalItems = null;
@@ -2400,7 +2400,7 @@ productClearFilters?.addEventListener("click", () => {
   if (productStructuredSearch) productStructuredSearch.value = "1";
   if (productSortSelect) productSortSelect.value = "recent";
   productsPage = 1;
-  void loadProducts().catch((error) => console.error("[admin-products] clear filters failed", error));
+  void loadProducts({ refreshFacets: true }).catch((error) => console.error("[admin-products] clear filters failed", error));
 });
 if (productFilterVisibility) {
   productFilterVisibility.addEventListener("change", () => {
@@ -2420,7 +2420,7 @@ if (productSortSelect) {
 if (adminProductsPageSize) {
   adminProductsPageSize.addEventListener("change", () => {
     clearProductSelection("page_size_changed");
-    productsPageSize = Number(adminProductsPageSize.value || 100);
+    productsPageSize = Math.min(100, Number(adminProductsPageSize.value || 50));
     productsPage = 1;
     void loadProducts().catch((error) => {
       console.error("[admin-products] page size load failed", error);
@@ -3649,6 +3649,10 @@ async function loadProducts(options = {}) {
   if (!productsTableBody) return;
   clearProductSelection("loadProducts");
   const { highlightId } = options;
+  const shouldRefreshFacets =
+    options.refreshFacets === true ||
+    !adminProductsFacets ||
+    Object.keys(adminProductsFacets).length === 0;
   const requestSeq = ++adminProductsRequestSeq;
   if (adminProductsAbortController) {
     adminProductsAbortController.abort();
@@ -3689,6 +3693,7 @@ async function loadProducts(options = {}) {
       sort: productFilters.sort || "recent",
     });
     if (productFilters.issue) query.set(productFilters.issue, "1");
+    if (shouldRefreshFacets) query.set("includeFacets", "1");
     const res = await apiFetch(`/api/admin/products?${query.toString()}`, {
       headers: getAdminHeaders(),
       signal: adminProductsAbortController.signal,
@@ -3722,7 +3727,7 @@ async function loadProducts(options = {}) {
       }
     }
     productsPage = Number(data.page || productsPage);
-    productsPageSize = Number(data.pageSize || productsPageSize);
+    productsPageSize = Math.min(100, Number(data.pageSize || productsPageSize));
     productsHasNextPage = data.hasNextPage === true;
     productsHasPrevPage = data.hasPrevPage === true || productsPage > 1;
     productsTotalItems =
@@ -3739,7 +3744,9 @@ async function loadProducts(options = {}) {
       Number.isFinite(Number(data.totalPages))
         ? Number(data.totalPages)
         : null;
-    applyAdminFacets(data.facets || {});
+    if (data.facets && Object.keys(data.facets).length > 0) {
+      applyAdminFacets(data.facets);
+    }
     syncProductTaxonomies(productsCache);
     renderProductsTable();
     updateProductsPaginationControls();
@@ -3772,28 +3779,30 @@ async function loadProducts(options = {}) {
     if (err?.name === "AbortError") return;
     console.error(err);
     let details = "";
-    try {
-      const debugQuery = new URLSearchParams({
-        page: String(productsPage),
-        pageSize: String(productsPageSize),
-        search: productFilters.query || "",
-        category: productFilters.category || "",
-        visibility: productFilters.visibility || "",
-        stockStatus: productFilters.stock || "",
-        sort: productFilters.sort || "recent",
-      });
-      const debugRes = await apiFetch(`/api/admin/products?${debugQuery.toString()}`, {
-        headers: getAdminHeaders(),
-        signal: adminProductsAbortController?.signal,
-      });
-      const debugBody = await debugRes.text();
-      details = ` (status ${debugRes.status}${debugBody ? `, body: ${debugBody.slice(0, 300)}` : ""})`;
-      console.error("admin-products-debug", {
-        status: debugRes.status,
-        body: debugBody.slice(0, 1000),
-      });
-    } catch (debugErr) {
-      console.error("admin-products-debug-failed", debugErr);
+    if (window.__NERIN_ADMIN_DEBUG__ === true) {
+      try {
+        const debugQuery = new URLSearchParams({
+          page: String(productsPage),
+          pageSize: String(productsPageSize),
+          search: productFilters.query || "",
+          category: productFilters.category || "",
+          visibility: productFilters.visibility || "",
+          stockStatus: productFilters.stock || "",
+          sort: productFilters.sort || "recent",
+        });
+        const debugRes = await apiFetch(`/api/admin/products?${debugQuery.toString()}`, {
+          headers: getAdminHeaders(),
+          signal: adminProductsAbortController?.signal,
+        });
+        const debugBody = await debugRes.text();
+        details = ` (status ${debugRes.status}${debugBody ? `, body: ${debugBody.slice(0, 300)}` : ""})`;
+        console.error("admin-products-debug", {
+          status: debugRes.status,
+          body: debugBody.slice(0, 1000),
+        });
+      } catch (debugErr) {
+        console.error("admin-products-debug-failed", debugErr);
+      }
     }
     productsLoadErrorMessage = `Error cargando productos: ${err.message || "No se pudieron cargar los productos."}${details}`;
     productsTableBody.innerHTML =

--- a/nerin_final_updated/package.json
+++ b/nerin_final_updated/package.json
@@ -23,7 +23,9 @@
     "check:no-products-full-parse": "node scripts/check-no-products-full-parse.js",
     "backup:sqlite": "node scripts/backup-sqlite.js",
     "test:catalog-rebuild-timeout": "node scripts/test-products-rebuild-timeout-fallback.js",
-    "test:catalog-schema-legacy-ready": "node scripts/test-catalog-schema-version-legacy-ready.js"
+    "test:catalog-schema-legacy-ready": "node scripts/test-catalog-schema-version-legacy-ready.js",
+    "test:admin-products-sqlite-performance": "node scripts/test-admin-products-sqlite-performance.js",
+    "debug:admin-products-query-plan": "node scripts/explain-admin-products-query.js"
   },
   "dependencies": {
     "@react-email/components": "^0.5.4",

--- a/nerin_final_updated/scripts/explain-admin-products-query.js
+++ b/nerin_final_updated/scripts/explain-admin-products-query.js
@@ -1,0 +1,49 @@
+const productsSqliteRepo = require("../backend/data/productsSqliteRepo");
+
+function parseArgs(argv = []) {
+  const params = {};
+  for (const arg of argv) {
+    const match = String(arg || "").match(/^--([^=]+)=(.*)$/);
+    if (!match) continue;
+    const key = match[1];
+    const value = match[2];
+    if (key === "partType") params.partType = value;
+    else if (key === "stock") params.stockStatus = value;
+    else if (key === "page" || key === "pageSize") params[key] = Number(value);
+    else params[key] = value;
+  }
+  return params;
+}
+
+async function main() {
+  const params = {
+    page: 1,
+    pageSize: 50,
+    sort: "recent",
+    ...parseArgs(process.argv.slice(2)),
+    debugQueryPlan: true,
+  };
+  const result = await productsSqliteRepo.queryAdminProducts(params);
+  console.log(JSON.stringify({
+    dbPath: process.env.DATABASE_PATH || "DATA_DIR/products.sqlite",
+    page: result.page,
+    pageSize: result.pageSize,
+    totalItems: result.totalItems,
+    rows: Array.isArray(result.items) ? result.items.length : 0,
+    countMs: result.countMs,
+    selectMs: result.selectMs,
+    mapMs: result.mapMs,
+    facetMs: result.facetMs,
+    totalDurationMs: result.totalDurationMs,
+    queryPlan: result.queryPlan,
+  }, null, 2));
+  await productsSqliteRepo.closeProductsDbForTests();
+}
+
+main().catch(async (error) => {
+  console.error("[explain-admin-products-query] failed", error);
+  try {
+    await productsSqliteRepo.closeProductsDbForTests();
+  } catch {}
+  process.exit(1);
+});

--- a/nerin_final_updated/scripts/test-admin-products-sqlite-performance.js
+++ b/nerin_final_updated/scripts/test-admin-products-sqlite-performance.js
@@ -1,0 +1,237 @@
+const assert = require("assert");
+const fs = require("fs");
+const fsp = fs.promises;
+const os = require("os");
+const path = require("path");
+const sqlite3 = require("sqlite3");
+
+function openDb(filePath) {
+  return new Promise((resolve, reject) => {
+    const db = new sqlite3.Database(filePath, (error) => {
+      if (error) reject(error);
+      else resolve(db);
+    });
+  });
+}
+
+function run(db, sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.run(sql, params, function onRun(error) {
+      if (error) reject(error);
+      else resolve(this);
+    });
+  });
+}
+
+function closeDb(db) {
+  return new Promise((resolve) => db.close(() => resolve()));
+}
+
+async function seedDb(db) {
+  await run(
+    db,
+    `CREATE TABLE products (
+      id TEXT, sku TEXT, code TEXT, slug TEXT, public_slug TEXT, image TEXT,
+      name TEXT, title TEXT, brand TEXT, model TEXT, category TEXT,
+      status TEXT, visibility TEXT, stock INTEGER, price REAL,
+      price_minorista REAL, price_mayorista REAL, precio_minorista REAL,
+      precio_mayorista REAL, precio_final REAL, precio_sin_impuestos REAL,
+      cost REAL, currency TEXT, enabled INTEGER, deleted INTEGER,
+      archived INTEGER, vip_only INTEGER, wholesale_only INTEGER,
+      is_public INTEGER, search_text TEXT, raw_json TEXT
+    )`,
+  );
+  await run(
+    db,
+    `CREATE TABLE product_search_index (
+      product_id TEXT, product_rowid INTEGER, public_slug TEXT, title TEXT,
+      normalized_title TEXT, sku TEXT, mpn TEXT, part_number TEXT, brand TEXT,
+      device_brand TEXT, compatible_brand TEXT, official_brand TEXT,
+      is_compatible_for_brand INTEGER, part_type TEXT, model_family TEXT,
+      model_base TEXT, model_generation TEXT, model_variant TEXT,
+      network_variant TEXT, quality_tier TEXT, has_frame INTEGER, color TEXT,
+      stock INTEGER, stock_status TEXT, is_stock_real INTEGER, price REAL,
+      has_image INTEGER, is_public INTEGER, classification_confidence REAL,
+      search_blob TEXT, filters_blob TEXT, updated_at TEXT
+    )`,
+  );
+
+  const heavyRawJson = JSON.stringify({
+    id: "admin-1",
+    description: "x".repeat(250000),
+    compatibilities: Array.from({ length: 1000 }, (_, index) => ({ model: `iphone-${index}` })),
+  });
+
+  for (let index = 1; index <= 80; index += 1) {
+    const isPrivate = index <= 65;
+    const productId = `admin-${index}`;
+    const title = index <= 65 ? `Display iPhone ${index}` : `Bateria Samsung ${index}`;
+    await run(
+      db,
+      `INSERT INTO products (
+        id, sku, code, slug, public_slug, image, name, title, brand, model,
+        category, status, visibility, stock, price, price_minorista,
+        price_mayorista, precio_minorista, precio_mayorista, precio_final,
+        precio_sin_impuestos, cost, currency, enabled, deleted, archived,
+        vip_only, wholesale_only, is_public, search_text, raw_json
+      ) VALUES (${Array.from({ length: 31 }, () => "?").join(", ")})`,
+      [
+        productId,
+        `SKU-${index}`,
+        `SKU-${index}`,
+        `slug-${index}`,
+        `slug-${index}`,
+        `/img/${index}.jpg`,
+        title,
+        title,
+        index <= 65 ? "Apple" : "Samsung",
+        index <= 65 ? "iPhone" : "Galaxy",
+        "Pantallas",
+        isPrivate ? "private" : "active",
+        isPrivate ? "private" : "public",
+        10 + index,
+        1000 + index,
+        1000 + index,
+        900 + index,
+        1000 + index,
+        900 + index,
+        1000 + index,
+        800 + index,
+        700 + index,
+        "ARS",
+        1,
+        0,
+        0,
+        0,
+        0,
+        isPrivate ? 0 : 1,
+        `${title} apple iphone display`,
+        index === 1 ? heavyRawJson : JSON.stringify({ id: productId, title }),
+      ],
+    );
+    await run(
+      db,
+      `INSERT INTO product_search_index (
+        product_id, product_rowid, public_slug, title, normalized_title, sku,
+        mpn, part_number, brand, device_brand, compatible_brand, official_brand,
+        is_compatible_for_brand, part_type, model_family, model_base,
+        model_generation, model_variant, network_variant, quality_tier,
+        has_frame, color, stock, stock_status, is_stock_real, price,
+        has_image, is_public, classification_confidence, search_blob,
+        filters_blob, updated_at
+      ) VALUES (${Array.from({ length: 32 }, () => "?").join(", ")})`,
+      [
+        productId,
+        index,
+        `slug-${index}`,
+        title,
+        title.toLowerCase(),
+        `SKU-${index}`,
+        "",
+        "",
+        index <= 65 ? "apple" : "samsung",
+        index <= 65 ? "apple" : "samsung",
+        index <= 65 ? "apple" : "samsung",
+        index <= 65 ? "apple" : "samsung",
+        0,
+        index <= 65 ? "display" : "battery",
+        "",
+        index <= 65 ? "iphone" : "galaxy",
+        "",
+        "",
+        "",
+        "standard",
+        0,
+        "",
+        10 + index,
+        "in_stock",
+        1,
+        1000 + index,
+        1,
+        isPrivate ? 0 : 1,
+        1,
+        `${title.toLowerCase()} apple iphone display sku-${index}`,
+        "{}",
+        new Date(Date.now() - index * 1000).toISOString(),
+      ],
+    );
+  }
+}
+
+async function main() {
+  const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "nerin-admin-products-perf-"));
+  process.env.NODE_ENV = "production";
+  process.env.CATALOG_AUTO_REBUILD = "false";
+  process.env.DATA_DIR = tempDir;
+  process.env.DATABASE_PATH = path.join(tempDir, "products.sqlite");
+
+  await fsp.writeFile(path.join(tempDir, "products.json"), JSON.stringify([{ id: "admin-1" }]), "utf8");
+  await fsp.writeFile(
+    path.join(tempDir, "products.manifest.json"),
+    JSON.stringify({
+      sqliteSchemaVersion: 6,
+      mappingVersion: 5,
+      productCount: 80,
+      publicProductCount: 15,
+    }),
+    "utf8",
+  );
+
+  const db = await openDb(process.env.DATABASE_PATH);
+  try {
+    await seedDb(db);
+  } finally {
+    await closeDb(db);
+  }
+
+  const repo = require("../backend/data/productsSqliteRepo");
+  const result = await repo.queryAdminProducts({
+    page: 1,
+    pageSize: 100,
+    sort: "recent",
+    debugQueryPlan: true,
+  });
+
+  assert.strictEqual(result.source, "sqlite_search_index_admin");
+  assert.strictEqual(result.items.length, 80);
+  assert.strictEqual(result.pageSize, 100);
+  assert.ok(Number.isFinite(result.countMs), "countMs debe estar presente");
+  assert.ok(Number.isFinite(result.selectMs), "selectMs debe estar presente");
+  assert.ok(Number.isFinite(result.mapMs), "mapMs debe estar presente");
+  assert.ok(Number.isFinite(result.totalDurationMs), "totalDurationMs debe estar presente");
+  assert.ok(result.queryPlan?.select?.length > 0, "debugQueryPlan debe devolver EXPLAIN QUERY PLAN");
+  assert.deepStrictEqual(result.facets, {}, "facetas no deben calcularse salvo includeFacets");
+
+  const first = result.items[0];
+  assert.ok(first.id && first.sku && first.title, "admin list debe devolver campos livianos basicos");
+  assert.strictEqual(first.raw_json, undefined, "admin list no debe exponer raw_json");
+  assert.strictEqual(first.description, undefined, "admin list no debe traer descripcion pesada");
+  assert.strictEqual(first.compatibilities, undefined, "admin list no debe parsear compatibilidades pesadas");
+
+  const filtered = await repo.queryAdminProducts({
+    page: 1,
+    pageSize: 50,
+    search: "iphone",
+    visibility: "private",
+    partType: "display",
+    sort: "recent",
+  });
+  assert.strictEqual(filtered.items.length, 50);
+  assert.ok(filtered.totalItems >= 65, "filtro admin debe encontrar productos privados consultables");
+
+  const facets = await repo.queryAdminProducts({
+    page: 1,
+    pageSize: 50,
+    includeFacets: true,
+  });
+  assert.ok(Array.isArray(facets.facets?.part_type), "includeFacets debe mantener facetas disponibles");
+
+  await repo.closeProductsDbForTests();
+  await fsp.rm(tempDir, { recursive: true, force: true });
+  console.log("[test-admin-products-sqlite-performance] ok");
+}
+
+main().catch((error) => {
+  console.error("[test-admin-products-sqlite-performance] failed", error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Resumen
- Optimiza el listado admin SQLite con proyeccion liviana, sin `raw_json` ni campos pesados en la lista.
- Agrega migracion incremental de columnas/indices e indices para filtros frecuentes y sort `recent`.
- Hace `EXPLAIN QUERY PLAN` opt-in via `debugQueryPlan=1` / `CATALOG_SQLITE_EXPLAIN=true` y agrega script manual.
- Evita recalcular facetas en cada request admin; el frontend las pide solo al inicio/refresh, mantiene abort/debounce y baja default pageSize a 50 con max 100.
- Mantiene Render Disk + SQLite existente; no cambia `DATABASE_PATH`, `USE_PG`, rebuild automatico, checkout, Mercado Pago, Resend ni secrets.

## Validacion
- `node --check backend/data/productsSqliteRepo.js`
- `node --check backend/server.js`
- `node --check frontend/js/admin.js`
- `node --check scripts/test-admin-products-sqlite-performance.js`
- `node --check scripts/explain-admin-products-query.js`
- `node scripts/test-admin-products-sqlite-performance.js`
- `node scripts/test-catalog-schema-version-legacy-ready.js`
- `node scripts/test-render-startup-nonblocking.js`