### PR TITLE
Enfocar Merchant y SEO en stock real local

### DIFF
--- a/nerin_final_updated/__tests__/backend/merchant-feed.test.js
+++ b/nerin_final_updated/__tests__/backend/merchant-feed.test.js
@@ -54,14 +54,62 @@ describe('merchant feed audit', () => {
     expect(audit.samplesEligible[0].availability_date).toBeNull();
   });
 
-  test('stock 0 vendible a pedido => preorder + availability_date', () => {
+  test('stock local > 0 entra al feed como in_stock', () => {
+    const { entries } = buildMerchantFeedEntries([baseRow({ id: 'local', sku: 'LOCAL', stock: 4, availability: 'in_stock' })]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ id: 'LOCAL', availability: 'in_stock', availability_date: '' });
+  });
+
+  test('stock 0 + remote_stock > 0 no entra', () => {
+    const audit = buildMerchantFeedAudit([baseRow({ id: 'remote', stock: 0, remote_stock: 8, raw_json: JSON.stringify({ remote_stock: 8 }) })]);
+    expect(audit.emittedCount).toBe(0);
+    expect(audit.skipped.remoteOrPreorderExcluded).toBe(1);
+  });
+
+  test('preorder backorder y out_of_stock no entran', () => {
+    const rows = [
+      baseRow({ id: 'preorder', stock: 0, availability: 'preorder' }),
+      baseRow({ id: 'backorder', stock: 0, availability: 'backorder' }),
+      baseRow({ id: 'out', stock: 0, availability: 'out_of_stock' }),
+    ];
+    const { entries, audit } = buildMerchantFeedEntries(rows);
+    expect(entries).toHaveLength(0);
+    expect(audit.skipped.remoteOrPreorderExcluded).toBe(2);
+    expect(audit.skipped.outOfStockExcluded).toBe(1);
+  });
+
+  test('producto publico sin imagen precio o slug no entra', () => {
+    const rows = [
+      baseRow({ id: 'no-image', image: null }),
+      baseRow({ id: 'no-price', price: null }),
+      baseRow({ id: 'no-slug', slug: '', public_slug: '' }),
+    ];
+    const audit = buildMerchantFeedAudit(rows);
+    expect(audit.emittedCount).toBe(0);
+    expect(audit.skipped.missingImage).toBe(1);
+    expect(audit.skipped.missingPrice).toBe(1);
+    expect(audit.skipped.missingLink).toBe(1);
+  });
+
+  test('auditoria marca error si cualquier entry no es in_stock', () => {
+    const entries = [
+      { id: 'ok', availability: 'in_stock' },
+      { id: 'bad-pre', availability: 'preorder' },
+      { id: 'bad-back', availability: 'backorder' },
+      { id: 'bad-out', availability: 'out_of_stock' },
+    ];
+    const invalid = entries.filter((entry) => entry.availability !== 'in_stock');
+    expect(invalid.map((entry) => entry.availability)).toEqual(['preorder', 'backorder', 'out_of_stock']);
+  });
+
+  test('stock 0 vendible a pedido no entra al feed Merchant', () => {
     const audit = buildMerchantFeedAudit([baseRow({ stock: 0 })]);
-    expect(audit.samplesEligible[0].availability).toBe('preorder');
-    expect(audit.samplesEligible[0].availability_date).toMatch(/^\d{4}-\d{2}-\d{2}T00:00-0300$/);
+    expect(audit.emittedCount).toBe(0);
+    expect(audit.skipped.outOfStockExcluded).toBe(1);
   });
 
   test('preorder comparte fecha entre feed, texto visible y JSON-LD', () => {
-    const availability = resolveProductAvailability(baseRow({ stock: 0, availability_date: '2026-06-16' }), { now: new Date('2026-05-19T12:00:00Z') });
+    const availability = resolveProductAvailability(baseRow({ stock: 0, availability: 'preorder', availability_date: '2026-06-16' }), { now: new Date('2026-05-19T12:00:00Z') });
     expect(availability.merchantAvailability).toBe('preorder');
     expect(availability.availabilityDateFeed).toBe('2026-06-16T00:00-0300');
     expect(availability.availabilityStarts).toBe('2026-06-16T00:00:00-03:00');
@@ -70,8 +118,8 @@ describe('merchant feed audit', () => {
   });
 
   test('availability_date vencido o mayor a un anio se normaliza a ventana valida', () => {
-    const older = resolveProductAvailability(baseRow({ stock: 0, availability_date: '2026-01-01' }), { now: new Date('2026-05-19T12:00:00Z') });
-    const tooFar = resolveProductAvailability(baseRow({ stock: 0, availability_date: '2028-01-01' }), { now: new Date('2026-05-19T12:00:00Z') });
+    const older = resolveProductAvailability(baseRow({ stock: 0, availability: 'preorder', availability_date: '2026-01-01' }), { now: new Date('2026-05-19T12:00:00Z') });
+    const tooFar = resolveProductAvailability(baseRow({ stock: 0, availability: 'preorder', availability_date: '2028-01-01' }), { now: new Date('2026-05-19T12:00:00Z') });
     expect(older.availabilityDateFeed).toBe('2026-05-20T00:00-0300');
     expect(tooFar.availabilityDateFeed).toBe('2027-05-19T00:00-0300');
   });
@@ -90,8 +138,8 @@ describe('merchant feed audit', () => {
       baseRow({ id: 'pre-ext', stock: 0, image: 'https://images.2service.nl/v7/Images/Part/1/img.jpg' }),
     ]);
     expect(audit.skipped.missingAvailability).toBe(0);
-    expect(audit.emittedCount).toBe(1);
-    expect(audit.samplesEligible[0].availability).toBe('preorder');
+    expect(audit.emittedCount).toBe(0);
+    expect(audit.skipped.outOfStockExcluded).toBe(1);
   });
 
 
@@ -133,7 +181,7 @@ describe('merchant feed audit', () => {
     const audit = buildMerchantFeedAudit(rows);
     expect(audit.ok).toBeUndefined();
     expect(audit.eligibleCount).toBeGreaterThan(0);
-    expect(audit.emittedCount).toBeGreaterThan(0);
+    expect(audit.emittedCount).toBe(1);
   });
 
   test('buildMerchantFeedAudit tolera raw_json null, vacío e inválido', () => {
@@ -197,10 +245,8 @@ describe('merchant feed audit', () => {
     const audit = buildMerchantFeedAudit([
       baseRow({ id: 'ok-ext', image: 'https://images.2service.nl/v7/Images/Part/1/img.jpg', stock: 0, raw_json: JSON.stringify({ allow_backorder: true }) }),
     ]);
-    expect(audit.emittedCount).toBe(1);
-    expect(audit.samplesEligible[0].id).toBe('ok-ext');
-    expect(audit.samplesEligible[0].image_link).toBe('https://images.2service.nl/v7/Images/Part/1/img.jpg');
-    expect(['in_stock', 'preorder', 'backorder']).toContain(audit.samplesEligible[0].availability);
+    expect(audit.emittedCount).toBe(0);
+    expect(audit.samplesSkipped[0].reason).toBe('outOfStockExcluded');
   });
 });
 
@@ -231,16 +277,14 @@ describe('merchant feed tsv payload', () => {
     expect(entries[0].description).not.toContain('oaicite');
   });
 
-  test('preorder e in_stock availability_date correcto y headers esperados', () => {
+  test('solo in_stock entra al feed y headers esperados', () => {
     const rows = [baseRow({ id: 'stk', stock: 3 }), baseRow({ id: 'pre', stock: 0 }), baseRow({ id: 'back', stock: 0, raw_json: JSON.stringify({ availability: 'backorder' }) })];
     const { entries } = buildMerchantFeedEntries(rows);
     const byId = Object.fromEntries(entries.map((e) => [e.id, e]));
     expect(byId.stk.availability).toBe('in_stock');
     expect(byId.stk.availability_date).toBe('');
-    expect(byId.pre.availability).toBe('preorder');
-    expect(byId.pre.availability_date).toMatch(/^\d{4}-\d{2}-\d{2}T00:00-0300$/);
-    expect(byId.back.availability).toBe('backorder');
-    expect(byId.back.availability_date).toMatch(/^\d{4}-\d{2}-\d{2}T00:00-0300$/);
+    expect(byId.pre).toBeUndefined();
+    expect(byId.back).toBeUndefined();
     expect(Object.keys(entries[0])).toEqual(['id','title','description','link','image_link','additional_image_link','availability','availability_date','price','condition','brand','mpn','identifier_exists','google_product_category','product_type']);
   });
 

--- a/nerin_final_updated/backend/__tests__/merchant-availability-ui.test.js
+++ b/nerin_final_updated/backend/__tests__/merchant-availability-ui.test.js
@@ -3,6 +3,8 @@ const os = require("os");
 const path = require("path");
 const request = require("supertest");
 
+jest.setTimeout(30000);
+
 function writeCatalog(dir) {
   const products = [
     {
@@ -141,7 +143,7 @@ describe("Merchant-safe availability UI", () => {
 });
 
 describe("Merchant feed availability fields", () => {
-  test("in_stock y out_of_stock no emiten availability_date; backorder si", () => {
+  test("solo stock fisico real entra al feed Merchant", () => {
     const { buildMerchantFeedEntries } = require("../utils/merchantFeed");
     const base = {
       description: "Repuesto para celulares disponible en NERIN Parts.",
@@ -162,9 +164,7 @@ describe("Merchant feed availability fields", () => {
     const byId = Object.fromEntries(entries.map((entry) => [entry.id, entry]));
     expect(byId.STOCK.availability).toBe("in_stock");
     expect(byId.STOCK.availability_date).toBe("");
-    expect(byId.PEDIDO.availability).toBe("backorder");
-    expect(byId.PEDIDO.availability_date).toBe("2026-06-19T00:00-0300");
-    expect(byId.OUT.availability).toBe("out_of_stock");
-    expect(byId.OUT.availability_date).toBe("");
+    expect(byId.PEDIDO).toBeUndefined();
+    expect(byId.OUT).toBeUndefined();
   });
 });

--- a/nerin_final_updated/backend/__tests__/organic-seo-stock-real.test.js
+++ b/nerin_final_updated/backend/__tests__/organic-seo-stock-real.test.js
@@ -3,6 +3,8 @@ const os = require("os");
 const path = require("path");
 const request = require("supertest");
 
+jest.setTimeout(30000);
+
 function writeCatalog(dir) {
   const products = [
     {
@@ -132,7 +134,7 @@ describe("organic stock-real SEO", () => {
     await withServer(async (server) => {
       const res = await request(server).get("/p/pantalla-samsung-galaxy-a15?debugSeo=1");
       expect(res.status).toBe(200);
-      expect(res.text).toContain("<title>Pantalla Samsung Galaxy A15 en stock | NERIN Parts</title>");
+      expect(res.text).toContain("<title>Pantalla Samsung Galaxy A15 Original Service Pack SAM-A15-DISPLAY en Stock | NERIN Parts</title>");
       expect(res.text).toContain("https://schema.org/InStock");
       expect(res.text).not.toContain("availabilityStarts");
       expect(res.text).toContain("data-debug-seo=\"1\"");
@@ -152,7 +154,7 @@ describe("organic stock-real SEO", () => {
 
   test("sitemap incluye paginas SEO validas y no genera paginas vacias", async () => {
     await withServer(async (server) => {
-      const res = await request(server).get("/sitemap.xml");
+      const res = await request(server).get("/sitemap-static.xml");
       expect(res.status).toBe(200);
       expect(res.text).toContain("<loc>https://nerinparts.example/stock-real</loc>");
       expect(res.text).toContain("<loc>https://nerinparts.example/pantallas-en-stock</loc>");

--- a/nerin_final_updated/backend/data/productsSqliteRepo.js
+++ b/nerin_final_updated/backend/data/productsSqliteRepo.js
@@ -3946,8 +3946,8 @@ async function querySearchIndex(params = {}) {
     params.sort === "price_desc" ? "si.price DESC, si.title ASC" :
     params.sort === "name_desc" ? "si.title DESC" :
     params.sort === "name_asc" ? "si.title ASC" :
-    params.sort === "stock_real" ? "si.is_stock_real DESC, si.title ASC" :
-    "si.is_stock_real DESC, si.classification_confidence DESC, si.title ASC";
+    params.sort === "stock_real" ? "si.is_stock_real DESC, si.stock DESC, CASE WHEN si.part_type = 'screen' THEN 0 ELSE 1 END ASC, si.title ASC" :
+    "si.is_stock_real DESC, si.stock DESC, CASE WHEN si.part_type = 'screen' THEN 0 ELSE 1 END ASC, CASE WHEN si.stock_status = 'preorder' THEN 1 WHEN si.stock_status = 'out_of_stock' THEN 2 ELSE 0 END ASC, si.classification_confidence DESC, si.title ASC";
   const selectColumns = [
     "si.product_id",
     "si.product_rowid",

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -90,6 +90,9 @@ const {
   getPublicPriceValue,
 } = require("./utils/productAvailability");
 const {
+  resolvePhysicalStockEligibility,
+} = require("./utils/merchantFeed");
+const {
   computeOrganicSeoPriority,
   getPartLabel: getOrganicPartLabel,
   isBrandDoubtful,
@@ -1796,7 +1799,7 @@ async function buildStockSitemapXml(baseUrl) {
     dbConn = await openSqliteReadonly(productsSqliteRepo.SQLITE_PATH);
     const rows = await sqliteAll(
       dbConn,
-      `SELECT si.public_slug, si.title, si.price, si.has_image, si.stock, si.is_stock_real, si.is_public, p.slug, p.raw_json
+      `SELECT si.public_slug, si.title, si.price, si.has_image, si.stock, si.is_stock_real, si.is_public, p.slug, p.raw_json, p.availability, p.stock_mode, p.fulfillment_mode, p.remote_stock, p.stock_remote, p.available_remote, p.remote_lead_days, p.remote_lead_min_days, p.remote_lead_max_days
        FROM product_search_index si
        JOIN products p ON p.rowid = si.product_rowid
        WHERE si.is_public = 1
@@ -1811,6 +1814,8 @@ async function buildStockSitemapXml(baseUrl) {
     const entries = rows
       .map((row) => {
         const raw = parseRawJsonObject(row.raw_json);
+        const physical = resolvePhysicalStockEligibility(row, raw);
+        if (!physical.eligible) return null;
         const slug = String(row.public_slug || raw.publicSlug || raw.public_slug || row.slug || raw.slug || "").trim();
         if (!slug) return null;
         return {
@@ -14420,6 +14425,7 @@ async function requestHandler(req, res) {
       "Disallow: /login",
     ];
     if (siteBase) {
+      lines.push(`Sitemap: ${siteBase}/sitemap-stock.xml`);
       lines.push(`Sitemap: ${siteBase}/sitemap.xml`);
     }
     res.writeHead(200, {
@@ -14924,8 +14930,9 @@ async function requestHandler(req, res) {
       ? numericPrice.toFixed(2)
       : "0.00";
     const organicSeo = computeOrganicSeoPriority(product);
-    const seoTitle = organicSeo.seoTitle || productSeo.title || buildProductSeoTitle(product);
-    const description = organicSeo.seoDescription || productSeo.description || buildProductMetaDescription(product);
+    const isStockRealSeo = availabilityInfo.merchantAvailability === "in_stock" && Number(availabilityInfo.stockLocal || product.stock || 0) > 0;
+    const seoTitle = isStockRealSeo ? (productSeo.title || organicSeo.seoTitle || buildProductSeoTitle(product)) : (organicSeo.seoTitle || productSeo.title || buildProductSeoTitle(product));
+    const description = isStockRealSeo ? (productSeo.description || organicSeo.seoDescription || buildProductMetaDescription(product)) : (organicSeo.seoDescription || productSeo.description || buildProductMetaDescription(product));
     const h1 = buildProductHeading(product);
     const ld = {
       "@context": "https://schema.org",

--- a/nerin_final_updated/backend/utils/merchantFeed.js
+++ b/nerin_final_updated/backend/utils/merchantFeed.js
@@ -6,7 +6,7 @@ const {
 } = require('./productAvailability');
 
 const GOOGLE_CATEGORY = 'Electrónica > Comunicaciones > Telefonía > Accesorios para móviles';
-const VALID_AVAILABILITY = new Set(['in_stock', 'preorder', 'backorder', 'out_of_stock']);
+const VALID_AVAILABILITY = new Set(['in_stock']);
 
 function safeMerchantText(value, max = 150) {
   const mojibakeFixes = [
@@ -66,6 +66,33 @@ function mergeProductData(row = {}, raw = {}) {
   return merged;
 }
 
+function getLocalStockValue(row = {}, raw = {}) {
+  const merged = mergeProductData(row, raw);
+  const stock = Number(merged.stock ?? merged.available_stock ?? merged.inventory ?? merged.stock_total ?? 0);
+  return Number.isFinite(stock) ? stock : 0;
+}
+
+function hasRemoteOrPreorderSignal(row = {}, raw = {}) {
+  const merged = mergeProductData(row, raw);
+  const textSignals = [
+    merged.name,
+    merged.title,
+    merged.description,
+    merged.category,
+    merged.subcategory,
+    merged.availability,
+    merged.disponibilidad,
+    merged.estado_stock,
+    merged.stock_mode,
+    merged.fulfillment_mode,
+  ].filter(Boolean).join(' ').toLowerCase();
+  return (
+    /preorder|backorder|a[_\s-]?pedido|bajo\s+pedido|pedido|remote|remoto|stock\s+remoto|consultar\s+disponibilidad/.test(textSignals) ||
+    Number(merged.remote_stock || merged.stock_remote || merged.available_remote || 0) > 0 ||
+    Number(merged.remote_lead_days || merged.remote_lead_min_days || merged.remote_lead_max_days || 0) > 0
+  );
+}
+
 function computeAvailability(row, raw, preorderDays = 30) {
   const merged = mergeProductData(row, raw);
   const explicitAvailability = String(merged.availability || merged.disponibilidad || merged.estado_stock || '').toLowerCase();
@@ -82,6 +109,20 @@ function computeAvailability(row, raw, preorderDays = 30) {
     availabilityDate: resolved.availabilityDateFeed || '',
     visibleAvailabilityText: resolved.visibleAvailabilityText || '',
     availabilityStarts: resolved.availabilityStarts || '',
+  };
+}
+
+function resolvePhysicalStockEligibility(row = {}, raw = {}, preorderDays = 30) {
+  const availability = computeAvailability(row, raw, preorderDays);
+  const localStock = getLocalStockValue(row, raw);
+  const remoteOrPreorder = hasRemoteOrPreorderSignal(row, raw) || ['preorder', 'backorder'].includes(availability.availability);
+  const outOfStock = availability.availability === 'out_of_stock' || localStock <= 0;
+  return {
+    eligible: availability.availability === 'in_stock' && localStock > 0 && !remoteOrPreorder,
+    availability,
+    localStock,
+    remoteOrPreorder,
+    outOfStock,
   };
 }
 
@@ -128,6 +169,7 @@ function getSkipTemplate() {
     notPublic: 0, privateOrHidden: 0, disabled: 0, deleted: 0, archived: 0, draft: 0, vipOnly: 0, wholesaleOnly: 0,
     missingId: 0, missingTitle: 0, missingDescription: 0, missingLink: 0, missingImage: 0, invalidImageUrl: 0,
     missingPrice: 0, invalidPrice: 0, missingAvailability: 0, invalidAvailability: 0, preorderWithoutAvailabilityDate: 0, backorderWithoutAvailabilityDate: 0, invalidAvailabilityDate: 0, taxonomyBlocked: 0, soft404Risk: 0,
+    notInPhysicalStock: 0, remoteOrPreorderExcluded: 0, outOfStockExcluded: 0,
   };
 }
 
@@ -198,9 +240,10 @@ function buildMerchantFeedEntries(rows, { limit = 500, offset = 0, preorderDays 
     }
     const priceNum = getPublicPriceValue(mergeProductData(row, raw));
     if (!Number.isFinite(priceNum) || priceNum <= 0) continue;
-    const av = computeAvailability(row, raw, preorderDays);
+    const physical = resolvePhysicalStockEligibility(row, raw, preorderDays);
+    const av = physical.availability;
+    if (!physical.eligible) continue;
     if (!VALID_AVAILABILITY.has(av.availability)) continue;
-    if ((av.availability === 'preorder' || av.availability === 'backorder') && !String(av.availabilityDate || '').match(/^\d{4}-\d{2}-\d{2}T00:00-0300$/)) continue;
     const productTypeDetected = detectMerchantProductType(row, raw, title);
     const product_type = safeMerchantText(mapProductTypeToFeed(productTypeDetected));
     if (!product_type) continue;
@@ -212,7 +255,7 @@ function buildMerchantFeedEntries(rows, { limit = 500, offset = 0, preorderDays 
     entries.push({
       id: identifier, title, description, link, image_link,
       additional_image_link: additional.join(','), availability: av.availability,
-      availability_date: (av.availability === 'preorder' || av.availability === 'backorder') ? av.availabilityDate : '',
+      availability_date: '',
       price: `${priceNum.toFixed(2)} ARS`, condition: 'new', brand, mpn, identifier_exists,
       google_product_category: GOOGLE_CATEGORY, product_type,
     });
@@ -294,7 +337,8 @@ function buildMerchantFeedAudit(rows, { limit = 500, offset = 0, preorderDays = 
     if (!priceNum) { skipped.missingPrice += 1; pushSample(samplesSkipped, { id: identifier, reason: 'missingPrice' }); continue; }
     if (!Number.isFinite(priceNum) || priceNum <= 0) { skipped.invalidPrice += 1; pushSample(samplesSkipped, { id: identifier, reason: 'invalidPrice' }); continue; }
 
-    const av = computeAvailability(row, raw, preorderDays);
+    const physical = resolvePhysicalStockEligibility(row, raw, preorderDays);
+    const av = physical.availability;
     if (!av.availability) { skipped.missingAvailability += 1; pushSample(samplesSkipped, {
       id: identifier,
       title,
@@ -312,13 +356,19 @@ function buildMerchantFeedAudit(rows, { limit = 500, offset = 0, preorderDays = 
       },
       reason: 'missingAvailability',
     }); continue; }
-    if (!VALID_AVAILABILITY.has(av.availability)) { skipped.invalidAvailability += 1; pushSample(samplesSkipped, { id: identifier, reason: 'invalidAvailability' }); continue; }
-
-    if (av.availability === 'preorder' && !av.availabilityDate) { skipped.preorderWithoutAvailabilityDate += 1; pushSample(samplesSkipped, { id: identifier, reason: 'preorderWithoutAvailabilityDate' }); continue; }
-    if (av.availability === 'backorder' && !av.availabilityDate) { skipped.backorderWithoutAvailabilityDate += 1; pushSample(samplesSkipped, { id: identifier, reason: 'backorderWithoutAvailabilityDate' }); continue; }
-    if ((av.availability === 'preorder' || av.availability === 'backorder') && !/^\d{4}-\d{2}-\d{2}T00:00-0300$/.test(String(av.availabilityDate || ''))) {
-      skipped.invalidAvailabilityDate += 1;
-      pushSample(samplesSkipped, { id: identifier, reason: 'invalidAvailabilityDate', availability: av.availability, availability_date: av.availabilityDate || null });
+    if (physical.remoteOrPreorder) {
+      skipped.remoteOrPreorderExcluded += 1;
+      pushSample(samplesSkipped, { id: identifier, title, reason: 'remoteOrPreorderExcluded', availability: av.availability, localStock: physical.localStock });
+      continue;
+    }
+    if (physical.outOfStock) {
+      skipped.outOfStockExcluded += 1;
+      pushSample(samplesSkipped, { id: identifier, title, reason: 'outOfStockExcluded', availability: av.availability, localStock: physical.localStock });
+      continue;
+    }
+    if (!physical.eligible || !VALID_AVAILABILITY.has(av.availability)) {
+      skipped.notInPhysicalStock += 1;
+      pushSample(samplesSkipped, { id: identifier, title, reason: 'notInPhysicalStock', availability: av.availability, localStock: physical.localStock });
       continue;
     }
 
@@ -337,7 +387,7 @@ function buildMerchantFeedAudit(rows, { limit = 500, offset = 0, preorderDays = 
     const safeProductType = safeMerchantText(productType);
     productTypeBreakdown[safeProductType] = (productTypeBreakdown[safeProductType] || 0) + 1;
     availabilityBreakdown[av.availability] = (availabilityBreakdown[av.availability] || 0) + 1;
-    pushSample(samplesEligible, { id: identifier, title: safeMerchantText(title), productType: safeProductType, availability: av.availability, availability_date: av.availabilityDate || null, price: `${priceNum.toFixed(2)} ARS`, link, image_link: imageLink, stock: Number(row.stock ?? raw.stock ?? 0) });
+    pushSample(samplesEligible, { id: identifier, title: safeMerchantText(title), productType: safeProductType, availability: av.availability, availability_date: null, price: `${priceNum.toFixed(2)} ARS`, link, image_link: imageLink, stock: physical.localStock });
   }
 
   return {
@@ -361,4 +411,4 @@ function buildMerchantFeedAudit(rows, { limit = 500, offset = 0, preorderDays = 
   };
 }
 
-module.exports = { GOOGLE_CATEGORY, mapProductTypeToFeed, buildMerchantTitle, computeAvailability, formatMerchantAvailabilityDate, isEligibleState, cleanText, safeMerchantText, detectProductType, buildMerchantFeedAudit, buildMerchantFeedEntries, normalizeMerchantImageUrl, isValidFeedUrl };
+module.exports = { GOOGLE_CATEGORY, mapProductTypeToFeed, buildMerchantTitle, computeAvailability, formatMerchantAvailabilityDate, isEligibleState, cleanText, safeMerchantText, detectProductType, buildMerchantFeedAudit, buildMerchantFeedEntries, normalizeMerchantImageUrl, isValidFeedUrl, getLocalStockValue, hasRemoteOrPreorderSignal, resolvePhysicalStockEligibility };

--- a/nerin_final_updated/backend/utils/productSeo.js
+++ b/nerin_final_updated/backend/utils/productSeo.js
@@ -1,4 +1,5 @@
 const { detectProductType } = require("./productTaxonomy");
+const { resolveProductAvailability } = require("./productAvailability");
 
 const GENERIC_SEO_TITLES = new Set([
   "repuesto original service pack | nerin parts",
@@ -75,11 +76,57 @@ function buildSafeProductDescription(product = {}, label = "") {
   return compactText(`${label || "Repuesto"} disponible en NERIN Parts. Verificá compatibilidad${skuCopy} y disponibilidad antes de comprar.`);
 }
 
+function buildCommercialModel(product = {}, label = "") {
+  const candidates = [
+    pickField(product, ["model", "modelo", "model_base", "Model"]),
+    label.match(/\b(?:Samsung\s+)?Galaxy\s+[A-Z]?\d{2,3}(?:\s*5G)?\b/i)?.[0],
+    label.match(/\bSM-[A-Z0-9]+(?:\/[A-Z0-9]+)?\b/i)?.[0],
+  ].filter(Boolean);
+  return normalizeText(candidates[0] || "");
+}
+
+function buildPartCode(product = {}, label = "") {
+  const explicit = normalizeText(pickField(product, ["sku", "SKU", "mpn", "part_number", "partNumber", "PartNumber", "Part Number"]));
+  const gh82 = label.match(/\bGH82[-A-Z0-9]+\b/i)?.[0] || "";
+  return normalizeText(gh82 || explicit);
+}
+
 function generateProductSeo(product = {}) {
   const productType = detectProductType(product);
   const label = buildSafeProductLabel(product);
   const brand = normalizeText(pickField(product, ["brand", "catalog_brand", "Brand"]));
   const sku = normalizeText(pickField(product, ["sku", "SKU", "part_number", "partNumber", "PartNumber", "Part Number"]));
+  const availability = resolveProductAvailability(product);
+  const isStockReal = availability.merchantAvailability === "in_stock" && Number(availability.stockLocal || product.stock || 0) > 0;
+
+  if (isStockReal) {
+    const model = buildCommercialModel(product, label);
+    const partCode = buildPartCode(product, label);
+    const isScreen = productType === "Pantalla / display";
+    const brandCopy = /samsung/i.test(brand || label) ? "Samsung" : brand;
+    const titleSubject = [
+      isScreen ? "Pantalla" : label,
+      brandCopy && isScreen ? brandCopy : "",
+      model,
+      "Original Service Pack",
+      partCode,
+      "en Stock",
+    ].filter(Boolean).join(" ");
+    const descriptionSubject = [
+      isScreen ? "pantalla original" : label,
+      brandCopy,
+      model,
+      partCode,
+      "Service Pack",
+    ].filter(Boolean).join(" ");
+    return {
+      title: truncateText(`${titleSubject} | NERIN Parts`, 160),
+      description: truncateText(`Compra ${descriptionSubject} con stock real en CABA, factura A/B, garantia tecnica y envio a todo Argentina.`, 200),
+      ogTitle: titleSubject,
+      ogDescription: `Stock real en CABA, factura A/B, garantia tecnica y envio a Argentina.`,
+      productType,
+    };
+  }
 
   const descriptionParts = [
     `${label} disponible en NERIN Parts. Verificá compatibilidad, SKU/código de pieza y disponibilidad antes de comprar.`,

--- a/nerin_final_updated/backend/utils/productTaxonomy.js
+++ b/nerin_final_updated/backend/utils/productTaxonomy.js
@@ -53,6 +53,7 @@ function detectProductType(product = {}) {
   if (has(text, /\b(screen\s+protection|screen\s+protector|tempered\s+glass|vidrio\s+templado|protector(?:\s+de\s+pantalla)?)\b/i)) return "Protector de pantalla";
   if (has(text, /\b(pressing\s+jig|repair\s+tool|tool|herramienta|jig|molde|fixture)\b/i)) return "Herramienta / accesorio técnico";
   if (has(text, /\b(display|screen|pantalla)\s+(adhesive|tape|sticker|seal|sealant|gasket|bonding|glue|oca)\b/i)) return "Adhesivo para pantalla";
+  if (has(text, /\b(gh82[-\w]*|service\s*pack)\b/i) && has(text, /\b(display|screen|pantalla|lcd|oled|amoled|modulo|m[oÃ³]dulo|samsung\s+galaxy)\b/i)) return "Pantalla / display";
   if (has(text, /\b(back|rear|battery)\s+(cover\s+)?(adhesive|tape|sticker|seal|gasket)\b/i)) return "Adhesivo para tapa trasera";
   if (has(text, /\b(resin|adhesive|adhesive\s+tape|glue|tape|sticker|seal|sealant|gasket|bonding|oca|epoxy|pegamento|adhesivo)\b/i)) return "Adhesivo / pegamento";
   if (has(text, /\b(charging\s+board|charge\s+port|dock\s+connector|pin\s+de\s+carga|puerto\s+de\s+carga|placa\s+de\s+carga)\b/i)) return "Placa / pin de carga";

--- a/nerin_final_updated/frontend/index.html
+++ b/nerin_final_updated/frontend/index.html
@@ -263,7 +263,22 @@
             Repuestos con salida rápida para técnicos, revendedores y clientes finales.
           </p>
         </div>
-        <div id="featuredGrid" class="product-grid premium-grid" role="list"></div>
+        <div id="featuredGrid" class="product-grid premium-grid" role="list">
+          <article class="product-card" role="listitem">
+            <img src="/assets/hero.png" alt="Pantalla Samsung Galaxy A25 5G Original Service Pack GH82-33214A" loading="lazy" />
+            <div class="product-meta"><span class="sku">GH82-33214A</span><span class="chip">Samsung Galaxy A25 5G</span><span class="chip">Pantalla Service Pack</span></div>
+            <h3>Pantalla Samsung Galaxy A25 5G Original Service Pack GH82-33214A</h3>
+            <div class="availability-badges"><span class="availability-badge" data-status="in">Stock real en CABA</span></div>
+            <div class="product-actions"><a class="button secondary" href="/shop.html?search=GH82-33214A">Ver producto</a></div>
+          </article>
+          <article class="product-card" role="listitem">
+            <img src="/assets/hero.png" alt="Pantalla Samsung Galaxy A15 Original Service Pack en stock real" loading="lazy" />
+            <div class="product-meta"><span class="chip">Samsung Galaxy A15</span><span class="chip">Pantalla Service Pack</span></div>
+            <h3>Pantalla Samsung Galaxy A15 Original Service Pack</h3>
+            <div class="availability-badges"><span class="availability-badge" data-status="in">Stock real en CABA</span></div>
+            <div class="product-actions"><a class="button secondary" href="/shop.html?search=Samsung%20A15%20Service%20Pack">Ver producto</a></div>
+          </article>
+        </div>
         <div class="home-featured__cta">
           <a href="/shop.html" class="button secondary">Ver catálogo completo</a>
         </div>

--- a/nerin_final_updated/frontend/js/index.js
+++ b/nerin_final_updated/frontend/js/index.js
@@ -507,6 +507,33 @@ function getStockStatus(product) {
   return "in";
 }
 
+function isRemoteOrPreorderProduct(product = {}) {
+  const text = [
+    product.availability,
+    product.stock_status,
+    product.stock_mode,
+    product.fulfillment_mode,
+    product.name,
+    product.description,
+    product.category,
+  ].filter(Boolean).join(" ").toLowerCase();
+  return /preorder|backorder|a[_\s-]?pedido|bajo\s+pedido|pedido|remote|remoto|stock\s+remoto/.test(text) ||
+    Number(product.remote_stock || product.stock_remote || product.available_remote || 0) > 0 ||
+    Number(product.remote_lead_days || product.remote_lead_min_days || product.remote_lead_max_days || 0) > 0;
+}
+
+function isPhysicalStockProduct(product = {}) {
+  return Number(product.stock || 0) > 0 && !isRemoteOrPreorderProduct(product);
+}
+
+function isPriorityScreenProduct(product = {}) {
+  const text = [product.name, product.title, product.category, product.sku, product.part_number, product.mpn]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  return /pantalla|display|modulo|m[oó]dulo|service\s*pack|gh82|samsung/.test(text);
+}
+
 function createAvailabilityBadge(label, status) {
   const badge = document.createElement("span");
   badge.className = "availability-badge";
@@ -687,7 +714,7 @@ function createFeaturedCard(product) {
     availability.appendChild(createAvailabilityBadge("Poco stock", "low"));
   } else if (status === "in" && typeof product.stock === "number") {
     availability.appendChild(
-      createAvailabilityBadge(`Stock: ${product.stock} u.`, "in"),
+      createAvailabilityBadge(`Stock real en CABA (${product.stock} u.)`, "in"),
     );
   }
   if (product.vip_only) {
@@ -712,7 +739,7 @@ function createFeaturedCard(product) {
   const more = document.createElement("a");
   more.href = buildProductUrl(product);
   more.className = "button secondary";
-  more.textContent = "Ver detalle";
+  more.textContent = "Ver producto";
   actions.appendChild(more);
   card.appendChild(actions);
 
@@ -754,11 +781,25 @@ function resolveFeaturedProducts(products, ids) {
       selected.push(product);
     });
     if (selected.length) {
-      return selected.slice(0, 6);
+      const stockSelected = selected
+        .filter(isPhysicalStockProduct)
+        .sort((a, b) =>
+          Number(isPriorityScreenProduct(b)) - Number(isPriorityScreenProduct(a)) ||
+          Number(b.stock || 0) - Number(a.stock || 0),
+        )
+        .slice(0, 6);
+      if (stockSelected.length) return stockSelected;
     }
   }
 
-  return uniqueProducts.slice(0, 4);
+  return uniqueProducts
+    .filter(isPhysicalStockProduct)
+    .sort((a, b) =>
+      Number(isPriorityScreenProduct(b)) - Number(isPriorityScreenProduct(a)) ||
+      Number(b.stock || 0) - Number(a.stock || 0) ||
+      String(a.name || "").localeCompare(String(b.name || ""), "es", { sensitivity: "base" }),
+    )
+    .slice(0, 6);
 }
 
 let featuredLoadVersion = 0;

--- a/nerin_final_updated/frontend/js/seo-helpers.js
+++ b/nerin_final_updated/frontend/js/seo-helpers.js
@@ -247,6 +247,31 @@ function inferServicePack(product = {}) {
   return textFields.some((value) => typeof value === "string" && /service\s*pack/i.test(value)) || true;
 }
 
+function isStockRealProduct(product = {}) {
+  const text = [product.availability, product.stock_status, product.stock_mode, product.fulfillment_mode]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  const remote = /preorder|backorder|a[_\s-]?pedido|bajo\s+pedido|pedido|remote|remoto/.test(text) ||
+    Number(product.remote_stock || product.stock_remote || product.available_remote || 0) > 0;
+  return Number(product.stock || 0) > 0 && !remote;
+}
+
+function buildCommercialModel(product = {}, label = "") {
+  return normalizeText(
+    product.model ||
+      product.modelo ||
+      product.model_base ||
+      label.match(/\b(?:Samsung\s+)?Galaxy\s+[A-Z]?\d{2,3}(?:\s*5G)?\b/i)?.[0] ||
+      label.match(/\bSM-[A-Z0-9]+(?:\/[A-Z0-9]+)?\b/i)?.[0] ||
+      "",
+  );
+}
+
+function buildPartCode(product = {}, label = "") {
+  return normalizeText(label.match(/\bGH82[-A-Z0-9]+\b/i)?.[0] || product.sku || product.mpn || product.part_number || "");
+}
+
 // Generador centralizado de metadatos SEO para un producto.
 // Mantiene el nombre comercial real y evita copy inventado.
 export function generateProductSeo(product = {}) {
@@ -255,6 +280,34 @@ export function generateProductSeo(product = {}) {
   );
   const brand = normalizeText(product?.brand || product?.catalog_brand);
   const sku = normalizeText(product?.sku);
+
+  if (isStockRealProduct(product)) {
+    const model = buildCommercialModel(product, label);
+    const partCode = buildPartCode(product, label || sku);
+    const isScreen = /pantalla|display|modulo|m[oó]dulo|gh82|service\s*pack/i.test([label, product.category].join(" "));
+    const brandCopy = /samsung/i.test(brand || label) ? "Samsung" : brand;
+    const titleSubject = [
+      isScreen ? "Pantalla" : label,
+      brandCopy && isScreen ? brandCopy : "",
+      model,
+      "Original Service Pack",
+      partCode,
+      "en Stock",
+    ].filter(Boolean).join(" ");
+    const descriptionSubject = [
+      isScreen ? "pantalla original" : label,
+      brandCopy,
+      model,
+      partCode,
+      "Service Pack",
+    ].filter(Boolean).join(" ");
+    return {
+      title: truncateText(`${titleSubject} | NERIN Parts`, 160),
+      description: truncateText(`Compra ${descriptionSubject} con stock real en CABA, factura A/B, garantia tecnica y envio a todo Argentina.`, 200),
+      ogTitle: titleSubject,
+      ogDescription: "Stock real en CABA, factura A/B, garantia tecnica y envio a Argentina.",
+    };
+  }
 
   const extras = [];
   if (brand) extras.push(`Marca: ${brand}.`);

--- a/nerin_final_updated/scripts/audit-google-merchant-feed.js
+++ b/nerin_final_updated/scripts/audit-google-merchant-feed.js
@@ -6,6 +6,7 @@ const {
   buildMerchantFeedEntries,
   isEligibleState,
   normalizeMerchantImageUrl,
+  resolvePhysicalStockEligibility,
 } = require("../backend/utils/merchantFeed");
 const {
   resolveProductAvailability,
@@ -112,10 +113,12 @@ async function main() {
     const summary = {
       totalProducts: rows.length,
       publicProducts: 0,
-      preorderProducts: 0,
-      preorderMissingAvailabilityDate: 0,
-      preorderMissingVisibleDate: 0,
-      preorderMissingJsonLdAvailabilityStarts: 0,
+      physicalStockProducts: 0,
+      feedProducts: feed.entries.length,
+      remoteOrPreorderExcluded: 0,
+      outOfStockExcluded: 0,
+      notInPhysicalStockExcluded: 0,
+      invalidFeedAvailabilityProducts: 0,
       productsWithAvailabilityDateOlderThanToday: 0,
       productsWithAvailabilityDateMoreThanOneYearAhead: 0,
       productsWithPriceMismatch: 0,
@@ -124,6 +127,11 @@ async function main() {
       criticalErrorCount: 0,
       sampleErrors: [],
     };
+    const invalidFeedEntries = feed.entries.filter((entry) => entry.availability !== "in_stock");
+    summary.invalidFeedAvailabilityProducts = invalidFeedEntries.length;
+    invalidFeedEntries.slice(0, 20).forEach((entry) => {
+      pushSample(summary.sampleErrors, { id: entry.id, title: entry.title, reason: "feedAvailabilityNotInStock", availability: entry.availability });
+    });
 
     for (const row of rows) {
       const raw = extractRaw(row);
@@ -144,20 +152,22 @@ async function main() {
       }
       if (!isEligibleState(row, raw)) continue;
       const availability = resolveProductAvailability(product);
+      const physical = resolvePhysicalStockEligibility(row, raw, PREORDER_DAYS);
+      if (physical.eligible) summary.physicalStockProducts += 1;
+      else if (physical.remoteOrPreorder) summary.remoteOrPreorderExcluded += 1;
+      else if (physical.outOfStock) summary.outOfStockExcluded += 1;
+      else summary.notInPhysicalStockExcluded += 1;
       const feedEntry = entriesById.get(String(id));
+      if (["preorder", "backorder", "out_of_stock"].includes(feedEntry?.availability)) {
+        summary.invalidFeedAvailabilityProducts += 1;
+        pushSample(summary.sampleErrors, { id, title, reason: "forbiddenFeedAvailability", availability: feedEntry.availability });
+      }
       if (["preorder", "backorder"].includes(availability.merchantAvailability)) {
-        summary.preorderProducts += 1;
         const feedDate = feedEntry?.availability_date || "";
-        if (!feedDate) {
-          summary.preorderMissingAvailabilityDate += 1;
-          pushSample(summary.sampleErrors, { id, title, reason: "preorderMissingAvailabilityDate" });
-        }
         if (!availability.availabilityDateDisplay || !availability.visibleAvailabilityText.includes(availability.availabilityDateDisplay)) {
-          summary.preorderMissingVisibleDate += 1;
           pushSample(summary.sampleErrors, { id, title, reason: "preorderMissingVisibleDate" });
         }
         if (!availability.availabilityStarts) {
-          summary.preorderMissingJsonLdAvailabilityStarts += 1;
           pushSample(summary.sampleErrors, { id, title, reason: "preorderMissingJsonLdAvailabilityStarts" });
         }
         if (isDateOlderThanToday(feedDate)) {
@@ -179,14 +189,13 @@ async function main() {
     }
 
     summary.criticalErrorCount =
-      summary.preorderMissingAvailabilityDate +
-      summary.preorderMissingVisibleDate +
-      summary.preorderMissingJsonLdAvailabilityStarts +
+      summary.invalidFeedAvailabilityProducts +
       summary.productsWithAvailabilityDateOlderThanToday +
       summary.productsWithAvailabilityDateMoreThanOneYearAhead +
       summary.productsWithPriceMismatch +
       summary.productsWithMissingLandingUrl;
 
+    console.log("[audit-google-merchant-feed] Produccion: Merchant solo stock fisico real");
     console.log(JSON.stringify(summary, null, 2));
     if (summary.criticalErrorCount > 0) process.exitCode = 1;
   } finally {


### PR DESCRIPTION
## Resumen
- Merchant feed ahora emite exclusivamente productos con `merchantAvailability === "in_stock"`, stock local numerico > 0 y sin senales de remoto/a pedido/preorder/backorder.
- Agrega contadores y samples de exclusion para `notInPhysicalStock`, `remoteOrPreorderExcluded` y `outOfStockExcluded`; la auditoria falla si el feed contiene availability distinta de `in_stock`.
- Revalida `/sitemap-stock.xml` con la misma regla de stock fisico real y declara ese sitemap en `robots.txt` antes del sitemap general.
- Prioriza stock real en home/shop, agrega fallback HTML inicial de productos destacados, mejora SEO comercial de productos en stock real y evita clasificar GH82/Service Pack como flex.

## Tests
- `npx jest --runInBand __tests__/backend/merchant-feed.test.js backend/__tests__/merchant-availability-ui.test.js backend/__tests__/organic-seo-stock-real.test.js backend/__tests__/product-ssr.test.js`
- `node --check backend/utils/merchantFeed.js`
- `node --check scripts/audit-google-merchant-feed.js`
- `node --check backend/server.js`