### PR TITLE
[codex] Priorizar stock real en SEO y Google Merchant

### DIFF
--- a/nerin_final_updated/__tests__/backend/catalog-visibility.test.js
+++ b/nerin_final_updated/__tests__/backend/catalog-visibility.test.js
@@ -1,0 +1,27 @@
+const {
+  deduplicateCatalogProducts,
+  sortCatalogProducts,
+} = require('../../backend/utils/catalogVisibility');
+
+describe('catalog visibility', () => {
+  test('orden recomendado: stock real, a pedido y sin stock', () => {
+    const products = [
+      { id: 'out', name: 'Sin stock', slug: 'out', stock: 0, availability: 'out_of_stock', price: 100, image: '/out.jpg' },
+      { id: 'remote', name: 'A pedido', slug: 'remote', stock: 0, stock_mode: 'remote', price: 100, image: '/remote.jpg' },
+      { id: 'real', name: 'Stock real', slug: 'real', stock: 3, price: 100, image: '/real.jpg' },
+    ];
+    expect(sortCatalogProducts(products).map((product) => product.id)).toEqual(['real', 'remote', 'out']);
+  });
+
+  test('elimina duplicados por MPN, SKU, slug o título normalizado', () => {
+    const products = [
+      { id: 'a', mpn: 'GH82-30480E', sku: 'A', slug: 'pantalla-a', name: 'Pantalla A' },
+      { id: 'b', mpn: 'gh82 30480e', sku: 'B', slug: 'pantalla-b', name: 'Pantalla B' },
+      { id: 'c', sku: 'A', slug: 'pantalla-c', name: 'Pantalla C' },
+      { id: 'd', sku: 'D', slug: 'pantalla-a', name: 'Pantalla D' },
+      { id: 'e', sku: 'E', slug: 'pantalla-e', name: 'Pántalla A' },
+      { id: 'f', sku: 'F', slug: 'pantalla-f', name: 'Pantalla F' },
+    ];
+    expect(deduplicateCatalogProducts(products).map((product) => product.id)).toEqual(['a', 'f']);
+  });
+});

--- a/nerin_final_updated/__tests__/backend/merchant-feed.test.js
+++ b/nerin_final_updated/__tests__/backend/merchant-feed.test.js
@@ -54,16 +54,16 @@ describe('merchant feed audit', () => {
     expect(audit.samplesEligible[0].availability_date).toBeNull();
   });
 
-  test('stock 0 vendible a pedido => preorder + availability_date', () => {
+  test('stock 0 sin señal remota => out_of_stock sin availability_date', () => {
     const audit = buildMerchantFeedAudit([baseRow({ stock: 0 })]);
-    expect(audit.samplesEligible[0].availability).toBe('preorder');
-    expect(audit.samplesEligible[0].availability_date).toMatch(/^\d{4}-\d{2}-\d{2}T00:00-0300$/);
+    expect(audit.samplesEligible[0].availability).toBe('out_of_stock');
+    expect(audit.samplesEligible[0].availability_date).toBeNull();
   });
 
   test('preorder comparte fecha entre feed, texto visible y JSON-LD', () => {
     const availability = resolveProductAvailability(baseRow({ stock: 0, availability_date: '2026-06-16' }), { now: new Date('2026-05-19T12:00:00Z') });
     expect(availability.merchantAvailability).toBe('preorder');
-    expect(availability.availabilityDateFeed).toBe('2026-06-16T00:00-0300');
+    expect(availability.availabilityDateFeed).toBe('2026-06-16T00:00:00-03:00');
     expect(availability.availabilityStarts).toBe('2026-06-16T00:00:00-03:00');
     expect(availability.visibleAvailabilityText).toContain('16/06/2026');
     expect(availability.seoAvailability).toBe('https://schema.org/PreOrder');
@@ -72,8 +72,8 @@ describe('merchant feed audit', () => {
   test('availability_date vencido o mayor a un anio se normaliza a ventana valida', () => {
     const older = resolveProductAvailability(baseRow({ stock: 0, availability_date: '2026-01-01' }), { now: new Date('2026-05-19T12:00:00Z') });
     const tooFar = resolveProductAvailability(baseRow({ stock: 0, availability_date: '2028-01-01' }), { now: new Date('2026-05-19T12:00:00Z') });
-    expect(older.availabilityDateFeed).toBe('2026-05-20T00:00-0300');
-    expect(tooFar.availabilityDateFeed).toBe('2027-05-19T00:00-0300');
+    expect(older.availabilityDateFeed).toBe('2026-05-20T00:00:00-03:00');
+    expect(tooFar.availabilityDateFeed).toBe('2027-05-19T00:00:00-03:00');
   });
   test('contadores reales pueden ser mayores al lote escaneado', () => {
     const rows = [baseRow({ id: 'a' }), baseRow({ id: 'b', is_public: 0 })];
@@ -87,7 +87,7 @@ describe('merchant feed audit', () => {
 
   test('producto público stock 0 con imagen externa válida no cae en missingAvailability', () => {
     const audit = buildMerchantFeedAudit([
-      baseRow({ id: 'pre-ext', stock: 0, image: 'https://images.2service.nl/v7/Images/Part/1/img.jpg' }),
+      baseRow({ id: 'pre-ext', stock: 0, stock_mode: 'remote', image: 'https://images.2service.nl/v7/Images/Part/1/img.jpg' }),
     ]);
     expect(audit.skipped.missingAvailability).toBe(0);
     expect(audit.emittedCount).toBe(1);
@@ -232,15 +232,15 @@ describe('merchant feed tsv payload', () => {
   });
 
   test('preorder e in_stock availability_date correcto y headers esperados', () => {
-    const rows = [baseRow({ id: 'stk', stock: 3 }), baseRow({ id: 'pre', stock: 0 }), baseRow({ id: 'back', stock: 0, raw_json: JSON.stringify({ availability: 'backorder' }) })];
+    const rows = [baseRow({ id: 'stk', stock: 3 }), baseRow({ id: 'pre', stock: 0, stock_mode: 'remote' }), baseRow({ id: 'back', stock: 0, raw_json: JSON.stringify({ availability: 'backorder' }) })];
     const { entries } = buildMerchantFeedEntries(rows);
     const byId = Object.fromEntries(entries.map((e) => [e.id, e]));
     expect(byId.stk.availability).toBe('in_stock');
     expect(byId.stk.availability_date).toBe('');
     expect(byId.pre.availability).toBe('preorder');
-    expect(byId.pre.availability_date).toMatch(/^\d{4}-\d{2}-\d{2}T00:00-0300$/);
+    expect(byId.pre.availability_date).toMatch(/^\d{4}-\d{2}-\d{2}T00:00:00-03:00$/);
     expect(byId.back.availability).toBe('backorder');
-    expect(byId.back.availability_date).toMatch(/^\d{4}-\d{2}-\d{2}T00:00-0300$/);
+    expect(byId.back.availability_date).toMatch(/^\d{4}-\d{2}-\d{2}T00:00:00-03:00$/);
     expect(Object.keys(entries[0])).toEqual(['id','title','description','link','image_link','additional_image_link','availability','availability_date','price','condition','brand','mpn','identifier_exists','google_product_category','product_type']);
   });
 
@@ -252,8 +252,8 @@ describe('merchant feed tsv payload', () => {
     ];
     const { entries } = buildMerchantFeedEntries(rows);
     const byId = Object.fromEntries(entries.map((e) => [e.id, e]));
-    expect(byId.moji.title).toContain('Módulo');
-    expect(byId.moji.title).toContain('Cámaras');
+    expect(byId.moji.title).toContain('Pantalla');
+    expect(byId.moji.title).not.toMatch(/MÃ|CÃ/);
     expect(byId.moji.additional_image_link).toBe('https://a.com/y.jpg');
     expect(byId.comp.product_type).toBe('Componentes electrónicos');
     expect(byId.cam.product_type).toBe('Cámaras y lentes');
@@ -297,6 +297,35 @@ describe('merchant feed tsv payload', () => {
     const byId = Object.fromEntries(entries.map((e) => [e.id, e.product_type]));
     expect(byId['disp-batt']).toBe('Pantallas');
     expect(byId['batt-main']).toBe('Baterias');
+  });
+
+  test('feed principal stock real excluye preorder, backorder y out_of_stock', () => {
+    const rows = [
+      baseRow({ id: 'real', sku: 'REAL', stock: 2 }),
+      baseRow({ id: 'pre', sku: 'PRE', stock: 0, stock_mode: 'remote' }),
+      baseRow({ id: 'back', sku: 'BACK', stock: 0, availability: 'backorder' }),
+      baseRow({ id: 'out', sku: 'OUT', stock: 0, availability: 'out_of_stock' }),
+    ];
+    const main = buildMerchantFeedEntries(rows, { feedScope: 'in_stock' }).entries;
+    expect(main.map((entry) => entry.id)).toEqual(['REAL']);
+    expect(main.every((entry) => entry.availability === 'in_stock' && entry.availability_date === '')).toBe(true);
+
+    const preorder = buildMerchantFeedEntries(rows, { feedScope: 'preorder' }).entries;
+    expect(preorder.map((entry) => entry.id).sort()).toEqual(['BACK', 'PRE']);
+    expect(preorder.every((entry) => /T00:00:00-03:00$/.test(entry.availability_date))).toBe(true);
+  });
+
+  test('feed separa marca comercial de compatibilidad', () => {
+    const compatible = baseRow({
+      id: 'compatible',
+      sku: 'COMP-1',
+      name: 'Display incl. frame Compatible soft For Samsung Galaxy S22 Plus - Black',
+      brand: 'Samsung',
+    }, { quality: 'Compatible soft', model: 'Galaxy S22 Plus' });
+    const [entry] = buildMerchantFeedEntries([compatible], { feedScope: 'in_stock' }).entries;
+    expect(entry.title).toContain('Pantalla compatible');
+    expect(entry.brand).toBe('Compatible');
+    expect(entry.identifier_exists).toBe('no');
   });
 
 });

--- a/nerin_final_updated/__tests__/backend/product-seo-taxonomy.test.js
+++ b/nerin_final_updated/__tests__/backend/product-seo-taxonomy.test.js
@@ -50,7 +50,34 @@ describe("product SEO taxonomy", () => {
   });
 
   test("pressing jig display is repair tool", () => {
-    expect(detectProductType({ name: "Pressing jig display" })).toBe("Herramienta / accesorio tecnico");
+    expect(detectProductType({ name: "Pressing jig display" })).toBe("Herramienta / accesorio técnico");
+  });
+
+  test("genera titulo comercial para Service Pack Samsung", () => {
+    const product = {
+      name: "Display (Original) - Grey, Samsung Galaxy S23; SM-S911B",
+      description: "Display (Original) - Grey, Samsung Galaxy S23; SM-S911B",
+      brand: "Samsung",
+      model: "Galaxy S23 SM-S911B",
+      quality: "Original",
+      mpn: "GH82-30480E",
+    };
+    expect(generateProductSeo(product).title).toBe("Pantalla original Samsung Galaxy S23 SM-S911B Gris Service Pack GH82-30480E | NERIN Parts");
+  });
+
+  test("un compatible no se presenta como original Samsung", () => {
+    const product = {
+      name: "Display incl. frame Compatible soft For Samsung Galaxy S22 Plus - Black",
+      description: "Display incl. frame Compatible soft For Samsung Galaxy S22 Plus - Black",
+      brand: "Samsung",
+      model: "Galaxy S22 Plus",
+      quality: "Compatible soft",
+      color: "Black",
+    };
+    const title = generateProductSeo(product).title;
+    expect(title).toContain("Pantalla compatible");
+    expect(title).toContain("Samsung Galaxy S22 Plus");
+    expect(title).not.toMatch(/original Samsung/i);
   });
 
   test("battery is battery", () => {

--- a/nerin_final_updated/__tests__/backend/seo-endpoints.test.js
+++ b/nerin_final_updated/__tests__/backend/seo-endpoints.test.js
@@ -84,6 +84,7 @@ describe('SEO endpoints', () => {
     expect(staticRes.status).toBe(200);
     expect(staticRes.text).toContain('<loc>https://nerinparts.example/</loc>');
     expect(staticRes.text).toContain('<loc>https://nerinparts.example/shop.html</loc>');
+    expect(staticRes.text).not.toContain('<loc>https://nerinparts.example/shop</loc>');
 
     const productsRes = await request(server).get('/sitemap-products-1.xml');
     expect(productsRes.status).toBe(200);

--- a/nerin_final_updated/backend/__tests__/merchant-availability-ui.test.js
+++ b/nerin_final_updated/backend/__tests__/merchant-availability-ui.test.js
@@ -3,6 +3,8 @@ const os = require("os");
 const path = require("path");
 const request = require("supertest");
 
+jest.setTimeout(30000);
+
 function writeCatalog(dir) {
   const products = [
     {
@@ -36,7 +38,7 @@ function writeCatalog(dir) {
       availability: "backorder",
       remote_lead_min_days: 20,
       remote_lead_max_days: 30,
-      availability_date: "2026-06-19",
+      availability_date: "2026-07-19",
       price_minorista: 1200,
       image: "/assets/product2.png",
       visibility: "public",
@@ -102,8 +104,8 @@ describe("Merchant-safe availability UI", () => {
       expect(res.status).toBe(200);
       expect(res.text).toContain("Disponible a pedido");
       expect(res.text).toContain("Entrega estimada: 20 a 30 dias");
-      expect(res.text).toContain('<time datetime="2026-06-19T00:00:00-03:00">19/06/2026</time>');
-      expect(res.text).toContain('"availabilityStarts":"2026-06-19T00:00:00-03:00"');
+      expect(res.text).toContain('<time datetime="2026-07-19T00:00:00-03:00">19/07/2026</time>');
+      expect(res.text).toContain('"availabilityStarts":"2026-07-19T00:00:00-03:00"');
       expect(res.text).toContain("Primero gestionamos el ingreso del repuesto.");
       expect(res.text).not.toContain("despacho prioritario en 24 h");
     });
@@ -155,7 +157,7 @@ describe("Merchant feed availability fields", () => {
     };
     const rows = [
       { ...base, id: "stock", sku: "STOCK", slug: "stock", public_slug: "stock", name: "Producto en stock", stock: 2, availability: "in_stock" },
-      { ...base, id: "pedido", sku: "PEDIDO", slug: "pedido", public_slug: "pedido", name: "Producto a pedido", stock: 0, stock_mode: "remote", availability: "backorder", availability_date: "2026-06-19", remote_lead_min_days: 20, remote_lead_max_days: 30 },
+      { ...base, id: "pedido", sku: "PEDIDO", slug: "pedido", public_slug: "pedido", name: "Producto a pedido", stock: 0, stock_mode: "remote", availability: "backorder", availability_date: "2026-07-19", remote_lead_min_days: 20, remote_lead_max_days: 30 },
       { ...base, id: "out", sku: "OUT", slug: "out", public_slug: "out", name: "Producto sin stock", stock: 0, availability: "out_of_stock" },
     ];
     const { entries } = buildMerchantFeedEntries(rows, { limit: 10, baseUrl: "https://nerinparts.com.ar" });
@@ -163,7 +165,7 @@ describe("Merchant feed availability fields", () => {
     expect(byId.STOCK.availability).toBe("in_stock");
     expect(byId.STOCK.availability_date).toBe("");
     expect(byId.PEDIDO.availability).toBe("backorder");
-    expect(byId.PEDIDO.availability_date).toBe("2026-06-19T00:00-0300");
+    expect(byId.PEDIDO.availability_date).toBe("2026-07-19T00:00:00-03:00");
     expect(byId.OUT.availability).toBe("out_of_stock");
     expect(byId.OUT.availability_date).toBe("");
   });

--- a/nerin_final_updated/backend/__tests__/organic-seo-stock-real.test.js
+++ b/nerin_final_updated/backend/__tests__/organic-seo-stock-real.test.js
@@ -3,7 +3,9 @@ const os = require("os");
 const path = require("path");
 const request = require("supertest");
 
-function writeCatalog(dir) {
+jest.setTimeout(30000);
+
+function writeCatalog(dir, { excludeBattery = false } = {}) {
   const products = [
     {
       id: "sam-a15-display",
@@ -56,7 +58,7 @@ function writeCatalog(dir) {
       availability: "backorder",
       remote_lead_min_days: 20,
       remote_lead_max_days: 30,
-      availability_date: "2026-06-19",
+      availability_date: "2026-07-19",
       price_minorista: 1200,
       image: "/assets/product3.png",
       visibility: "public",
@@ -81,24 +83,28 @@ function writeCatalog(dir) {
       enabled: true,
       is_public: true,
     },
-  ];
+  ].filter((product) => !(excludeBattery && product.id === "iphone-12-battery"));
   fs.writeFileSync(path.join(dir, "products.json"), JSON.stringify({ products }, null, 2), "utf8");
   fs.writeFileSync(path.join(dir, "config.json"), JSON.stringify({ publicUrl: "https://nerinparts.example" }, null, 2), "utf8");
 }
 
-async function withServer(testFn) {
+async function withServer(testFn, options = {}) {
   const previousDataDir = process.env.DATA_DIR;
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nerin-organic-seo-"));
   process.env.DATA_DIR = dir;
-  writeCatalog(dir);
+  writeCatalog(dir, options);
   jest.resetModules();
   const { createServer } = require("../server");
-  await require("../data/productsSqliteRepo").ensureProductsDbOnce();
+  const productsSqliteRepo = require("../data/productsSqliteRepo");
+  await productsSqliteRepo.ensureProductsDbOnce();
   const server = createServer();
   try {
     await testFn(server);
   } finally {
     if (server.close) server.close();
+    if (typeof productsSqliteRepo.closeProductsDbForTests === "function") {
+      await productsSqliteRepo.closeProductsDbForTests();
+    }
     process.env.DATA_DIR = previousDataDir;
     jest.resetModules();
   }
@@ -132,10 +138,24 @@ describe("organic stock-real SEO", () => {
     await withServer(async (server) => {
       const res = await request(server).get("/p/pantalla-samsung-galaxy-a15?debugSeo=1");
       expect(res.status).toBe(200);
-      expect(res.text).toContain("<title>Pantalla Samsung Galaxy A15 en stock | NERIN Parts</title>");
+      expect(res.text).toContain("<title>Pantalla original Samsung Galaxy A15 | NERIN Parts</title>");
       expect(res.text).toContain("https://schema.org/InStock");
       expect(res.text).not.toContain("availabilityStarts");
+      expect(res.text).toContain("En stock real · 5 unidades disponibles");
+      expect(res.text).toContain("Agregar al carrito / Comprar ahora");
+      expect(res.text).toContain("Consultar compatibilidad por WhatsApp");
+      expect(res.text).toContain("Factura A/B disponible");
       expect(res.text).toContain("data-debug-seo=\"1\"");
+    });
+  });
+
+  test("producto sin stock desactiva compra y publica OutOfStock", async () => {
+    await withServer(async (server) => {
+      const res = await request(server).get("/p/display-out-of-stock");
+      expect(res.status).toBe(200);
+      expect(res.text).toContain("https://schema.org/OutOfStock");
+      expect(res.text).toContain("Sin stock — compra desactivada");
+      expect(res.text).toContain('data-ssr-product-cta="1" disabled');
     });
   });
 
@@ -144,15 +164,15 @@ describe("organic stock-real SEO", () => {
       const res = await request(server).get("/p/display-iphone-13-pedido");
       expect(res.status).toBe(200);
       expect(res.text).toContain("Disponible a pedido");
-      expect(res.text).toContain('<time datetime="2026-06-19T00:00:00-03:00">19/06/2026</time>');
-      expect(res.text).toContain('"availabilityStarts":"2026-06-19T00:00:00-03:00"');
+      expect(res.text).toContain('<time datetime="2026-07-19T00:00:00-03:00">19/07/2026</time>');
+      expect(res.text).toContain('"availabilityStarts":"2026-07-19T00:00:00-03:00"');
       expect(res.text).not.toContain("stock real en CABA. Factura");
     });
   });
 
   test("sitemap incluye paginas SEO validas y no genera paginas vacias", async () => {
     await withServer(async (server) => {
-      const res = await request(server).get("/sitemap.xml");
+      const res = await request(server).get("/sitemap-static.xml");
       expect(res.status).toBe(200);
       expect(res.text).toContain("<loc>https://nerinparts.example/stock-real</loc>");
       expect(res.text).toContain("<loc>https://nerinparts.example/pantallas-en-stock</loc>");
@@ -160,6 +180,41 @@ describe("organic stock-real SEO", () => {
       expect(res.text).toContain("<loc>https://nerinparts.example/repuestos-samsung</loc>");
       expect(res.text).toContain("<loc>https://nerinparts.example/repuestos-iphone</loc>");
       expect(res.text).not.toContain("sin-productos");
+    });
+  });
+
+  test("/baterias-en-stock vacia responde 200 noindex y deja de estar linkeada", async () => {
+    await withServer(async (server) => {
+      const landing = await request(server).get("/baterias-en-stock");
+      expect(landing.status).toBe(200);
+      expect(landing.text).toContain('name="robots" content="noindex,follow"');
+      expect(landing.text).toContain('rel="canonical" href="https://nerinparts.example/baterias-en-stock"');
+
+      const home = await request(server).get("/");
+      expect(home.status).toBe(200);
+      expect(home.text).not.toContain('href="/baterias-en-stock"');
+
+      const sitemap = await request(server).get("/sitemap-static.xml");
+      expect(sitemap.text).not.toContain("/baterias-en-stock</loc>");
+    }, { excludeBattery: true });
+  });
+
+  test("feeds Merchant separan stock real y productos a pedido", async () => {
+    await withServer(async (server) => {
+      const main = await request(server).get("/merchant-feed.tsv?limit=20");
+      expect(main.status).toBe(200);
+      expect(main.text).toContain("SAM-A15-DISPLAY");
+      expect(main.text).toContain("IPH12-BAT");
+      expect(main.text).not.toContain("PEDIDO-SEO");
+      expect(main.text).not.toContain("OUT-SEO");
+      expect(main.text).not.toMatch(/\t(preorder|backorder|out_of_stock)\t/);
+
+      const preorder = await request(server).get("/merchant-feed-preorder.tsv?limit=20");
+      expect(preorder.status).toBe(200);
+      expect(preorder.text).toContain("PEDIDO-SEO");
+      expect(preorder.text).toContain("2026-07-19T00:00:00-03:00");
+      expect(preorder.text).not.toContain("SAM-A15-DISPLAY");
+      expect(preorder.text).not.toContain("OUT-SEO");
     });
   });
 

--- a/nerin_final_updated/backend/__tests__/product-ssr.test.js
+++ b/nerin_final_updated/backend/__tests__/product-ssr.test.js
@@ -1,6 +1,8 @@
 const path = require('path');
 const request = require('supertest');
 
+jest.setTimeout(30000);
+
 process.env.DATA_DIR = path.join(__dirname, '..', '..', 'data');
 
 const { createServer } = require('../server');
@@ -80,6 +82,13 @@ describe('product SSR', () => {
     const res = await request(server).get('/p/not-found');
     expect(res.status).toBe(404);
     expect(res.text).toContain('<meta name="robots" content="noindex">');
+  });
+
+  test('product.html?id redirige a la ficha canónica por slug', async () => {
+    const product = productsData.find((item) => item?.id != null && item?.slug);
+    const res = await request(server).get(`/product.html?id=${encodeURIComponent(product.id)}`);
+    expect(res.status).toBe(301);
+    expect(res.headers.location).toBe(`/p/${encodeURIComponent(product.slug)}`);
   });
 });
 

--- a/nerin_final_updated/backend/data/productsSqliteRepo.js
+++ b/nerin_final_updated/backend/data/productsSqliteRepo.js
@@ -15,6 +15,7 @@ const {
   isRealScreenProduct,
   isScreenAdhesiveProduct,
 } = require("../utils/screenProductClassifier");
+const { deduplicateCatalogProducts } = require("../utils/catalogVisibility");
 
 const PRODUCTS_JSON_PATH = dataPath("products.json");
 function resolveSqlitePath() {
@@ -3942,12 +3943,13 @@ async function querySearchIndex(params = {}) {
   const orderBy =
     params.sort === "recent" ? "si.product_rowid DESC" :
     params.sort === "stock" || params.sort === "stock_desc" ? "si.stock DESC, si.title ASC" :
+    params.sort === "stock_asc" ? "si.stock ASC, si.title ASC" :
     params.sort === "price_asc" ? "si.price ASC, si.title ASC" :
     params.sort === "price_desc" ? "si.price DESC, si.title ASC" :
     params.sort === "name_desc" ? "si.title DESC" :
     params.sort === "name_asc" ? "si.title ASC" :
-    params.sort === "stock_real" ? "si.is_stock_real DESC, si.title ASC" :
-    "si.is_stock_real DESC, si.classification_confidence DESC, si.title ASC";
+    params.sort === "stock_real" ? "CASE si.stock_status WHEN 'in_stock' THEN 0 WHEN 'preorder' THEN 1 ELSE 2 END, si.is_stock_real DESC, si.has_image DESC, CASE WHEN si.price > 0 THEN 1 ELSE 0 END DESC, si.title ASC" :
+    "CASE si.stock_status WHEN 'in_stock' THEN 0 WHEN 'preorder' THEN 1 ELSE 2 END, si.is_stock_real DESC, si.has_image DESC, CASE WHEN si.price > 0 THEN 1 ELSE 0 END DESC, si.classification_confidence DESC, si.title ASC";
   const selectColumns = [
     "si.product_id",
     "si.product_rowid",
@@ -4021,7 +4023,8 @@ async function querySearchIndex(params = {}) {
   const rows = pageEntries.map((entry) => entry.row);
   const selectMs = Date.now() - selectStartedAt;
   const mapStartedAt = Date.now();
-  const items = rows.map((row) => params.adminMode ? buildAdminProductListSummary(row) : buildProductSummary(row));
+  const mappedItems = rows.map((row) => params.adminMode ? buildAdminProductListSummary(row) : buildProductSummary(row));
+  const items = params.adminMode ? mappedItems : deduplicateCatalogProducts(mappedItems);
   const mapMs = Date.now() - mapStartedAt;
   const facetStartedAt = Date.now();
   const facets = includeFacets
@@ -4267,7 +4270,7 @@ async function getPublicSitemapStats() {
       db,
       `SELECT
         COUNT(*) AS totalPublicProducts,
-        SUM(CASE WHEN public_slug IS NOT NULL AND trim(public_slug) != '' THEN 1 ELSE 0 END) AS indexableProducts,
+        COUNT(DISTINCT CASE WHEN public_slug IS NOT NULL AND trim(public_slug) != '' THEN lower(trim(public_slug)) END) AS indexableProducts,
         SUM(CASE WHEN public_slug IS NULL OR trim(public_slug) = '' THEN 1 ELSE 0 END) AS missingSlugProducts
        FROM product_search_index
        WHERE is_public = 1`,
@@ -4300,12 +4303,13 @@ async function listPublicSitemapProducts({ page = 1, pageSize = 2500 } = {}) {
     const selectStartedAt = Date.now();
     const rows = await all(
       db,
-      `SELECT product_rowid, product_id, public_slug, updated_at
+      `SELECT MIN(product_rowid) AS product_rowid, MIN(product_id) AS product_id, MIN(public_slug) AS public_slug, MAX(updated_at) AS updated_at
        FROM product_search_index
        WHERE is_public = 1
          AND public_slug IS NOT NULL
          AND trim(public_slug) != ''
-       ORDER BY product_rowid ASC
+       GROUP BY lower(trim(public_slug))
+       ORDER BY MIN(product_rowid) ASC
        LIMIT ? OFFSET ?`,
       [safePageSize, offset],
     );

--- a/nerin_final_updated/backend/server.js
+++ b/nerin_final_updated/backend/server.js
@@ -99,6 +99,15 @@ const {
   getOrganicSeoPageConfig,
   listOrganicSeoPages,
 } = require("./utils/organicSeoPages");
+const {
+  deduplicateCatalogProducts,
+  sortCatalogProducts,
+} = require("./utils/catalogVisibility");
+const {
+  resolveCommercialBrand,
+  resolveCommercialMpn,
+  resolveCompatibleWith,
+} = require("./utils/productCommercial");
 const { readJsonFile } = require("./utils/jsonFile");
 const {
   appendEvent,
@@ -346,6 +355,7 @@ const publicSearchCache = new Map();
 const merchantFeedRuntimeCache = new Map();
 const DISK_CACHE_DIR = dataPath("cache");
 let sitemapStockCache = { t: 0, baseUrl: null, xml: null, count: 0 };
+let organicNavigationCache = { t: 0, pages: [] };
 
 function getDetailedAnalyticsTtlMs(range = "7d") {
   if (range === "today") return 60_000;
@@ -395,6 +405,7 @@ function invalidateCatalogCaches(reason = "unknown") {
   publicSearchCache.clear();
   merchantFeedRuntimeCache.clear();
   sitemapStockCache = { t: 0, baseUrl: null, xml: null, count: 0 };
+  organicNavigationCache = { t: 0, pages: [] };
   console.log(`[catalog-cache] invalidated reason=${reason}`);
 }
 const importJobs = new Map();
@@ -1530,8 +1541,9 @@ function calculateNetNoNationalTaxes(value, taxRate = 0.21) {
 }
 
 function buildProductUrl(product) {
-  if (product && typeof product.slug === "string" && product.slug.trim()) {
-    return `/p/${encodeURIComponent(product.slug.trim())}`;
+  const slug = product?.publicSlug || product?.public_slug || product?.slug;
+  if (typeof slug === "string" && slug.trim()) {
+    return `/p/${encodeURIComponent(slug.trim())}`;
   }
   const id = product?.id != null ? String(product.id) : "";
   return `/product.html?id=${encodeURIComponent(id)}`;
@@ -1927,15 +1939,20 @@ function renderProductInfoSsr(product, siteBase) {
   const description = buildFeaturePhrase(product);
   const availabilityInfo = resolveProductAvailability(product);
   const availabilityPresentation = buildAvailabilityPresentation(product);
-  const brand = normalizeTextInput(product?.brand);
+  const brand = normalizeTextInput(resolveCommercialBrand(product));
+  const compatibleWith = normalizeTextInput(resolveCompatibleWith(product)) || [normalizeTextInput(product?.brand), normalizeTextInput(product?.model)].filter(Boolean).join(" ");
   const model = normalizeTextInput(product?.model);
   const sku = normalizeTextInput(product?.sku);
+  const mpn = normalizeTextInput(resolveCommercialMpn(product));
   const category = normalizeTextInput(product?.category);
   const stockValue = typeof product?.stock === "number" ? product.stock : null;
   const technology = inferDisplayTechnology(product);
   const frame = inferHasFrame(product);
   const color = inferColor(product);
   let stockCopy = availabilityPresentation.primaryLabel || availabilityInfo.availabilityLabel || "";
+  if (availabilityPresentation.isStockReal && stockValue != null && stockValue > 0) {
+    stockCopy = `En stock real · ${stockValue} unidad${stockValue === 1 ? "" : "es"} disponible${stockValue === 1 ? "" : "s"}`;
+  }
   if (!stockCopy && stockValue != null) {
     if (stockValue <= 0) stockCopy = "Sin stock disponible";
     else if (product?.min_stock != null && stockValue < product.min_stock) {
@@ -1949,13 +1966,14 @@ function renderProductInfoSsr(product, siteBase) {
     model ? `<li><strong>Modelo:</strong> ${esc(model)}</li>` : "",
     category ? `<li><strong>Categoría:</strong> ${esc(category)}</li>` : "",
     sku ? `<li><strong>SKU:</strong> ${esc(sku)}</li>` : "",
+    mpn && mpn !== sku ? `<li><strong>MPN:</strong> ${esc(mpn)}</li>` : "",
     technology ? `<li><strong>Tecnología:</strong> ${esc(technology)}</li>` : "",
     frame ? `<li><strong>Montaje:</strong> ${esc(frame)}</li>` : "",
     color ? `<li><strong>Color:</strong> ${esc(color)}</li>` : "",
   ]
     .filter(Boolean)
     .join("");
-  const compatibility = [brand, model, sku].filter(Boolean).join(" ");
+  const compatibility = [compatibleWith || model, mpn || sku].filter(Boolean).join(" ");
   const compatibilityHtml = compatibility
     ? `<p class=\"product-compatibility\">Compatible con ${esc(compatibility)}.</p>`
     : "";
@@ -1979,13 +1997,18 @@ function renderProductInfoSsr(product, siteBase) {
   }</div>`;
   void wholesalePrice; // El precio mayorista no se renderiza en storefront público SSR.
   const trustList = [
-    "Asesoría especializada en repuestos originales y OEM.",
-    "Logística a todo el país con despachos en 24h.",
+    "Factura A/B disponible.",
+    availabilityPresentation.isStockReal ? "Despacho desde CABA y envíos a todo el país." : "Envíos a todo el país cuando el repuesto esté disponible.",
     "Garantía técnica NERIN con soporte real.",
   ]
     .map((item) => `<li>${esc(item)}</li>`)
     .join("");
   const backLink = `<p class=\"product-backlink\"><a href=\"/shop.html\">Volver al catálogo</a></p>`;
+  const whatsappText = encodeURIComponent(`Hola NERIN, quiero consultar compatibilidad de ${heading}${mpn ? ` (${mpn})` : ""}.`);
+  const purchaseActions = `<div class="product-buy-actions product-buy-actions--ssr">
+    <button type="button" class="button primary product-buy-main-cta" data-ssr-product-cta="1"${availabilityInfo.checkoutAllowed ? "" : " disabled"}>${availabilityInfo.checkoutAllowed ? "Agregar al carrito / Comprar ahora" : "Sin stock — compra desactivada"}</button>
+    <a class="button secondary" href="https://wa.me/5491130341550?text=${whatsappText}" target="_blank" rel="noopener">Consultar compatibilidad por WhatsApp</a>
+  </div>`;
   return `
     <header class=\"product-summary\">
       <h1>${esc(heading)}</h1>
@@ -2013,6 +2036,7 @@ function renderProductInfoSsr(product, siteBase) {
         ${renderAndreaniShippingSsr(availabilityPresentation)}
         <div class=\"quiet-trust-banner\">Seguimos operando normalmente. Estamos mejorando la experiencia de compra. Ante cualquier duda de compatibilidad o stock, escribinos por WhatsApp.</div>
         ${priceBlock}
+        ${purchaseActions}
         <p class=\"product-promo\">Consultá por instalación y descuentos para servicios técnicos.</p>
         ${backLink}
       </aside>
@@ -2187,18 +2211,63 @@ async function fetchOrganicProducts({ limit = 300, stockRealOnly = false } = {})
 }
 
 function sortOrganicProducts(products = []) {
-  return [...products].sort((a, b) => {
+  const sorted = [...products].sort((a, b) => {
     const seoA = computeOrganicSeoPriority(a);
     const seoB = computeOrganicSeoPriority(b);
     const stockA = Number(a.stock || 0);
     const stockB = Number(b.stock || 0);
     return seoB.priorityScore - seoA.priorityScore || stockB - stockA || String(a.name || "").localeCompare(String(b.name || ""), "es", { sensitivity: "base" });
   });
+  return deduplicateCatalogProducts(sortCatalogProducts(sorted));
 }
 
 async function getOrganicProductsForPage(pageKey, limit = 48) {
   const candidates = await fetchOrganicProducts({ limit: 800, stockRealOnly: true });
   return sortOrganicProducts(candidates.filter((product) => matchesOrganicPage(product, pageKey))).slice(0, limit);
+}
+
+async function getAvailableOrganicNavigationPages() {
+  const now = Date.now();
+  if (organicNavigationCache.t && now - organicNavigationCache.t < 5 * 60 * 1000) {
+    return organicNavigationCache.pages;
+  }
+  const pages = [];
+  try {
+    for (const config of listOrganicSeoPages()) {
+      if (!config?.key || !config?.canonicalPath) continue;
+      const products = await getOrganicProductsForPage(config.key, 1);
+      if (products.length) pages.push(config);
+    }
+  } catch (error) {
+    console.warn("[organic-navigation:unavailable]", error?.message || error);
+    return organicNavigationCache.pages || [];
+  }
+  organicNavigationCache = { t: now, pages };
+  return pages;
+}
+
+function renderOrganicNavigation(pages = []) {
+  const labels = {
+    "stock-real": "Stock real",
+    "pantallas-en-stock": "Pantallas",
+    "baterias-en-stock": "Baterías",
+    "repuestos-samsung": "Samsung",
+    "repuestos-iphone": "iPhone",
+  };
+  return pages
+    .map((page) => `<a href="${esc(page.canonicalPath)}">${esc(labels[page.key] || page.h1 || page.key)}</a>`)
+    .join("\n      ");
+}
+
+function stripUnavailableOrganicLinks(html = "", availablePages = []) {
+  const allowed = new Set(availablePages.map((page) => page.canonicalPath));
+  let next = String(html || "");
+  for (const page of listOrganicSeoPages()) {
+    if (!page?.canonicalPath || allowed.has(page.canonicalPath)) continue;
+    const escapedPath = page.canonicalPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    next = next.replace(new RegExp(`<a\\b[^>]*href=["']${escapedPath}["'][^>]*>[\\s\\S]*?<\\/a>`, "gi"), "");
+  }
+  return next;
 }
 
 function buildOrganicProductCard(product, siteBase) {
@@ -2256,7 +2325,7 @@ function renderSeoDebugBlock(payload = {}) {
   return `<section class="seo-debug" data-debug-seo="1"><h2>SEO debug</h2><pre>${esc(JSON.stringify(payload, null, 2))}</pre></section>`;
 }
 
-function renderOrganicSeoPage(config, products, siteBase, { debugSeo = false, includedInSitemap = true } = {}) {
+function renderOrganicSeoPage(config, products, siteBase, { debugSeo = false, includedInSitemap = true, navigationPages = [] } = {}) {
   const canonical = absoluteUrl(config.canonicalPath, siteBase);
   const cards = products.map((product) => buildOrganicProductCard(product, siteBase)).join("");
   const itemList = buildOrganicItemListSchema(products, siteBase, canonical);
@@ -2296,11 +2365,7 @@ function renderOrganicSeoPage(config, products, siteBase, { debugSeo = false, in
   <header class="organic-header">
     <a class="organic-header__brand" href="/">NERIN Parts</a>
     <nav aria-label="Categorias organicas">
-      <a href="/stock-real">Stock real</a>
-      <a href="/pantallas-en-stock">Pantallas</a>
-      <a href="/baterias-en-stock">Baterias</a>
-      <a href="/repuestos-samsung">Samsung</a>
-      <a href="/repuestos-iphone">iPhone</a>
+      ${renderOrganicNavigation(navigationPages)}
     </nav>
   </header>
   <main class="organic-page">
@@ -2564,11 +2629,11 @@ function buildSitemapPlan(baseUrl, products = []) {
   const siteBase = normalizeBaseUrl(baseUrl) || FALLBACK_BASE_URL;
   const generatedAt = toIsoString(new Date());
   const toAbsolute = (pathSegment) => absoluteUrl(pathSegment, siteBase);
-  const staticEntries = ["/", "/shop.html", "/shop", "/contact.html", "/garantia.html"].map((path) => ({
+  const staticEntries = ["/", "/shop.html", "/contact.html", "/garantia.html"].map((path) => ({
     loc: toAbsolute(path), lastmod: generatedAt, changefreq: "daily", priority: path === "/" ? "1.0" : "0.8",
   }));
   const productEntries = products.filter((p)=>isProductPublic(p)).map((product)=>{
-    const slug = typeof product.slug === "string" && product.slug.trim() ? product.slug.trim() : null;
+    const slug = String(product.publicSlug || product.public_slug || product.slug || "").trim() || null;
     if (!slug) return null;
     return { loc: toAbsolute(`/p/${encodeURIComponent(slug)}`), lastmod: toIsoString(getProductLastModifiedDate(product)) || generatedAt, changefreq: "weekly", priority: "0.8" };
   }).filter(Boolean);
@@ -2584,7 +2649,6 @@ function buildSitemapXml(baseUrl, products = []) {
   const staticPages = [
     { path: "/", changefreq: "daily", priority: "1.0" },
     { path: "/shop.html", changefreq: "daily", priority: "0.9" },
-    { path: "/shop", changefreq: "daily", priority: "0.9" },
     { path: "/contact.html", changefreq: "monthly", priority: "0.5" },
     { path: "/garantia.html", changefreq: "monthly", priority: "0.4" },
   ];
@@ -2601,10 +2665,7 @@ function buildSitemapXml(baseUrl, products = []) {
   const productUrls = products
     .filter((product) => isProductPublic(product))
     .map((product) => {
-      const slug =
-        typeof product.slug === "string" && product.slug.trim()
-          ? product.slug.trim()
-          : null;
+      const slug = String(product.publicSlug || product.public_slug || product.slug || "").trim() || null;
       if (!slug) return null;
       const pathSegment = `/p/${encodeURIComponent(slug)}`;
       const lastModifiedDate = getProductLastModifiedDate(product);
@@ -7467,11 +7528,11 @@ function sitemapLog(stage, details = {}) {
 }
 
 function buildStaticSitemapEntries(base, generatedAt) {
-  return ["/", "/shop.html", "/shop", "/contact.html", "/garantia.html"].map((pathSegment) => ({
+  return ["/", "/shop.html", "/contact.html", "/garantia.html"].map((pathSegment) => ({
     loc: absoluteUrl(pathSegment, base),
     lastmod: generatedAt,
-    changefreq: pathSegment === "/" || pathSegment === "/shop.html" || pathSegment === "/shop" ? "daily" : "monthly",
-    priority: pathSegment === "/" ? "1.0" : pathSegment === "/shop.html" || pathSegment === "/shop" ? "0.9" : "0.5",
+    changefreq: pathSegment === "/" || pathSegment === "/shop.html" ? "daily" : "monthly",
+    priority: pathSegment === "/" ? "1.0" : pathSegment === "/shop.html" ? "0.9" : "0.5",
   }));
 }
 
@@ -14451,7 +14512,7 @@ async function requestHandler(req, res) {
   }
 
 
-  if ((pathname === "/merchant-feed.tsv" || pathname === "/merchant-feed-sample.tsv" || pathname === "/merchant-feed-debug.json") && req.method === "GET") {
+  if ((pathname === "/merchant-feed.tsv" || pathname === "/merchant-feed-stock-real.tsv" || pathname === "/merchant-feed-preorder.tsv" || pathname === "/merchant-feed-sample.tsv" || pathname === "/merchant-feed-debug.json") && req.method === "GET") {
     const startedAt = Date.now();
     const cfg = getConfig();
     const feedEnabled = String(process.env.MERCHANT_FEED_ENABLED || 'true').toLowerCase() !== 'false';
@@ -14460,6 +14521,9 @@ async function requestHandler(req, res) {
     const baseUrl = 'https://nerinparts.com.ar';
     const defaultLimit = 500;
     const isSample = pathname === "/merchant-feed-sample.tsv";
+    const feedScope = pathname === "/merchant-feed-preorder.tsv" || (pathname === "/merchant-feed-debug.json" && String(parsedUrl.query?.scope || "").toLowerCase() === "preorder")
+      ? "preorder"
+      : "in_stock";
     const emittedLimit = Math.max(1, Number(parsedUrl.query?.limit || process.env.MERCHANT_FEED_LIMIT || (isSample ? 100 : defaultLimit)) || defaultLimit);
     const emittedOffset = Math.max(0, Number(parsedUrl.query?.offset || process.env.MERCHANT_FEED_OFFSET || 0) || 0);
     const preorderDays = Math.max(1, Number(process.env.MERCHANT_PREORDER_DAYS || 30) || 30);
@@ -14468,6 +14532,7 @@ async function requestHandler(req, res) {
       offset: emittedOffset,
       preorderDays,
       baseUrl,
+      feedScope,
     });
     if (pathname !== "/merchant-feed-debug.json") {
       const cachedFeed = getCacheEntry(merchantFeedRuntimeCache, feedCacheKey, MERCHANT_FEED_CACHE_MS);
@@ -14523,12 +14588,14 @@ async function requestHandler(req, res) {
         }
       }
       const selectSql = `SELECT ${selectedColumns.join(',')} FROM products ORDER BY rowid ASC LIMIT ? OFFSET ?`;
-      allRows = await sqliteAll(dbConn, selectSql, [emittedLimit + emittedOffset + 2000, 0]);
+      const scanLimit = Math.max(emittedLimit + emittedOffset + 2000, Math.min(100000, Number(process.env.MERCHANT_FEED_SCAN_LIMIT || 50000) || 50000));
+      allRows = await sqliteAll(dbConn, selectSql, [scanLimit, 0]);
       const feedPayload = buildMerchantFeedEntries(allRows, {
         limit: emittedLimit,
         offset: emittedOffset,
         preorderDays,
         baseUrl,
+        feedScope,
       });
       const entries = feedPayload.entries;
       eligibleCount = feedPayload.audit.eligibleCount;
@@ -14583,6 +14650,7 @@ async function requestHandler(req, res) {
         baseUrl,
         totalCatalogProducts,
         publicProductsCount,
+        feedScope,
       });
       return sendJson(res, 200, audit);
     }
@@ -14729,15 +14797,18 @@ async function requestHandler(req, res) {
       return;
     }
     const products = await getOrganicProductsForPage(config.key, 48);
+    const navigationPages = await getAvailableOrganicNavigationPages();
     if (!products.length) {
-      const html = `<!doctype html><html lang="es-AR"><head><meta charset="utf-8"><meta name="robots" content="noindex,follow"><title>${esc(config.h1)} | Sin productos disponibles</title></head><body><main><h1>${esc(config.h1)}</h1><p>No hay productos en stock real para esta pagina en este momento.</p></main></body></html>`;
-      res.writeHead(404, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "no-store" });
+      const canonical = absoluteUrl(config.canonicalPath, siteBase);
+      const html = `<!doctype html><html lang="es-AR"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><meta name="robots" content="noindex,follow"><link rel="canonical" href="${esc(canonical)}"><title>${esc(config.h1)} | Sin productos disponibles</title><link rel="stylesheet" href="/style.css?v=organic-seo"></head><body><header class="organic-header"><a class="organic-header__brand" href="/">NERIN Parts</a><nav aria-label="Categorias organicas">${renderOrganicNavigation(navigationPages)}</nav></header><main class="organic-page"><h1>${esc(config.h1)}</h1><p>No hay productos con stock real en esta categoría en este momento.</p><p><a class="button primary" href="/stock-real">Ver todos los productos con stock real</a> <a class="button secondary" href="https://wa.me/5491130341550?text=Hola%20NERIN%2C%20quiero%20consultar%20disponibilidad">Consultar disponibilidad por WhatsApp</a></p></main></body></html>`;
+      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=300" });
       res.end(html);
       return;
     }
     const html = renderOrganicSeoPage(config, products, siteBase, {
       debugSeo: parsedUrl.query?.debugSeo === "1",
       includedInSitemap: true,
+      navigationPages,
     });
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=600" });
     res.end(html);
@@ -14836,6 +14907,34 @@ async function requestHandler(req, res) {
     return;
   }
 
+  // La URL histórica no compite con la ficha canónica.
+  if (pathname === "/product.html" && req.method === "GET" && parsedUrl.query?.id) {
+    const identifier = String(parsedUrl.query.id).trim();
+    let legacyProduct = null;
+    try {
+      const found = await productsSqliteRepo.getProductByPublicSlugOrAnyIdentifier(identifier);
+      legacyProduct = found?.product || null;
+    } catch (error) {
+      console.warn("[product-legacy-redirect:sqlite-error]", error?.message || error);
+    }
+    if (!legacyProduct) {
+      legacyProduct = await productsStreamRepo.getProductById(identifier, { filePath: PRODUCTS_FILE_PATH });
+    }
+    const canonicalSlug = legacyProduct?.publicSlug || legacyProduct?.public_slug || legacyProduct?.slug;
+    if (canonicalSlug) {
+      res.writeHead(301, {
+        Location: `/p/${encodeURIComponent(String(canonicalSlug).trim())}`,
+        "Cache-Control": "public, max-age=86400",
+      });
+      res.end();
+      return;
+    }
+    const html = '<!doctype html><html lang="es-AR"><head><meta charset="utf-8"><meta name="robots" content="noindex"><title>Producto no encontrado</title></head><body><main><h1>Producto no encontrado</h1></main></body></html>';
+    res.writeHead(404, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "no-store" });
+    res.end(html);
+    return;
+  }
+
   // SSR de productos
   if (pathname.startsWith("/p/") && req.method === "GET") {
     // Decodificar slug con guardas para evitar URIError (e.g. /p/%E0)
@@ -14907,10 +15006,9 @@ async function requestHandler(req, res) {
     const primaryAlt = normalizedAlts[0] || defaultAlt;
     const availabilityInfo = resolveProductAvailability(product);
     const availability = availabilityInfo.seoAvailability;
-    const brandName =
-      typeof product.brand === "string" && product.brand.trim()
-        ? product.brand.trim()
-        : "NERIN Parts";
+    const brandName = resolveCommercialBrand(product);
+    const mpnValue = resolveCommercialMpn(product);
+    const compatibleWith = resolveCompatibleWith(product);
     const skuValue =
       typeof product.sku === "string" && product.sku.trim()
         ? product.sku.trim()
@@ -14924,7 +15022,7 @@ async function requestHandler(req, res) {
       ? numericPrice.toFixed(2)
       : "0.00";
     const organicSeo = computeOrganicSeoPriority(product);
-    const seoTitle = organicSeo.seoTitle || productSeo.title || buildProductSeoTitle(product);
+    const seoTitle = productSeo.title || organicSeo.seoTitle || buildProductSeoTitle(product);
     const description = organicSeo.seoDescription || productSeo.description || buildProductMetaDescription(product);
     const h1 = buildProductHeading(product);
     const ld = {
@@ -14933,9 +15031,13 @@ async function requestHandler(req, res) {
       name: h1,
       ...(imageList.length ? { image: imageList } : {}),
       ...(description ? { description } : descriptionValue ? { description: descriptionValue } : {}),
-      ...(skuValue ? { sku: skuValue, mpn: skuValue } : {}),
+      ...(skuValue ? { sku: skuValue } : {}),
+      ...(mpnValue ? { mpn: mpnValue } : {}),
       ...(brandName
         ? { brand: { "@type": "Brand", name: brandName } }
+        : {}),
+      ...(compatibleWith
+        ? { additionalProperty: [{ "@type": "PropertyValue", name: "Compatible con", value: compatibleWith }] }
         : {}),
       offers: {
         "@type": "Offer",
@@ -15057,6 +15159,20 @@ async function requestHandler(req, res) {
     return;
   }
 
+  // Home SEO-aware: no enlaza landings vacías, pero las vuelve a mostrar
+  // automáticamente cuando aparece stock real elegible.
+  if ((pathname === "/" || pathname === "/index.html") && req.method === "GET") {
+    const availablePages = await getAvailableOrganicNavigationPages();
+    const template = await fsp.readFile(path.join(__dirname, "../frontend/index.html"), "utf8");
+    const html = stripUnavailableOrganicLinks(template, availablePages);
+    res.writeHead(200, {
+      "Content-Type": "text/html; charset=utf-8",
+      "Cache-Control": "public, max-age=300",
+    });
+    res.end(html);
+    return;
+  }
+
   // SSR del catalogo
   if (
     (pathname === "/shop.html" || pathname === "/shop" || pathname === "/shop/") &&
@@ -15104,6 +15220,7 @@ async function requestHandler(req, res) {
     });
     const hydratedHead = applyShopSeoHead(replaceBasePlaceholders(templateHead, siteBase), seo);
     let hydratedBody = replaceBasePlaceholders(templateBody, siteBase);
+    hydratedBody = stripUnavailableOrganicLinks(hydratedBody, await getAvailableOrganicNavigationPages());
     hydratedBody = hydratedBody.replace(
       /<div\s+id=\"productGrid\"[^>]*>\s*<\/div>/i,
       '<div id="productGrid" class="product-grid premium-grid" role="list">' + listing + '</div>',

--- a/nerin_final_updated/backend/utils/catalogVisibility.js
+++ b/nerin_final_updated/backend/utils/catalogVisibility.js
@@ -1,0 +1,70 @@
+const { getPublicPriceValue, resolveProductAvailability } = require("./productAvailability");
+
+function normalizeIdentity(value) {
+  return String(value || "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function identityKeys(product = {}) {
+  const keys = [];
+  const add = (prefix, value) => {
+    const normalized = normalizeIdentity(value);
+    if (normalized) keys.push(`${prefix}:${normalized}`);
+  };
+  add("mpn", product.mpn || product.part_number || product.partNumber);
+  add("sku", product.sku || product.code);
+  add("slug", product.publicSlug || product.public_slug || product.slug);
+  add("title", product.normalized_title || product.name || product.title);
+  return keys;
+}
+
+function deduplicateCatalogProducts(products = []) {
+  const seen = new Set();
+  const result = [];
+  for (const product of products) {
+    if (!product || typeof product !== "object") continue;
+    const keys = identityKeys(product);
+    if (keys.some((key) => seen.has(key))) continue;
+    keys.forEach((key) => seen.add(key));
+    result.push(product);
+  }
+  return result;
+}
+
+function availabilityRank(product = {}) {
+  const availability = resolveProductAvailability(product).merchantAvailability;
+  if (availability === "in_stock") return 0;
+  if (availability === "preorder" || availability === "backorder") return 1;
+  return 2;
+}
+
+function completenessRank(product = {}) {
+  const price = getPublicPriceValue(product) > 0 ? 1 : 0;
+  const image = product.image || product.image_url || (Array.isArray(product.images) ? product.images.find(Boolean) : "");
+  const slug = product.publicSlug || product.public_slug || product.slug;
+  return price + (image ? 1 : 0) + (slug ? 1 : 0);
+}
+
+function sortCatalogProducts(products = []) {
+  return [...products].sort((a, b) => {
+    const availabilityDiff = availabilityRank(a) - availabilityRank(b);
+    if (availabilityDiff) return availabilityDiff;
+    const completenessDiff = completenessRank(b) - completenessRank(a);
+    if (completenessDiff) return completenessDiff;
+    const stockDiff = Number(b.stock || 0) - Number(a.stock || 0);
+    if (stockDiff) return stockDiff;
+    return String(a.name || a.title || "").localeCompare(String(b.name || b.title || ""), "es", { sensitivity: "base" });
+  });
+}
+
+module.exports = {
+  availabilityRank,
+  deduplicateCatalogProducts,
+  identityKeys,
+  normalizeIdentity,
+  sortCatalogProducts,
+};

--- a/nerin_final_updated/backend/utils/merchantFeed.js
+++ b/nerin_final_updated/backend/utils/merchantFeed.js
@@ -4,6 +4,12 @@ const {
   formatMerchantAvailabilityDate,
   getPublicPriceValue,
 } = require('./productAvailability');
+const {
+  buildCommercialProductTitle,
+  hasRealBrandAndMpn,
+  resolveCommercialBrand,
+  resolveCommercialMpn,
+} = require('./productCommercial');
 
 const GOOGLE_CATEGORY = 'Electrónica > Comunicaciones > Telefonía > Accesorios para móviles';
 const VALID_AVAILABILITY = new Set(['in_stock', 'preorder', 'backorder', 'out_of_stock']);
@@ -55,7 +61,8 @@ function mapProductTypeToFeed(label) {
 }
 
 function buildMerchantTitle(row, raw) {
-  return safeMerchantText(row.name || row.title || raw.name || raw.title || raw.description || '');
+  const merged = mergeProductData(row, raw);
+  return safeMerchantText(buildCommercialProductTitle(merged) || row.name || row.title || raw.name || raw.title || raw.description || '');
 }
 
 function mergeProductData(row = {}, raw = {}) {
@@ -127,8 +134,22 @@ function getSkipTemplate() {
   return {
     notPublic: 0, privateOrHidden: 0, disabled: 0, deleted: 0, archived: 0, draft: 0, vipOnly: 0, wholesaleOnly: 0,
     missingId: 0, missingTitle: 0, missingDescription: 0, missingLink: 0, missingImage: 0, invalidImageUrl: 0,
-    missingPrice: 0, invalidPrice: 0, missingAvailability: 0, invalidAvailability: 0, preorderWithoutAvailabilityDate: 0, backorderWithoutAvailabilityDate: 0, invalidAvailabilityDate: 0, taxonomyBlocked: 0, soft404Risk: 0,
+    missingPrice: 0, invalidPrice: 0, missingAvailability: 0, invalidAvailability: 0, preorderWithoutAvailabilityDate: 0, backorderWithoutAvailabilityDate: 0, invalidAvailabilityDate: 0, outsideFeedScope: 0, taxonomyBlocked: 0, soft404Risk: 0,
   };
+}
+
+function normalizeFeedScope(value = 'all') {
+  const scope = String(value || 'all').trim().toLowerCase();
+  if (['in_stock', 'stock_real', 'stock-real', 'physical'].includes(scope)) return 'in_stock';
+  if (['preorder', 'backorder', 'remote', 'a_pedido'].includes(scope)) return 'preorder';
+  return 'all';
+}
+
+function matchesFeedScope(availability, scope) {
+  const normalizedScope = normalizeFeedScope(scope);
+  if (normalizedScope === 'in_stock') return availability === 'in_stock';
+  if (normalizedScope === 'preorder') return availability === 'preorder' || availability === 'backorder';
+  return true;
 }
 
 function pushSample(bucket, entry, max = 10) {
@@ -147,8 +168,9 @@ function normalizeComparableUrl(url) {
 }
 
 function detectMerchantProductType(row, raw, title) {
-  const lowerTitle = String(title || '').toLowerCase();
-  let productTypeDetected = detectProductType({ ...raw, ...row, title, name: title, category: row.category || raw.category || '' });
+  const sourceTitle = safeMerchantText(row.name || row.title || raw.name || raw.title || title || '');
+  const lowerTitle = String(sourceTitle).toLowerCase();
+  let productTypeDetected = detectProductType({ ...raw, ...row, description: sourceTitle, title: sourceTitle, name: sourceTitle, category: row.category || raw.category || '' });
   if (/display\s*(incl\.?|with|\+)\s*battery/.test(lowerTitle)) productTypeDetected = 'Pantalla / display';
   if (/adhesive\s*tape\s*display/.test(lowerTitle)) productTypeDetected = 'Adhesivo para pantalla';
   if (/charging\s*board|charge\s*port|dock\s*connector/.test(lowerTitle)) productTypeDetected = 'Placa / pin de carga';
@@ -162,8 +184,9 @@ function extractRaw(row) {
   return raw;
 }
 
-function buildMerchantFeedEntries(rows, { limit = 500, offset = 0, preorderDays = 30, baseUrl = 'https://nerinparts.com.ar' } = {}) {
-  const audit = buildMerchantFeedAudit(rows, { limit, offset, preorderDays, baseUrl });
+function buildMerchantFeedEntries(rows, { limit = 500, offset = 0, preorderDays = 30, baseUrl = 'https://nerinparts.com.ar', feedScope = 'all' } = {}) {
+  const normalizedFeedScope = normalizeFeedScope(feedScope);
+  const audit = buildMerchantFeedAudit(rows, { limit, offset, preorderDays, baseUrl, feedScope: normalizedFeedScope });
   const entries = [];
   const sanitizedLimit = Math.max(1, Number(limit) || 500);
   const sanitizedOffset = Math.max(0, Number(offset) || 0);
@@ -200,15 +223,17 @@ function buildMerchantFeedEntries(rows, { limit = 500, offset = 0, preorderDays 
     if (!Number.isFinite(priceNum) || priceNum <= 0) continue;
     const av = computeAvailability(row, raw, preorderDays);
     if (!VALID_AVAILABILITY.has(av.availability)) continue;
-    if ((av.availability === 'preorder' || av.availability === 'backorder') && !String(av.availabilityDate || '').match(/^\d{4}-\d{2}-\d{2}T00:00-0300$/)) continue;
+    if ((av.availability === 'preorder' || av.availability === 'backorder') && !String(av.availabilityDate || '').match(/^\d{4}-\d{2}-\d{2}T00:00:00-03:00$/)) continue;
+    if (!matchesFeedScope(av.availability, normalizedFeedScope)) continue;
     const productTypeDetected = detectMerchantProductType(row, raw, title);
     const product_type = safeMerchantText(mapProductTypeToFeed(productTypeDetected));
     if (!product_type) continue;
     eligibleCount += 1;
     if (eligibleCount <= sanitizedOffset || entries.length >= sanitizedLimit) continue;
-    const brand = safeMerchantText(String(row.brand || raw.brand || '').trim(), 70);
-    const mpn = safeMerchantText(String(row.mpn || row.part_number || row.sku || raw.mpn || raw.part_number || raw.sku || '').trim(), 70);
-    const identifier_exists = (brand && mpn) ? 'yes' : 'no';
+    const mergedProduct = mergeProductData(row, raw);
+    const brand = safeMerchantText(resolveCommercialBrand(mergedProduct), 70);
+    const mpn = safeMerchantText(resolveCommercialMpn(mergedProduct), 70);
+    const identifier_exists = hasRealBrandAndMpn(mergedProduct) ? 'yes' : 'no';
     entries.push({
       id: identifier, title, description, link, image_link,
       additional_image_link: additional.join(','), availability: av.availability,
@@ -220,7 +245,7 @@ function buildMerchantFeedEntries(rows, { limit = 500, offset = 0, preorderDays 
   return { entries, audit };
 }
 
-function buildMerchantFeedAudit(rows, { limit = 500, offset = 0, preorderDays = 30, baseUrl = 'https://nerinparts.com.ar', totalCatalogProducts = null, publicProductsCount = null } = {}) {
+function buildMerchantFeedAudit(rows, { limit = 500, offset = 0, preorderDays = 30, baseUrl = 'https://nerinparts.com.ar', totalCatalogProducts = null, publicProductsCount = null, feedScope = 'all' } = {}) {
   const skipped = getSkipTemplate();
   const samplesEligible = [];
   const samplesSkipped = [];
@@ -228,6 +253,7 @@ function buildMerchantFeedAudit(rows, { limit = 500, offset = 0, preorderDays = 
   const availabilityBreakdown = {};
   const sanitizedLimit = Math.max(1, Number(limit) || 500);
   const sanitizedOffset = Math.max(0, Number(offset) || 0);
+  const normalizedFeedScope = normalizeFeedScope(feedScope);
 
   let publicProductsInScan = 0;
   let eligibleCount = 0;
@@ -316,9 +342,14 @@ function buildMerchantFeedAudit(rows, { limit = 500, offset = 0, preorderDays = 
 
     if (av.availability === 'preorder' && !av.availabilityDate) { skipped.preorderWithoutAvailabilityDate += 1; pushSample(samplesSkipped, { id: identifier, reason: 'preorderWithoutAvailabilityDate' }); continue; }
     if (av.availability === 'backorder' && !av.availabilityDate) { skipped.backorderWithoutAvailabilityDate += 1; pushSample(samplesSkipped, { id: identifier, reason: 'backorderWithoutAvailabilityDate' }); continue; }
-    if ((av.availability === 'preorder' || av.availability === 'backorder') && !/^\d{4}-\d{2}-\d{2}T00:00-0300$/.test(String(av.availabilityDate || ''))) {
+    if ((av.availability === 'preorder' || av.availability === 'backorder') && !/^\d{4}-\d{2}-\d{2}T00:00:00-03:00$/.test(String(av.availabilityDate || ''))) {
       skipped.invalidAvailabilityDate += 1;
       pushSample(samplesSkipped, { id: identifier, reason: 'invalidAvailabilityDate', availability: av.availability, availability_date: av.availabilityDate || null });
+      continue;
+    }
+    if (!matchesFeedScope(av.availability, normalizedFeedScope)) {
+      skipped.outsideFeedScope += 1;
+      pushSample(samplesSkipped, { id: identifier, reason: 'outsideFeedScope', availability: av.availability });
       continue;
     }
 
@@ -348,6 +379,7 @@ function buildMerchantFeedAudit(rows, { limit = 500, offset = 0, preorderDays = 
     emittedCount,
     limit: sanitizedLimit,
     offset: sanitizedOffset,
+    feedScope: normalizedFeedScope,
     skipped,
     productTypeBreakdown,
     availabilityBreakdown,
@@ -361,4 +393,4 @@ function buildMerchantFeedAudit(rows, { limit = 500, offset = 0, preorderDays = 
   };
 }
 
-module.exports = { GOOGLE_CATEGORY, mapProductTypeToFeed, buildMerchantTitle, computeAvailability, formatMerchantAvailabilityDate, isEligibleState, cleanText, safeMerchantText, detectProductType, buildMerchantFeedAudit, buildMerchantFeedEntries, normalizeMerchantImageUrl, isValidFeedUrl };
+module.exports = { GOOGLE_CATEGORY, mapProductTypeToFeed, buildMerchantTitle, computeAvailability, formatMerchantAvailabilityDate, isEligibleState, cleanText, safeMerchantText, detectProductType, buildMerchantFeedAudit, buildMerchantFeedEntries, normalizeMerchantImageUrl, isValidFeedUrl, matchesFeedScope, normalizeFeedScope };

--- a/nerin_final_updated/backend/utils/productAvailability.js
+++ b/nerin_final_updated/backend/utils/productAvailability.js
@@ -1,5 +1,5 @@
 const DAY_MS = 24 * 60 * 60 * 1000;
-const ARG_FEED_OFFSET = "-0300";
+const ARG_FEED_OFFSET = "-03:00";
 const ARG_SCHEMA_OFFSET = "-03:00";
 const MAX_AVAILABILITY_DAYS = 365;
 
@@ -76,7 +76,7 @@ function formatMerchantAvailabilityDate(value) {
   const parsed = value instanceof Date ? value : parseAvailabilityDate(value);
   if (!parsed) return "";
   const p = dateParts(parsed);
-  return `${p.y}-${p.m}-${p.d}T00:00${ARG_FEED_OFFSET}`;
+  return `${p.y}-${p.m}-${p.d}T00:00:00${ARG_FEED_OFFSET}`;
 }
 
 function formatSchemaAvailabilityStarts(value) {
@@ -120,15 +120,19 @@ function resolveProductAvailability(product = {}, options = {}) {
     .filter(Boolean)
     .join(" ")
     .toLowerCase();
-  const explicitAvailability = normalizeAvailability(product.availability || product.disponibilidad || product.estado_stock);
+  const explicitAvailability = normalizeAvailability(product.availability || product.disponibilidad || product.estado_stock || product.stock_status || product.stockStatus);
   const explicitMode = String(product.stock_mode || product.fulfillment_mode || product.stockMode || product.fulfillmentMode || "").trim().toLowerCase();
   const remoteStock = toFiniteNumber(product.remote_stock ?? product.stock_remote ?? product.available_remote, 0);
   const minLead = toFiniteNumber(product.remote_lead_min_days || product.remote_lead_days || product.lead_min_days, 0);
   const maxLead = toFiniteNumber(product.remote_lead_max_days || product.remote_lead_days || product.lead_max_days, 0);
   const hasRemoteSignal = /stock remoto|a pedido|bajo pedido|encargo|preorder|backorder/.test(textSignals);
   const forcedRemote = ["preorder", "backorder"].includes(explicitAvailability);
-  const isRemote = forcedRemote || explicitMode === "remote" || explicitMode === "remoto" || remoteStock > 0 || minLead > 0 || maxLead > 0 || hasRemoteSignal;
-  const hasRemoteStock = isRemote && (remoteStock > 0 || minLead > 0 || maxLead > 0 || hasRemoteSignal || forcedRemote);
+  const hasAvailabilityDate = Boolean(
+    product.availability_date || product.availabilityDate || product.preorder_date || product.preorderDate || product.available_at || product.availableAt,
+  );
+  const allowsRemoteOrder = Boolean(product.allow_backorder || product.allowBackorder || product.sellable_on_demand || product.canBeOrdered);
+  const isRemote = forcedRemote || explicitMode === "remote" || explicitMode === "remoto" || remoteStock > 0 || minLead > 0 || maxLead > 0 || hasRemoteSignal || hasAvailabilityDate || allowsRemoteOrder;
+  const hasRemoteStock = isRemote && (remoteStock > 0 || minLead > 0 || maxLead > 0 || hasRemoteSignal || forcedRemote || hasAvailabilityDate || allowsRemoteOrder);
 
   if (hasLocalStock && !forcedRemote) {
     return {
@@ -161,6 +165,9 @@ function resolveProductAvailability(product = {}, options = {}) {
     const availabilityDate = resolveAvailabilityDate(product, leadEnd, now);
     const availabilityDateDisplay = formatDisplayAvailabilityDate(availabilityDate);
     const merchantAvailability = explicitAvailability === "backorder" ? "backorder" : "preorder";
+    const schemaAvailability = merchantAvailability === "backorder"
+      ? "https://schema.org/BackOrder"
+      : "https://schema.org/PreOrder";
     return {
       stockLocal,
       hasLocalStock: false,
@@ -174,8 +181,8 @@ function resolveProductAvailability(product = {}, options = {}) {
       feedAvailability: merchantAvailability,
       deliveryLabel: `Fecha estimada de despacho: ${availabilityDateDisplay}`,
       checkoutAllowed: true,
-      seoAvailability: "https://schema.org/PreOrder",
-      schemaAvailability: "https://schema.org/PreOrder",
+      seoAvailability: schemaAvailability,
+      schemaAvailability,
       availabilityDate,
       availabilityDateFeed: formatMerchantAvailabilityDate(availabilityDate),
       availabilityStarts: formatSchemaAvailabilityStarts(availabilityDate),

--- a/nerin_final_updated/backend/utils/productCommercial.js
+++ b/nerin_final_updated/backend/utils/productCommercial.js
@@ -1,0 +1,130 @@
+const { buildProductAutoContent } = require("./productAutoContent");
+const { detectProductType } = require("./productTaxonomy");
+
+function cleanText(value) {
+  return String(value || "").replace(/\s+/g, " ").trim();
+}
+
+function productText(product = {}) {
+  const metadata = product.metadata && typeof product.metadata === "object" ? product.metadata : {};
+  const supplier = metadata.supplierImport && typeof metadata.supplierImport === "object"
+    ? metadata.supplierImport
+    : {};
+  return [
+    product.name,
+    product.title,
+    product.description,
+    product.quality,
+    product.brand,
+    product.model,
+    product.category,
+    metadata.quality,
+    supplier.quality,
+    supplier.description,
+  ].map(cleanText).filter(Boolean).join(" ");
+}
+
+function pick(product = {}, keys = []) {
+  const metadata = product.metadata && typeof product.metadata === "object" ? product.metadata : {};
+  const supplier = metadata.supplierImport && typeof metadata.supplierImport === "object"
+    ? metadata.supplierImport
+    : {};
+  for (const key of keys) {
+    const value = product[key] ?? metadata[key] ?? supplier[key];
+    if (cleanText(value)) return cleanText(value);
+  }
+  return "";
+}
+
+function isCompatibleProduct(product = {}) {
+  return /\b(compatible|aftermarket|generic|generico|gen[eé]rico|soft\s+oled|hard\s+oled|in[\s-]?cell)\b/i.test(productText(product));
+}
+
+function isOriginalProduct(product = {}) {
+  const text = productText(product);
+  return !isCompatibleProduct(product) && /\b(original|genuine|service\s*pack)\b/i.test(text);
+}
+
+function resolveCommercialMpn(product = {}) {
+  const explicit = pick(product, ["mpn", "part_number", "partNumber", "supplierPartNumber"]);
+  if (explicit) return explicit;
+  const textMatch = productText(product).match(/\bGH82-\d{4,6}[A-Z]?\b/i);
+  if (textMatch) return textMatch[0].toUpperCase();
+  return pick(product, ["sku", "code"]);
+}
+
+function resolveCommercialBrand(product = {}) {
+  if (isCompatibleProduct(product)) {
+    return pick(product, ["manufacturer_brand", "actual_brand", "maker_brand"]) || "Compatible";
+  }
+  const explicit = pick(product, ["brand", "manufacturer", "manufacturerName"]);
+  if (explicit) return explicit.replace(/^for\s+/i, "").trim();
+  if (/\b(samsung|galaxy|GH82-)\b/i.test(productText(product)) && isOriginalProduct(product)) return "Samsung";
+  return "Genérico";
+}
+
+function resolveCompatibleWith(product = {}) {
+  if (!isCompatibleProduct(product)) return "";
+  const brand = pick(product, ["compatible_brand", "device_brand", "brand"]);
+  const model = pick(product, ["compatible_model", "model", "modelo"]);
+  return [brand, model].filter(Boolean).join(" ").trim();
+}
+
+function detectCommercialColor(product = {}) {
+  const explicit = pick(product, ["color", "colour"]);
+  const text = `${explicit} ${productText(product)}`;
+  const colors = [
+    ["Negra", /\b(black|negro|negra)\b/i],
+    ["Blanca", /\b(white|blanco|blanca)\b/i],
+    ["Gris", /\b(gray|grey|gris)\b/i],
+    ["Azul", /\b(blue|azul)\b/i],
+    ["Verde", /\b(green|verde)\b/i],
+    ["Roja", /\b(red|rojo|roja)\b/i],
+    ["Violeta", /\b(purple|violeta|morado|morada)\b/i],
+    ["Dorada", /\b(gold|dorado|dorada)\b/i],
+    ["Plata", /\b(silver|plata)\b/i],
+  ];
+  const found = colors.find(([, pattern]) => pattern.test(text));
+  return found ? found[0] : explicit;
+}
+
+function buildCommercialProductTitle(product = {}) {
+  const fallback = pick(product, ["name", "title", "description", "sku", "id"]) || "Repuesto";
+  if (detectProductType(product) !== "Pantalla / display") return fallback;
+
+  const auto = buildProductAutoContent(product);
+  let title = cleanText(auto.h1) || fallback;
+  if (isCompatibleProduct(product) && !/\bcompatible\b/i.test(title)) {
+    title = title.replace(/^Pantalla\b/i, "Pantalla compatible");
+  } else if (isOriginalProduct(product) && !/\boriginal\b/i.test(title)) {
+    title = title.replace(/^Pantalla\b/i, "Pantalla original");
+  }
+
+  const color = detectCommercialColor(product);
+  if (color && !new RegExp(`\\b${color.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`, "i").test(title)) {
+    title = `${title} ${color}`;
+  }
+
+  const mpn = resolveCommercialMpn(product);
+  const commercialBrand = resolveCommercialBrand(product);
+  if (commercialBrand === "Samsung" && isOriginalProduct(product) && /^GH82-/i.test(mpn) && !title.includes(mpn)) {
+    title = `${title} Service Pack ${mpn}`;
+  }
+  return cleanText(title);
+}
+
+function hasRealBrandAndMpn(product = {}) {
+  const brand = resolveCommercialBrand(product);
+  const mpn = resolveCommercialMpn(product);
+  return Boolean(mpn && brand && !/^(compatible|gen[eé]rico)$/i.test(brand));
+}
+
+module.exports = {
+  buildCommercialProductTitle,
+  hasRealBrandAndMpn,
+  isCompatibleProduct,
+  isOriginalProduct,
+  resolveCommercialBrand,
+  resolveCommercialMpn,
+  resolveCompatibleWith,
+};

--- a/nerin_final_updated/backend/utils/productSeo.js
+++ b/nerin_final_updated/backend/utils/productSeo.js
@@ -1,4 +1,5 @@
 const { detectProductType } = require("./productTaxonomy");
+const { buildCommercialProductTitle } = require("./productCommercial");
 
 const GENERIC_SEO_TITLES = new Set([
   "repuesto original service pack | nerin parts",
@@ -77,7 +78,7 @@ function buildSafeProductDescription(product = {}, label = "") {
 
 function generateProductSeo(product = {}) {
   const productType = detectProductType(product);
-  const label = buildSafeProductLabel(product);
+  const label = buildCommercialProductTitle(product) || buildSafeProductLabel(product);
   const brand = normalizeText(pickField(product, ["brand", "catalog_brand", "Brand"]));
   const sku = normalizeText(pickField(product, ["sku", "SKU", "part_number", "partNumber", "PartNumber", "Part Number"]));
 

--- a/nerin_final_updated/data/config.json
+++ b/nerin_final_updated/data/config.json
@@ -100,7 +100,7 @@
       ]
     },
     "featured": {
-      "title": "Productos destacados",
+      "title": "Productos con stock real listos para enviar",
       "description": "Seleccionamos los módulos con mejor rendimiento y disponibilidad inmediata.",
       "productIds": []
     },

--- a/nerin_final_updated/docs/SEO_MERCHANT_STOCK_REAL.md
+++ b/nerin_final_updated/docs/SEO_MERCHANT_STOCK_REAL.md
@@ -1,0 +1,58 @@
+# SEO y Merchant Center: prioridad de stock real
+
+## Qué cambió
+
+- Las landings `/stock-real` y `/pantallas-en-stock` sólo publican productos con stock físico, precio, imagen y slug canónico.
+- `/baterias-en-stock`, `/repuestos-samsung` y `/repuestos-iphone` responden `200`. Cuando no tienen stock real usan `noindex,follow`, muestran una alternativa útil y dejan de estar enlazadas desde home, catálogo y navegación SEO.
+- El catálogo ordena primero stock real, luego productos a pedido y finalmente productos sin stock. Los resultados visibles se deduplican por MPN, SKU, slug y título normalizado.
+- La home muestra únicamente productos destacados con stock real, precio, imagen y slug.
+- Las fichas muestran cantidad física, precio, CTA de compra, consulta de compatibilidad por WhatsApp, Factura A/B, despacho desde CABA, envíos nacionales y SKU/MPN. La compra queda desactivada cuando no hay stock.
+- Los títulos comerciales de pantallas se generan en español. Los compatibles se identifican como compatibles y no usan Samsung como marca del producto; Samsung queda como compatibilidad.
+- El JSON-LD `Product`/`Offer` usa `InStock`, `PreOrder`, `BackOrder` u `OutOfStock` según el mismo resolvedor que usa la interfaz. `availabilityStarts` sólo se emite para preorder/backorder.
+- `product.html?id=...` redirige permanentemente a `/p/{slug}`.
+- El sitemap sólo incluye URLs canónicas; `/shop` ya no se duplica con `/shop.html` y las categorías vacías quedan fuera.
+
+## Feeds de Google Merchant Center
+
+- Feed principal de stock real: `GET /merchant-feed.tsv`
+- Alias explícito del feed principal: `GET /merchant-feed-stock-real.tsv`
+- Feed separado para productos a pedido: `GET /merchant-feed-preorder.tsv`
+- Muestra del feed principal: `GET /merchant-feed-sample.tsv`
+- Auditoría: `GET /merchant-feed-debug.json`
+- Auditoría de productos a pedido: `GET /merchant-feed-debug.json?scope=preorder`
+
+El feed principal sólo admite `availability=in_stock` y nunca emite `availability_date`. El feed a pedido sólo admite `preorder`/`backorder` y exige una fecha RFC 3339, por ejemplo `2026-07-19T00:00:00-03:00`. Ningún producto sin stock se envía a esos feeds.
+
+## Criterios de elegibilidad Merchant
+
+Un producto debe ser público y estar habilitado, tener identificador, título comercial, descripción, `/p/{slug}`, imagen HTTP(S) válida y precio positivo en ARS. Los productos privados, borradores, archivados, mayoristas/VIP o sin datos mínimos quedan excluidos.
+
+`identifier_exists=yes` sólo se usa cuando existen una marca real y un MPN real. Los repuestos compatibles usan la marca real del fabricante si está informada; de lo contrario usan `Compatible` y `identifier_exists=no`. Para Service Pack Samsung se prioriza el MPN GH82.
+
+## Cómo probar
+
+```bash
+npm ci
+npm test -- --runInBand
+```
+
+Validación dirigida:
+
+```bash
+npx jest backend/__tests__/organic-seo-stock-real.test.js backend/__tests__/merchant-availability-ui.test.js backend/__tests__/product-ssr.test.js __tests__/backend/merchant-feed.test.js __tests__/backend/catalog-visibility.test.js __tests__/backend/seo-endpoints.test.js --runInBand
+```
+
+Comprobar manualmente:
+
+- `/`, `/shop.html`, `/stock-real`, `/pantallas-en-stock`, `/baterias-en-stock`, `/repuestos-samsung` y `/repuestos-iphone`.
+- `/sitemap.xml`, `/sitemap-static.xml`, `/sitemap-stock.xml` y un sitemap de productos.
+- Los tres estados de ficha: stock real, a pedido y sin stock.
+- Los feeds principal, stock-real y preorder; verificar que disponibilidad y fecha coincidan con la ficha.
+
+## Próximos pasos operativos
+
+1. En Search Console, enviar únicamente `https://nerinparts.com.ar/sitemap.xml` y solicitar reindexación de las landings con stock real.
+2. En Merchant Center, usar `/merchant-feed.tsv` como fuente principal. Mantener `/merchant-feed-preorder.tsv` como fuente separada sólo si las fechas visibles pueden sostenerse operativamente.
+3. Revisar Diagnóstico de Merchant después de cada actualización de catálogo: precio, imagen, MPN, disponibilidad y discrepancias de landing.
+4. No indexar ni enlazar una landing vacía. El sitio la reactivará automáticamente al ingresar stock físico elegible.
+5. No modificar precios desde estos procesos; sólo se normaliza su representación como `0.00 ARS`.

--- a/nerin_final_updated/frontend/index.html
+++ b/nerin_final_updated/frontend/index.html
@@ -258,7 +258,7 @@
       <section class="home-featured" data-home-section="featured">
         <div class="home-featured__header">
           <p class="eyebrow">Destacados</p>
-          <h2 data-home-text="featured.title">Productos destacados</h2>
+          <h2 data-home-text="featured.title">Productos con stock real listos para enviar</h2>
           <p data-home-text="featured.description">
             Repuestos con salida rápida para técnicos, revendedores y clientes finales.
           </p>
@@ -311,7 +311,7 @@
 
     <div id="footer-root"></div>
     <!-- Configuración y analíticas -->
-    <script type="module" src="/js/index.js"></script>
+    <script type="module" src="/js/index.js?v=seo-stock-real-20260621-v3"></script>
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
     <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>
     <script type="module" src="/js/analytics-autotrack.js?v=ecommerce-organic-funnel"></script>

--- a/nerin_final_updated/frontend/js/availability.js
+++ b/nerin_final_updated/frontend/js/availability.js
@@ -1,5 +1,5 @@
 const DAY_MS = 24 * 60 * 60 * 1000;
-const ARG_FEED_OFFSET = "-0300";
+const ARG_FEED_OFFSET = "-03:00";
 const ARG_SCHEMA_OFFSET = "-03:00";
 const MAX_AVAILABILITY_DAYS = 365;
 
@@ -76,7 +76,7 @@ function formatMerchantAvailabilityDate(value) {
   const parsed = value instanceof Date ? value : parseAvailabilityDate(value);
   if (!parsed) return "";
   const p = dateParts(parsed);
-  return `${p.y}-${p.m}-${p.d}T00:00${ARG_FEED_OFFSET}`;
+  return `${p.y}-${p.m}-${p.d}T00:00:00${ARG_FEED_OFFSET}`;
 }
 
 function formatSchemaAvailabilityStarts(value) {
@@ -120,15 +120,19 @@ export function resolveProductAvailability(product = {}, options = {}) {
     .filter(Boolean)
     .join(" ")
     .toLowerCase();
-  const explicitAvailability = normalizeAvailability(product.availability || product.disponibilidad || product.estado_stock);
+  const explicitAvailability = normalizeAvailability(product.availability || product.disponibilidad || product.estado_stock || product.stock_status || product.stockStatus);
   const explicitMode = String(product.stock_mode || product.fulfillment_mode || product.stockMode || product.fulfillmentMode || "").trim().toLowerCase();
   const remoteStock = toFiniteNumber(product.remote_stock ?? product.stock_remote ?? product.available_remote, 0);
   const minLead = toFiniteNumber(product.remote_lead_min_days || product.remote_lead_days || product.lead_min_days, 0);
   const maxLead = toFiniteNumber(product.remote_lead_max_days || product.remote_lead_days || product.lead_max_days, 0);
   const hasRemoteSignal = /stock remoto|a pedido|bajo pedido|encargo|preorder|backorder/.test(textSignals);
   const forcedRemote = ["preorder", "backorder"].includes(explicitAvailability);
-  const isRemote = forcedRemote || explicitMode === "remote" || explicitMode === "remoto" || remoteStock > 0 || minLead > 0 || maxLead > 0 || hasRemoteSignal;
-  const hasRemoteStock = isRemote && (remoteStock > 0 || minLead > 0 || maxLead > 0 || hasRemoteSignal || forcedRemote);
+  const hasAvailabilityDate = Boolean(
+    product.availability_date || product.availabilityDate || product.preorder_date || product.preorderDate || product.available_at || product.availableAt,
+  );
+  const allowsRemoteOrder = Boolean(product.allow_backorder || product.allowBackorder || product.sellable_on_demand || product.canBeOrdered);
+  const isRemote = forcedRemote || explicitMode === "remote" || explicitMode === "remoto" || remoteStock > 0 || minLead > 0 || maxLead > 0 || hasRemoteSignal || hasAvailabilityDate || allowsRemoteOrder;
+  const hasRemoteStock = isRemote && (remoteStock > 0 || minLead > 0 || maxLead > 0 || hasRemoteSignal || forcedRemote || hasAvailabilityDate || allowsRemoteOrder);
 
   if (hasLocalStock && !forcedRemote) return {
     stockLocal, hasLocalStock, isRemote, hasRemoteStock, isSellable: true,
@@ -146,13 +150,16 @@ export function resolveProductAvailability(product = {}, options = {}) {
     const availabilityDate = resolveAvailabilityDate(product, leadEnd, now);
     const availabilityDateDisplay = formatDisplayAvailabilityDate(availabilityDate);
     const merchantAvailability = explicitAvailability === "backorder" ? "backorder" : "preorder";
+    const schemaAvailability = merchantAvailability === "backorder"
+      ? "https://schema.org/BackOrder"
+      : "https://schema.org/PreOrder";
     return {
       stockLocal, hasLocalStock: false, isRemote: true, hasRemoteStock: true, isSellable: true,
       availabilityLabel: "Disponible a pedido",
       visibleAvailabilityText: `Disponible a pedido. Fecha estimada de despacho: ${availabilityDateDisplay}`,
       availabilityBadge: "remote_available", merchantAvailability, feedAvailability: merchantAvailability,
       deliveryLabel: `Fecha estimada de despacho: ${availabilityDateDisplay}`,
-      checkoutAllowed: true, seoAvailability: "https://schema.org/PreOrder", schemaAvailability: "https://schema.org/PreOrder",
+      checkoutAllowed: true, seoAvailability: schemaAvailability, schemaAvailability,
       availabilityDate, availabilityDateFeed: formatMerchantAvailabilityDate(availabilityDate),
       availabilityStarts: formatSchemaAvailabilityStarts(availabilityDate), availabilityDateDisplay,
       leadMinDays: leadStart, leadMaxDays: leadEnd,

--- a/nerin_final_updated/frontend/js/delivery-policy.js
+++ b/nerin_final_updated/frontend/js/delivery-policy.js
@@ -1,4 +1,4 @@
-const DELIVERY_POLICY_VERSION = "delivery-policy-20260503-v2";
+const DELIVERY_POLICY_VERSION = "seo-stock-real-20260621-v3";
 const REMOTE_MIN_DAYS = 20;
 const REMOTE_MAX_DAYS = 30;
 
@@ -108,7 +108,26 @@ function hasRemoteCopySignal(product = {}) {
 }
 
 export function resolveDeliveryProfile(product = {}) {
-  if (!product || typeof product !== "object") return { mode: "remote", minDays: REMOTE_MIN_DAYS, maxDays: REMOTE_MAX_DAYS };
+  if (!product || typeof product !== "object") return { mode: "unavailable", minDays: 0, maxDays: 0 };
+
+  const explicitAvailability = normalizeText(product.availability || product.stock_status || product.stockStatus);
+  const stock = toNumberOrNull(product.stock ?? product.available_stock ?? product.quantity);
+  if (["preorder", "backorder", "a pedido", "a_pedido"].includes(explicitAvailability)) {
+    const rawMin = toNumberOrNull(product.remote_lead_min_days ?? product.remote_lead_days);
+    const rawMax = toNumberOrNull(product.remote_lead_max_days ?? rawMin);
+    return {
+      mode: "remote",
+      minDays: Math.max(REMOTE_MIN_DAYS, Math.floor(rawMin || REMOTE_MIN_DAYS)),
+      maxDays: Math.max(REMOTE_MAX_DAYS, Math.floor(rawMax || REMOTE_MAX_DAYS)),
+      reason: "explicit_preorder",
+    };
+  }
+  if (["out of stock", "out_of_stock", "sin stock", "agotado"].includes(explicitAvailability)) {
+    return { mode: "unavailable", minDays: 0, maxDays: 0, reason: "explicit_out_of_stock" };
+  }
+  if (Number.isFinite(stock) && stock > 0) {
+    return { mode: "physical", minDays: 1, maxDays: 2, reason: "local_stock" };
+  }
 
   if (hasExplicitPhysicalSignal(product)) {
     return { mode: "physical", minDays: 1, maxDays: 2, reason: "explicit_physical" };
@@ -129,7 +148,7 @@ export function resolveDeliveryProfile(product = {}) {
     return { mode: "physical", minDays: 1, maxDays: 2, reason: "local_uploaded_asset" };
   }
 
-  return { mode: "remote", minDays: REMOTE_MIN_DAYS, maxDays: REMOTE_MAX_DAYS, reason: "default_remote" };
+  return { mode: "unavailable", minDays: 0, maxDays: 0, reason: "no_sellable_stock_signal" };
 }
 
 export function applyDeliveryPolicyToProduct(product = {}) {
@@ -147,7 +166,7 @@ export function applyDeliveryPolicyToProduct(product = {}) {
     normalized.remote_lead_max_days = profile.maxDays;
     normalized.deliveryPromise = `Entrega estimada: ${profile.minDays} a ${profile.maxDays} días.`;
     normalized.delivery_promise = normalized.deliveryPromise;
-  } else {
+  } else if (profile.mode === "physical") {
     normalized.stock_mode = "physical";
     normalized.fulfillment_mode = "physical";
     normalized.remote_stock = 0;
@@ -155,6 +174,15 @@ export function applyDeliveryPolicyToProduct(product = {}) {
     normalized.remote_lead_min_days = 0;
     normalized.remote_lead_max_days = 0;
     normalized.deliveryPromise = "Entrega estimada: 24 a 48 hs hábiles.";
+    normalized.delivery_promise = normalized.deliveryPromise;
+  } else {
+    normalized.stock_mode = "unavailable";
+    normalized.fulfillment_mode = "unavailable";
+    normalized.remote_stock = 0;
+    normalized.remote_lead_days = 0;
+    normalized.remote_lead_min_days = 0;
+    normalized.remote_lead_max_days = 0;
+    normalized.deliveryPromise = "Sin stock. Consultar disponibilidad.";
     normalized.delivery_promise = normalized.deliveryPromise;
   }
 

--- a/nerin_final_updated/frontend/js/index.js
+++ b/nerin_final_updated/frontend/js/index.js
@@ -2,6 +2,7 @@ import { fetchProducts, isWholesale, getUserRole } from "./api.js";
 import { createPriceLegalBlock } from "./components/PriceLegalBlock.js";
 import { buildCartItemFromProduct, readCart, writeCart } from "./cart-utils.js";
 import { calculateNetNoNationalTaxes } from "./utils/pricing.js";
+import { resolveProductAvailability } from "./availability.js?v=seo-stock-real-20260621-v3";
 
 const CONFIG_CACHE_KEY = "nerin:config-cache";
 
@@ -124,7 +125,7 @@ const DEFAULT_HOME_CONTENT = {
     ],
   },
   featured: {
-    title: "Productos destacados",
+    title: "Productos con stock real listos para enviar",
     description:
       "Seleccionamos los módulos con mejor rendimiento y disponibilidad inmediata.",
     productIds: [],
@@ -733,14 +734,33 @@ function createFeaturedCard(product) {
 function resolveFeaturedProducts(products, ids) {
   if (!Array.isArray(products) || !products.length) return [];
   const byId = new Map();
+  const seenIdentity = new Set();
   const uniqueProducts = [];
   products.forEach((product) => {
     if (!product || product.id == null) return;
+    const availability = resolveProductAvailability(product);
+    const price = resolveDisplayPrice(product);
+    const image = getPrimaryImage(product);
+    const slug = product.publicSlug || product.public_slug || product.slug;
+    if (availability.merchantAvailability !== "in_stock" || !(price > 0) || !image || !slug) return;
+    const identityKeys = [
+      ["mpn", product.mpn || product.part_number],
+      ["sku", product.sku],
+      ["slug", slug],
+      ["title", product.name || product.title],
+    ].map(([type, value]) => {
+      const normalized = String(value || "").normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+      return normalized ? `${type}:${normalized}` : "";
+    }).filter(Boolean);
+    if (identityKeys.some((key) => seenIdentity.has(key))) return;
+    identityKeys.forEach((key) => seenIdentity.add(key));
     const key = String(product.id);
     if (byId.has(key)) return;
     byId.set(key, product);
     uniqueProducts.push(product);
   });
+
+  uniqueProducts.sort((a, b) => Number(b.stock || 0) - Number(a.stock || 0));
 
   if (Array.isArray(ids) && ids.length) {
     const seen = new Set();

--- a/nerin_final_updated/frontend/js/product.js
+++ b/nerin_final_updated/frontend/js/product.js
@@ -8,7 +8,7 @@ import {
 import { createPriceLegalBlock } from "./components/PriceLegalBlock.js";
 import { buildCartItemFromProduct, readCart, writeCart, getProductIdentifier } from "./cart-utils.js";
 import { calculateNetNoNationalTaxes } from "./utils/pricing.js";
-import { buildAvailabilityPresentation, resolveProductAvailability } from "./availability.js";
+import { buildAvailabilityPresentation, resolveProductAvailability } from "./availability.js?v=seo-stock-real-20260621-v3";
 import { trackAddToCart, trackStockRealAddToCart, trackStockRealProductView, trackViewItem } from "./analytics.js";
 
 const detailSection = document.getElementById("productDetail");
@@ -118,6 +118,10 @@ function resolveFulfillmentProfile(product) {
     .trim()
     .toLowerCase();
   const stock = toNumberOrNull(product?.stock);
+  const explicitAvailability = String(product?.availability || product?.stock_status || "").trim().toLowerCase();
+  if (explicitMode === "unavailable" || ["out_of_stock", "outofstock", "sin_stock"].includes(explicitAvailability)) {
+    return { mode: "unavailable", isConfigured: true, minDays: 0, maxDays: 0 };
+  }
   const textSignals = [product?.name, product?.description, product?.category, product?.subcategory]
     .filter(Boolean)
     .join(" ")
@@ -371,6 +375,35 @@ function getVisibleProductName(product) {
   return normalizeText(String(raw)) || "Producto";
 }
 
+function isCompatibleProduct(product = {}) {
+  const text = [product.name, product.title, product.description, product.quality]
+    .filter(Boolean)
+    .join(" ");
+  return /\b(compatible|aftermarket|generic|generico|gen[eé]rico|soft\s+oled|hard\s+oled|in[\s-]?cell)\b/i.test(text);
+}
+
+function getCommercialBrandName(product = {}) {
+  if (isCompatibleProduct(product)) {
+    return product.manufacturer_brand || product.actual_brand || "Compatible";
+  }
+  return product.brand || product.manufacturer || "Genérico";
+}
+
+function getCompatibleWith(product = {}) {
+  if (!isCompatibleProduct(product)) return "";
+  return [product.compatible_brand || product.device_brand || product.brand, product.compatible_model || product.model]
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+}
+
+function getProductMpn(product = {}) {
+  const explicit = product.mpn || product.part_number || product.partNumber || product.supplierPartNumber;
+  if (explicit) return String(explicit).trim();
+  const match = [product.name, product.description, product.sku].filter(Boolean).join(" ").match(/\bGH82-\d{4,6}[A-Z]?\b/i);
+  return match ? match[0].toUpperCase() : getProductSku(product);
+}
+
 function resolveSeo(product) {
   const { product: enriched, generated } = applySeoDefaults(product || {});
   return {
@@ -584,11 +617,10 @@ function updateJsonLd(product, images, productUrl) {
   const formattedPrice = Number.isFinite(numericPrice)
     ? numericPrice.toFixed(2)
     : "0.00";
-  const brandName =
-    typeof product.brand === "string" && product.brand.trim()
-      ? product.brand.trim()
-      : "";
+  const brandName = getCommercialBrandName(product);
   const skuValue = getProductSku(product);
+  const mpnValue = getProductMpn(product);
+  const compatibleWith = getCompatibleWith(product);
   const description = getProductDescription(product, { preferMeta: true });
   const schema = {
     "@context": "https://schema.org",
@@ -598,8 +630,10 @@ function updateJsonLd(product, images, productUrl) {
     name: heading,
     ...(absoluteImages.length ? { image: absoluteImages } : {}),
     ...(description ? { description } : {}),
-    ...(skuValue ? { sku: skuValue, mpn: skuValue } : {}),
+    ...(skuValue ? { sku: skuValue } : {}),
+    ...(mpnValue ? { mpn: mpnValue } : {}),
     ...(brandName ? { brand: { "@type": "Brand", name: brandName } } : {}),
+    ...(compatibleWith ? { additionalProperty: [{ "@type": "PropertyValue", name: "Compatible con", value: compatibleWith }] } : {}),
     offers: {
       "@type": "Offer",
       url: productUrl,
@@ -992,7 +1026,9 @@ function buildGallery(root, urls, alts = []) {
 function buildAttributes(product) {
   const attrs = [
     { label: "SKU", value: product.sku },
-    { label: "Marca", value: product.brand },
+    { label: "MPN", value: getProductMpn(product) },
+    { label: "Marca", value: getCommercialBrandName(product) },
+    { label: "Compatible con", value: getCompatibleWith(product) },
     { label: "Modelo", value: product.model },
     { label: "Categoría", value: product.category },
     {
@@ -1344,11 +1380,20 @@ function renderProduct(product) {
   const meta = document.createElement("div");
   meta.className = "product-meta";
 
-  if (product.brand) {
+  const commercialBrand = getCommercialBrandName(product);
+  if (commercialBrand) {
     const brand = document.createElement("span");
     brand.className = "product-meta__item";
-    brand.innerHTML = `<strong>Marca:</strong> ${product.brand}`;
+    brand.innerHTML = `<strong>Marca:</strong> ${commercialBrand}`;
     meta.appendChild(brand);
+  }
+
+  const compatibleWith = getCompatibleWith(product);
+  if (compatibleWith) {
+    const compatibility = document.createElement("span");
+    compatibility.className = "product-meta__item";
+    compatibility.innerHTML = `<strong>Compatible con:</strong> ${compatibleWith}`;
+    meta.appendChild(compatibility);
   }
 
   if (skuValue) {
@@ -1374,7 +1419,10 @@ function renderProduct(product) {
 
   const availability = resolveProductAvailability(product);
   const availabilityPresentation = buildAvailabilityPresentation(product);
-  const stockCopy = availabilityPresentation.primaryLabel || availability.availabilityLabel;
+  let stockCopy = availabilityPresentation.primaryLabel || availability.availabilityLabel;
+  if (availabilityPresentation.isStockReal && Number(availability.stockLocal) > 0) {
+    stockCopy = `En stock real · ${availability.stockLocal} unidad${availability.stockLocal === 1 ? "" : "es"} disponible${availability.stockLocal === 1 ? "" : "s"}`;
+  }
 
   summary.appendChild(meta);
 
@@ -1427,10 +1475,12 @@ function renderProduct(product) {
   shippingBanner.innerHTML = `
     <div class="shipping-banner__badge" aria-hidden="true">🚚</div>
     <div class="shipping-banner__copy">
-      <span class="shipping-banner__title">Envío a todo el país</span>
+      <span class="shipping-banner__title">${fulfillment.mode === "unavailable" ? "Disponibilidad" : "Envío a todo el país"}</span>
       <span class="shipping-banner__meta">
         ${
-          fulfillment.mode === "remote"
+          fulfillment.mode === "unavailable"
+            ? "Sin stock actual. Consultanos por WhatsApp para conocer alternativas o una fecha de reposición."
+            : fulfillment.mode === "remote"
             ? `Producto disponible bajo pedido. Fecha estimada de despacho: ${leadCopy}. Sujeto a disponibilidad del proveedor.`
             : fulfillment.isConfigured
               ? "Stock físico: despacho prioritario en 24 h hábiles con seguimiento en vivo."
@@ -1514,6 +1564,13 @@ function renderProduct(product) {
   addBtn.className = "button primary product-buy-main-cta";
   addBtn.disabled = !availability.checkoutAllowed;
 
+  const compatibilityLink = document.createElement("a");
+  compatibilityLink.className = "button secondary product-whatsapp-compatibility";
+  compatibilityLink.target = "_blank";
+  compatibilityLink.rel = "noopener";
+  compatibilityLink.href = `https://wa.me/5491130341550?text=${encodeURIComponent(`Hola NERIN, quiero consultar compatibilidad de ${product.name || "este repuesto"}${skuValue ? ` (${skuValue})` : ""}.`)}`;
+  compatibilityLink.textContent = "Consultar compatibilidad por WhatsApp";
+
   const priceLabel = document.createElement("p");
   priceLabel.className = "product-detail-unit-price";
 
@@ -1583,6 +1640,7 @@ function renderProduct(product) {
 
   purchaseCard.append(
     addBtn,
+    compatibilityLink,
     priceLabel,
     taxFreeNote,
     billingNote,

--- a/nerin_final_updated/frontend/js/shop.js
+++ b/nerin_final_updated/frontend/js/shop.js
@@ -1,7 +1,7 @@
 import { fetchProductsPage, getUserRole, isWholesale } from "./api.js";
 import { createPriceLegalBlock } from "./components/PriceLegalBlock.js";
 import { calculateNetNoNationalTaxes } from "./utils/pricing.js";
-import { buildAvailabilityPresentation } from "./availability.js";
+import { buildAvailabilityPresentation } from "./availability.js?v=seo-stock-real-20260621-v3";
 import { buildCartItemFromProduct, readCart, writeCart } from "./cart-utils.js";
 import { trackAddToCart, trackSearch, trackSelectItem, trackStockRealAddToCart, trackViewItemList } from "./analytics.js";
 
@@ -109,6 +109,33 @@ let totalFilteredItems = 0;
 let hasRealCatalogResponse = false;
 let latestRequestId = 0;
 let filtersInitialized = false;
+
+function normalizeProductIdentity(value) {
+  return String(value || "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function deduplicateVisibleProducts(products = []) {
+  const seen = new Set();
+  return products.filter((product) => {
+    const keys = [
+      ["mpn", product.mpn || product.part_number],
+      ["sku", product.sku || product.code],
+      ["slug", product.publicSlug || product.public_slug || product.slug],
+      ["title", product.name || product.title],
+    ].map(([type, value]) => {
+      const normalized = normalizeProductIdentity(value);
+      return normalized ? `${type}:${normalized}` : "";
+    }).filter(Boolean);
+    if (keys.some((key) => seen.has(key))) return false;
+    keys.forEach((key) => seen.add(key));
+    return true;
+  });
+}
 let productsAbortController = null;
 let searchDebounceTimer = null;
 let priceDebounceTimer = null;
@@ -220,9 +247,14 @@ function getFulfillmentMode(product) {
   if (explicitMode === "remote" || explicitMode === "remoto") return "remote";
   if (explicitMode === "physical" || explicitMode === "fisico" || explicitMode === "físico") return "physical";
 
+  const stockStatus = cleanLabel(product.stock_status || product.stockStatus || product.availability || "").toLowerCase();
+  if (stockStatus === "preorder" || stockStatus === "backorder") return "remote";
+  if (stockStatus === "in_stock" || stockStatus === "out_of_stock") return "physical";
+
   if (Number(product.remote_stock) > 0 || Number(product.remote_lead_days) > 0) return "remote";
 
   const stock = resolveStockQuantity(product);
+  if (Number.isFinite(stock) && stock > 0) return "physical";
   const textSignals = [product.name, product.description, product.category, product.subcategory]
     .filter(Boolean)
     .join(" ")
@@ -1022,7 +1054,7 @@ async function renderProducts({ page = currentProductsPage, scrollToTop = false 
     .map(normalizeStorefrontProduct)
     .map(sanitizePublicProduct)
     .filter(Boolean);
-  const filteredItems = normalizedItems;
+  const filteredItems = deduplicateVisibleProducts(normalizedItems);
 
   if (!filtersInitialized) {
     populateFilters(normalizedItems);

--- a/nerin_final_updated/frontend/product.html
+++ b/nerin_final_updated/frontend/product.html
@@ -156,8 +156,8 @@
         <img src="/assets/whatsapp.svg" alt="WhatsApp" />
       </a>
     </div>
-    <script type="module" src="/js/delivery-policy.js?v=delivery-policy-20260503"></script>
-    <script type="module" src="/js/product.js?v=delivery-policy-20260503"></script>
+    <script type="module" src="/js/delivery-policy.js?v=seo-stock-real-20260621-v3"></script>
+    <script type="module" src="/js/product.js?v=seo-stock-real-20260621-v4"></script>
     <!-- Configuración y analíticas globales -->
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
     <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>

--- a/nerin_final_updated/frontend/shop.html
+++ b/nerin_final_updated/frontend/shop.html
@@ -312,9 +312,9 @@
       </a>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
-    <script type="module" src="/js/delivery-policy.js?v=delivery-policy-20260503"></script>
+    <script type="module" src="/js/delivery-policy.js?v=seo-stock-real-20260621-v3"></script>
     <script type="module" src="/js/config.js?v=nav-admin-fix-20260504"></script>
     <script type="module" src="/js/analytics-autotrack.js?v=ecommerce-organic-funnel"></script>
-    <script type="module" src="/js/shop.js?v=delivery-policy-20260503"></script>
+    <script type="module" src="/js/shop.js?v=seo-stock-real-20260621-v3"></script>
   </body>
 </html>


### PR DESCRIPTION
## Resumen

- Centraliza la clasificación de disponibilidad y el orden comercial: **stock real → a pedido → sin stock**.
- Elimina duplicados del catálogo y prioriza fichas completas con precio, imagen y slug.
- Separa Google Merchant en un feed principal de stock físico y otro exclusivo para preventa/a pedido con `availability_date` RFC 3339.
- Mejora títulos, marca/MPN, compatibilidad, JSON-LD, canonicales, sitemap y redirección de URLs antiguas.
- Actualiza home, tienda, landings orgánicas y fichas de producto con cantidad disponible, Factura A/B, despacho y CTAs coherentes.
- Evita enlazar landings orgánicas vacías y conserva una respuesta útil con `noindex,follow`.
- Documenta criterios de Merchant, pruebas y pasos posteriores en Search Console/Merchant Center.

## Causa corregida

La política del frontend trataba productos sin una señal explícita como “a pedido”, incluso algunos sin stock. Ahora el stock físico tiene prioridad, la preventa requiere señales reales y los productos no vendibles quedan como “Sin stock”.

## Validación

- 7 suites enfocadas aprobadas: **67/67 pruebas**.
- Verificación en navegador de home, tienda y las tres variantes de ficha: stock real, a pedido y sin stock.
- Feeds verificados:
  - `/merchant-feed.tsv`: solo stock real.
  - `/merchant-feed-preorder.tsv`: solo preventa/a pedido con fecha válida.
- Sitemaps verificados sin `/shop` ni URLs antiguas `product.html?id=...`.
- La suite completa mejoró de 13 a 7 suites fallidas. Las 7 restantes ya fallaban antes y corresponden a fixtures/rutas Windows, SQLite temporal, analytics, emails y ranking ajenos a este cambio.

## Alcance protegido

No se cambia el flujo de checkout, Mercado Pago, la interfaz de administración ni Resend.